### PR TITLE
[Model] Update OpenLLaMA appearances

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -682,7 +682,7 @@ def get_model(args, hf_config):
     if (
         model_name.startswith("vicuna-")
         or model_name.startswith("llama-")
-        or model_name.startswith("open-llama-")
+        or model_name.startswith("open_llama")
         or model_name.startswith("gorilla-")
     ):
         config = LlamaConfig(**hf_config, dtype=dtype)

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -70,7 +70,7 @@ def argparse_postproc_common(args: argparse.Namespace) -> None:
         "stablelm-": ("stablelm", "gpt_neox"),
         "redpajama-": ("redpajama_chat", "gpt_neox"),
         "moss-": ("moss", "moss"),
-        "open-llama-": ("LM", "llama"),
+        "open_llama": ("LM", "llama"),
         "rwkv-": ("rwkv", "rwkv"),
         "gorilla-": ("gorilla", "llama"),
     }


### PR DESCRIPTION
The official OpenLLaMA model repository is named as "`open_llama`" (for example, https://huggingface.co/openlm-research/open_llama_7b), while previously the codebase used "`open-llama`", which disabled downloading and compiling the OpenLLaMA model using `hf-path`.

This PR renames two occurrences of `open-llama` to `open_llama`. Using `hf-path` to compile model is tested locally.