### PR TITLE
Support model reload in chat module and CLI

### DIFF
--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/LLMChat.java
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/LLMChat.java
@@ -26,7 +26,7 @@ public class LLMChat {
         assert systemlib_func != null;
         Module lib = systemlib_func.invoke().asModule();
         assert lib != null;
-        Function fcreate = Function.getFunction("mlc.llm_chat_create");
+        Function fcreate = Function.getFunction("mlc.llm_chat_create_legacy");
         assert fcreate != null;
         String dist_path = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath();
         String tokenizer_path = dist_path + "/vicuna-v1-7b/tokenizer.model";

--- a/cpp/llm_chat.h
+++ b/cpp/llm_chat.h
@@ -22,10 +22,12 @@ namespace mlc {
 namespace llm {
 
 // explicit export via TVM_DLL
-MLC_LLM_DLL tvm::runtime::Module CreateChatModule(
-    tvm::runtime::Module executable,
-    const tvm::runtime::String& tokenizer_path,
-    const tvm::runtime::String& param_path, DLDevice device);
+MLC_LLM_DLL tvm::runtime::Module CreateChatModule(DLDevice device);
+
+MLC_LLM_DLL tvm::runtime::Module CreateChatModuleLegacy(tvm::runtime::Module executable,
+                                                        const tvm::runtime::String& tokenizer_path,
+                                                        const tvm::runtime::String& param_path,
+                                                        DLDevice device);
 
 }  // namespace llm
 }  // namespace mlc

--- a/ios/MLCChat/LLMChat.mm
+++ b/ios/MLCChat/LLMChat.mm
@@ -22,8 +22,8 @@ class LLMChatModuleWrapper {
     // load module
     tvm::runtime::Module lib = (*tvm::runtime::Registry::Get("runtime.SystemLib"))();
 
-    const PackedFunc* fcreate = tvm::runtime::Registry::Get("mlc.llm_chat_create");
-    ICHECK(fcreate) << "Cannot find mlc.llm_chat_create";
+    const PackedFunc* fcreate = tvm::runtime::Registry::Get("mlc.llm_chat_create_legacy");
+    ICHECK(fcreate) << "Cannot find mlc.llm_chat_create_legacy";
 
     // lookup bundle path
     std::string bundle_path = NSBundle.mainBundle.bundlePath.UTF8String;


### PR DESCRIPTION
This PR introduces the model reload functionality to the chat module and the CLI.
* In CLI, the usage is `/reload [model_id]`, for example `model_id` can be `vicuna-v1-7b-q3f16_0`. When `model_id` is specified, CLI will search the corresponding model for `model_id` in candidate paths, and load the specified model. When it is not specified, CLI will reload the currently running model again.
* The effect of the reload operation is to load the (specified) model as if loading it at the very beginning. This means the chat module will completely release and forget everything happened before reload.
* Regarding the implementation, this PR unifies the previous `init_chat` function with the `Init` function into the `Reload` function.
* Verified the behavior of reload between Vicuna-v1-7b and RedPajama-INCITE-Chat-3B.
* Verified on Mac Studio and Linux that the reload operation will not cause memory leak.
* Given the iOS/Android app does not support reading json config string yet, the refactor of this PR keeps some existing functions that required by the iOS/Android app as legacy functions. TODO items are marked where legacy functions are. I have verified that the legacy functions work.