### PR TITLE
ParamManager and new quantization framework

### DIFF
--- a/mlc_llm/__init__.py
+++ b/mlc_llm/__init__.py
@@ -1,4 +1,5 @@
+from . import dispatch
+from . import quantization
 from . import relax_model
 from . import transform
 from . import utils
-from . import dispatch

--- a/mlc_llm/dispatch/llama/main.py
+++ b/mlc_llm/dispatch/llama/main.py
@@ -4235,7 +4235,7 @@ def NT_matmul1_fp16_sch_func():
 
 @T.prim_func
 def decode6(rxplaceholder: T.Buffer((T.int64(512), T.int64(4096)), "uint32"), rxplaceholder_1: T.Buffer((T.int64(128), T.int64(4096)), "uint32"), T_transpose: T.Buffer((T.int64(4096), T.int64(4096)), "float32")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(4096), T.int64(4096)))
     for i, j in T.grid(T.int64(4096), T.int64(4096)):
@@ -4254,7 +4254,7 @@ def decode6(rxplaceholder: T.Buffer((T.int64(512), T.int64(4096)), "uint32"), rx
 
 @T.prim_func
 def decode7(rxplaceholder: T.Buffer((T.int64(512), T.int64(11008)), "uint32"), rxplaceholder_1: T.Buffer((T.int64(128), T.int64(11008)), "uint32"), T_transpose: T.Buffer((T.int64(11008), T.int64(4096)), "float32")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(4096), T.int64(11008)))
     for i, j in T.grid(T.int64(4096), T.int64(11008)):
@@ -4273,7 +4273,7 @@ def decode7(rxplaceholder: T.Buffer((T.int64(512), T.int64(11008)), "uint32"), r
 
 @T.prim_func
 def decode8(rxplaceholder: T.Buffer((T.int64(1376), T.int64(4096)), "uint32"), rxplaceholder_1: T.Buffer((T.int64(344), T.int64(4096)), "uint32"), T_transpose: T.Buffer((T.int64(4096), T.int64(11008)), "float32")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(11008), T.int64(4096)))
     for i, j in T.grid(T.int64(11008), T.int64(4096)):
