### PR TITLE
Initial `q4f16_1` quantization support with fusion

### DIFF
--- a/build.py
+++ b/build.py
@@ -300,11 +300,11 @@ def mod_transform_before_build(
                 storage_nbit=args.quantization.storage_nbit,
                 dtype=args.quantization.model_dtype,
             )(mod)
-    mod = mlc_llm.transform.FuseTransposeMatmul()(mod)  # pylint: disable=not-callable
     mod = mlc_llm.transform.FuseDecodeTranspose()(mod)  # pylint: disable=not-callable
+    mod = mlc_llm.transform.FuseTransposeMatmul()(mod)  # pylint: disable=not-callable
     mod = relax.pipeline.get_pipeline()(mod)  # pylint: disable=no-value-for-parameter
     mod = mlc_llm.transform.FuseDecodeMatmulEwise(  # pylint: disable=not-callable
-        args.quantization.model_dtype, args.target_kind
+        args.quantization.name, args.target_kind
     )(mod)
     mod = mlc_llm.transform.FuseDecodeTake()(mod)
     # Apply DCE differently for compatibility of the old/new quantization framework.

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -48,6 +48,19 @@ quantization_schemes = {
         ),
         final_fc_weight="same_as_linear_weight",
     ),
+    "q4f16_1": QuantizationScheme(
+        name="q4f16_1",
+        linear_weight=GroupQuantizationSpec(
+            dtype="float16",
+            mode="int4",
+            sym=True,
+            storage_nbit=32,
+            group_size=32,
+            transpose=False,
+        ),
+        embedding_table="same_as_linear_weight",
+        final_fc_weight="same_as_linear_weight",
+    ),
     "q4f32_0": QuantizationScheme(
         name="q4f32_0",
         linear_weight=GroupQuantizationSpec(

--- a/mlc_llm/transform/decode_matmul_ewise.py
+++ b/mlc_llm/transform/decode_matmul_ewise.py
@@ -21,32 +21,31 @@ def check_decoding(ctx: relax.transform.PatternCheckContext) -> bool:
     return gv.name_hint.startswith("decode") or gv.name_hint.startswith("fused_decode")
 
 
-def check_matmul(ctx: relax.transform.PatternCheckContext, target_kind: str) -> bool:
+def check_matmul(ctx: relax.transform.PatternCheckContext) -> bool:
     call = ctx.annotated_expr["matmul"]
     if not isinstance(call, relax.Call):
         return False
     gv = call.args[0]
     if not isinstance(gv, relax.GlobalVar):
         return False
-    is_matmul = gv.name_hint.startswith("matmul") or gv.name_hint.startswith(
-        "fused_matmul"
+    return (
+        gv.name_hint.startswith("matmul")
+        or gv.name_hint.startswith("fused_matmul")
+        or gv.name_hint.startswith("NT_matmul")
+        or gv.name_hint.startswith("fused_NT_matmul")
     )
-    is_NT_matmul = gv.name_hint.startswith("NT_matmul") or gv.name_hint.startswith(
-        "fused_NT_matmul"
-    )
-    return (is_matmul or is_NT_matmul) if target_kind == "android" else is_matmul
 
 
-def pattern_check(target_kind: str):
+def pattern_check(gemv_only: bool):
     def f_pattern_check(ctx: relax.transform.PatternCheckContext) -> bool:
-        if target_kind != "android" and not check_x_1dim(ctx):
+        if gemv_only and not check_x_1dim(ctx):
             return False
-        return check_decoding(ctx) and check_matmul(ctx, target_kind)
+        return check_decoding(ctx) and check_matmul(ctx)
 
     return f_pattern_check
 
 
-def decode_matmul_pattern(match_ewise: int, n_aux_tensor: int, target_kind: str):
+def decode_matmul_pattern(match_ewise: int, n_aux_tensor: int, gemv_only: bool):
     assert n_aux_tensor == 1 or n_aux_tensor == 2 or n_aux_tensor == 4
 
     w_scaled = wildcard()
@@ -71,14 +70,13 @@ def decode_matmul_pattern(match_ewise: int, n_aux_tensor: int, target_kind: str)
         "w_scaled": w_scaled,
     }
 
-    return matmul, annotations, pattern_check(target_kind)
+    return matmul, annotations, pattern_check(gemv_only)
 
 
 @tvm.transform.module_pass(opt_level=0, name="FuseDecodeMatmulEwise")
 class FuseDecodeMatmulEwise:
-    def __init__(self, dtype: str, target_kind: str) -> None:
-        self.dtype = dtype
-        self.target_kind = target_kind
+    def __init__(self, quantization_name: str, target_kind: str) -> None:
+        self.gemv_only = quantization_name != "q4f16_1" and target_kind != "android"
 
     def transform_module(
         self, mod: IRModule, ctx: tvm.transform.PassContext
@@ -92,7 +90,7 @@ class FuseDecodeMatmulEwise:
                         (
                             "decode_matmul",
                             *decode_matmul_pattern(
-                                match_ewise, n_aux_tensor, self.target_kind
+                                match_ewise, n_aux_tensor, self.gemv_only
                             ),
                         )
                     ]

--- a/mlc_llm/transform/transpose_matmul.py
+++ b/mlc_llm/transform/transpose_matmul.py
@@ -17,22 +17,7 @@ class TransposeMatmulCodeGenerator(relax.PyExprMutator):
         annotations = {"o": o, "w": w, "x": x, "wT": wT}
 
         def _check(context: relax.transform.PatternCheckContext) -> bool:
-            x = context.annotated_expr["x"]
             transpose_call = context.annotated_expr["wT"]
-
-            # Do not fuse transpose with static-shape GeMV.
-            if (
-                isinstance(x.struct_info.shape[-2], tir.IntImm)
-                and x.struct_info.shape[-2].value == 1
-                and all(
-                    [
-                        isinstance(l, tir.IntImm)
-                        for l in transpose_call.struct_info.shape.values
-                    ]
-                )
-            ):
-                return False
-
             ndim = transpose_call.args[0].struct_info.ndim
             if ndim == -1:
                 return False

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -35,6 +35,9 @@ quantization_dict = {
     "q4f16_0": Quantization(
         name="q4f16_0", mode="int4", sym=True, storage_nbit=32, model_dtype="float16"
     ),
+    "q4f16_1": Quantization(
+        name="q4f16_1", mode="int4", sym=True, storage_nbit=32, model_dtype="float16"
+    ),
     "q4f32_0": Quantization(
         name="q4f32_0", mode="int4", sym=False, storage_nbit=32, model_dtype="float32"
     ),


### PR DESCRIPTION
This PR supports the quantization scheme `q4f16_1` with desired fusion pattern. Compared with `q3f16_0` or `q4f16_0`,

* this scheme does not transpose the linear layer weights in quantization,
* under this scheme we fuse all transpose with matmul so that the fused matmul is of layout "NT".

The purpose of this PR is to provide initial support of the quantization scheme and ensure the desired fusion pattern under this scheme. The TIR functions under this scheme is not fully optimized. We will introduce the optimization with dlight (the default schedule package) soon.

The performance of other quantization schemes are not affected. We will do clean up for some of the optimization passes in the future (for example, remove the "`gemv_only`" condition in decode-matmul-ewise fusion) when dlight and ParamManager get more mature.