### PR TITLE
Allow specifying model name in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ If you have a local directory that has the model parameters, the tokenizer, and 
 # Create the local build directory and compile the model
 mkdir build
 python build.py --model-path=/path/to/local/directory
+
+# If the model path is in the form of `dist/models/model_name`,
+# we can simplify the build command to
+# python build.py --model=model_name
 ```
 
 Similarly, the compiled model will be available at `dist/dolly-v2-3b-q3f16_0`, where the exact path will vary depending on your model type and specified quantization. Follow the platform specific instructions to build and run MLC LLM for [iOS](https://github.com/mlc-ai/mlc-llm/blob/main/ios/README.md), [Android](https://github.com/mlc-ai/mlc-llm/blob/main/android/README.md), and [CLI](https://github.com/mlc-ai/mlc-llm/tree/main/cpp/README.md).

--- a/android/README.md
+++ b/android/README.md
@@ -38,11 +38,12 @@ We are excited to share that we have enabled the Android support for MLC-LLM. Ch
     git clone https://github.com/mlc-ai/mlc-llm.git --recursive
     cd mlc-llm
 
-    # From Hugging Face URL
-    python3 build.py --hf-path databricks/dolly-v2-3b --quantization q4f16_0 --target android --max-seq-len 768
-
     # From local directory
     python3 build.py --model-path path/to/vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
+
+    # If the model path is `dist/models/vicuna-v1-7b`,
+    # we can simplify the build command to
+    # python build.py --model=vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
     ```
 
 5. Build libraries for Android app.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -7,10 +7,14 @@
     cd mlc-llm
 
     # From Hugging Face URL
-    python3 build.py --hf-path databricks/dolly-v2-3b --quantization q3f16_0 --target iphone --max-seq-len 768
+    python3 build.py --hf-path databricks/dolly-v2-3b --quantization q3f16_0 --max-seq-len 768
 
     # From local directory
-    python3 build.py --model-path path/to/vicuna-v1-7b --quantization q3f16_0 --target iphone --max-seq-len 768
+    python3 build.py --model-path path/to/vicuna-v1-7b --quantization q3f16_0 --max-seq-len 768
+
+    # If the model path is in the form of `dist/models/model_name`,
+    # we can simplify the build command to
+    # python build.py --model model_name --quantization q3f16_0 --max-seq-len 768
     ```
 
 2. Build the CLI.

--- a/ios/README.md
+++ b/ios/README.md
@@ -26,11 +26,12 @@ Note: You will need Apple Developer Account to build iOS App locally.
     git clone https://github.com/mlc-ai/mlc-llm.git --recursive
     cd mlc-llm
 
-    # From Hugging Face URL
-    python3 build.py --hf-path databricks/dolly-v2-3b --quantization q3f16_0 --target iphone --max-seq-len 768
-
     # From local directory
     python3 build.py --model-path path/to/vicuna-v1-7b --quantization q3f16_0 --target iphone --max-seq-len 768
+
+    # If the model path is `dist/models/vicuna-v1-7b`,
+    # we can simplify the build command to
+    # python build.py --model vicuna-v1-7b --quantization q3f16_0 --target iphone --max-seq-len 768
     ```
 
 3. Prepare lib and params


### PR DESCRIPTION
Previously when we introducing the support of "local model path" and "HuggingFace model path", we removed the support of specifying model name when build. This turns out preventing us from only specifying the much shorter model name, as well as doing automatic search for models existing on the disk.

Therefore, this PR brings back the argparse support for `--model`. Now we will carefully handle the case where both the model name and one of the model path / HF path are specified. We now also support model searching on disk, and support specifying the model only by a short model name.