@@ -4292,7 +4292,7 @@ def decode8(rxplaceholder: T.Buffer((T.int64(1376), T.int64(4096)), "uint32"), r
 
 @T.prim_func
 def decode4_fp16(rxplaceholder: T.Buffer((T.int64(512), T.int64(4096)), "uint32"), rxplaceholder_1: T.Buffer((T.int64(128), T.int64(4096)), "float16"), rxplaceholder_2: T.Buffer((T.int64(128), T.int64(4096)), "float16"), T_transpose: T.Buffer((T.int64(4096), T.int64(4096)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(4096), T.int64(4096)), "float16")
     for i, j in T.grid(T.int64(4096), T.int64(4096)):
@@ -4310,7 +4310,7 @@ def decode4_fp16(rxplaceholder: T.Buffer((T.int64(512), T.int64(4096)), "uint32"
 
 @T.prim_func
 def decode5_fp16(rxplaceholder: T.Buffer((T.int64(512), T.int64(11008)), "uint32"), rxplaceholder_1: T.Buffer((T.int64(128), T.int64(11008)), "float16"), rxplaceholder_2: T.Buffer((T.int64(128), T.int64(11008)), "float16"), T_transpose: T.Buffer((T.int64(11008), T.int64(4096)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(4096), T.int64(11008)), "float16")
     for i, j in T.grid(T.int64(4096), T.int64(11008)):
@@ -4328,7 +4328,7 @@ def decode5_fp16(rxplaceholder: T.Buffer((T.int64(512), T.int64(11008)), "uint32
 
 @T.prim_func
 def decode6_fp16(rxplaceholder: T.Buffer((T.int64(1376), T.int64(4096)), "uint32"), rxplaceholder_1: T.Buffer((T.int64(344), T.int64(4096)), "float16"), rxplaceholder_2: T.Buffer((T.int64(344), T.int64(4096)), "float16"), T_transpose: T.Buffer((T.int64(4096), T.int64(11008)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(11008), T.int64(4096)), "float16")
     for i, j in T.grid(T.int64(11008), T.int64(4096)):
@@ -4347,7 +4347,7 @@ def decode6_fp16(rxplaceholder: T.Buffer((T.int64(1376), T.int64(4096)), "uint32
 
 @T.prim_func
 def decode_int3_fp16(A: T.Buffer((T.int64(412), T.int64(4096)), "uint32"), B: T.Buffer((T.int64(103), T.int64(4096)), "float16"), T_transpose: T.Buffer((T.int64(4096), T.int64(4096)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode_1 = T.alloc_buffer((T.int64(4096), T.int64(4096)), "float16")
     for i, j in T.grid(T.int64(4096), T.int64(4096)):
@@ -4365,7 +4365,7 @@ def decode_int3_fp16(A: T.Buffer((T.int64(412), T.int64(4096)), "uint32"), B: T.
 
 @T.prim_func
 def decode1_int3_fp16(A: T.Buffer((T.int64(412), T.int64(11008)), "uint32"), B: T.Buffer((T.int64(103), T.int64(11008)), "float16"), T_transpose: T.Buffer((T.int64(11008), T.int64(4096)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(4096), T.int64(11008)), "float16")
     for i, j in T.grid(T.int64(4096), T.int64(11008)):
@@ -4383,7 +4383,7 @@ def decode1_int3_fp16(A: T.Buffer((T.int64(412), T.int64(11008)), "uint32"), B: 
 
 @T.prim_func
 def decode2_int3_fp16(A: T.Buffer((T.int64(1104), T.int64(4096)), "uint32"), B: T.Buffer((T.int64(276), T.int64(4096)), "float16"), T_transpose: T.Buffer((T.int64(4096), T.int64(11008)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(11008), T.int64(4096)), "float16")
     for i, j in T.grid(T.int64(11008), T.int64(4096)):
@@ -4402,7 +4402,7 @@ def decode2_int3_fp16(A: T.Buffer((T.int64(1104), T.int64(4096)), "uint32"), B: 
 
 @T.prim_func
 def decode_int3_int16_fp16(A: T.Buffer((T.int64(824), T.int64(4096)), "uint16"), B: T.Buffer((T.int64(103), T.int64(4096)), "float16"), T_transpose: T.Buffer((T.int64(4096), T.int64(4096)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode_1 = T.alloc_buffer((T.int64(4096), T.int64(4096)), "float16")
     for i, j in T.grid(T.int64(4096), T.int64(4096)):
@@ -4420,7 +4420,7 @@ def decode_int3_int16_fp16(A: T.Buffer((T.int64(824), T.int64(4096)), "uint16"),
 
 @T.prim_func
 def decode1_int3_int16_fp16(A: T.Buffer((T.int64(824), T.int64(11008)), "uint16"), B: T.Buffer((T.int64(103), T.int64(11008)), "float16"), T_transpose: T.Buffer((T.int64(11008), T.int64(4096)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(4096), T.int64(11008)), "float16")
     for i, j in T.grid(T.int64(4096), T.int64(11008)):
@@ -4438,7 +4438,7 @@ def decode1_int3_int16_fp16(A: T.Buffer((T.int64(824), T.int64(11008)), "uint16"
 
 @T.prim_func
 def decode2_int3_int16_fp16(A: T.Buffer((T.int64(2208), T.int64(4096)), "uint16"), B: T.Buffer((T.int64(276), T.int64(4096)), "float16"), T_transpose: T.Buffer((T.int64(4096), T.int64(11008)), "float16")):
-    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    T.func_attr({"tir.noalias": T.bool(True)})
     # with T.block("root"):
     decode = T.alloc_buffer((T.int64(11008), T.int64(4096)), "float16")
     for i, j in T.grid(T.int64(11008), T.int64(4096)):

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -1,0 +1,72 @@
+from .quantization import FQuantize, FDequantize
+from .quantization import QuantizationScheme
+from .quantization import QuantizationSpec, NoQuantizationSpec, ParamQuantKind
+from .group_quantization import GroupQuantizationSpec
+
+
+# The predefined quantization schemes.
+quantization_schemes = {
+    "q0f16": QuantizationScheme("q0f16", NoQuantizationSpec("float16")),
+    "q0f32": QuantizationScheme("q0f32", NoQuantizationSpec("float32")),
+    "q3f16_0": QuantizationScheme(
+        name="q3f16_0",
+        linear_weight=GroupQuantizationSpec(
+            dtype="float16",
+            mode="int3",
+            sym=True,
+            storage_nbit=16,
+            group_size=40,
+            transpose=True,
+        ),
+        embedding_table=GroupQuantizationSpec(
+            dtype="float16",
+            mode="int3",
+            sym=True,
+            storage_nbit=16,
+            group_size=40,
+            transpose=False,
+        ),
+        final_fc_weight="same_as_linear_weight",
+    ),
+    "q4f16_0": QuantizationScheme(
+        name="q4f16_0",
+        linear_weight=GroupQuantizationSpec(
+            dtype="float16",
+            mode="int4",
+            sym=True,
+            storage_nbit=32,
+            group_size=32,
+            transpose=True,
+        ),
+        embedding_table=GroupQuantizationSpec(
+            dtype="float16",
+            mode="int4",
+            sym=True,
+            storage_nbit=32,
+            group_size=32,
+            transpose=False,
+        ),
+        final_fc_weight="same_as_linear_weight",
+    ),
+    "q4f32_0": QuantizationScheme(
+        name="q4f32_0",
+        linear_weight=GroupQuantizationSpec(
+            dtype="float32",
+            mode="int4",
+            sym=False,
+            storage_nbit=32,
+            group_size=32,
+            transpose=True,
+        ),
+        embedding_table=GroupQuantizationSpec(
+            dtype="float32",
+            mode="int4",
+            sym=False,
+            storage_nbit=32,
+            group_size=32,
+            transpose=False,
+        ),
+        final_fc_weight="same_as_linear_weight",
+    ),
+    # NOTE: `q8f16_0` and `q8f32_0` are not yet supported in the new quantization framework.
+}

--- a/mlc_llm/quantization/group_quantization.py
+++ b/mlc_llm/quantization/group_quantization.py
@@ -1,0 +1,183 @@
+from dataclasses import dataclass
+from typing import List, Literal, Optional
+
+from tvm import relax, te, tir, topi
+from tvm.script import tir as T
+
+from . import tir_utils
+from .quantization import QuantizationSpec
+from .quantization import FQuantize, FDequantize
+
+
+@dataclass
+class GroupQuantizationSpec(QuantizationSpec):
+    """The quantization specification for group quantization algorithm."""
+
+    mode: Literal["int3", "int4"]
+    sym: bool
+    storage_nbit: int
+    group_size: int
+    transpose: bool
+
+    def get_quantize_func(
+        self, param_info: relax.TensorStructInfo
+    ) -> Optional[FQuantize]:
+        return encoding_func(
+            sym=self.sym,
+            group_size=self.group_size,
+            nbit=int(self.mode[-1]),
+            mode=self.mode,
+            storage_nbit=self.storage_nbit,
+            transpose=self.transpose,
+            dtype=self.dtype,
+        )
+
+    def get_dequantize_func(
+        self,
+        param_info: relax.TensorStructInfo,
+        qparam_info: List[relax.TensorStructInfo],
+    ) -> Optional[FDequantize]:
+        return decoding_func(
+            sym=self.sym,
+            group_size=self.group_size,
+            nbit=int(self.mode[-1]),
+            mode=self.mode,
+            storage_nbit=self.storage_nbit,
+            dim_length=param_info.shape.values[-1],
+            data_transposed=self.transpose,
+            transpose_output=self.transpose,
+            dtype=self.dtype,
+        )
+
+
+# fmt: off
+def encoding_func(sym: bool, group_size: int, nbit: int, mode: str, storage_nbit: int, transpose: bool=True, dtype: str = "float32") -> FQuantize:
+    def te_encode_asym(weight: te.Tensor):
+        assert weight.shape[1] % group_size == 0
+        n_group = weight.shape[1] // group_size
+        n_float_per_u32 = 32 // nbit
+
+        scale_min_shape = (weight.shape[0], n_group)
+        k = te.reduce_axis((0, group_size), name="k")
+        min_value = te.compute(shape=scale_min_shape, fcompute=lambda i, j: te.min(weight[i, j * group_size + k], axis=k), name="min_value")
+        max_value = te.compute(shape=scale_min_shape, fcompute=lambda i, j: te.max(weight[i, j * group_size + k], axis=k), name="max_value")
+        scale = te.compute(shape=scale_min_shape, fcompute=lambda i, j: (max_value[i, j] - min_value[i, j]) / tir.const((1 << nbit) - 1, dtype), name="scale")
+
+        def f_scale_weight(i, j):
+            group_idx = j // group_size
+            w_scaled = tir.round((weight[i, j] - min_value[i, group_idx]) / scale[i, group_idx]).astype("int32")
+            w_scaled = T.min(T.max(w_scaled, tir.const(0, "int32")), tir.const((1 << nbit) - 1, "int32"))
+            w_scaled = w_scaled.astype("uint32")
+            return w_scaled
+
+        k = te.reduce_axis((0, n_float_per_u32), name="k")
+        reducer = te.comm_reducer(fcombine=lambda x, y: tir.bitwise_or(x, y), fidentity=lambda dtype: tir.const(0, dtype), name="bitwise_or")
+        if dtype == "float32":
+            if transpose:
+                w_gathered = te.compute(shape=(weight.shape[1] // n_float_per_u32, weight.shape[0]), fcompute=lambda j, i: reducer(f_scale_weight(i, j * n_float_per_u32 + k) << (k * nbit).astype("uint32"), axis=k), name="w_gathered")
+                scale_bias = te.compute(shape=(n_group, weight.shape[0]), fcompute=lambda j, i: tir_utils._tir_f32x2_to_bf16x2_to_u32(scale[i, j], min_value[i, j], round_to_even=True), name="scale_min")
+            else:
+                w_gathered = te.compute(shape=(weight.shape[0], weight.shape[1] // n_float_per_u32), fcompute=lambda i, j: reducer(f_scale_weight(i, j * n_float_per_u32 + k) << (k * nbit).astype("uint32"), axis=k), name="w_gathered")
+                scale_bias = te.compute(shape=(weight.shape[0], n_group), fcompute=lambda i, j: tir_utils._tir_f32x2_to_bf16x2_to_u32(scale[i, j], min_value[i, j], round_to_even=True), name="scale_min")
+            return w_gathered, scale_bias
+        else:
+            if transpose:
+                w_gathered = te.compute(shape=(weight.shape[1] // n_float_per_u32, weight.shape[0]), fcompute=lambda j, i: reducer(f_scale_weight(i, j * n_float_per_u32 + k) << (k * nbit).astype("uint32"), axis=k), name="w_gathered")
+                scale = te.compute(shape=(n_group, weight.shape[0]), fcompute=lambda j, i: scale[i, j], name="scale_transpose")
+                min_value = te.compute(shape=(n_group, weight.shape[0]), fcompute=lambda j, i: min_value[i, j], name="min_transpose")
+            else:
+                w_gathered = te.compute(shape=(weight.shape[0], weight.shape[1] // n_float_per_u32), fcompute=lambda i, j: reducer(f_scale_weight(i, j * n_float_per_u32 + k) << (k * nbit).astype("uint32"), axis=k), name="w_gathered")
+            return w_gathered, scale, min_value
+
+    def te_encode_sym(weight: te.Tensor):
+        n_group = tir.ceildiv(weight.shape[1], group_size)
+        n_float_per_int = storage_nbit // nbit
+        max_int_value = (1 << (nbit - 1)) - 1
+        assert group_size % n_float_per_int == 0
+
+        scale_min_shape = (weight.shape[0], n_group)
+        k = te.reduce_axis((0, group_size), name="k")
+        max_abs_value = te.compute(shape=scale_min_shape, fcompute=lambda i, j: te.max(tir.if_then_else(j * group_size + k < weight.shape[1], te.abs(weight[i, j * group_size + k]), tir.min_value(dtype)), axis=k), name="max_abs_value")
+
+        def f_compute_scale(i, j):
+            max_value = tir.max(max_abs_value[i, j], tir.const(1e-4, dtype))
+            return (max_value / tir.const(max_int_value, dtype)) if mode.startswith("int") else max_value
+
+        scale = te.compute(shape=scale_min_shape, fcompute=f_compute_scale, name="scale")
+        storage_dtype = ("uint" + str(storage_nbit)) if mode.startswith("int") else "uint32"
+
+        def f_scale_weight(i, j):
+            group_idx = j // group_size
+            if mode.startswith("int"):
+                w_scaled = tir.round(weight[i, j] / scale[i, group_idx] + tir.const(max_int_value, dtype))
+                w_scaled = T.min(T.max(w_scaled, tir.const(0, dtype)), tir.const(max_int_value * 2, dtype)).astype(storage_dtype)
+                return w_scaled
+            else:
+                f_convert = tir_utils._tir_f32_to_uint_to_f4 if dtype == "float32" else tir_utils._tir_f16_to_uint_to_f4
+                return f_convert(weight[i, j] / scale[i, group_idx])
+
+        k = te.reduce_axis((0, n_float_per_int), name="k")
+        reducer = te.comm_reducer(fcombine=lambda x, y: tir.bitwise_or(x, y), fidentity=lambda dtype: tir.const(0, dtype), name="bitwise_or")
+        n_i32 = tir.ceildiv(group_size, n_float_per_int) * n_group
+        if transpose:
+            w_gathered = te.compute(shape=(n_i32, weight.shape[0]), fcompute=lambda j, i: reducer(tir.if_then_else(j * n_float_per_int + k < weight.shape[1], f_scale_weight(i, j * n_float_per_int + k) << (k.astype(storage_dtype) * tir.const(nbit, storage_dtype)), tir.const(0, storage_dtype)), axis=k), name="w_gathered")
+            scale = te.compute(shape=(n_group, weight.shape[0]), fcompute=lambda j, i: scale[i, j])
+        else:
+            w_gathered = te.compute(shape=(weight.shape[0], n_i32), fcompute=lambda i, j: reducer(tir.if_then_else(j * n_float_per_int + k < weight.shape[1], f_scale_weight(i, j * n_float_per_int + k) << (k.astype(storage_dtype) * tir.const(nbit, storage_dtype)), tir.const(0, storage_dtype)), axis=k), name="w_gathered")
+        return w_gathered, scale
+
+    return te_encode_sym if sym else te_encode_asym
+
+
+def decoding_func(sym: bool, group_size: int, nbit: int, mode: str, storage_nbit: int, dim_length: tir.PrimExpr, data_transposed: bool=True, transpose_output: bool=False, dtype: str = "float32") -> FDequantize:
+    def te_decode_asym(*args):
+        n_float_per_u32 = 32 // nbit
+        data = args[0]
+        if dtype == "float32":
+            scale_bias_bf16x2 = args[1]
+        else:
+            scale, min_value = args[1], args[2]
+
+        def f_decode_asym(i, j):
+            if data_transposed:
+                data_float = tir_utils._tir_u32_to_int_to_float(nbit, data[i // n_float_per_u32, j], i % n_float_per_u32, dtype=dtype)
+                if dtype == "float32":
+                    scale_float, bias_float = tir_utils._tir_u32_to_bf16x2_to_f32x2(scale_bias_bf16x2[i // group_size, j])
+                else:
+                    scale_float, bias_float = scale[i // group_size, j], min_value[i // group_size, j]
+            else:
+                data_float = tir_utils._tir_u32_to_int_to_float(nbit, data[i, j // n_float_per_u32], j % n_float_per_u32, dtype=dtype)
+                if dtype == "float32":
+                    scale_float, bias_float = tir_utils._tir_u32_to_bf16x2_to_f32x2(scale_bias_bf16x2[i, j // group_size])
+                else:
+                    scale_float, bias_float = scale[i, j // group_size], min_value[i, j // group_size]
+            w = data_float * scale_float + bias_float
+            return w
+
+        shape = (dim_length, data.shape[1]) if data_transposed else (data.shape[0], dim_length)
+        w = te.compute(shape=shape, fcompute=f_decode_asym, name="decode")
+        if transpose_output:
+            w = topi.transpose(w)
+        return w
+
+    def te_decode_sym(data, scale):
+        n_float_per_int = storage_nbit // nbit
+
+        def f_decode_sym(i, j):
+            f_convert = tir_utils._tir_packed_uint_to_uint_to_float(storage_nbit) if mode.startswith("int") else (tir_utils._tir_u32_to_f4_to_f32 if dtype == "float32" else tir_utils._tir_u32_to_f4_to_f16)
+            if data_transposed:
+                data_float = f_convert(nbit, data[i // n_float_per_int, j], i % n_float_per_int, dtype=dtype)
+                scale_float = scale[i // group_size, j]
+            else:
+                data_float = f_convert(nbit, data[i, j // n_float_per_int], j % n_float_per_int, dtype=dtype)
+                scale_float = scale[i, j // group_size]
+            return data_float * scale_float
+
+        shape = (dim_length, data.shape[1]) if data_transposed else (data.shape[0], dim_length)
+        w = te.compute(shape=shape, fcompute=f_decode_sym, name="decode")
+        if transpose_output:
+            w = topi.transpose(w)
+        return w
+
+    return te_decode_sym if sym else te_decode_asym
+# fmt: on

--- a/mlc_llm/quantization/quantization.py
+++ b/mlc_llm/quantization/quantization.py
@@ -1,0 +1,149 @@
+import enum
+from dataclasses import dataclass
+from typing import Callable, List, Literal, Optional, Union
+
+from tvm import relax, te
+
+FQuantize = Callable[[te.Tensor], List[te.Tensor]]
+FDequantize = Callable[[List[te.Tensor]], te.Tensor]
+
+
+@dataclass
+class QuantizationSpec:
+    """The base dataclass of quantization specification.
+    A specification describes how a parameter is quantized and dequantized.
+
+    A subclass of QuantizationSpec
+      - contains more data fields (e.g., the "group size" in group quantization)
+      which instruct the quantization/dequantization,
+      - defines the `get_quantize_func` method, which returns a TE function
+      (`Callable[[te.Tensor], List[te.Tensor]]`) that describes the computation
+      algorithm of the quantization.
+      - defines the `get_dequantize_func` method, which returns a TE function
+      (`Callable[[List[te.Tensor]], te.Tensor]`) that describes the computation
+      algorithm of the dequantization.
+      - optionally overloads the `get_loaded_tensor_info` when the parameter is
+      pre-quantized, in which case `get_loaded_tensor_info` needs to be overloaded
+      so that we know how many quantized data tensors there are, and the dtype
+      and shape of each quantized data tensor.
+    """
+
+    dtype: str
+
+    def get_loaded_tensor_info(
+        self, param_info: relax.TensorStructInfo
+    ) -> List[relax.TensorStructInfo]:
+        """Returns the shape and dtype of the tensors that need to be loaded
+        from the disk.
+
+        It is useful when the parameter is pre-quantized. In such cases, we need
+        to know how many tensors the parameter is quantized into, and together
+        with the dtype and shape of each tensor, so that we can load the
+        pre-quantized tensors in.
+        """
+        return [param_info]
+
+    def get_quantize_func(
+        self, param_info: relax.TensorStructInfo
+    ) -> Optional[FQuantize]:
+        """Returns the TE function which computes quantization.
+        Returning `None` means the parameter does not need quantization or is
+        pre-quantized.
+        """
+        return NotImplementedError()
+
+    def get_dequantize_func(
+        self,
+        param_info: relax.TensorStructInfo,
+        qparam_info: List[relax.TensorStructInfo],
+    ) -> Optional[FDequantize]:
+        """Returns the TE function which computes dequantization.
+        Returning `None` means the parameter does not need dequantization.
+        """
+        return NotImplementedError()
+
+
+@dataclass
+class NoQuantizationSpec(QuantizationSpec):
+    """The quantization specification that describes doing no quantization."""
+
+    def get_quantize_func(
+        self, param_info: relax.TensorStructInfo
+    ) -> Optional[FQuantize]:
+        return None
+
+    def get_dequantize_func(
+        self,
+        param_info: relax.TensorStructInfo,
+        qparam_info: List[relax.TensorStructInfo],
+    ) -> Optional[FDequantize]:
+        return None
+
+
+class ParamQuantKind(enum.IntEnum):
+    """The parameter quantization kind class.
+
+    We categorized all the parameters in a model into four kinds:
+    - the weights of the internal linear layers, which are the main targets of quantization,
+    - the embedding table of every token,
+    - the weight of the fully-connected layer at the end of the model, which is
+    used for computes the logits of each input token,
+    - other parameters (e.g., the weight of layer normalization, etc.).
+    """
+
+    linear_weight = 0
+    embedding_table = 1
+    final_fc_weight = 2
+    others = 3
+
+
+class QuantizationScheme:
+    """The quantization scheme class describes how an entire model is quantized.
+    It contains the quantization specification for each parameter quantization kind.
+    """
+
+    name: str
+    linear_weight: QuantizationSpec
+    embedding_table: QuantizationSpec
+    final_fc_weight: QuantizationSpec
+    others: QuantizationSpec
+
+    def __init__(
+        self,
+        name: str,
+        linear_weight: QuantizationSpec,
+        *,
+        embedding_table: Optional[
+            Union[QuantizationSpec, Literal["same_as_linear_weight"]]
+        ] = None,
+        final_fc_weight: Optional[
+            Union[QuantizationSpec, Literal["same_as_linear_weight"]]
+        ] = None,
+        others: Optional[QuantizationSpec] = None
+    ) -> None:
+        self.name = name
+        self.linear_weight = linear_weight
+        self.others = (
+            others if others is not None else NoQuantizationSpec(self.model_dtype)
+        )
+
+        if embedding_table is None:
+            self.embedding_table = self.others
+        elif embedding_table == "same_as_linear_weight":
+            self.embedding_table = self.linear_weight
+        else:
+            self.embedding_table = embedding_table
+
+        if final_fc_weight is None:
+            self.final_fc_weight = self.others
+        elif final_fc_weight == "same_as_linear_weight":
+            self.final_fc_weight = self.linear_weight
+        else:
+            self.final_fc_weight = final_fc_weight
+
+    @property
+    def model_dtype(self) -> str:
+        """Returns the overall model dtype, which is defined as the dtype of
+        the linear layers.
+        """
+        return self.linear_weight.dtype

--- a/mlc_llm/quantization/tir_utils.py
+++ b/mlc_llm/quantization/tir_utils.py
@@ -1,0 +1,94 @@
+"""TIR computation utilities for quantization."""
+
+import tvm
+from tvm import tir
+
+# fmt: off
+def _tir_f32x2_to_bf16x2_to_u32(v0: tir.PrimExpr, v1: tir.PrimExpr, round_to_even: bool=True):
+    mask = tir.const((1 << 16) - 1, "uint32")
+    res = []
+    for data in [v0, v1]:
+        u32_val = tir.reinterpret("uint32", data)
+        if round_to_even:
+            rounding_bias = ((u32_val >> tir.const(16, "uint32")) & tir.const(1, "uint32")) + tir.const(0x7FFF, "uint32")
+            u32_val += rounding_bias
+        res.append((u32_val >> tir.const(16, "uint32")) & mask)
+    return res[0] | (res[1] << tir.const(16, "uint32"))
+
+
+def _tir_u32_to_bf16x2_to_f32x2(x: tir.PrimExpr):
+    mask = tir.const((1 << 16) - 1, "uint32")
+    x0 = x & mask
+    x1 = (x >> 16) & mask
+    return (tir.reinterpret("float32", x << tir.const(16, "uint32")) for x in [x0, x1])
+
+
+def _tir_u32_to_int_to_float(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype: str):
+    assert val.dtype == "uint32"
+    mask = tvm.tir.const((1 << nbit) - 1, "uint32")
+    return tir.Cast(dtype, (val >> (pos * nbit).astype("uint32")) & mask)
+
+
+def _tir_packed_uint_to_uint_to_float(storage_nbit: int):
+    storage_dtype = "uint" + str(storage_nbit)
+
+    def f_convert(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype: str):
+        assert val.dtype == storage_dtype
+        max_int_value = (1 << (nbit - 1)) - 1
+        return ((val >> (pos.astype("uint32") * tir.const(nbit, "uint32"))) & tir.const((1 << nbit) - 1, "uint32")).astype(dtype) - tir.const(max_int_value, dtype)
+
+    return f_convert
+
+
+def _tir_f32_to_uint_to_f4(val: tir.PrimExpr):
+    assert val.dtype == "float32"
+    val_u32 = tir.reinterpret("uint32", val)
+    # e_f32 >  120 -> e_f4 = min(e_f32 - 120 + M_h, 7)
+    # e_f32 == 120 -> e_f4 = 1
+    # e_f32 < 120 -> e_f4 = 0
+    m_h = (val_u32 >> tir.const(22, "uint32")) & tir.const(1, "uint32")
+    e_f32 = (val_u32 >> tir.const(23, "uint32")) & tir.const(255, "uint32")
+    s = (val_u32 >> tir.const(31, "uint32"))
+    e_f4 = tir.Select(e_f32 > tir.const(120, "uint32"), tir.Min(e_f32 - tir.const(120, "uint32") + m_h, tir.const(7, "uint32")), tir.Select(e_f32 == tir.const(120, "uint32"), tir.const(1, "uint32"), tir.const(0, "uint32")))
+    return (s << tir.const(3, "uint32")) | e_f4
+
+
+def _tir_f16_to_uint_to_f4(val: tir.PrimExpr):
+    assert val.dtype == "float16"
+    val_u32 = tir.Cast("uint32", tir.reinterpret("uint16", val))
+    m_h = (val_u32 >> tir.const(9, "uint32")) & tir.const(1, "uint32")
+    e_f16 = (val_u32 >> tir.const(10, "uint32")) & tir.const(31, "uint32")
+    s = (val_u32 >> tir.const(15, "uint32"))
+    e_f4 = tir.Select(e_f16 > tir.const(8, "uint32"), tir.Min(e_f16 - tir.const(8, "uint32") + m_h, tir.const(7, "uint32")), tir.Select(e_f16 == tir.const(8, "uint32"), tir.const(1, "uint32"), tir.const(0, "uint32")))
+    return (s << tir.const(3, "uint32")) | e_f4
+
+
+def _tir_u32_to_f4_to_f32(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype: str):
+    assert nbit == 4
+    assert dtype == "float32"
+    assert val.dtype == "uint32"
+    # e_f4 == 0 -> e_f32 = 0
+    # e_f4 != 0 -> e_f32 = e_f4 + 120 = e_f4 | (1111000)_2
+    mask = tvm.tir.const((1 << nbit) - 1, "uint32")
+    f4 = (val >> (pos.astype("uint32") * tir.const(nbit, "uint32"))) & mask
+    s = f4 >> tir.const(3, "uint32")
+    e_f4 = f4 & tir.const(7, "uint32")
+    e_f32 = e_f4 | tir.const(120, "uint32")
+    val_f32 = tir.reinterpret("float32", (e_f32 | (s << tir.const(8, "uint32"))) << tir.const(23, "uint32"))
+    return tir.Select(e_f4 == tir.const(0, "uint32"), tir.const(0, "float32"), val_f32)
+
+
+def _tir_u32_to_f4_to_f16(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype: str):
+    assert nbit == 4
+    assert dtype == "float16"
+    assert val.dtype == "uint32"
+    # e_f4 == 0 -> e_f16 = 0
+    # e_f4 != 0 -> e_f16 = e_f4 + 8 = e_f4 | (1000)_2
+    mask = tvm.tir.const((1 << nbit) - 1, "uint32")
+    f4 = (val >> (pos.astype("uint32") * tir.const(nbit, "uint32"))) & mask
+    s = f4 >> tir.const(3, "uint32")
+    e_f4 = f4 & tir.const(7, "uint32")
+    e_f16 = e_f4 | tir.const(8, "uint32")
+    val_f16 = tir.reinterpret("float16", (e_f16 | (s << tir.const(5, "uint32"))) << tir.const(10, "uint32"))
+    return tir.Select(e_f4 == tir.const(0, "uint32"), tir.const(0, "float16"), val_f16)
+# fmt: on

--- a/mlc_llm/relax_model/param_manager.py
+++ b/mlc_llm/relax_model/param_manager.py
@@ -1,0 +1,488 @@
+from typing import Callable, Dict, List, Set, Tuple
+
+import tvm
+from tvm import relax, tir
+from tvm.relax.expr import Expr, Function, Var
+from tvm.relax.testing import nn
+from tvm.relax.analysis import remove_all_unused
+from tvm.relax.expr_functor import PyExprMutator, mutator
+
+from .. import quantization
+from .modules import named_parameters
+
+
+class Parameter:
+    """The abstraction of weight tensors (e.g., linear layer weight, embedding
+    table, etc.) in a model.
+
+    Attributes
+    ----------
+    name : str
+        The name of the parameter.
+        The name of a weight is got by `named_parameters()` method, similar to
+        PyTorch's `named_parameters()` function.
+        An example name is `model.layers.11.self_attn.k_proj.weight`.
+        In a model, the name is the **unique** identifier of a parameter.
+
+    param_info : relax.TensorStructInfo
+        The shape and dtype of the parameter.
+        The shape can be accessed by `param_info.shape`, which is a relax.ShapeExpr instance.
+        And the dtype can be accessed by `param_info.dtype`, which is a Python string.
+
+    quant_spec : quantization.QuantizationSpec
+        The quantization specification of this parameter.
+        It specifies the algorithm to quantize and dequantize this parameter (or
+        this parameter does not need quantization).
+    """
+
+    name: str
+    param_info: relax.TensorStructInfo
+    quant_spec: quantization.QuantizationSpec
+
+    def __init__(
+        self,
+        name: str,
+        param_info: relax.TensorStructInfo,
+        quant_spec: quantization.QuantizationSpec,
+    ) -> None:
+        self.name = name
+        self.param_info = param_info
+        self.quant_spec = quant_spec
+
+
+class ParamManager:
+    """The model-wise data structure which contains the information of every
+    weight in the model and is in charge of applying quantization and dequantization
+    to the parameters at the entire model level.
+
+    Attributes
+    ----------
+    params : Dict[str, Parameter]
+        The mapping from parameter names to parameters.
+
+    param_names : List[str]
+        The name list of all the parameters.
+        To enforce a unique order or all the parameters for determinism, the
+        parameter names are kept in the list, and the parameter order is
+        uniquely determined by the parameter name list.
+
+    func_raw_param_map : Dict[relax.Var, Tuple[str, Parameter]]
+        The mapping from each relax.Var that denotes a weight parameter to the
+        name of the function the var is in (e.g., "prefill" or "decode"), and
+        the Parameter it corresponds to.
+        This mapping is used for applying quantization transformation to the
+        Relax functions (e.g., the "prefill", "decode", etc.) in the model.
+
+    param2qrange : Dict[Parameter, range]
+        The mapping from each parameter to the range of its quantized tensors
+        in the list of quantized tensors of all parameters.
+        Each parameter is quantized into multiple tensors.
+        For example, assume we have parameters `p0`, `p1`, `p2`.
+        - `p0` is quantized into `t0_0`, `t0_1`,
+        - `p1` is quantized into `t1_0`, and
+        - `p2` is quantized into `t2_0`, `t2_1` and `t2_2`.
+        Then the list of all quantized tensors is `[t0_0, t0_1, t1_0, t2_0, t2_1, t2_2]`,
+        and the dict `param2qrange` is
+        `{p0: range(0, 2), p1: range(2, 3), p2: range(3, 6)}`.
+    """
+
+    params: Dict[str, Parameter]
+    param_names: List[str]
+
+    func_raw_param_map: Dict[relax.Var, Tuple[str, Parameter]]
+    param2qrange: Dict[Parameter, range]
+
+    def __init__(self) -> None:
+        self.params = {}
+        self.param_names = []
+
+        self.func_raw_param_map = {}
+        self.param2qrange = {}
+
+    def register_params(
+        self,
+        model: nn.Module,
+        func_name: str,
+        quantization_scheme: quantization.QuantizationScheme,
+        f_get_param_quant_kind: Callable[
+            [str, relax.TensorStructInfo], quantization.ParamQuantKind
+        ],
+    ) -> None:
+        """Register the parameters of the input model (within the context of the
+        input function) in the parameter manager.
+
+        Parameters
+        ----------
+        model : nn.Module
+            The input model whose parameters are registered.
+
+        func_name : str
+            The name of the function the input model is in.
+            For example, the "prefill" function or the "decode" function.
+
+        quantization_scheme : quantization.QuantizationScheme
+            The quantization scheme of the input model, which describes how
+            to quantize the model.
+
+        f_get_param_quant_kind: Callable[[str, relax.TensorStructInfo], quantization.ParamQuantKind]
+            A function which takes the name and StructInfo (effectively shape
+            and dtype) of a parameter, and returns which quantization kind this
+            parameter uses.
+            This is used for applying quantization to the parameters.
+        """
+
+        # For each parameter in the input model, get its quantization kind and
+        # register the parameter with its name and quantization kind.
+        for name, param in named_parameters(model).items():
+            quant_kind = f_get_param_quant_kind(name, param.struct_info)
+            getattr(quantization_scheme, quant_kind.name)
+            self.register_param(
+                name, param, getattr(quantization_scheme, quant_kind.name), func_name
+            )
+
+    def quantization_transform(
+        self, mod: tvm.IRModule
+    ) -> Tuple[tvm.IRModule, Dict[int, str]]:
+        """The entrance function of all quantization-related transformation,
+        including creating the function that computes quantization, and
+        updating the input IRModule with quantized data as function input and
+        dequantization computation.
+
+        Parameters
+        ----------
+        mod : tvm.IRModule
+            The input IRModule to be applied quantization/dequantization.
+            The IRModule contains all the constructed Relax functions
+            (e.g., the "prefill"/"decode" functions) and is expected to
+            have all of its parameters registered in the ParamManager.
+
+        Returns
+        -------
+        updated_mod : tvm.IRModule
+            The IRModule updated with the quantization function and the
+            dequantization computation.
+
+        pidx2pname : Dict[int, str]
+            The mapping from each parameter's index in the ParamManager
+            to the parameter' name.
+            This mapping is used for loading weight tensors from disk and
+            applying quantization at runtime.
+        """
+        # Create the quantization function.
+        mod_transform = self.create_quantize_func()
+
+        # For each Relax function in the input IRModule (e.g., "prefill"),
+        # we create its input relax.Var of all the quantized data, and
+        # store the mapping from function name to the var.
+        func2param_var: Dict[str, relax.Var] = {}
+        for gv, func in mod.functions.items():
+            if not isinstance(func, relax.Function):
+                continue
+            if func.attrs is None or not "num_input" in func.attrs:
+                continue
+            func2param_var[gv.name_hint] = relax.Var(
+                "params", mod_transform["transform_params"].struct_info.ret
+            )
+
+        # Define a var replacement function for applying dequantization.
+        def f_replace(var: relax.Var, bb: relax.BlockBuilder) -> relax.Var:
+            assert var in self.func_raw_param_map
+            func_name, param = self.func_raw_param_map[var]
+            return self.dequantize(param, func2param_var[func_name], bb)
+
+        # Create the function mutator for applying dequantization.
+        replacer = ParamReplacer(mod, func2param_var, f_replace)
+        # Update the input IRModule with dequantization.
+        mod = replacer.transform()
+
+        # Merge the quantization IRModule into the updated input IRModule.
+        for gv, func in mod_transform.functions.items():
+            mod[gv] = func
+
+        # Return the merged IRModule and the mapping from each parameter's
+        # index to the parameter' name.
+        return mod, {pidx: pname for pidx, pname in enumerate(self.param_names)}
+
+    #################### Below are internally called methods ####################
+
+    def register_param(
+        self,
+        name: str,
+        var: relax.Var,
+        quant_spec: quantization.QuantizationSpec,
+        func_name: str,
+    ) -> None:
+        """Register a single parameter in the parameter manager.
+        In most cases, this method is not directly used outside this class:
+        it is called by `register_params` above.
+
+        Parameters
+        ----------
+        name : str
+            The name of the parameter to register.
+            Name serves as the unique identifier of the parameter.
+
+        var : relax.Var
+            The parameter relax.Var on the nn.Module side.
+
+        quant_spec : quantization.QuantizationSpec
+            The quantization specification of the parameter
+
+        func_name : str
+            The name of the function the input var is in.
+            For example, the "prefill" function or the "decode" function.
+        """
+
+        assert (
+            var not in self.func_raw_param_map
+        ), "The input var is not supposed to be already registered."
+        assert isinstance(
+            var.struct_info.shape, relax.ShapeExpr
+        ), "The parameter to register is expected to have static shape"
+        assert all(
+            [
+                isinstance(dim_len, tir.IntImm)
+                for dim_len in var.struct_info.shape.values
+            ]
+        ), "The parameter to register is expected to have static shape"
+
+        if name in self.params:
+            # When the input name appears in `self.params`, it means the input
+            # parameter has been previously registered in some other function.
+            # Thus, we check if the dtype, shape and the quantization specification
+            # of both sides are consistent.
+            param = self.params[name]
+            assert (
+                param.quant_spec == quant_spec
+            ), "One parameter is expected to be quantized by single specification in all functions."
+            assert (
+                param.param_info.dtype == var.struct_info.dtype
+            ), "Dtype mismatch of one parameter in two functions."
+            assert (
+                param.param_info.ndim == var.struct_info.ndim
+            ), "Shape mismatch of one parameter in two functions."
+            for len0, len1 in zip(
+                param.param_info.shape.values, var.struct_info.shape.values
+            ):
+                assert (
+                    len0.value == len1.value
+                ), "Shape mismatch of one parameter in two functions."
+        else:
+            # Otherwise, the parameter is registered for the first time.
+            param = Parameter(name, var.struct_info, quant_spec)
+            self.params[name] = param
+            self.param_names.append(name)
+
+        # Record the mapping from the input relax.Var to the function name and
+        # the parameter in the manager.
+        self.func_raw_param_map[var] = (func_name, param)
+
+    def create_quantize_func(self) -> tvm.IRModule:
+        """Construct the Relax function which computes quantization.
+        This method is called by `quantization_transform` below, and is not
+        directly invoked outside the class.
+
+        Returns
+        -------
+        The created function which computes quantization.
+        Precisely, an IRModule which contains the main quantization Relax function
+        and a series of TIR functions is returned.
+        """
+        bb = relax.BlockBuilder()
+
+        # Construct the input of the function.
+        # Similar to `self.param2qrange`, we need a list of ranges for each
+        # parameter to get its corresponding tensors loaded from disk.
+        input_tensor_info: List[relax.TensorStructInfo] = []
+        loaded_tensor_ranges: List[range] = []
+        for name in self.param_names:
+            param = self.params[name]
+            loaded_tensor_info = param.quant_spec.get_loaded_tensor_info(
+                param.param_info
+            )
+            loaded_tensor_ranges.append(
+                range(
+                    len(input_tensor_info),
+                    len(input_tensor_info) + len(loaded_tensor_info),
+                )
+            )
+            input_tensor_info += loaded_tensor_info
+        raw_param_tuple = relax.Var("params", relax.TupleStructInfo(input_tensor_info))
+
+        with bb.function("transform_params", params=[raw_param_tuple]):
+            with bb.dataflow():
+                quantized_params: List[relax.Var] = []
+                for pidx, name in enumerate(self.param_names):
+                    param = self.params[name]
+                    param_vars: List[relax.Var] = []
+                    # Emit relax.TupleGetItem to get the raw parameters or pre-quantized params.
+                    for loaded_tensor_idx in loaded_tensor_ranges[pidx]:
+                        param_vars.append(
+                            bb.emit(
+                                relax.TupleGetItem(raw_param_tuple, loaded_tensor_idx)
+                            )
+                        )
+
+                    # Get the quantization function of this parameter.
+                    f_quantize = param.quant_spec.get_quantize_func(param.param_info)
+                    if f_quantize is None:
+                        # If the parameter does not have a quantization function, either it
+                        # does not need quantization or it is pre-quantized.
+                        self.param2qrange[param] = range(
+                            len(quantized_params),
+                            len(quantized_params) + len(param_vars),
+                        )
+                        quantized_params += param_vars
+                    else:
+                        # If the parameter has a quantization function, it is not expected
+                        # to be pre-quantized.
+                        assert len(param_vars) == 1, (
+                            "A parameter with quantization function is not expected "
+                            "to be pre-quantized."
+                        )
+
+                        # Apply the quantization function.
+                        quantized_data = bb.emit_te(
+                            f_quantize, param_vars[0], primfunc_name_hint="encode"
+                        )
+
+                        if isinstance(
+                            quantized_data.struct_info, relax.TupleStructInfo
+                        ):
+                            n_tensor = len(quantized_data.struct_info.fields)
+                            assert n_tensor > 1
+                            # Record the range of quantized tensors of this parameter.
+                            self.param2qrange[param] = range(
+                                len(quantized_params), len(quantized_params) + n_tensor
+                            )
+                            # Collect the quantized tensors to return.
+                            for i in range(n_tensor):
+                                quantized_params.append(
+                                    bb.emit(relax.TupleGetItem(quantized_data, i))
+                                )
+                        else:
+                            assert isinstance(
+                                quantized_data.struct_info, relax.TensorStructInfo
+                            )
+                            self.param2qrange[param] = range(
+                                len(quantized_params), len(quantized_params) + 1
+                            )
+                            quantized_params.append(quantized_data)
+
+                output = bb.emit_output(relax.Tuple(quantized_params))
+            bb.emit_func_output(output)
+
+        # Return the created IRModule.
+        return bb.get()
+
+    def dequantize(
+        self, param: Parameter, quantized_tuple: relax.Var, bb: relax.BlockBuilder
+    ) -> relax.Var:
+        """Applying dequantization to the input parameter.
+        This method is called by `quantization_transform` below, and is not
+        directly invoked outside the class.
+
+        Parameters
+        ----------
+        param : Parameter
+            The parameter whose quantized tensors are to be dequantized.
+
+        quantized_tuple : relax.Var
+            The relax.Var of the quantized tensors of all parameters in the model.
+
+        bb : relax.BlockBuilder
+            The Relax BlockBuilder used for inserting the dequantization computations.
+
+        Returns
+        -------
+        The dequantized parameter, in the form of a relax.Var.
+        """
+        # Get the corresponding Relax vars of the quantized tensors of this parameter.
+        qparams: List[relax.Var] = []
+        for qparam_idx in self.param2qrange[param]:
+            qparams.append(bb.emit(relax.TupleGetItem(quantized_tuple, qparam_idx)))
+
+        # Get the dequantization function of this parameter.
+        f_dequantize = param.quant_spec.get_dequantize_func(
+            param_info=param.param_info,
+            qparam_info=[qparam.struct_info for qparam in qparams],
+        )
+        if f_dequantize is None:
+            # If the parameter does not have a dequantization function, its "quantized
+            # data" is expected to have only one element.
+            assert len(qparams) == 1, (
+                "A parameter without dequantization function is expected not to have "
+                'more than one "quantized data".'
+            )
+            return qparams[0]
+        else:
+            # Apply the dequantization function.
+            return bb.emit_te(f_dequantize, *qparams, primfunc_name_hint="decode")
+
+
+@mutator
+class ParamReplacer(PyExprMutator):
+    """The function mutator that updates the model with dequantization.
+
+    Attributes
+    ----------
+    mod : tvm.IRModule
+        The IRModule of the model to be updated.
+
+    func2param_var : Dict[str, relax.Var]
+        The mapping from each function name to its input var of quantized data tuple.
+
+    f_replace : Callable[[relax.Var, relax.BlockBuilder], relax.Var]
+        The function for updating a previous parameter in functions with dequantization.
+
+    param_set : Set[relax.Var]
+        The set of previous parameters (before applying quantization and dequantization)
+        in the relax functions.
+    """
+
+    mod: tvm.IRModule
+    func2param_var: Dict[str, relax.Var]
+    f_replace: Callable[[relax.Var, relax.BlockBuilder], relax.Var]
+    param_set: Set[relax.Var]
+
+    def __init__(
+        self,
+        mod: tvm.IRModule,
+        func2param_var: Dict[str, relax.Var],
+        f_replace: Callable[[relax.Var, relax.BlockBuilder], relax.Var],
+    ):
+        super().__init__(mod)
+        self.mod = mod
+        self.func2param_var = func2param_var
+        self.f_replace = f_replace
+
+    def transform(self) -> tvm.IRModule:
+        for gv, func in self.mod.functions.items():
+            if not isinstance(func, relax.Function):
+                continue
+            if func.attrs is None or not "num_input" in func.attrs:
+                continue
+
+            assert gv.name_hint in self.func2param_var
+            updated_func = self.rewrite_func(func, self.func2param_var[gv.name_hint])
+            updated_func = remove_all_unused(updated_func)
+            self.builder_.update_func(gv, updated_func)
+        return self.builder_.get()
+
+    def rewrite_func(self, func: Function, param_var: relax.Var) -> relax.Function:
+        num_input = int(func.attrs["num_input"])
+        self.param_set = set(func.params[num_input:])
+
+        body = self.visit_expr(func.body)
+        return relax.Function(
+            params=func.params[:num_input] + [param_var],
+            body=body,
+            ret_struct_info=func.ret_struct_info,
+            is_pure=func.is_pure,
+            attrs=func.attrs,
+        ).without_attr("num_input")
+
+    def visit_var_(self, var: Var) -> Expr:
+        if var not in self.param_set:
+            return super().visit_var_(var)
+        return self.f_replace(var, self.builder_)

--- a/mlc_llm/transform/__init__.py
+++ b/mlc_llm/transform/__init__.py
@@ -1,4 +1,6 @@
 from .decode_matmul_ewise import FuseDecodeMatmulEwise
+from .decode_take import FuseDecodeTake
+from .decode_transpose import FuseDecodeTranspose
 from .lift_tir_global_buffer_alloc import LiftTIRGlobalBufferAlloc
 from .quantization import GroupQuantize
 from .reorder_transform_func import ReorderTransformFunc

--- a/mlc_llm/transform/decode_matmul_ewise.py
+++ b/mlc_llm/transform/decode_matmul_ewise.py
@@ -18,7 +18,7 @@ def check_decoding(ctx: relax.transform.PatternCheckContext) -> bool:
     gv = call.args[0]
     if not isinstance(gv, relax.GlobalVar):
         return False
-    return gv.name_hint.startswith("decode")
+    return gv.name_hint.startswith("decode") or gv.name_hint.startswith("fused_decode")
 
 
 def check_matmul(ctx: relax.transform.PatternCheckContext, target_kind: str) -> bool:

--- a/mlc_llm/transform/decode_take.py
+++ b/mlc_llm/transform/decode_take.py
@@ -1,0 +1,69 @@
+"""Fusing and inlining decode function into embedding table lookup."""
+import tvm
+from tvm import relax, tir
+from tvm.ir.module import IRModule
+from tvm.relax.dpl.pattern import GlobalVarPattern, TuplePattern, is_op, wildcard
+
+
+def pattern_check(ctx: relax.transform.PatternCheckContext) -> bool:
+    take = ctx.annotated_expr["take"]
+    decode = ctx.annotated_expr["decode"]
+    if not isinstance(take.args[0], relax.GlobalVar) or not isinstance(
+        decode.args[0], relax.GlobalVar
+    ):
+        return False
+    return "take" in take.args[0].name_hint and "decode" in decode.args[0].name_hint
+
+
+def decode_take_pattern(n_aux_tensor: int):
+    aux_tensors = [wildcard(), wildcard(), wildcard()]
+    decode = is_op("relax.call_tir")(
+        GlobalVarPattern(),
+        TuplePattern([*aux_tensors[0:n_aux_tensor]]),
+        add_constraint=False,
+    )
+    indices = wildcard()
+    take_args = [decode, indices]
+    take = is_op("relax.call_tir")(
+        GlobalVarPattern(), TuplePattern(take_args), add_constraint=False
+    )
+
+    annotations = {
+        "take": take,
+        "decode": decode,
+        "indices": indices,
+    }
+
+    return take, annotations, pattern_check
+
+
+@tvm.transform.module_pass(opt_level=0, name="FuseDecodeTake")
+class FuseDecodeTake:
+    def transform_module(
+        self, mod: IRModule, ctx: tvm.transform.PassContext
+    ) -> IRModule:
+        for n_aux_tensor in [2, 3]:
+            mod = relax.transform.FuseOpsByPattern(
+                [
+                    (
+                        "decode_take",
+                        *decode_take_pattern(n_aux_tensor),
+                    )
+                ]
+            )(mod)
+        mod = relax.transform.FuseTIR()(mod)
+
+        for gv, func in mod.functions.items():
+            if not isinstance(func, tir.PrimFunc):
+                continue
+            if "fused_decode" not in gv.name_hint or "take" not in gv.name_hint:
+                continue
+
+            downcasted_mod = tir.transform.ForceNarrowIndexToInt32()(
+                tvm.IRModule({"main": func})
+            )["main"]
+            sch = tir.Schedule(downcasted_mod)
+            sch.compute_inline("decode")
+            mod[gv] = sch.mod["main"]
+
+        return mod

--- a/mlc_llm/transform/decode_transpose.py
+++ b/mlc_llm/transform/decode_transpose.py
@@ -1,0 +1,90 @@
+"""Fusing and inlining transpose function into decode function."""
+import tvm
+from tvm import relax, tir
+from tvm.ir.module import IRModule
+from tvm.relax.analysis import remove_all_unused
+from tvm.relax.expr_functor import PyExprMutator, mutator
+
+
+@tvm.transform.module_pass(opt_level=0, name="FuseDecodeTranspose")
+class FuseDecodeTranspose:
+    def transform_module(
+        self, mod: IRModule, ctx: tvm.transform.PassContext
+    ) -> IRModule:
+        @mutator
+        class DecodeTransposeFusor(PyExprMutator):
+            def __init__(self, mod: IRModule):
+                super().__init__(mod)
+                self.mod = mod
+
+            def transform(self) -> IRModule:
+                for gv, func in self.mod.functions.items():
+                    if not isinstance(func, relax.Function):
+                        continue
+
+                    updated_func = self.visit_expr(func)
+                    updated_func = remove_all_unused(updated_func)
+                    self.builder_.update_func(gv, updated_func)
+
+                return self.builder_.get()
+
+            def visit_call_(self, call: relax.Call) -> relax.Expr:
+                call = self.visit_expr_post_order(call)
+
+                if (
+                    call.op != tvm.ir.Op.get("relax.permute_dims")
+                    or call.args[0].struct_info.ndim != 2
+                    or call.attrs.axes is not None
+                ):
+                    return call
+
+                transpose_input = self.lookup_binding(call.args[0])
+                if (
+                    not isinstance(transpose_input, relax.Call)
+                    or transpose_input.op != tvm.ir.Op.get("relax.call_tir")
+                    or not transpose_input.args[0].name_hint.startswith("decode")
+                    or not isinstance(
+                        transpose_input.struct_info, relax.TensorStructInfo
+                    )
+                ):
+                    return call
+
+                decode_tir_func = self.mod[transpose_input.args[0]]
+                assert isinstance(decode_tir_func, tir.PrimFunc)
+                if (
+                    len(decode_tir_func.body.block.alloc_buffers) != 1
+                    or not isinstance(decode_tir_func.body.block.body, tir.SeqStmt)
+                    or len(decode_tir_func.body.block.body) != 2
+                    or not isinstance(decode_tir_func.body.block.body[1], tir.For)
+                    or not isinstance(
+                        decode_tir_func.body.block.body[1].body.body, tir.BlockRealize
+                    )
+                    or decode_tir_func.body.block.body[1].body.body.block.name_hint
+                    != "T_transpose"
+                ):
+                    return call
+
+                new_func_buffers = [
+                    decode_tir_func.buffer_map[var] for var in decode_tir_func.params
+                ]
+                new_func_buffers[-1] = decode_tir_func.body.block.alloc_buffers[0]
+                new_func = tir.PrimFunc(
+                    params=new_func_buffers,
+                    body=tir.BlockRealize(
+                        iter_values=[],
+                        predicate=True,
+                        block=tir.Block(
+                            iter_vars=[],
+                            reads=[],
+                            writes=[],
+                            name_hint="root",
+                            body=decode_tir_func.body.block.body[0],
+                        ),
+                    ),
+                )
+                gv = self.builder_.add_func(new_func, func_name="decode")
+                return relax.call_tir(
+                    gv, transpose_input.args[1], out_sinfo=call.struct_info
+                )
+
+        return DecodeTransposeFusor(mod).transform()

--- a/mlc_llm/transform/quantization.py
+++ b/mlc_llm/transform/quantization.py
@@ -204,7 +204,7 @@ def decoding_func(sym: bool, group_size: int, nbit: int, mode: str, storage_nbit
             w = data_float * scale_float + bias_float
             return w
 
-        shape = (dim_length, data.shape[1]) if data_transposed else (data.shape[0], data.shape[1] * n_float_per_u32)
+        shape = (dim_length, data.shape[1]) if data_transposed else (data.shape[0], dim_length)
         w = te.compute(shape=shape, fcompute=f_decode_asym, name="decode")
         if transpose_output:
             w = topi.transpose(w)
@@ -223,7 +223,7 @@ def decoding_func(sym: bool, group_size: int, nbit: int, mode: str, storage_nbit
                 scale_float = scale[i, j // group_size]
             return data_float * scale_float
 
-        shape = (dim_length, data.shape[1]) if data_transposed else (data.shape[0], data.shape[1] * n_float_per_int)
+        shape = (dim_length, data.shape[1]) if data_transposed else (data.shape[0], dim_length)
         w = te.compute(shape=shape, fcompute=f_decode_sym, name="decode")
         if transpose_output:
             w = topi.transpose(w)
@@ -319,7 +319,7 @@ class GroupQuantize:
                 for global_var, func in self.mod.functions.items():
                     if not isinstance(func, relax.Function):
                         continue
-                    if not "num_input" in func.attrs:
+                    if func.attrs is None or not "num_input" in func.attrs:
                         continue
                     num_inputs = func.attrs["num_input"]
                     for i in range(int(num_inputs), len(func.params)):

--- a/mlc_llm/transform/reorder_transform_func.py
+++ b/mlc_llm/transform/reorder_transform_func.py
@@ -214,6 +214,7 @@ class ReorderTransformFunc:
         self.pidx2binname: Dict[int, str] = {
             pidx: pname2binname[f_convert_pname_fwd(pname)]
             for pidx, pname in pidx2pname.items()
+            if f_convert_pname_fwd(pname) in pname2binname
         }
 
     def transform_module(
@@ -221,7 +222,7 @@ class ReorderTransformFunc:
     ) -> IRModule:
         for gv, func in list(mod.functions.items()):
             if isinstance(func, relax.Function):
-                assert gv.name_hint.endswith("_transform_params")
+                assert gv.name_hint.endswith("transform_params")
                 func_updated = reorder_func(func, self.pidx2binname)
                 mod[gv] = func_updated
         return mod


### PR DESCRIPTION
This PR introduces parameter manager, which keeps information of all parameters throughout the entire model, and is in charge of applying quantization and dequantization to the model. Now all parameters are managed in a unified and deterministic way, and the quantization computation will no longer be affected by the optimization passes.

Together with the ParamManager, this PR does an overhaul of the quantization framework with more modular and customizable quantization modules. Specifically, we have

- QuantizationScheme, which describes how an entire model is quantized, and
- QuantizationSpec, which describes how a particular parameter is quantized.

With them and the ParamManager, we now decoupled the quantization algorithm description with the model transformation, which provides us with better customizability for quantization.

We will further support loading models whose weights are pre-quantized. This PR sets up the framework, while some followup changes are needed to fully support this functionality.

Please refer to `mlc_llm/relax_model/param_manager.py` for more documentation on the design and implementation of the ParamManager, and to `mlc_llm/quantization/quantization.py` for more documentation on the new quantization framework.

-----

This PR also adds two fusion passes which are essential to performance. They are required because the previous quantization framework operates on subgraph level, while the new quantization framework only works on single relax.Var level. The previous quantization framework directly rewrites some subgraphs into fused pattern, which is not realizable in the new framework, making the fusion passes needed.

-----

To enable other ongoing works that were blocked by ParamManager, this PR **only supports LLaMA with ParamManager and the latest quantization framework**. We will update other model architectures accordingly soon. Meanwhile, this PR marks that we starts a stage where both the old and new quantization framework co-exist. We will clean the old one once all model architectures are updated with ParamManager and the new quantization framework.

This PR keeps the compilation flow of other model architectures unaffected. Performance of RedPajama and RWKV are tested locally through CLI, and their performance are not affected by this PR.