### PR TITLE
[Android] Fix compile error (#310) and `ndk-build` cannot reference

### DIFF
--- a/android/MLCChat/app/build.gradle
+++ b/android/MLCChat/app/build.gradle
@@ -33,7 +33,7 @@ task buildJni(type: Exec, description: 'Build JNI libs') {
     def buildPath = "${project.projectDir}/src/main/jni"
     Properties properties = new Properties()
     properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    commandLine "ndk-build", "--directory", buildPath
+    commandLine "${properties.getProperty('ndk.dir')}/ndk-build", "--directory", buildPath
 }
 
 tasks.withType(JavaCompile) {

--- a/android/MLCChat/app/src/main/jni/tvm_runtime.h
+++ b/android/MLCChat/app/src/main/jni/tvm_runtime.h
@@ -1,0 +1,7 @@
+#define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
+#define TVM_USE_LIBBACKTRACE 0
+
+#include <dlfcn.h>
+#include <dmlc/logging.h>
+#include <dmlc/thread_local.h>
+#include <tvm/runtime/c_runtime_api.h>


### PR DESCRIPTION
1. Restore tvm_runtime.h file
2. Revert code that reads ndk-build path from local.properties