### PR TITLE
[Android] Replace some functions in `AppViewModel` and `ChatModule` to make the code more in line with the usage habits of Android developers

### DIFF
--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/ChatModule.kt
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/ChatModule.kt
@@ -1,101 +1,97 @@
 package ai.mlc.mlcchat
 
 import android.os.Looper
+import android.util.Log
 import org.apache.tvm.Device
 import org.apache.tvm.Function
 import org.apache.tvm.Module
 
 class ChatModule {
-    private var reload_func: Function? = null
-    private var unload_func: Function? = null
-    private var prefill_func_: Function? = null
-    private var decode_func_: Function? = null
-    private var get_message_: Function? = null
-    private var stopped_func_: Function? = null
-    private var reset_chat_func_: Function? = null
-    private var runtime_stats_text_func_: Function? = null
-    private var llm_chat_: Module;
+    private var reloadFunc: Function
+    private var unloadFunc: Function
+    private var prefillFunc: Function
+    private var decodeFunc: Function
+    private var getMessage: Function
+    private var stoppedFunc: Function
+    private var resetChatFunc: Function
+    private var runtimeStatsTextFunc: Function
+    private var llmChat: Module
 
     init {
         val fcreate = Function.getFunction("mlc.llm_chat_create")
-        assert(fcreate != null)
-        llm_chat_ = fcreate.pushArg(Device.opencl().deviceType).pushArg(0).invoke().asModule()
+        require(fcreate != null)
+        llmChat = fcreate.pushArg(Device.opencl().deviceType).pushArg(0).invoke().asModule()
 
-        reload_func = llm_chat_.getFunction("reload")
-        unload_func = llm_chat_.getFunction("unload")
-        prefill_func_ = llm_chat_.getFunction("prefill")
-        decode_func_ = llm_chat_.getFunction("decode")
-        get_message_ = llm_chat_.getFunction("get_message")
-        stopped_func_ = llm_chat_.getFunction("stopped")
-        reset_chat_func_ = llm_chat_.getFunction("reset_chat")
-        runtime_stats_text_func_ = llm_chat_.getFunction("runtime_stats_text")
-
-        assert(reload_func != null)
-        assert(unload_func != null)
-        assert(prefill_func_ != null)
-        assert(decode_func_ != null)
-        assert(get_message_ != null)
-        assert(stopped_func_ != null)
-        assert(reset_chat_func_ != null)
-        assert(runtime_stats_text_func_ != null)
+        reloadFunc = llmChat.getFunction("reload")
+        unloadFunc = llmChat.getFunction("unload")
+        prefillFunc = llmChat.getFunction("prefill")
+        decodeFunc = llmChat.getFunction("decode")
+        getMessage = llmChat.getFunction("get_message")
+        stoppedFunc = llmChat.getFunction("stopped")
+        resetChatFunc = llmChat.getFunction("reset_chat")
+        runtimeStatsTextFunc = llmChat.getFunction("runtime_stats_text")
     }
 
     fun unload() {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        unload_func!!.invoke()
+        require(!Looper.getMainLooper().isCurrentThread)
+        unloadFunc.invoke()
     }
 
     fun reload(modelLib: String, modelPath: String) {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        var lib_prefix = modelLib
-        System.err.println("lib_prefix: $lib_prefix")
-        lib_prefix = lib_prefix.replace('-', '_')
-        lib_prefix += "_"
-        System.err.println("lib_prefix: $lib_prefix")
-        var system_lib_func = Function.getFunction("runtime.SystemLib")
-        assert(system_lib_func != null)
-        System.err.println("system_lib_func: $system_lib_func")
-        system_lib_func = system_lib_func.pushArg(lib_prefix)
-        val lib = system_lib_func!!.invoke().asModule()
-        assert(lib != null)
-        System.err.println("lib: $lib")
-        System.err.println("modelPath: $modelPath")
-        System.err.println("reload_func: $reload_func")
-        reload_func = reload_func!!.pushArg(lib).pushArg(modelPath)
-        reload_func!!.invoke()
+        require(!Looper.getMainLooper().isCurrentThread)
+        var libPrefix = modelLib
+        Log.i(TAG, "lib_prefix: $libPrefix")
+        libPrefix = libPrefix.replace('-', '_')
+        libPrefix += "_"
+        Log.i(TAG, "lib_prefix: $libPrefix")
+        var systemLibFunc = Function.getFunction("runtime.SystemLib")
+        require(systemLibFunc != null)
+        Log.i(TAG, "system_lib_func: $systemLibFunc")
+        systemLibFunc = systemLibFunc.pushArg(libPrefix)
+        val lib = systemLibFunc.invoke().asModule()
+        require(lib != null)
+        Log.i(TAG, "lib: $lib")
+        Log.i(TAG, "modelPath: $modelPath")
+        Log.i(TAG, "reload_func: $reloadFunc")
+        reloadFunc = reloadFunc.pushArg(lib).pushArg(modelPath)
+        reloadFunc.invoke()
     }
 
     fun resetChat() {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        reset_chat_func_!!.invoke();
+        require(!Looper.getMainLooper().isCurrentThread)
+        resetChatFunc.invoke();
     }
 
     fun prefill(input: String) {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        prefill_func_!!.pushArg(input).invoke();
+        require(!Looper.getMainLooper().isCurrentThread)
+        prefillFunc.pushArg(input).invoke();
     }
 
     fun getMessage(): String {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        return get_message_!!.invoke().asString()
+        require(!Looper.getMainLooper().isCurrentThread)
+        return getMessage.invoke().asString()
     }
 
     fun runtimeStatsText(): String {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        return runtime_stats_text_func_!!.invoke().asString()
+        require(!Looper.getMainLooper().isCurrentThread)
+        return runtimeStatsTextFunc.invoke().asString()
     }
 
     fun evaluate() {
-        llm_chat_.getFunction("evaluate").invoke()
+        llmChat.getFunction("evaluate").invoke()
     }
 
     fun stopped(): Boolean {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        return stopped_func_!!.invoke().asLong() != 0L
+        require(!Looper.getMainLooper().isCurrentThread)
+        return stoppedFunc.invoke().asLong() != 0L
     }
 
     fun decode() {
-        assert(!Looper.getMainLooper().isCurrentThread)
-        decode_func_!!.invoke()
+        require(!Looper.getMainLooper().isCurrentThread)
+        decodeFunc.invoke()
+    }
+
+    companion object {
+        private const val TAG = "ChatModule"
     }
 }


### PR DESCRIPTION
Replace some functions in `AppViewModel` and `ChatModule` to make the code more in line with the usage habits of Android developers

1. Replace `assert` with `require`, `assert` is generally only used in unit tests
2. Use `android.util.Log` instead of `System.err` to output key information
3. The naming of some `func*` definitions in ChatModule adopts a unified camel case naming style
4. The `func*` variable is defined as non-null instead of nullable, because `getFunction` internally returns a non-null object as much as possible (or throws IllegalArgumentException)