### PR TITLE
[Hotfix] Fix duplicate labels in documentation and add `mlc-chat-nightly` to requirments

### DIFF
--- a/docs/deploy/python.rst
+++ b/docs/deploy/python.rst
@@ -24,7 +24,7 @@ Verify Installation
 You are expected to see the information about the :class:`ChatModule` class.
 
 If the prebuild is unavailable on your platform, or you would like to build a runtime
-that supports other GPU runtime than the prebuilt version. Please refer our :ref:`Build MLC-Chat Package From Source<mlcchat_build_from_source>` tutorial.
+that supports other GPU runtime than the prebuilt version. Please refer our :ref:`Build MLC-Chat Package From Source<mlcchat_package_build_from_source>` tutorial.
 
 API Reference
 -------------

--- a/docs/deploy/rest.rst
+++ b/docs/deploy/rest.rst
@@ -23,7 +23,7 @@ Verify Installation
 
 You are expected to see the help information of the REST API.
 
-.. _mlcchat_build_from_source:
+.. _mlcchat_package_build_from_source:
 
 Optional: Build from Source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ sphinxcontrib_httpdomain==1.8.1
 sphinxcontrib-napoleon==0.7
 --find-links https://mlc.ai/wheels
 mlc-ai-nightly
+mlc-chat-nightly


### PR DESCRIPTION
- `mlcchat_build_from_source` is a duplicate label.
- `mlc-chat-nightly` need to be added to the requirements for building autodoc.