### PR TITLE
Isolate model fetching in a separate process

### DIFF
--- a/build.py
+++ b/build.py
@@ -352,6 +352,7 @@ def main():
     cache_path = os.path.join(
         ARGS.artifact_path, f"mod_cache_before_build_{ARGS.target_kind}.pkl"
     )
+    ARGS.raw_params_path = os.path.join(ARGS.artifact_path, "raw_params")
     use_cache = ARGS.use_cache and os.path.isfile(cache_path)
     with open(os.path.join(ARGS.model_path, "config.json"), encoding="utf-8") as i_f:
         config = json.load(i_f)
@@ -380,7 +381,7 @@ def main():
         if not ARGS.reuse_lib:
             build(mod, ARGS)
         else:
-            print("Reuse existing preuilt lib {ARGS.reuse_lib}...")
+            print("Reuse existing prebuilt lib {ARGS.reuse_lib}...")
         dump_default_mlc_chat_config(ARGS)
 
 

--- a/mlc_llm/transformers.py
+++ b/mlc_llm/transformers.py
@@ -48,6 +48,7 @@ def get_model(model: str, dump_path: str):
     from typing import List, Tuple
 
     import numpy as np
+    from tqdm import tqdm
 
     with multiprocessing.Pool(processes=1) as pool:
         result = pool.map(
@@ -61,7 +62,7 @@ def get_model(model: str, dump_path: str):
     with open(config_path, "r", encoding="utf-8") as i_f:
         config = json.load(i_f)
     param_dict: List[Tuple[str, np.ndarray]] = []
-    for i, name in enumerate(config):
+    for i, name in tqdm(enumerate(config), total=len(config)):
         param_path = os.path.join(dump_path, f"param_{i}.npy")
         param_dict.append((name, np.load(param_path)))
     print("Loading done")

--- a/mlc_llm/transformers.py
+++ b/mlc_llm/transformers.py
@@ -1,0 +1,68 @@
+# pylint: disable=import-outside-toplevel
+def _get_model_worker(_args) -> None:
+    import json
+    import os
+
+    import numpy as np
+    from transformers import AutoModelForCausalLM  # type: ignore[import]
+
+    model: str
+    dump_path: str
+    model, dump_path = _args
+    config_path = os.path.join(dump_path, "config.json")
+    if os.path.exists(config_path):
+        print("Model weights already exist under:", dump_path)
+        return
+
+    print("Extracting weights for model:", model)
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        model,
+        trust_remote_code=True,
+    )
+    params = [
+        (
+            name,
+            param.detach().cpu().numpy(),
+        )
+        for name, param in hf_model.named_parameters()
+    ]
+    del hf_model
+
+    os.makedirs(dump_path, exist_ok=True)
+    for i, (name, param) in enumerate(params):
+        param_path = os.path.join(dump_path, f"param_{i}.npy")
+        np.save(param_path, param)
+
+    with open(config_path, "w", encoding="utf-8") as o_f:
+        json.dump(
+            [name for name, _ in params],
+            o_f,
+        )
+    print("Model weights dumped to:", dump_path)
+
+
+def get_model(model: str, dump_path: str):
+    import json
+    import multiprocessing
+    import os
+    from typing import List, Tuple
+
+    import numpy as np
+
+    with multiprocessing.Pool(processes=1) as pool:
+        result = pool.map(
+            _get_model_worker,
+            [
+                (model, dump_path),
+            ],
+        )
+    print("Loading model weights from:", dump_path)
+    config_path = os.path.join(dump_path, "config.json")
+    with open(config_path, "r", encoding="utf-8") as i_f:
+        config = json.load(i_f)
+    param_dict: List[Tuple[str, np.ndarray]] = []
+    for i, name in enumerate(config):
+        param_path = os.path.join(dump_path, f"param_{i}.npy")
+        param_dict.append((name, np.load(param_path)))
+    print("Loading done")
+    return param_dict

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -251,37 +251,73 @@ def get_database(db_paths: str) -> ms.Database:
     return db
 
 
+def _detect_local_metal():
+    dev = tvm.metal()
+    if not dev.exist:
+        return None
+    return tvm.target.Target(
+        {
+            "kind": "metal",
+            "max_shared_memory_per_block": 32768,
+            "max_threads_per_block": dev.max_threads_per_block,
+            "thread_warp_size": 32,
+        },
+        host=tvm.target.Target(  # TODO: assuming ARM mac for now
+            {
+                "kind": "llvm",
+                "mtriple": "arm64-apple-macos",
+                "mcpu": "apple-latest",
+            }
+        ),
+    )
+
+
+def _detect_local_cuda():
+    dev = tvm.cuda()
+    if not dev.exist:
+        return None
+    return tvm.target.Target(
+        {
+            "kind": "cuda",
+            "max_shared_memory_per_block": dev.max_shared_memory_per_block,
+            "max_threads_per_block": dev.max_threads_per_block,
+            "thread_warp_size": dev.warp_size,
+            "registers_per_block": 65536,
+            "arch": "sm_" + tvm.cuda().compute_version.replace(".", ""),
+        }
+    )
+
+
+def _detect_local_vulkan():
+    dev = tvm.vulkan()
+    if not dev.exist:
+        return None
+    return tvm.target.Target(
+        {
+            "kind": "vulkan",
+            "max_threads_per_block": dev.max_threads_per_block,
+            "max_shared_memory_per_block": dev.max_shared_memory_per_block,
+            "thread_warp_size": dev.warp_size,
+            "supports_float16": 1,
+            "supports_int16": 1,
+            "supports_16bit_buffer": 1,
+        }
+    )
+
+
 def detect_local_target():
     dev = tvm.metal()
     if dev.exist:
         return tvm.target.Target("apple/m1-gpu")
 
