### PR TITLE
[Github] Fix the issue templates format issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,8 @@
 ---
 name: "🐛 Bug Report"
 about: Submit a bug report to help us improve MLC-LLM
-title: ''
-labels: ''
+title: '[Bug] '
+labels: ['bug']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,5 +3,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Check the MLC-LLM Documentation
     url: https://mlc.ai/mlc-llm/docs/
+    about: Our documentation might provide answers to your questions.
   - name: Chat on Discord
     url: https://discord.gg/9Xpy2HGBuD
+    about: Join the Discord Server to live chat with the community.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,8 +1,8 @@
 ---
 name: "\U0001F4DA Documentation"
 about: Report an issue related to https://mlc.ai/mlc-llm/docs
-title: ''
-labels: ''
+title: '[Doc] '
+labels: ['type: documentation']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,8 +1,8 @@
 ---
 name: "\U0001F680 Feature Request"
 about: Submit a proposal/request for a new MLC-LLM feature, or an enhancement on existing features.
-title: ''
-labels: ''
+title: '[Feature Request] '
+labels: ['type: feature request']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,8 +1,8 @@
 ---
 name: "❓ General Questions"
-about: .
-title: ''
-labels: ''
+about: General questions you have about MLC-LLM.
+title: '[Question] '
+labels: ['type: question']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/model-request.md
+++ b/.github/ISSUE_TEMPLATE/model-request.md
@@ -1,8 +1,8 @@
 ---
 name: "️️⚙️  Model Request"
 about: Request a new model in MLC-LLM
-title: ''
-labels: ''
+title: '[Model Request] '
+labels: ['new-models']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/speed-report.md
+++ b/.github/ISSUE_TEMPLATE/speed-report.md
@@ -1,8 +1,8 @@
 ---
 name: " 🏎️  Speed Report"
 about: Submit a speed report of an model running in MLC-LLM
-title: ''
-labels: ''
+title: '[Speed] '
+labels: ['status: help wanted', 'performance']
 assignees: ''
 
 ---


### PR DESCRIPTION
The `about` field of `contact_links` in `config.yml` is missing.

Also, add labels for each issue template.