### PR TITLE
Minor bug fix and reorganization on ChatModule embed separation

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import tvm
@@ -623,7 +623,7 @@ def create_embed_func(
         bb.emit_func_output(gv, params)
 
     mod = bb.get()
-    gv = mod.get_global_var("embed")
+    gv = mod.get_global_var(func_name)
     bb.update_func(gv, mod[gv].with_attr("num_input", 1))
 
 


### PR DESCRIPTION
This PR fixes a bug in ChatModule embedding separation. Besides, this PR also reorganizes the logic a bit, including:

* extracts some common code for share by "PrefillStep" and "EmbedStep",
* defines `embed_total_time` for embedding time accumulation,
* renames two "Forward" functions to "ForwardTokens" and "ForwardEmbeddings" respectively.

With this PR, Vicuna-v1-7B performance is validated on q3f16_0.