### PR TITLE
[Doc] Link `libmlc_llm.so` for auto doucmenting Python APIs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,6 +28,8 @@ jobs:
     - name: Installing dependencies
       run: |
         python -m pip install -r docs/requirements.txt
+        mkdir -p build/
+        ln -s $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/mlc_chat/*.so build/
         gem install jekyll jekyll-remote-theme
 
     - name: Deploying on GitHub Pages


### PR DESCRIPTION
The `libmlc_llm.so` need to be loaded from `build/` directory for autodoc to work for Python APIs.