### PR TITLE
Fix seg fault when trying to run REST server on macOS

### DIFF
--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -77,10 +77,19 @@ class AsyncChatCompletionStream:
     def __aiter__(self):
         return self
 
+    async def get_next_msg(self):
+        session["chat_mod"].decode()
+        msg = session["chat_mod"].get_message()
+        return msg
+
     async def __anext__(self):
         if not session["chat_mod"].stopped():
-            session["chat_mod"].decode()
-            msg = session["chat_mod"].get_message()
+            # loop = asyncio.get_event_loop()
+            # msg = await loop.run_in_executor(None, self.get_next_msg)
+            # msg = asyncio.create_task(self.get_next_msg())
+
+            task = asyncio.create_task(self.get_next_msg())
+            msg = await task
             return msg
         else:
             raise StopAsyncIteration

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -77,22 +77,17 @@ class AsyncChatCompletionStream:
     def __aiter__(self):
         return self
 
-    def get_next_msg(self):
-        session["chat_mod"].decode()
-        msg = session["chat_mod"].get_message()
-        return msg
-
     async def __anext__(self):
         if not session["chat_mod"].stopped():
-            loop = asyncio.get_event_loop()
-            msg = await loop.run_in_executor(None, self.get_next_msg)
+            session["chat_mod"].decode()
+            msg = session["chat_mod"].get_message()
             return msg
         else:
             raise StopAsyncIteration
 
 
 @app.post("/v1/chat/completions")
-def request_completion(request: ChatCompletionRequest):
+async def request_completion(request: ChatCompletionRequest):
     """
     Creates model response for the given chat conversation.
     """
@@ -138,7 +133,7 @@ def request_completion(request: ChatCompletionRequest):
 
 
 @app.post("/chat/reset")
-def reset():
+async def reset():
     """
     Reset the chat for the currently initialized model.
     """
@@ -146,7 +141,7 @@ def reset():
 
 
 @app.get("/stats")
-def read_stats():
+async def read_stats():
     """
     Get the runtime stats.
     """
@@ -155,4 +150,4 @@ def read_stats():
 
 ARGS = _parse_args()
 if __name__ == "__main__":
-    uvicorn.run("mlc_chat.rest:app", port=ARGS.port, reload=True, access_log=False)
+    uvicorn.run("mlc_chat.rest:app", port=ARGS.port, reload=False, access_log=False)

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -84,10 +84,6 @@ class AsyncChatCompletionStream:
 
     async def __anext__(self):
         if not session["chat_mod"].stopped():
-            # loop = asyncio.get_event_loop()
-            # msg = await loop.run_in_executor(None, self.get_next_msg)
-            # msg = asyncio.create_task(self.get_next_msg())
-
             task = asyncio.create_task(self.get_next_msg())
             msg = await task
             return msg


### PR DESCRIPTION
When requests are defined in `async def`, FastAPI will run them on the main thread, whereas when they are defined in `def`, FastAPI will delegate them to a worker thread. Since we had defined the requests in `def`, the prefill function was being called from a worker thread, leading to a memory issue when trying to call `CopyFromBytes` within `GetInputTokenNDArray`. This caused a segmentation fault. 

This PR changes all the function to `async def` so we run everything on the main thread. It also updates the streaming logic to use `create_task` instead of `create_task` so that we can ensure `get_next_msg` runs on the main thread. The logic has been tested on both macOS and Linux, and works in both environments.