### PR TITLE
fix supported_models  import error

### DIFF
--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -1,4 +1,4 @@
-from .chat_module import ChatModule, supported_models, quantization_keys
+from .chat_module import ChatModule, quantization_keys
 
 from pydantic import BaseModel
 from fastapi import FastAPI, HTTPException


### PR DESCRIPTION
supported_models not define on chat_module