-    dev = tvm.cuda()
-    if dev.exist:
-        return tvm.target.Target(
-            {
-                "kind": "cuda",
-                "max_shared_memory_per_block": dev.max_shared_memory_per_block,
-                "max_threads_per_block": dev.max_threads_per_block,
-                "thread_warp_size": dev.warp_size,
-                "registers_per_block": 65536,
-                "arch": "sm_" + tvm.cuda().compute_version.replace(".", ""),
-            }
-        )
-
-    dev = tvm.vulkan()
-    if dev.exist:
-        return tvm.target.Target(
-            {
-                "kind": "vulkan",
-                "max_threads_per_block": dev.max_threads_per_block,
-                "max_shared_memory_per_block": dev.max_shared_memory_per_block,
-                "thread_warp_size": dev.warp_size,
-                "supports_float16": 1,
-                "supports_int16": 1,
-                "supports_16bit_buffer": 1,
-            }
-        )
+    for method in [
+        _detect_local_metal,
+        _detect_local_cuda,
+        _detect_local_vulkan,
+    ]:
+        target = method()
+        if target is not None:
+            return target
 
     print("Failed to detect local GPU, falling back to CPU as a target")
     return tvm.target.Target("llvm")
@@ -292,91 +328,35 @@ def parse_target(args: argparse.Namespace) -> None:
         return
     if args.target == "auto":
         target = detect_local_target()
-        print(f"Automatically configuring target: {target}")
-        args.target = tvm.target.Target(target, host="llvm")
+        if target.host is None:
+            target = tvm.target.Target(
+                target,
+                host="llvm",  # TODO: detect host CPU
+            )
+        args.target = target
         args.target_kind = args.target.kind.default_keys[0]
-    elif args.target == "webgpu":
-        args.target = tvm.target.Target(
-            "webgpu", host="llvm -mtriple=wasm32-unknown-unknown-wasm"
-        )
-        args.target_kind = "webgpu"
-        args.lib_format = "wasm"
-        args.system_lib = True
-    elif args.target.startswith("iphone"):
-        from tvm.contrib import tar, xcode  # pylint: disable=import-outside-toplevel
-
-        # override
-        @tvm.register_func("tvm_callback_metal_compile")
-        def compile_metal(src):
-            return xcode.compile_metal(src, sdk="iphoneos")
-
-        dylib = args.target == "iphone-dylib"
-
-        args.target = tvm.target.Target(
-            tvm.target.Target(
-                {
-                    "kind": "metal",
-                    "max_threads_per_block": 256,
-                    "max_shared_memory_per_block": 32768,
-                    "thread_warp_size": 1,
-                }
-            ),
-            host="llvm -mtriple=arm64-apple-darwin",
-        )
-        args.target_kind = "iphone"
-        args.export_kwargs = {"fcompile": tar.tar}
-
-        if dylib:
-            args.export_kwargs = {
-                "fcompile": xcode.create_dylib,
-                "sdk": "iphoneos",
-                "arch": "arm64",
-            }
-            args.lib_format = "dylib"
-        else:
-            args.lib_format = "tar"
-            args.system_lib = True
-            system_lib_prefix = f"{args.model}-{args.quantization}_"
-            args.system_lib_prefix = system_lib_prefix.replace("-", "_")
-
-    elif args.target.startswith("android"):
-        # android-opencl
-        from tvm.contrib import cc, ndk
-
-        dylib = args.target == "android-dylib"
-
-        args.target = tvm.target.Target(
-            "opencl",
-            host="llvm -mtriple=aarch64-linux-android",  # Only support arm64 for now
-        )
-        args.target_kind = "android"
-        if dylib:
-            args.export_kwargs = {
-                "fcompile": ndk.create_shared,
-            }
-            args.lib_format = "so"
-        else:
-            args.export_kwargs = {
-                "fcompile": ndk.create_staticlib,
-            }
-            args.lib_format = "a"
-            args.system_lib = True
-
-    elif args.target == "vulkan":
-        args.target = tvm.target.Target(
-            tvm.target.Target(
-                {
-                    "kind": "vulkan",
-                    "max_threads_per_block": 256,
-                    "max_shared_memory_per_block": 32768,
-                    "thread_warp_size": 1,
-                    "supports_float16": 1,
-                    "supports_int16": 1,
-                    "supports_16bit_buffer": 1,
-                }
-            ),
-            host="llvm",
-        )
+    elif args.target == "metal":
+        target = _detect_local_metal()
+        if target is None:
+            print("Cannot detect local Apple Metal GPU target! Falling back...")
+            target = tvm.target.Target(
+                tvm.target.Target(
+                    {
+                        "kind": "metal",
+                        "max_threads_per_block": 256,
+                        "max_shared_memory_per_block": 32768,
+                        "thread_warp_size": 1,
+                    }
+                ),
+                host=tvm.target.Target(  # TODO: assuming ARM mac for now
+                    {
+                        "kind": "llvm",
+                        "mtriple": "arm64-apple-macos",
+                        "mcpu": "apple-latest",
+                    }
+                ),
+            )
+        args.target = target
         args.target_kind = args.target.kind.default_keys[0]
     elif args.target == "metal_x86_64":
         from tvm.contrib import xcode  # pylint: disable=import-outside-toplevel
