### PR TITLE
Unify model specification in build / Hardcode cached rotary emb size / Update config name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ git clone https://github.com/mlc-ai/mlc-llm.git
 
 # Create the local build directory and compile the model
 # This will automatically download the parameters, tokenizer, and config from Hugging Face
-mkdir build
 python build.py --hf-path=databricks/dolly-v2-3b
 ```
 
@@ -88,8 +87,7 @@ If you have a local directory that has the model parameters, the tokenizer, and 
 
 ```shell
 # Create the local build directory and compile the model
-mkdir build
-python build.py --model-path=/path/to/local/directory
+python build.py --model=/path/to/local/directory
 
 # If the model path is in the form of `dist/models/model_name`,
 # we can simplify the build command to

--- a/android/README.md
+++ b/android/README.md
@@ -39,11 +39,11 @@ We are excited to share that we have enabled the Android support for MLC-LLM. Ch
     cd mlc-llm
 
     # From local directory
-    python3 build.py --model-path path/to/vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
+    python3 build.py --model path/to/vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
 
     # If the model path is `dist/models/vicuna-v1-7b`,
     # we can simplify the build command to
-    # python build.py --model=vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
+    # python build.py --model vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
     ```
 
 5. Build libraries for Android app.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -10,7 +10,7 @@
     python3 build.py --hf-path databricks/dolly-v2-3b --quantization q3f16_0 --max-seq-len 768
 
     # From local directory
-    python3 build.py --model-path path/to/vicuna-v1-7b --quantization q3f16_0 --max-seq-len 768
+    python3 build.py --model path/to/vicuna-v1-7b --quantization q3f16_0 --max-seq-len 768
 
     # If the model path is in the form of `dist/models/model_name`,
     # we can simplify the build command to

--- a/ios/README.md
+++ b/ios/README.md
@@ -27,7 +27,7 @@ Note: You will need Apple Developer Account to build iOS App locally.
     cd mlc-llm
 
     # From local directory
-    python3 build.py --model-path path/to/vicuna-v1-7b --quantization q3f16_0 --target iphone --max-seq-len 768
+    python3 build.py --model path/to/vicuna-v1-7b --quantization q3f16_0 --target iphone --max-seq-len 768
 
     # If the model path is `dist/models/vicuna-v1-7b`,
     # we can simplify the build command to

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -188,7 +188,13 @@ def split_static_dynamic_tir(mod: tvm.IRModule):
 
 def copy_tokenizer(args: argparse.Namespace) -> None:
     for filename in os.listdir(args.model_path):
-        if filename.startswith("tokenizer") or filename == "vocab.json":
+        if filename in [
+            "tokenizer.model",
+            "tokenizer.json",
+            "vocab.json",
+            "merges.txt",
+            "added_tokens.json",
+        ]:
             shutil.copy(
                 os.path.join(args.model_path, filename),
                 os.path.join(args.artifact_path, "params"),


### PR DESCRIPTION
This PR updates three places for better experience.
* Unify the `--model-path` and `--model` args in build.py. Now we only take `--model`.
* Hardcode the rotary embedding size for LLaMA to 2048. This enables us to build a model with different max sequence length without changing the built weights.
* Update the generated config file name to `mlc-chat-config.json`.