### PR TITLE
Fix incorrect import in REST API

### DIFF
--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -1,4 +1,4 @@
-from .chat_module import ChatModule, supported_models, quantization_keys
+from .chat_module import ChatModule, quantization_keys
 
 from pydantic import BaseModel
 from fastapi import FastAPI, HTTPException
@@ -63,7 +63,7 @@ def _parse_args():
     args.add_argument(
         "--model", type=str, default="vicuna-v1-7b"
     )
-    args.add_argument("--artifact-path", type=str, default="dist")
+    args.add_argument("--artifact-path", type=str, default="../dist")
     args.add_argument(
         "--quantization",
         type=str,

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -63,7 +63,7 @@ def _parse_args():
     args.add_argument(
         "--model", type=str, default="vicuna-v1-7b"
     )
-    args.add_argument("--artifact-path", type=str, default="../dist")
+    args.add_argument("--artifact-path", type=str, default="dist")
     args.add_argument(
         "--quantization",
         type=str,

--- a/python/mlc_chat/sample_client.py
+++ b/python/mlc_chat/sample_client.py
@@ -4,10 +4,6 @@ import json
 # To launch the server, run
 # $ python -m mlc_chat.rest
 
-# List the models that are currently supported
-r = requests.get("http://127.0.0.1:8000/models")
-print(f"Supported models: {r.json()}\n")
-
 # Get a response using a prompt without streaming
 payload = {
     "prompt": "Write a haiku"


### PR DESCRIPTION
Fix an unnecessary import and change default artifact path to be the path to dist when `rest.py` is invoked using `python -m mlc_chat.rest`.