### PR TITLE
[FIX] Fix Crash when running Conversations without system prompts

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -509,6 +509,7 @@ class LLMChat {
 
     std::vector<int32_t> prompt_tokens = this->GetInputTokens();
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
+    if (token_len == 0) return;
 
     auto tstart = std::chrono::high_resolution_clock::now();
 


### PR DESCRIPTION
Fix the bug reported by https://github.com/mlc-ai/mlc-llm/issues/307