### PR TITLE
Add missing mkdir to cpp/README.md

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -20,6 +20,7 @@
 2. Build the CLI.
     ```shell
     # Compile and build
+    mkdir -p build
     cd build
     cmake ..
     make


### PR DESCRIPTION
In the README for `cpp/` it seems that there is a missing `mkdir` command so this PR just adds the command.