### PR TITLE
Further reorganize artifact structure

### DIFF
--- a/build.py
+++ b/build.py
@@ -16,7 +16,24 @@ from mlc_llm.relax_model import gpt_neox, llama, moss
 
 def _parse_args():
     args = argparse.ArgumentParser()
-    utils.argparse_add_common(args)
+    args.add_argument(
+        "--model-path",
+        type=str,
+        default=None,
+        help="Custom model path that contains params, tokenizer, and config",
+    )
+    args.add_argument(
+        "--hf-path",
+        type=str,
+        default=None,
+        help="Hugging Face path from which to download params, tokenizer, and config from",
+    )
+    args.add_argument(
+        "--quantization",
+        type=str,
+        choices=[*utils.quantization_dict.keys()],
+        default=list(utils.quantization_dict.keys())[0],
+    )
     args.add_argument("--max-seq-len", type=int, default=-1)
     args.add_argument("--target", type=str, default="auto")
     args.add_argument(
@@ -62,9 +79,12 @@ def _parse_args():
 
     return parsed
 
+
 def _setup_model_path(args):
     if args.model_path and args.hf_path:
-        assert (args.model_path and not args.hf_path) or (args.hf_path and not args.model_path), "You cannot specify both a model path and a HF path. Please select one to specify."
+        assert (args.model_path and not args.hf_path) or (
+            args.hf_path and not args.model_path
+        ), "You cannot specify both a model path and a HF path. Please select one to specify."
     if args.model_path:
         validate_config(args)
         with open(os.path.join(args.model_path, "config.json")) as f:
@@ -78,7 +98,9 @@ def _setup_model_path(args):
         else:
             os.makedirs(args.model_path, exist_ok=True)
             os.system("git lfs install")
-            os.system(f"git clone https://huggingface.co/{args.hf_path} {args.model_path}")
+            os.system(
+                f"git clone https://huggingface.co/{args.hf_path} {args.model_path}"
+            )
             print(f"Downloaded weights to {args.model_path}")
         validate_config(args)
     else:
@@ -86,12 +108,20 @@ def _setup_model_path(args):
     print(f"Using model path {args.model_path}")
     return args
 
+
 def validate_config(args):
-    assert os.path.exists(os.path.join(args.model_path, "config.json")), "Model path must contain valid config file."
+    assert os.path.exists(
+        os.path.join(args.model_path, "config.json")
+    ), "Model path must contain valid config file."
     with open(os.path.join(args.model_path, "config.json")) as f:
         config = json.load(f)
-        assert ("model_type" in config) and ("_name_or_path" in config), "Invalid config format."
-        assert config["model_type"] in utils.supported_model_types, f"Model type {config['model_type']} not supported."
+        assert ("model_type" in config) and (
+            "_name_or_path" in config
+        ), "Invalid config format."
+        assert (
+            config["model_type"] in utils.supported_model_types
+        ), f"Model type {config['model_type']} not supported."
+
 
 def debug_dump_script(mod, name, args):
     """Debug dump mode"""
@@ -177,7 +207,7 @@ def dump_default_mlc_llm_config(args):
     config["stream_interval"] = 2
     config["mean_gen_len"] = 128
     config["shift_fill_factor"] = 0.3
-    dump_path = os.path.join(args.artifact_path, "mlc_llm_config.json")
+    dump_path = os.path.join(args.artifact_path, "params", "mlc-llm-config.json")
     with open(dump_path, "w") as outfile:
         json.dump(config, outfile, indent=4)
     print(f"Finish exporting mlc_llm_config to {dump_path}")
@@ -255,10 +285,7 @@ if __name__ == "__main__":
                 mod, params = llama.get_model(ARGS, config)
             elif ARGS.model_category == "gpt_neox":
                 mod, params = gpt_neox.get_model(
-                    ARGS.model,
-                    ARGS.model_path,
-                    ARGS.quantization.model_dtype,
-                    config
+                    ARGS.model, ARGS.model_path, ARGS.quantization.model_dtype, config
                 )
             elif ARGS.model_category == "moss":
                 mod, params = moss.get_model(ARGS, config)

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -46,25 +46,6 @@ quantization_dict = {
 
 supported_model_types = set(["llama", "gpt_neox", "moss"])
 
-def argparse_add_common(args: argparse.ArgumentParser) -> None:
-    args.add_argument(
-        "--quantization",
-        type=str,
-        choices=[*quantization_dict.keys()],
-        default=list(quantization_dict.keys())[0],
-    )
-    args.add_argument(
-        "--model-path",
-        type=str,
-        default=None,
-        help="Custom model path that contains params, tokenizer, and config"
-    )
-    args.add_argument(
-        "--hf-path",
-        type=str,
-        default=None,
-        help="Hugging Face path from which to download params, tokenizer, and config from"
-    )
 
 def argparse_postproc_common(args: argparse.Namespace) -> None:
     if hasattr(args, "device_name"):
@@ -208,7 +189,10 @@ def split_static_dynamic_tir(mod: tvm.IRModule):
 def copy_tokenizer(args: argparse.Namespace) -> None:
     for filename in os.listdir(args.model_path):
         if filename.startswith("tokenizer") or filename == "vocab.json":
-            shutil.copy(os.path.join(args.model_path, filename), args.artifact_path)
+            shutil.copy(
+                os.path.join(args.model_path, filename),
+                os.path.join(args.artifact_path, "params"),
+            )
 
 
 def parse_target(args: argparse.Namespace) -> None:

--- a/tests/chat.py
+++ b/tests/chat.py
@@ -28,12 +28,13 @@ class Colors:
 
 def _parse_args():
     args = argparse.ArgumentParser()
-    utils.argparse_add_common(args)
+    args.add_argument("--local-id", type=str, required=True)
     args.add_argument("--device-name", type=str, default="auto")
     args.add_argument("--debug-dump", action="store_true", default=False)
     args.add_argument("--artifact-path", type=str, default="dist")
     args.add_argument("--max-gen-len", type=int, default=2048)
     parsed = args.parse_args()
+    parsed.model, parsed.quantization = parsed.local_id.rsplit("-", 1)
     utils.argparse_postproc_common(parsed)
     parsed.artifact_path = os.path.join(
         parsed.artifact_path, f"{parsed.model}-{parsed.quantization.name}"
@@ -223,7 +224,7 @@ def main():
     if ARGS.debug_dump:
         torch.manual_seed(12)
     tokenizer = AutoTokenizer.from_pretrained(
-        ARGS.artifact_path, trust_remote_code=True
+        os.path.join(ARGS.artifact_path, "params"), trust_remote_code=True
     )
     tokenizer.pad_token_id = tokenizer.eos_token_id
     if ARGS.model.startswith("dolly-"):

--- a/tests/evaluate.py
+++ b/tests/evaluate.py
@@ -18,13 +18,14 @@ from mlc_llm import utils
 
 def _parse_args():
     args = argparse.ArgumentParser()
-    utils.argparse_add_common(args)
+    args.add_argument("--local-id", type=str, required=True)
     args.add_argument("--device-name", type=str, default="auto")
     args.add_argument("--debug-dump", action="store_true", default=False)
     args.add_argument("--artifact-path", type=str, default="dist")
     args.add_argument("--prompt", type=str, default="The capital of Canada is")
     args.add_argument("--profile", action="store_true", default=False)
     parsed = args.parse_args()
+    parsed.model, parsed.quantization = parsed.local_id.rsplit("-", 1)
     utils.argparse_postproc_common(parsed)
     parsed.artifact_path = os.path.join(
         parsed.artifact_path, f"{parsed.model}-{parsed.quantization.name}"
@@ -91,7 +92,7 @@ def deploy_to_pipeline(args) -> None:
     vm = relax.VirtualMachine(ex, device)
 
     tokenizer = AutoTokenizer.from_pretrained(
-        args.artifact_path, trust_remote_code=True
+        os.path.join(args.artifact_path, "params"), trust_remote_code=True
     )
 
     print("Tokenizing...")


### PR DESCRIPTION
This PR reorganizes the artifact structure. We now have two separate types of directories to store the libs/weights/..., with one "prebuilt" directory which holds all the prebuilt libs and weights downloaded from internet, and other model directories that are generated by local builds.

CLI and test scripts are updated accordingly for this change.