### PR TITLE
Introduce preset compilation modes and organize artifact name

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -653,7 +653,7 @@ def get_model(args):
 
     model_name = args.model
     model_path = args.model_path
-    dtype = args.dtype
+    dtype = args.quantization.model_dtype
     max_seq_len = args.max_seq_len
 
     if model_name.startswith("vicuna-") or model_name.startswith("llama-"):

--- a/mlc_llm/relax_model/moss.py
+++ b/mlc_llm/relax_model/moss.py
@@ -569,7 +569,7 @@ def get_model(args):
 
     model_name = args.model
     model_path = args.model_path
-    dtype = args.dtype
+    dtype = args.quantization.dtype
     max_seq_len = args.max_seq_len
 
     if model_name in MODEL_CONFIG.keys():


### PR DESCRIPTION
This PR introduces three preset compilation modes, which specify the quantization options and model dtype of the compilation flow.

At this moment, only three modes are supported. To ease running commands, we turned off manual customization (like specifying all options one by one). If you do want to customize, you can choose to add a preset mode to the codebase.

This PR thereby also reorganizes the artifact names (including the library name, cached IRModule name, etc.). Therefore, we will need to update the HuggingFace model repo and the binary repo after merging this PR.

The behaviors of `build.py`, `tests/chat.py`, `tests/evaluate.py` and `tests/debug/compare_lib.py` and the CLI (including Conda install and build from source) are tested.