### PR TITLE
[Bugfix] Fix json config overriding conv template logic

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -191,16 +191,18 @@ class LLMChat {
     } else {
       CHECK(partial_update) << "Key \"shift_fill_factor\" not found.";
     }
-    if (config.count("conv_template") || config.count("conv_config")) {
-      if (config.count("conv_template")) {
+    if (config.count("conv_template")) {
         ICHECK(config["conv_template"].is<std::string>());
         std::string conv_template = config["conv_template"].get<std::string>();
         this->conversation_ = Conversation::FromTemplate(conv_template);
-      }
-      if (config.count("conv_config")) {
-        // conv_config can override conv_template
-        this->conversation_.LoadJSONOverride(config["conv_config"]);
-      }
+
+        if (config.count("conv_config")) {
+          // conv_config can override conv_template
+          this->conversation_.LoadJSONOverride(config["conv_config"], true);
+        }
+    } else if (config.count("conv_config")) {
+      // without conv template, conv_config needs to be a complete config
+      this->conversation_.LoadJSONOverride(config["conv_config"], false);
     } else {
       CHECK(partial_update) << "Key \"conv_template\" and \"conv_config\" not found.";
     }

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -195,7 +195,6 @@ class LLMChat {
         ICHECK(config["conv_template"].is<std::string>());
         std::string conv_template = config["conv_template"].get<std::string>();
         this->conversation_ = Conversation::FromTemplate(conv_template);
-
         if (config.count("conv_config")) {
           // conv_config can override conv_template
           this->conversation_.LoadJSONOverride(config["conv_config"], true);


### PR DESCRIPTION
**Problem**
There was a problem with the json config file properly overriding the default conv template specified. 

**Solution**
I have rearranged the logic (with as little code as possible to achieve the logic below) that checks whether a conv template or conv config exists so as to behave as expected:

- If only a conv template exists, load the template
- If a conv template _and_ conv config exists, load the template then load the config with partial update
- If only a conv config exists, load the config with no partial update

**Bug details**
Currently, the bug can be recreated like so:
1. specify a valid conv_template string within the mlc-chat-config.json file
2. specify a conv_config with only a subset of attributes required, eg:
```
...
"conv_config": {
    "separator_style": 1
}
...
```

Then the resulting error would occur:
```
Check failed: (partial_update) is false: Key "name" not found.
```