### PR TITLE
Update mlc_chat_cli pipeline without kv cache

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -290,8 +290,11 @@ class LLMChat {
         << "Cannot find env function vm.builtin.attention_kv_cache_array_popn";
     fkvcache_array_popn_ = *fkvcache_array_popn;
 
-    // Step 4. KV cache creation.
-    kv_cache_ = vm_->GetFunction("create_kv_cache")();
+    // Step 4. KV cache creation if need.
+    auto kv_cache_func = vm_->GetFunction("create_kv_cache");
+    if (kv_cache_func.defined()) {
+      kv_cache_ = kv_cache_func();
+    }
 
     // Step 5. KV cache reset.
     reset_kv_cache_func_ = vm_->GetFunction("reset_kv_cache");

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -706,7 +706,11 @@ class LLMChat {
       for (int i = 0; i < input_tokens.size(); ++i) {
         NDArray input_data = this->GetInputTokenNDArray({input_tokens[i]});
         int64_t pos = cur_pos + i + 1 - input_tokens.size();
-        ret = decode_func_(input_data, ShapeTuple({pos}), kv_cache_, params_);
+        if (kv_cache_.empty()){
+          ret = decode_func_(input_data, params_);
+        } else {
+          ret = decode_func_(input_data, ShapeTuple({pos}), kv_cache_, params_);
+        }
       }
     }
     return Downcast<NDArray>(ret[0]);


### PR DESCRIPTION
It is not necessary that transformer-based models use kv cache (example, mpt-7b-instruct and possibly implemented rwkv). But mlc_chat_cli pipeline requires create_kv_cache function. There is fix allowing to not usekv_cache, it does not affect usual pipeline for llama

cc @tqchen 