### PR TITLE
[Hotfix] Add mlc-ai-nightly as requirements for documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,5 @@ sphinx-toolbox == 3.4.0
 tlcpack-sphinx-addon==0.2.2
 sphinxcontrib_httpdomain==1.8.1
 sphinxcontrib-napoleon==0.7
+--find-links https://mlc.ai/wheels
+mlc-ai-nightly


### PR DESCRIPTION
Currently, the autodoc for Python API doesn't work because of the following error:
```
WARNING: autodoc: failed to import class 'ChatModule' from module 'mlc_chat'; the following exception was raised:
No module named 'tvm'
```

This PR fixes the issue by adding mlc-ai-nightly as documentation requirements.