### PR TITLE
Fix Android app stats collection

### DIFF
--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/MainActivity.java
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/MainActivity.java
@@ -72,10 +72,7 @@ public class MainActivity extends AppCompatActivity {
                         appendMessage(new MessageData(MessageRole.BOT, bundle.getString(Config.MSG_KEY)));
                         break;
                     case Config.END:
-                        String stats = bundle.getString(Config.STATS_KEY);
-                        int pos = stats.indexOf("sample");
-                        stats = stats.substring(0, pos - 2);
-                        speedText.setText(stats);
+                        speedText.setText(bundle.getString(Config.STATS_KEY));
                         resumeSend();
                         break;
                     case Config.PARAMS_DONE:


### PR DESCRIPTION
This PR is a quick fix for the android app on stats collection. Without this PR the android app will crash when build in Android Studio.

The released APK doesn't have this issue so no need to build a new APK.