@@ -399,6 +379,88 @@ def parse_target(args: argparse.Namespace) -> None:
             "arch": "x86_64",
         }
         args.lib_format = "dylib"
+    elif args.target in ["iphone", "iphone-dylib", "iphone-tar"]:
+        from tvm.contrib import tar, xcode  # pylint: disable=import-outside-toplevel
+
+        if args.target == "iphone-dylib":
+            args.export_kwargs = {
+                "fcompile": xcode.create_dylib,
+                "sdk": "iphoneos",
+                "arch": "arm64",
+            }
+            args.lib_format = "dylib"
+        else:
+            args.export_kwargs = {"fcompile": tar.tar}
+            args.lib_format = "tar"
+            args.system_lib = True
+            args.system_lib_prefix = f"{args.model}_{args.quantization}_".replace(
+                "-", "_"
+            )
+
+        @tvm.register_func("tvm_callback_metal_compile")
+        def compile_metal(src, target):
+            return xcode.compile_metal(src, sdk="iphoneos")
+
+        target = tvm.target.Target(
+            tvm.target.Target(
+                {
+                    "kind": "metal",
+                    "max_threads_per_block": 256,
+                    "max_shared_memory_per_block": 32768,
+                    "thread_warp_size": 1,
+                }
+            ),
+            host="llvm -mtriple=arm64-apple-darwin",
+        )
+        args.target = target
+        args.target_kind = "iphone"
+    elif args.target == "vulkan":
+        target = _detect_local_vulkan()
+        if target is None:
+            print("Cannot detect local Vulkan GPU target! Falling back...")
+            target = tvm.target.Target(
+                tvm.target.Target(
+                    {
+                        "kind": "vulkan",
+                        "max_threads_per_block": 256,
+                        "max_shared_memory_per_block": 32768,
+                        "thread_warp_size": 1,
+                        "supports_float16": 1,
+                        "supports_int16": 1,
+                        "supports_16bit_buffer": 1,
+                    }
+                ),
+                host="llvm",
+            )
+        args.target = target
+        args.target_kind = args.target.kind.default_keys[0]
+    elif args.target == "webgpu":
+        args.target = tvm.target.Target(
+            "webgpu",
+            host="llvm -mtriple=wasm32-unknown-unknown-wasm",
+        )
+        args.target_kind = "webgpu"
+        args.lib_format = "wasm"
+        args.system_lib = True
+    elif args.target in ["android", "android-dylib"]:  # android-opencl
+        from tvm.contrib import cc, ndk
+
+        if args.target == "android-dylib":
+            args.export_kwargs = {
+                "fcompile": ndk.create_shared,
+            }
+            args.lib_format = "so"
+        else:
+            args.export_kwargs = {
+                "fcompile": ndk.create_staticlib,
+            }
+            args.lib_format = "a"
+            args.system_lib = True
+        args.target = tvm.target.Target(
+            "opencl",
+            host="llvm -mtriple=aarch64-linux-android",  # TODO: Only support arm64 for now
+        )
+        args.target_kind = "android"
     else:
         args.target = tvm.target.Target(args.target, host="llvm")
         args.target_kind = args.target.kind.default_keys[0]
@@ -417,3 +479,5 @@ def parse_target(args: argparse.Namespace) -> None:
         }
         args.target = args.target.with_host("llvm -mtriple=x86_64-w64-windows-gnu")
         args.lib_format = "dll"
+
+    print(f"Target configured: {args.target}")

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -399,7 +399,9 @@ def parse_target(args: argparse.Namespace) -> None:
 
         @tvm.register_func("tvm_callback_metal_compile")
         def compile_metal(src, target):
-            return xcode.compile_metal(src, sdk="iphoneos")
+            if target.libs:
+                return xcode.compile_metal(src, sdk=target.libs[0])
+            return xcode.compile_metal(src)
 
         target = tvm.target.Target(
             tvm.target.Target(
@@ -408,6 +410,7 @@ def parse_target(args: argparse.Namespace) -> None:
                     "max_threads_per_block": 256,
                     "max_shared_memory_per_block": 32768,
                     "thread_warp_size": 1,
+                    "libs": ["iphoneos"],
                 }
             ),
             host="llvm -mtriple=arm64-apple-darwin",


### PR DESCRIPTION
To avoid potential symbolic conflicts in some shared libraries (e.g. LLVM)