### PR TITLE
[Hotfix] Replace ssh with https for relax submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/google/googletest.git
 [submodule "3rdparty/tvm"]
 	path = 3rdparty/tvm
-	url = git@github.com:mlc-ai/relax.git
+	url = https://github.com/mlc-ai/relax.git


### PR DESCRIPTION
In https://github.com/mlc-ai/mlc-llm/pull/368 we uses ssh for relax submodule which is problematic on machines without github ssh configuration such as CI.