### PR TITLE
Fix symbolic link to tvm_home

### DIFF
--- a/ios/prepare_libs.sh
+++ b/ios/prepare_libs.sh
@@ -23,6 +23,6 @@ cmake --build . --target install --config release -j
 cd ..
 
 rm -rf build/tvm_home
-ln -s ../3rdparty/tvm build/tvm_home
+ln -s ../../3rdparty/tvm build/tvm_home
 
 python prepare_model_lib.py


### PR DESCRIPTION
The first part of the `ln` command is relative to the position of the symlink, not where the `ln` command is run. This fixes the missing dependencies in the xcode project.