### PR TITLE
Moving most device memory static

### DIFF
--- a/ios/MLCChat/MLCChat-Bridging-Header.h
+++ b/ios/MLCChat/MLCChat-Bridging-Header.h
@@ -3,6 +3,7 @@
 //
 // Exposed interface of Object-C, enables swift binding.
 #import <Foundation/Foundation.h>
+#include <os/proc.h>
 
 @interface LLMChatInstance : NSObject
 - (void)initialize;


### PR DESCRIPTION
This PR makes the chat.cc mostly static allocate memory to reduce overall memory allocations in runtime.