### PR TITLE
refactor gradio interface

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -17,6 +17,6 @@ There is currently a dependency to build from source in order to use the [REST A
 
 ## Gradio API
 
-To launch the Gradio API, locate to the root of the mlc-llm repo. The arguments you need to provide are `artifact-path` which stores your pre-built models, `device-name` (default cuda) and `device-id` (default 0). After launched, the Gradio API allows you to select different models and quantization types in its interface.
+To launch the Gradio API, in the current folder, run the following example command. The `--share` argument is for optionally creating a publicly shareable link for the interface.
 
-    PYTHONPATH=python python3 -m mlc_chat.gradio --artifact-path /path/to/your/models --device-name cuda --device-id 0
+    PYTHONPATH=python python3 -m mlc_chat.gradio --artifact-path /path/to/your/models --device-name cuda --device-id 0 --share

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -1,10 +1,12 @@
 """Python runtime for MLC chat."""
 #! pylint: disable=unused-import
+import ctypes
 import os
 import sys
-import ctypes
+
 import tvm
 import tvm._ffi.base
+
 from . import libinfo
 
 
@@ -30,7 +32,7 @@ def quantization_keys():
 
 
 class ChatModule:
-    def __init__(self, mlc_lib_path, target="cuda", device_id=0):
+    def __init__(self, target="cuda", device_id=0):
         fcreate = tvm.get_global_func("mlc.llm_chat_create")
         assert fcreate is not None
         if target == "cuda":


### PR DESCRIPTION
In this PR, the Gradio interface is refactored to accommodate the formal package in #266. In addition, it makes the following changes:
1. Allow the selection from local model ids, which is consistent with web-llm.
2. Disable the launching of HF tunnel by default.