### PR TITLE
Add support for WizardLM

### DIFF
--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -296,20 +296,21 @@ Conversation CodeGPT() {
 }
 
 Conversation WizardLM() {
+  // 7B version; does not support multi-round; similar to ConvOneShot
   Conversation conv;
   conv.name = "wizardlm";
-  conv.system = "{instruction}\n\n### Response:" ;
-  conv.roles = {"USER", "ASSISTANT"};
+  conv.system = "";
+  conv.roles = {"User", "Response"};
   conv.messages = {};
   conv.offset = 0;
   conv.separator_style = SeparatorStyle::kSepRoleMsg;
-  conv.seps = {"\n", "</s>"};
+  conv.seps = {"###"};
   conv.role_msg_sep = ": ";
   conv.role_empty_sep = ":";
   // TODO(mlc-team): add eos to mlc-chat-config
   // and remove eos from stop token setting.
   conv.stop_tokens = {2};
-  conv.stop_str = "</s>";
+  conv.stop_str = "###";
   conv.add_bos = true;
   return conv;
 }

--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -295,6 +295,25 @@ Conversation CodeGPT() {
   return conv;
 }
 
+Conversation WizardLM() {
+  Conversation conv;
+  conv.name = "wizardlm";
+  conv.system = "{instruction}\n\n### Response:" ;
+  conv.roles = {"USER", "ASSISTANT"};
+  conv.messages = {};
+  conv.offset = 0;
+  conv.separator_style = SeparatorStyle::kSepRoleMsg;
+  conv.seps = {"\n", "</s>"};
+  conv.role_msg_sep = ": ";
+  conv.role_empty_sep = ":";
+  // TODO(mlc-team): add eos to mlc-chat-config
+  // and remove eos from stop token setting.
+  conv.stop_tokens = {2};
+  conv.stop_str = "</s>";
+  conv.add_bos = true;
+  return conv;
+}
+
 }  // namespace
 
 using ConvFactory = Conversation (*)();
@@ -312,6 +331,7 @@ Conversation Conversation::FromTemplate(const std::string& name) {
       {"moss", MOSS},
       {"LM", VanillaLM},
       {"code_gpt", CodeGPT},
+      {"wizardlm", WizardLM},
   };
   auto it = factory.find(name);
   if (it == factory.end()) {

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -775,6 +775,7 @@ def get_model(args, hf_config):
         or model_name.startswith("llama-")
         or model_name.startswith("open_llama")
         or model_name.startswith("gorilla-")
+        or model_name.startswith("wizardlm-")
     ):
         config = LlamaConfig(**hf_config, dtype=dtype)
         if max_seq_len != -1:

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -82,6 +82,7 @@ def argparse_postproc_common(args: argparse.Namespace) -> None:
         "gorilla-": ("gorilla", "llama"),
         "starcoder": ("code_gpt", "gpt_bigcode"),
         "wizardcoder-": ("code_gpt", "gpt_bigcode"),
+        "wizardlm-": ("wizardlm", "llama"),
     }
     model = args.model.lower()
     for prefix, (conv_template, model_category) in supported_model_prefix.items():


### PR DESCRIPTION
This PR adds support for [WizardLM](https://github.com/nlpxucan/WizardLM). 

Step 1: Download relevant files
```
# Go to the corresponding folder for model weights
cd mlc-llm/dist/models
git lfs install

# Download WizardLM's weight delta
git clone https://huggingface.co/WizardLM/WizardLM-7B-V1.0

# Download WizardLM's repo
git clone https://github.com/nlpxucan/WizardLM.git

# Create a folder to store the resulting weights
mkdir wizardlm-v1-7b

# Make sure we have everything we need (including llama weights)
ls 
>>> WizardLM WizardLM-7B-V1.0 llama-7b-hf wizardlm-v1-7b

# Go into WizardLM's repo
cd WizardLM/WizardLM/src
```

Step 2: Add missing file
Create a document `train.py` in `src`, paste in the following, which can be found in [this repo](https://github.com/artidoro/qlora/blob/main/qlora.py#L363) or [this repo](https://github.com/tatsu-lab/stanford_alpaca/blob/main/train.py):
```
from typing import Dict
import transformers

def smart_tokenizer_and_embedding_resize(
    special_tokens_dict: Dict,
    tokenizer: transformers.PreTrainedTokenizer,
    model: transformers.PreTrainedModel,
):
    """Resize tokenizer and embedding.

    Note: This is the unoptimized version that may make your embedding size not be divisible by 64.
    """
    num_new_tokens = tokenizer.add_special_tokens(special_tokens_dict)
    model.resize_token_embeddings(len(tokenizer))

    if num_new_tokens > 0:
        input_embeddings = model.get_input_embeddings().weight.data
        output_embeddings = model.get_output_embeddings().weight.data

        input_embeddings_avg = input_embeddings[:-num_new_tokens].mean(dim=0, keepdim=True)
        output_embeddings_avg = output_embeddings[:-num_new_tokens].mean(dim=0, keepdim=True)

        input_embeddings[-num_new_tokens:] = input_embeddings_avg
        output_embeddings[-num_new_tokens:] = output_embeddings_avg
```

Step 3: Apply weight delta (there can be various issues in this step, where I will address in a separate comment)
```
cd ..

python src/weight_diff_wizard.py recover --path_raw ../../llama-7b-hf --path_diff ../../WizardLM-7B-V1.0 --path_tuned ../../wizardlm-v1-7b
```

Step 4: Compile model
```
python3 build.py --model wizardlm-v1-7b --target cuda --quantization q4f16_0
```

Step 5: Run CLI (with sample output)
```
./build/mlc_chat_cli --local-id wizardlm-v1-7b-q4f16_0

Use MLC config: "/home/ubuntu/workspace/mlc-llm/dist/wizardlm-v1-7b-q4f16_0/params/mlc-chat-config.json"
Use model weights: "/home/ubuntu/workspace/mlc-llm/dist/wizardlm-v1-7b-q4f16_0/params/ndarray-cache.json"
Use model library: "/home/ubuntu/workspace/mlc-llm/dist/wizardlm-v1-7b-q4f16_0/wizardlm-v1-7b-q4f16_0-cuda.so"
You can use the following special commands:
  /help               print the special commands
  /exit               quit the cli
  /stats              print out the latest stats (token/sec)
  /reset              restart a fresh chat
  /reload [local_id]  reload model `local_id` from disk, or reload the current model if `local_id` is not specified

Loading model...
Loading finished
Running system prompts...
System prompts finished
USER: Tell me a joke
ASSISTANT: Sure, here's one:
Why did the chicken cross the playground?
To get to the other slide, of course!
```
