### PR TITLE
Initialize chat module from config JSON string

### DIFF
--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/LLMChat.java
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/LLMChat.java
@@ -50,12 +50,12 @@ public class LLMChat {
         assert stopped_func_ != null;
         assert runtime_stats_text_func_ != null;
 
+        String conv_template = "vicuna_v1.1";
         double temperature = 0.7;
         double top_p = 0.95;
-        int stream_interval = 1;
         int mean_gen_len = 128;
         double shift_fill_factor = 0.2;
-        llm_chat_.getFunction("init_chat").pushArg(temperature).pushArg(top_p).pushArg(stream_interval).pushArg(mean_gen_len).pushArg(shift_fill_factor).invoke();
+        llm_chat_.getFunction("init_chat_legacy").pushArg(conv_template).pushArg(temperature).pushArg(top_p).pushArg(mean_gen_len).pushArg(shift_fill_factor).invoke();
 
         systemlib_func.release();
         lib.release();

--- a/build.py
+++ b/build.py
@@ -229,13 +229,12 @@ def dump_default_mlc_llm_config(args):
     config["conv_template"] = args.conv_template
     config["temperature"] = 0.7
     config["top_p"] = 0.95
-    config["stream_interval"] = 2
     config["mean_gen_len"] = 128
     config["shift_fill_factor"] = 0.3
     dump_path = os.path.join(args.artifact_path, "params", "mlc-chat-config.json")
     with open(dump_path, "w") as outfile:
         json.dump(config, outfile, indent=4)
-    print(f"Finish exporting mlc_llm_config to {dump_path}")
+    print(f"Finish exporting chat config to {dump_path}")
 
 
 def build(mod_deploy: tvm.IRModule, args: argparse.Namespace) -> None:

--- a/ios/MLCChat/LLMChat.mm
+++ b/ios/MLCChat/LLMChat.mm
@@ -45,13 +45,13 @@ class LLMChatModuleWrapper {
     ICHECK(stopped_func_ != nullptr);
     ICHECK(runtime_stats_text_func_ != nullptr);
 
+    std::string conv_template = "vicuna_v1.1";
     double temperature = 0.7;
     double top_p = 0.95;
-    int stream_interval = 1;
     int mean_gen_len = 128;
     double shift_fill_factor = 0.2;
-    llm_chat_->GetFunction("init_chat")(temperature, top_p, stream_interval, mean_gen_len,
-                                        shift_fill_factor);
+    llm_chat_->GetFunction("init_chat_legacy")(conv_template, temperature, top_p, mean_gen_len,
+                                               shift_fill_factor);
   }
 
   void Evaluate() {

--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -7,7 +7,6 @@ from tvm import relax
 def create_metadata_func(
     bb: relax.BlockBuilder,
     model_name: str,
-    conv_template: str,
     max_window_size: int,
     stop_tokens: List[int],
     add_prefix_space: bool,
@@ -15,7 +14,6 @@ def create_metadata_func(
     metadata = json.dumps(
         {
             "model_name": model_name,
-            "conv_template": conv_template,
             "max_window_size": max_window_size,
             "stop_tokens": stop_tokens,
             "add_prefix_space": add_prefix_space,

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -587,10 +587,8 @@ def get_model(model_name: str, model_path: str, dtype: str, hf_config):
     from transformers import AutoModelForCausalLM  # type: ignore[import]
 
     if model_name.startswith("dolly"):
-        conv_template = "dolly"
         stop_tokens = [2]
     elif model_name.startswith("stablelm"):
-        conv_template = "stablelm"
         stop_tokens = [50278, 50279, 50277, 1, 0]
     else:
         raise ValueError(f"Unsupported model {model_name}")
@@ -646,7 +644,6 @@ def get_model(model_name: str, model_path: str, dtype: str, hf_config):
     create_metadata_func(
         bb,
         model_name=model_name,
-        conv_template=conv_template,
         max_window_size=config.max_sequence_length,
         stop_tokens=stop_tokens,
         add_prefix_space=False,

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -682,7 +682,6 @@ def get_model(args, hf_config):
         create_metadata_func(
             bb,
             model_name=model_name,
-            conv_template="vicuna_v1.1" if model_name.startswith("vicuna") else "",
             max_window_size=config.max_sequence_length,
             stop_tokens=[2],
             add_prefix_space=False,

--- a/mlc_llm/relax_model/moss.py
+++ b/mlc_llm/relax_model/moss.py
@@ -617,7 +617,6 @@ def get_model(args, hf_config):
     create_metadata_func(
         bb,
         model_name=model_name,
-        conv_template="moss",
         max_window_size=config.max_sequence_length,
         stop_tokens=[106068],
         add_prefix_space=True,


### PR DESCRIPTION
This PR supports initialization the chat module from JSON-structured string.
* The CLI is updated with the latest json initialization.
* The iOS/Android app sides are remained using the previous way of initialization. Now the previous function is renamed to `init_chat_legacy`, which we will remove after updating the app and web sides accordingly.
* This PR reverts part of the previous metadata PR as a wrong assumption was made on the conversation template.
* This PR removes `stream_interval` from chat module as it is unused. Now `stream_interval` is only kept on the CLI side.