### PR TITLE
Remove picojson submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "3rdparty/googletest"]
 	path = 3rdparty/googletest
 	url = https://github.com/google/googletest.git
-[submodule "3rdparty/picojson"]
-	path = 3rdparty/picojson
-	url = https://github.com/kazuho/picojson.git


### PR DESCRIPTION
Currently, MLC-LLM relies on the TVM-Unity codebase which already incorporates picojson.
This PR removes picojson submodule to avoid duplication.