### PR TITLE
gradio polish and minigpt cli

### DIFF
--- a/build.py
+++ b/build.py
@@ -193,6 +193,7 @@ def validate_config(model_path: str):
             " format instead.".format(model_path)
         )
     if model_path.split("/")[-1].startswith("minigpt"):
+        # minigpt does not contain a config.json file so we skip the check
         return
     config_path = os.path.join(model_path, "config.json")
     assert os.path.exists(

--- a/build.py
+++ b/build.py
@@ -11,7 +11,7 @@ from tvm import relax
 
 import mlc_llm
 from mlc_llm import utils
-from mlc_llm.relax_model import gpt_bigcode, gpt_neox, llama, moss, rwkv
+from mlc_llm.relax_model import gpt_bigcode, gpt_neox, llama, minigpt, moss, rwkv
 
 
 def _parse_args():
@@ -192,6 +192,8 @@ def validate_config(model_path: str):
             " directory (or hf-path) that contains the pre-compiled model in raw HuggingFace"
             " format instead.".format(model_path)
         )
+    if model_path.split("/")[-1].startswith("minigpt"):
+        return
     config_path = os.path.join(model_path, "config.json")
     assert os.path.exists(
         config_path
@@ -282,6 +284,8 @@ def mod_transform_before_build(
             "get_metadata",
             "reset_kv_cache",
         ]
+    elif ARGS.model.startswith("minigpt"):
+        model_names = ["embed"]
     else:
         model_names = [
             "prefill",
@@ -417,39 +421,47 @@ def main():
     )
     ARGS.raw_params_path = os.path.join(ARGS.artifact_path, "raw_params")
     use_cache = ARGS.use_cache and os.path.isfile(cache_path)
-    with open(os.path.join(ARGS.model_path, "config.json"), encoding="utf-8") as i_f:
-        config = json.load(i_f)
-        if not use_cache:
-            if ARGS.model_category == "llama":
-                mod, params = llama.get_model(ARGS, config)
-            elif ARGS.model_category == "gpt_neox":
-                mod, params = gpt_neox.get_model(ARGS, config)
-            elif ARGS.model_category == "gpt_bigcode":
-                mod, params = gpt_bigcode.get_model(ARGS, config)
-            elif ARGS.model_category == "moss":
-                mod, params = moss.get_model(ARGS, config)
-            elif ARGS.model_category == "rwkv":
-                mod, params = rwkv.get_model(ARGS, config)
-            else:
-                raise ValueError(f"Model {ARGS.model} not supported")
-            mod = mod_transform_before_build(mod, params, ARGS)
-            with open(cache_path, "wb") as outfile:
-                pickle.dump(mod, outfile)
-            print(f"Save a cached module to {cache_path}.")
+    if ARGS.sep_embed and ARGS.model_category != "llama":
+        raise ValueError(f"separate embedding not supported on {ARGS.model}")
+    if ARGS.model_category != "minigpt":
+        with open(
+            os.path.join(ARGS.model_path, "config.json"), encoding="utf-8"
+        ) as i_f:
+            config = json.load(i_f)
+    if not use_cache:
+        if ARGS.model_category == "llama":
+            mod, params = llama.get_model(ARGS, config)
+        elif ARGS.model_category == "gpt_neox":
+            mod, params = gpt_neox.get_model(ARGS, config)
+        elif ARGS.model_category == "gpt_bigcode":
+            mod, params = gpt_bigcode.get_model(ARGS, config)
+        elif ARGS.model_category == "minigpt":
+            mod, params = minigpt.get_model(ARGS)
+        elif ARGS.model_category == "moss":
+            mod, params = moss.get_model(ARGS, config)
+        elif ARGS.model_category == "rwkv":
+            mod, params = rwkv.get_model(ARGS, config)
+        else:
+            raise ValueError(f"Model {ARGS.model} not supported")
+        mod = mod_transform_before_build(mod, params, ARGS)
+        with open(cache_path, "wb") as outfile:
+            pickle.dump(mod, outfile)
+        print(f"Save a cached module to {cache_path}.")
+        if ARGS.model_category != "minigpt":
             utils.copy_tokenizer(ARGS)
-        else:
-            print(
-                f"Load cached module from {cache_path} and skip tracing. "
-                "You can use --use-cache=0 to retrace"
-            )
-            with open(cache_path, "rb") as pkl:
-                mod = pickle.load(pkl)
-        dump_split_tir(mod, ARGS)
-        if not ARGS.reuse_lib:
-            build(mod, ARGS)
-        else:
-            print("Reuse existing prebuilt lib {ARGS.reuse_lib}...")
-        dump_default_mlc_chat_config(ARGS)
+    else:
+        print(
+            f"Load cached module from {cache_path} and skip tracing. "
+            "You can use --use-cache=0 to retrace"
+        )
+        with open(cache_path, "rb") as pkl:
+            mod = pickle.load(pkl)
+    dump_split_tir(mod, ARGS)
+    if not ARGS.reuse_lib:
+        build(mod, ARGS)
+    else:
+        print("Reuse existing prebuilt lib {ARGS.reuse_lib}...")
+    dump_default_mlc_chat_config(ARGS)
 
 
 if __name__ == "__main__":

--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -242,6 +242,27 @@ Conversation StableLM() {
   return conv;
 }
 
+Conversation MiniGPT() {
+  Conversation conv;
+  conv.name = "minigpt";
+  conv.system =
+      ("Give the following image: <Img>ImageContent</Img>. "
+       "You will be able to see the image once I provide it to you. Please answer my questions.");
+  conv.roles = {"Human", "Assistant"};
+  conv.messages = {};
+  conv.offset = 0;
+  conv.separator_style = SeparatorStyle::kSepRoleMsg;
+  conv.seps = {"###"};
+  conv.role_msg_sep = ": ";
+  conv.role_empty_sep = ":";
+  // TODO(mlc-team): add eos to mlc-chat-config
+  // and remove eos from stop token setting.
+  conv.stop_tokens = {835, 2277, 29937};
+  conv.stop_str = "</s>";
+  conv.add_bos = true;
+  return conv;
+}
+
 Conversation MOSS() {
   Conversation conv;
   conv.name = "moss";
@@ -331,6 +352,7 @@ Conversation Conversation::FromTemplate(const std::string& name) {
       {"dolly", Dolly},
       {"oasst", Oasst},
       {"stablelm", StableLM},
+      {"minigpt", MiniGPT},
       {"moss", MOSS},
       {"LM", VanillaLM},
       {"code_gpt", CodeGPT},

--- a/cpp/conversation.h
+++ b/cpp/conversation.h
@@ -24,7 +24,7 @@ enum class SeparatorStyle {
 enum class PlaceInPrompt : int {
   /*! \brief The input message should have role and/or sep appended at both the beginning and in the
    * end. */
-  kWhole,
+  kAll,
   /*! \brief The input message is only the beginning part of a prompt, no role and sep should be
      appended in the end. */
   kBegin,
@@ -160,7 +160,7 @@ class Conversation {
    * \param place_in_prompt The place of the input message in the prompt.
    * \return A vector of strings storing the prompt array.
    */
-  std::vector<std::string> GetPromptArray(PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
+  std::vector<std::string> GetPromptArray(PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
     return GetPromptArrayInternal(0, place_in_prompt);
   }
 
@@ -170,7 +170,7 @@ class Conversation {
    * \param place_in_prompt The place of the input message in the prompt.
    */
   std::vector<std::string> GetPromptArrayLastRound(
-      PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
+      PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
     ICHECK_GE(this->messages.size(), 2);
     return GetPromptArrayInternal(this->messages.size() - 2, place_in_prompt);
   }
@@ -204,15 +204,14 @@ class Conversation {
   std::vector<std::string> GetPromptArrayInternal(
       std::string system_prefix, size_t start_pos, std::string role_msg_sep,
       std::string role_empty_sep, FProcMessage fproc_message,
-      PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) const {
+      PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) const {
     std::vector<std::string> ret;
     ret.reserve(messages.size() - start_pos + 1);
     if (start_pos == 0) {
       if (system_prefix.length() != 0) {
         ret.push_back(system_prefix);
       }
-    } else if (place_in_prompt == PlaceInPrompt::kBegin ||
-               place_in_prompt == PlaceInPrompt::kWhole) {
+    } else if (place_in_prompt == PlaceInPrompt::kBegin || place_in_prompt == PlaceInPrompt::kAll) {
       // need to add a sep of last response
       // which was not added in the processing step.
       ret.push_back(this->seps[1 % this->seps.size()]);
@@ -242,7 +241,7 @@ class Conversation {
       } else {
         ICHECK(item.size() == 1);
         if (!(i == this->messages.size() - 1) || place_in_prompt == PlaceInPrompt::kEnd ||
-            place_in_prompt == PlaceInPrompt::kWhole) {
+            place_in_prompt == PlaceInPrompt::kAll) {
           ret.push_back(role + role_empty_sep);
         }
       }
@@ -254,7 +253,7 @@ class Conversation {
    * \param place_in_prompt The place of the input message in the prompt.
    */
   std::vector<std::string> GetPromptArrayInternal(
-      size_t start_pos, PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
+      size_t start_pos, PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
     if (this->separator_style == SeparatorStyle::kSepRoleMsg) {
       std::string system_prefix;
       if (!this->system.empty()) {

--- a/cpp/conversation.h
+++ b/cpp/conversation.h
@@ -21,6 +21,16 @@ enum class SeparatorStyle {
   kLM,
 };
 
+/*! \brief The place of an input message in a prompt, at the beginning / in the middle / in the end
+ * or as a whole.
+ */
+enum PlaceInPrompt {
+  Whole = 0,
+  Begin = 1,
+  Middle = 2,
+  End = 3,
+};
+
 /*!
  * \brief helper class to keep track of conversation.
  */
@@ -142,17 +152,21 @@ class Conversation {
 
   /*!
    * \brief Get the entire prompt array
+   * \param place_in_prompt The place of the input message in the prompt.
    * \return A vector of strings storing the prompt array.
    */
-  std::vector<std::string> GetPromptArray() { return GetPromptArrayInternal(0); }
+  std::vector<std::string> GetPromptArray(PlaceInPrompt place_in_prompt = Whole) {
+    return GetPromptArrayInternal(0, place_in_prompt);
+  }
 
   /**
    * \brief Get prompt array for the last round.
    * The last round conversation is usually unprocessed by LM
+   * \param place_in_prompt The place of the input message in the prompt.
    */
-  std::vector<std::string> GetPromptArrayLastRound() {
+  std::vector<std::string> GetPromptArrayLastRound(PlaceInPrompt place_in_prompt = Whole) {
     ICHECK_GE(this->messages.size(), 2);
-    return GetPromptArrayInternal(this->messages.size() - 2);
+    return GetPromptArrayInternal(this->messages.size() - 2, place_in_prompt);
   }
 
   void AppendMessage(std::string role, std::string message) {
@@ -178,19 +192,21 @@ class Conversation {
    * \param start_pos The start message position.
    * \param role_msg_sep The separator between role and message.
    * \param role_empty_sep The separator to appending to role when we do not yet have a message.
+   * \param place_in_prompt The place of the input message in the prompt.
    */
   template <typename FProcMessage>
   std::vector<std::string> GetPromptArrayInternal(std::string system_prefix, size_t start_pos,
                                                   std::string role_msg_sep,
                                                   std::string role_empty_sep,
-                                                  FProcMessage fproc_message) const {
+                                                  FProcMessage fproc_message,
+                                                  PlaceInPrompt place_in_prompt = Whole) const {
     std::vector<std::string> ret;
     ret.reserve(messages.size() - start_pos + 1);
     if (start_pos == 0) {
       if (system_prefix.length() != 0) {
         ret.push_back(system_prefix);
       }
-    } else {
+    } else if (place_in_prompt == Begin || place_in_prompt == Whole) {
       // need to add a sep of last response
       // which was not added in the processing step.
       ret.push_back(this->seps[1 % this->seps.size()]);
@@ -199,21 +215,38 @@ class Conversation {
     ICHECK_EQ(start_pos % 2, 0);
     for (size_t i = start_pos; i < this->messages.size(); ++i) {
       const auto& item = this->messages[i];
-      // seps[0]  or seps[1] depending on current location.
+      // seps[0] or seps[1] depending on current location.
       const auto& end_sep = this->seps[i % this->seps.size()];
       const auto& role = item[0];
       if (item.size() == 2) {
         const std::string message = fproc_message(item[1]);
-        ret.push_back(role + role_msg_sep + message + end_sep);
+        if (i == this->messages.size() - 2 && i == start_pos && place_in_prompt == Middle) {
+          ret.push_back(message);
+        } else if (i == this->messages.size() - 2 &&
+                   (place_in_prompt == Begin || place_in_prompt == Middle)) {
+          ret.push_back(role + role_msg_sep + message);
+        } else if (i == start_pos && (place_in_prompt == End || place_in_prompt == Middle)) {
+          ret.push_back(message + end_sep);
+        } else {
+          ret.push_back(role + role_msg_sep + message + end_sep);
+        }
+
       } else {
         ICHECK(item.size() == 1);
-        ret.push_back(role + role_empty_sep);
+        if (!(i == this->messages.size() - 1) || place_in_prompt == End ||
+            place_in_prompt == Whole) {
+          ret.push_back(role + role_empty_sep);
+        }
       }
     }
     return ret;
   }
-  // dispatcher based on separator style
-  std::vector<std::string> GetPromptArrayInternal(size_t start_pos) {
+  /**
+   * \brief dispatcher based on separator style
+   * \param place_in_prompt The place of the input message in the prompt.
+   */
+  std::vector<std::string> GetPromptArrayInternal(size_t start_pos,
+                                                  PlaceInPrompt place_in_prompt = Whole) {
     if (this->separator_style == SeparatorStyle::kSepRoleMsg) {
       std::string system_prefix;
       if (!this->system.empty()) {
@@ -224,7 +257,8 @@ class Conversation {
           /* start_pos= */ start_pos,
           /* role_msg_sep= */ role_msg_sep,
           /* role_empty_sep= */ role_empty_sep,
-          /* fproc_message= */ Identity);
+          /* fproc_message= */ Identity,
+          /* place_in_prompt= */ place_in_prompt);
     } else {
       ICHECK(this->separator_style == SeparatorStyle::kLM) << "Unsupported separator_style";
       // special handle LM, LM mode have no memory

--- a/cpp/conversation.h
+++ b/cpp/conversation.h
@@ -22,17 +22,18 @@ enum class SeparatorStyle {
 };
 
 enum class PlaceInPrompt : int {
-  /*! \brief The input message should have role and/or sep appended at both the beginning and in the
-   * end. */
+  /*! \brief The input message should have role names and corresponding seperators appended both
+     prior to it and after it, making it a complete prompt. */
   kAll,
-  /*! \brief The input message is only the beginning part of a prompt, no role and sep should be
-     appended in the end. */
+  /*! \brief The input message is only the beginning part of a prompt, no role name and separator
+     should be appended after the message since there will be future messages appended after the
+     message. */
   kBegin,
   /*! \brief The input message is in the middle of a prompt, nothing should be appended before or
      after the message. */
   kMiddle,
-  /*! \brief The input message is the ending part of a prompt, no role and sep should be appended
-     before that. */
+  /*! \brief The input message is the ending part of a prompt, no role name and separator should be
+     appended prior to it since the message is concatenated to some prior messages. */
   kEnd,
 };
 

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -399,7 +399,7 @@ class LLMChat {
    * \brief Get input tokens based on history
    * \param place_in_prompt The place of the input message in the prompt.
    */
-  std::vector<int32_t> GetInputTokens(PlaceInPrompt place_in_prompt = Whole) {
+  std::vector<int32_t> GetInputTokens(PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
     std::vector<int32_t> tokens;
     std::vector<std::string> prompts;
 
@@ -492,8 +492,9 @@ class LLMChat {
     return std::string(Downcast<String>(ret));
   }
 
-  std::vector<int32_t> PrepareBeforeEmbedding(std::string inp, bool append_conversation = true,
-                                              PlaceInPrompt place_in_prompt = Whole) {
+  std::vector<int32_t> PrepareBeforeEmbedding(
+      std::string inp, bool append_conversation = true,
+      PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
     if (conversation_.name == "LM") {
       this->ResetChat();
     }
@@ -516,7 +517,7 @@ class LLMChat {
    * \brief Given the text input, generate the embedding of the tokenized prompt.
    */
   NDArray EmbedStep(std::string inp, bool append_conversation = true,
-                    PlaceInPrompt place_in_prompt = Whole) {
+                    PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
     std::vector<int32_t> prompt_tokens =
         PrepareBeforeEmbedding(inp, append_conversation, place_in_prompt);
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
@@ -572,7 +573,7 @@ class LLMChat {
    * \brief Generate the next token given a prompt. Can optionally decode the output next token.
    */
   void PrefillStep(std::string inp, bool append_conversation = true, bool decode_next_token = true,
-                   PlaceInPrompt place_in_prompt = Whole) {
+                   PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
     if (embed_func_.defined() && prefill_with_embed_func_.defined()) {
       // Temporarily placed inside `PrefillStep` for compatibility in transition.
       // Will be separated out in the future.

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -399,7 +399,7 @@ class LLMChat {
    * \brief Get input tokens based on history
    * \param place_in_prompt The place of the input message in the prompt.
    */
-  std::vector<int32_t> GetInputTokens(PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
+  std::vector<int32_t> GetInputTokens(PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
     std::vector<int32_t> tokens;
     std::vector<std::string> prompts;
 
@@ -492,9 +492,8 @@ class LLMChat {
     return std::string(Downcast<String>(ret));
   }
 
-  std::vector<int32_t> PrepareBeforeEmbedding(
-      std::string inp, bool append_conversation = true,
-      PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
+  std::vector<int32_t> PrepareBeforeEmbedding(std::string inp, bool append_conversation = true,
+                                              PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
     if (conversation_.name == "LM") {
       this->ResetChat();
     }
@@ -517,7 +516,7 @@ class LLMChat {
    * \brief Given the text input, generate the embedding of the tokenized prompt.
    */
   NDArray EmbedStep(std::string inp, bool append_conversation = true,
-                    PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
+                    PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
     std::vector<int32_t> prompt_tokens =
         PrepareBeforeEmbedding(inp, append_conversation, place_in_prompt);
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
@@ -573,7 +572,7 @@ class LLMChat {
    * \brief Generate the next token given a prompt. Can optionally decode the output next token.
    */
   void PrefillStep(std::string inp, bool append_conversation = true, bool decode_next_token = true,
-                   PlaceInPrompt place_in_prompt = PlaceInPrompt::kWhole) {
+                   PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
     if (embed_func_.defined() && prefill_with_embed_func_.defined()) {
       // Temporarily placed inside `PrefillStep` for compatibility in transition.
       // Will be separated out in the future.

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -208,8 +208,7 @@ class LLMChat {
 
   /*!
    * \brief Load JSON config and override options.
-   * \param config_json A json config in picojson type that is partially specifies
-   *        some of the options.
+   * \param config_str A json config string that partially specifies some of the options.
    * \param partial_update Whether it's a partial update or full update, if set to true,
    *        we perform a partial update on some of the provided options; if set to false, all
    *        options must be provided.
@@ -514,6 +513,10 @@ class LLMChat {
 
   /*!
    * \brief Given the text input, generate the embedding of the tokenized prompt.
+   * \param inp The input text string.
+   * \param append_conversation Whether to append the input message to conversation.
+   * \param place_in_prompt The place of the input message in the prompt.
+   * \return the embedding of the tokenized prompt.
    */
   NDArray EmbedStep(std::string inp, bool append_conversation = true,
                     PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
@@ -539,6 +542,8 @@ class LLMChat {
 
   /*!
    * \brief Prefill given embeddings. Can optionally decode the output next token.
+   * \param embedding The embedding to prefill with.
+   * \param decode_next_token Whether to decode next token.
    */
   void PrefillWithEmbedStep(NDArray embedding, bool decode_next_token = true) {
     if (embedding.Shape().size() == 0) {
@@ -570,6 +575,10 @@ class LLMChat {
 
   /*!
    * \brief Generate the next token given a prompt. Can optionally decode the output next token.
+   * \param inp The input text string.
+   * \param append_conversation Whether to append the input message to conversation.
+   * \param decode_next_token Whether to decode next token.
+   * \param place_in_prompt The place of the input message in the prompt.
    */
   void PrefillStep(std::string inp, bool append_conversation = true, bool decode_next_token = true,
                    PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {

--- a/mlc_llm/dispatch/dispatch_tir_operator.py
+++ b/mlc_llm/dispatch/dispatch_tir_operator.py
@@ -16,6 +16,9 @@ class DispatchTIROperator:  # pylint: disable=too-few-public-methods
         elif model == "gpt_bigcode":
             lookup = None
 
+        elif model == "minigpt":
+            lookup = None
+
         elif model == "rwkv":
             lookup = None
 

--- a/mlc_llm/relax_model/minigpt.py
+++ b/mlc_llm/relax_model/minigpt.py
@@ -1,0 +1,592 @@
+import math
+import os
+from dataclasses import dataclass
+
+import torch
+import tvm
+from tvm import relax
+from tvm.relax.testing import nn
+
+
+@dataclass
+class MiniGPTConfig:
+    dtype: str = "float16"
+    image_size: int = 224
+    num_query_token: int = 32
+    max_txt_len: int = 160
+    vocab_size: int = 32000
+    patch_size: int = 14
+    word_embed: int = 768
+    visual_encoder_embed_dim: int = 1408
+    visual_encoder_attn_heads: int = 16
+    visual_encoder_attn_hidden_dim: int = 257
+    visual_encoder_fc_hidden_dim: int = 6144
+    visual_encoder_num_blocks: int = 39
+    bert_hidden_layers: int = 12
+    bert_num_attn_heads: int = 12
+    bert_attn_head_size: int = 64
+    bert_interm_query: int = 3072
+    llama_proj_size: int = 4096
+
+
+MODEL_CONFIG = {
+    "minigpt4-7b": {},
+}
+
+
+class MiniGPTPatchEmbed(nn.Module):
+    def __init__(
+        self, image_size, patch_size, embed_dim, dtype: str, in_chans=3, bias=True
+    ):
+        self.strides = (patch_size, patch_size)
+        self.embed_dim = embed_dim
+        self.out_shape = image_size // patch_size
+
+        bs = 1
+        self.cls_token = nn.Parameter((bs, 1, embed_dim), dtype=dtype, name="cls_token")
+        self.pos_embed = nn.Parameter(
+            (1, self.out_shape * self.out_shape + 1, embed_dim),
+            dtype=dtype,
+            name="pos_embed",
+        )
+        self.weight = nn.Parameter(
+            (embed_dim, in_chans, patch_size, patch_size),
+            dtype=dtype,
+            name="patch_embed_weight",
+        )
+        if bias:
+            self.bias = nn.Parameter((embed_dim,), dtype=dtype, name="patch_embed_bias")
+        else:
+            self.bias = None
+
+    def forward(self, input: relax.Expr) -> relax.Var:
+        bs = input.struct_info.shape[0]
+        x = nn.emit(relax.op.nn.conv2d(input, self.weight, self.strides))
+        if self.bias:
+            bias = relax.op.reshape(self.bias, [1, self.embed_dim, 1, 1])
+            x = relax.op.add(x, bias)
+        x = relax.op.reshape(x, (bs, self.embed_dim, self.out_shape * self.out_shape))
+        x = relax.op.permute_dims(x, [0, 2, 1])
+        # concatenate with cls_tokens
+        x_concat = relax.op.concat([self.cls_token, x], axis=1)
+        # add with pos_embed
+        res = relax.op.add(x_concat, self.pos_embed)
+        return res
+
+
+class MiniGPTVisualEncoderAttention(nn.Module):
+    def __init__(self, config: MiniGPTConfig):
+        self.embed_dim = config.visual_encoder_embed_dim
+        self.num_heads = config.visual_encoder_attn_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        self.scale = self.head_dim ** (-0.5)
+        self.dtype = config.dtype
+        self.N = config.visual_encoder_attn_hidden_dim
+
+        self.q_bias = nn.Parameter((self.embed_dim,), dtype=self.dtype, name="q_bias")
+        self.v_bias = nn.Parameter((self.embed_dim,), dtype=self.dtype, name="v_bias")
+        self.qkv_weight = nn.Parameter(
+            (self.embed_dim * 3, self.embed_dim), dtype=self.dtype, name="qkv_weight"
+        )
+        self.proj_weight = nn.Parameter(
+            (self.embed_dim, self.embed_dim), dtype=self.dtype, name="proj_weight"
+        )
+        self.proj_bias = nn.Parameter(
+            (self.embed_dim,), dtype=self.dtype, name="proj_bias"
+        )
+
+    def forward(self, input: relax.Expr):
+        from tvm.relax.op import (
+            concat,
+            linear,
+            matmul,
+            permute_dims,
+            reshape,
+            squeeze,
+            strided_slice,
+            zeros,
+        )
+
+        bs = 1
+        k_bias = zeros((self.embed_dim,), self.dtype)
+        qkv_bias = concat([self.q_bias, k_bias, self.v_bias], axis=0)
+        x = linear(input, self.qkv_weight, qkv_bias)
+        x = reshape(x, (bs, self.N, 3, self.num_heads, self.head_dim))
+        x = permute_dims(x, [2, 0, 3, 1, 4])
+        q = squeeze(strided_slice(x, axes=[0], begin=[0], end=[1]), [0])
+        k = squeeze(strided_slice(x, axes=[0], begin=[1], end=[2]), [0])
+        v = squeeze(strided_slice(x, axes=[0], begin=[2], end=[3]), [0])
+        q = q * relax.const(self.scale, self.dtype)
+        attn = matmul(q, permute_dims(k, [0, 1, 3, 2]))
+        attn = relax.op.nn.softmax(attn, -1)
+        res = permute_dims(matmul(attn, v), [0, 2, 1, 3])
+        res = reshape(res, (bs, self.N, self.embed_dim))
+        res = linear(res, self.proj_weight, self.proj_bias)
+        return res
+
+
+class MiniGPTMLP(nn.Module):
+    def __init__(self, config: MiniGPTConfig):
+        self.hidden_dim = config.visual_encoder_fc_hidden_dim
+        self.embed_dim = config.visual_encoder_embed_dim
+        self.dtype = config.dtype
+
+        self.fc1_weight = nn.Parameter(
+            (self.hidden_dim, self.embed_dim), dtype=self.dtype, name="fc1_weight"
+        )
+        self.fc1_bias = nn.Parameter(
+            (self.hidden_dim,), dtype=self.dtype, name="fc1_bias"
+        )
+        self.fc2_weight = nn.Parameter(
+            (self.embed_dim, self.hidden_dim), dtype=self.dtype, name="fc2_weight"
+        )
+        self.fc2_bias = nn.Parameter(
+            (self.embed_dim,), dtype=self.dtype, name="fc2_bias"
+        )
+
+    def forward(self, input: relax.Expr):
+        res = relax.op.linear(input, self.fc1_weight, self.fc1_bias)
+        res = relax.op.nn.gelu(res)
+        res = relax.op.linear(res, self.fc2_weight, self.fc2_bias)
+        return res
+
+
+class MiniGPTVisualEncoderBlock(nn.Module):
+    def __init__(self, config: MiniGPTConfig):
+        embed_dim = config.visual_encoder_embed_dim
+        dtype = config.dtype
+        self.norm1_weight = nn.Parameter((embed_dim,), dtype=dtype, name="norm1_weight")
+        self.norm1_bias = nn.Parameter((embed_dim,), dtype=dtype, name="norm1_bias")
+        self.attn = MiniGPTVisualEncoderAttention(config)
+        self.norm2_weight = nn.Parameter((embed_dim,), dtype=dtype, name="norm2_weight")
+        self.norm2_bias = nn.Parameter((embed_dim,), dtype=dtype, name="norm2_bias")
+        self.mlp = MiniGPTMLP(config)
+
+    def forward(self, input: relax.Expr):
+        x = relax.op.nn.layer_norm(input, self.norm1_weight, self.norm1_bias, axes=[-1])
+        proj = self.attn(x)
+        proj = relax.op.add(input, proj)
+        res = relax.op.nn.layer_norm(
+            proj, self.norm2_weight, self.norm2_bias, axes=[-1]
+        )
+        res = self.mlp(res)
+        res = relax.op.add(proj, res)
+        return res
+
+
+class MiniGPTVisualEncoder(nn.Module):
+    def __init__(self, config: MiniGPTConfig):
+        self.embed_dim = config.visual_encoder_embed_dim
+        self.dtype = config.dtype
+        self.patch_embed = MiniGPTPatchEmbed(
+            config.image_size,
+            config.patch_size,
+            config.visual_encoder_embed_dim,
+            config.dtype,
+        )
+        self.num_blocks = config.visual_encoder_num_blocks
+        self.blocks = [
+            MiniGPTVisualEncoderBlock(config) for _ in range(self.num_blocks)
+        ]
+
+        self.ln_vision_weight = nn.Parameter(
+            (self.embed_dim,), dtype=self.dtype, name="ln_vision_weight"
+        )
+        self.ln_vision_bias = nn.Parameter(
+            (self.embed_dim,), dtype=self.dtype, name="ln_vision_bias"
+        )
+
+    def forward(self, input_image: relax.Expr):
+        res = self.patch_embed(input_image)
+        for block in self.blocks:
+            res = block(res)
+        res = relax.op.nn.layer_norm(
+            res, self.ln_vision_weight, self.ln_vision_bias, axes=[-1]
+        )
+        return res
+
+
+class MiniGPTEmbedding(nn.Module):
+    def __init__(self, config: MiniGPTConfig):
+        self.word_embed = config.word_embed
+        self.dtype = config.dtype
+        self.eps = 1e-12
+
+        self.norm_weight = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="norm_weight"
+        )
+        self.norm_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="norm_bias"
+        )
+
+    def forward(self, embedding: relax.Expr):
+        res = relax.op.nn.layer_norm(
+            embedding, self.norm_weight, self.norm_bias, axes=[-1], epsilon=self.eps
+        )
+        return res
+
+
+class MiniGPTBertAttention(nn.Module):
+    def __init__(self, config: MiniGPTConfig, hidden_dim: int):
+        self.word_embed = config.word_embed
+        self.num_query_token = config.num_query_token
+        self.num_attn_heads = config.bert_num_attn_heads
+        self.attn_head_size = config.bert_attn_head_size
+        self.visual_encoder_attn_hidden_dim = config.visual_encoder_attn_hidden_dim
+        self.dtype = config.dtype
+        self.eps = 1e-12
+
+        self.query_weight = nn.Parameter(
+            (self.word_embed, self.word_embed), dtype=self.dtype, name="query_weight"
+        )
+        self.query_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="query_bias"
+        )
+        self.key_weight = nn.Parameter(
+            (self.word_embed, hidden_dim), dtype=self.dtype, name="key_weight"
+        )
+        self.key_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="key_bias"
+        )
+        self.value_weight = nn.Parameter(
+            (self.word_embed, hidden_dim), dtype=self.dtype, name="value_weight"
+        )
+        self.value_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="value_bias"
+        )
+        self.dense_weight = nn.Parameter(
+            (self.word_embed, self.word_embed), dtype=self.dtype, name="dense_weight"
+        )
+        self.dense_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="dense_bias"
+        )
+        self.norm_weight = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="norm_weight"
+        )
+        self.norm_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="norm_bias"
+        )
+
+    def forward(
+        self,
+        hidden_states: relax.Expr,
+        attention_mask: relax.Expr,
+        encoder_hidden_states=None,
+        encoder_extend_attention_mask=None,
+    ):
+        from tvm.relax.op import add, linear, matmul, permute_dims, reshape
+
+        bs = 1
+        states = (
+            encoder_hidden_states
+            if encoder_hidden_states is not None
+            else hidden_states
+        )
+        mask = (
+            encoder_extend_attention_mask
+            if encoder_extend_attention_mask is not None
+            else attention_mask
+        )
+        hidden_dim = (
+            self.visual_encoder_attn_hidden_dim
+            if encoder_hidden_states is not None
+            else self.num_query_token
+        )
+        key = linear(states, self.key_weight, self.key_bias)
+        value = linear(states, self.value_weight, self.value_bias)
+        key = reshape(key, [bs, hidden_dim, self.num_attn_heads, self.attn_head_size])
+        key = permute_dims(key, [0, 2, 1, 3])
+        value = reshape(
+            value, [bs, hidden_dim, self.num_attn_heads, self.attn_head_size]
+        )
+        value = permute_dims(value, [0, 2, 1, 3])
+        query = linear(hidden_states, self.query_weight, self.query_bias)
+        query = reshape(
+            query, [bs, self.num_query_token, self.num_attn_heads, self.attn_head_size]
+        )
+        query = permute_dims(query, [0, 2, 1, 3])
+        scores = matmul(query, permute_dims(key, [0, 1, 3, 2]))
+        scores = scores / relax.const(math.sqrt(self.attn_head_size), dtype=self.dtype)
+        scores = add(scores, mask)
+        probs = relax.op.nn.softmax(scores, axis=-1)
+        context = matmul(probs, value)
+        context = permute_dims(context, [0, 2, 1, 3])
+        context = reshape(context, [bs, self.num_query_token, self.word_embed])
+        # calculate the output
+        context = linear(context, self.dense_weight, self.dense_bias)
+        context = add(context, hidden_states)
+        res = relax.op.nn.layer_norm(
+            context, self.norm_weight, self.norm_bias, axes=[-1], epsilon=self.eps
+        )
+        return res, key, value
+
+
+class MiniGPTBertLayer(nn.Module):
+    def __init__(self, config: MiniGPTConfig, use_cross_attention=False):
+        self.word_embed = config.word_embed
+        self.embed_dim = config.visual_encoder_embed_dim
+        self.interm_query = config.bert_interm_query
+        self.dtype = config.dtype
+        self.eps = 1e-12
+
+        self.attention = MiniGPTBertAttention(config, self.word_embed)
+        if use_cross_attention:
+            self.cross_attention = MiniGPTBertAttention(config, self.embed_dim)
+        else:
+            self.cross_attention = None
+        self.interm_query_weight = nn.Parameter(
+            (self.interm_query, self.word_embed),
+            dtype=self.dtype,
+            name="interm_query_weight",
+        )
+        self.interm_query_bias = nn.Parameter(
+            (self.interm_query,), dtype=self.dtype, name="interm_query_bias"
+        )
+        self.output_query_weight = nn.Parameter(
+            (self.word_embed, self.interm_query),
+            dtype=self.dtype,
+            name="output_query_weight",
+        )
+        self.output_query_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="output_query_bias"
+        )
+        self.norm_weight = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="norm_weight"
+        )
+        self.norm_bias = nn.Parameter(
+            (self.word_embed,), dtype=self.dtype, name="norm_bias"
+        )
+
+    def forward(
+        self,
+        embedding: relax.Expr,
+        extend_attention_mask: relax.Expr,
+        encoder_hidden_states: relax.Expr,
+        encoder_extend_attention_mask: relax.Expr,
+    ):
+        attn_output, key, value = self.attention(embedding, extend_attention_mask)
+        if self.cross_attention:
+            attn_output, _, _ = self.cross_attention(
+                attn_output,
+                extend_attention_mask,
+                encoder_hidden_states,
+                encoder_extend_attention_mask,
+            )
+        res = relax.op.linear(
+            attn_output, self.interm_query_weight, self.interm_query_bias
+        )
+        res = relax.op.nn.gelu(res)
+        res = relax.op.linear(res, self.output_query_weight, self.output_query_bias)
+        res = relax.op.add(res, attn_output)
+        res = relax.op.nn.layer_norm(
+            res, self.norm_weight, self.norm_bias, axes=[-1], epsilon=self.eps
+        )
+        return res, key, value
+
+
+class MiniGPTQFormer(nn.Module):
+    def __init__(self, config: MiniGPTConfig):
+        self.N = config.visual_encoder_attn_hidden_dim
+        self.num_query_token = config.num_query_token
+        self.word_embed = config.word_embed
+        self.num_layers = config.bert_hidden_layers
+        self.dtype = config.dtype
+
+        bs = 1
+        self.query_tokens = nn.Parameter(
+            (bs, self.num_query_token, self.word_embed),
+            dtype=self.dtype,
+            name="query_tokens",
+        )
+        self.embedding = MiniGPTEmbedding(config)
+        self.bert_layers = [
+            MiniGPTBertLayer(config, i % 2 == 0) for i in range(self.num_layers)
+        ]
+
+    def forward(self, image_embeds: relax.Expr):
+        from tvm.relax.op import expand_dims, ones
+
+        bs = 1
+        image_attns = ones((bs, self.N), self.dtype)
+        embedding = self.embedding(self.query_tokens)
+        attention_mask = ones((bs, self.num_query_token), self.dtype)
+        extend_attention_mask = expand_dims(attention_mask, [1, 2])
+        extend_attention_mask = (
+            relax.const(1.0, self.dtype) - extend_attention_mask
+        ) * relax.const(-10000.0, self.dtype)
+        encoder_extend_attention_mask = expand_dims(image_attns, [1, 2])
+        encoder_extend_attention_mask = (
+            relax.const(1.0, self.dtype) - encoder_extend_attention_mask
+        )
+        for layer in self.bert_layers:
+            embedding, _, _ = layer(
+                embedding,
+                extend_attention_mask,
+                image_embeds,
+                encoder_extend_attention_mask,
+            )
+        return embedding
+
+
+class MiniGPTLLaMAProj(nn.Module):
+    def __init__(self, config: MiniGPTConfig):
+        self.proj_size = config.llama_proj_size
+        self.word_embed = config.word_embed
+        self.dtype = config.dtype
+
+        self.weight = nn.Parameter(
+            (self.proj_size, self.word_embed), dtype=self.dtype, name="weight"
+        )
+        self.bias = nn.Parameter((self.proj_size,), dtype=self.dtype, name="bias")
+
+    def forward(self, embedding: relax.Expr):
+        return relax.op.linear(embedding, self.weight, self.bias)
+
+
+def create_encoding_func(bb: relax.BlockBuilder, config: MiniGPTConfig) -> None:
+    bs, img_chan = 1, 3
+    with bb.function("embed"):
+        visual_encoder = MiniGPTVisualEncoder(config)
+        q_former = MiniGPTQFormer(config)
+        llama_proj = MiniGPTLLaMAProj(config)
+        input_image = nn.Placeholder(
+            (bs, img_chan, config.image_size, config.image_size),
+            dtype=config.dtype,
+            name="input_image",
+        )
+        with bb.dataflow():
+            output = visual_encoder(input_image)
+            output = q_former(output)
+            output = llama_proj(output)
+            params = (
+                [input_image]
+                + visual_encoder.parameters()
+                + q_former.parameters()
+                + llama_proj.parameters()
+            )
+            gv = bb.emit_output(output)
+        bb.emit_func_output(gv, params)
+
+    mod = bb.get()
+    gv = mod.get_global_var("embed")
+    bb.update_func(gv, mod[gv].with_attr("num_input", 1))
+
+
+def get_model(args):
+    model_name = args.model
+    model_path = args.model_path
+
+    if model_name.startswith("minigpt"):
+        config = MiniGPTConfig(**MODEL_CONFIG[model_name])
+        config.dtype = args.quantization.model_dtype
+        # build the relax model
+        bb = relax.BlockBuilder()
+        create_encoding_func(bb, config)
+        mod = bb.get()
+
+        # load visual encoder weights
+        visual_encoder_url = "https://storage.googleapis.com/sfr-vision-language-research/LAVIS/models/BLIP2/eva_vit_g.pth"
+        visual_encoder_cached_file = download_cached_file(
+            visual_encoder_url, check_hash=False, progress=True
+        )
+        visual_encoder_state_dict = torch.load(
+            visual_encoder_cached_file, map_location="cpu"
+        )
+
+        # load QFormer weights
+        q_former_url = "https://storage.googleapis.com/sfr-vision-language-research/LAVIS/models/BLIP2/blip2_pretrained_flant5xxl.pth"
+        q_former_cached_file = download_cached_file(
+            q_former_url, check_hash=False, progress=True
+        )
+        q_former_state_dict = torch.load(q_former_cached_file, map_location="cpu")[
+            "model"
+        ]
+
+        # load llama and llama proj weights
+        if os.path.isdir(model_path):
+            raise ValueError(
+                "MiniGPT model path should be a single file instead of a directory."
+            )
+        llama_state_dict = torch.load(model_path, map_location="cpu")["model"]
+
+        param_list = []
+        device = tvm.cpu()
+        visual_encoder_key_list = list(visual_encoder_state_dict.keys())[
+            : 4 + 13 * config.visual_encoder_num_blocks
+        ]
+        for key in visual_encoder_key_list:
+            param_list.append(
+                tvm.nd.array(
+                    visual_encoder_state_dict[key].numpy().astype(config.dtype), device
+                )
+            )
+        q_former_key_list = (
+            list(q_former_state_dict.keys())[1:3]
+            + [list(q_former_state_dict.keys())[0]]
+            + list(q_former_state_dict.keys())[
+                6 : 8 + (26 + 16) * config.bert_hidden_layers // 2
+            ]
+        )
+        for key in q_former_key_list:
+            param_list.append(
+                tvm.nd.array(
+                    q_former_state_dict[key].numpy().astype(config.dtype), device
+                )
+            )
+        llama_key_list = list(llama_state_dict.keys())[-2:]
+        for key in llama_key_list:
+            param_list.append(
+                tvm.nd.array(llama_state_dict[key].numpy().astype(config.dtype), device)
+            )
+
+        return mod, param_list
+
+    raise ValueError(f"Unsupported model: {model_name}")
+
+
+# helper functions for distributed download of model weights from URL
+# source: https://github.com/Vision-CAIR/MiniGPT-4/blob/main/minigpt4/common/dist_utils.py (originally credit to Salesforce)
+
+import timm.models.hub as timm_hub
+import torch.distributed as dist
+
+
+def is_dist_avail_and_initialized():
+    if not dist.is_available():
+        return False
+    if not dist.is_initialized():
+        return False
+    return True
+
+
+def get_rank():
+    if not is_dist_avail_and_initialized():
+        return 0
+    return dist.get_rank()
+
+
+def is_main_process():
+    return get_rank() == 0
+
+
+def download_cached_file(url, check_hash=True, progress=False):
+    """
+    Download a file from a URL and cache it locally. If the file already exists, it is not downloaded again.
+    If distributed, only the main process downloads the file, and the other processes wait for the file to be downloaded.
+    """
+
+    def get_cached_file_path():
+        # a hack to sync the file path across processes
+        parts = torch.hub.urlparse(url)
+        filename = os.path.basename(parts.path)
+        cached_file = os.path.join(timm_hub.get_cache_dir(), filename)
+
+        return cached_file
+
+    if is_main_process():
+        timm_hub.download_cached_file(url, check_hash, progress)
+
+    if is_dist_avail_and_initialized():
+        dist.barrier()
+
+    return get_cached_file_path()

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -55,7 +55,9 @@ quantization_dict = {
     ),
 }
 
-supported_model_types = set(["llama", "gpt_neox", "gpt_bigcode", "moss", "rwkv"])
+supported_model_types = set(
+    ["llama", "gpt_neox", "gpt_bigcode", "minigpt", "moss", "rwkv"]
+)
 
 
 def argparse_postproc_common(args: argparse.Namespace) -> None:
@@ -76,6 +78,7 @@ def argparse_postproc_common(args: argparse.Namespace) -> None:
         "dolly-": ("dolly", "gpt_neox"),
         "stablelm-": ("stablelm", "gpt_neox"),
         "redpajama-": ("redpajama_chat", "gpt_neox"),
+        "minigpt": ("minigpt", "minigpt"),
         "moss-": ("moss", "moss"),
         "open_llama": ("LM", "llama"),
         "rwkv-": ("rwkv", "rwkv"),

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -15,7 +15,7 @@ class PlaceInPrompt(Enum):
     """The place of an input message in a prompt."""
 
     # The input message should have role and/or sep appended at both the beginning and in the end.
-    Whole = 0
+    All = 0
     # The input message is only the beginning part of a prompt, no role and sep should be appended in the end.
     Begin = 1
     # The input message is in the middle of a prompt, nothing should be appended before or after the message.
@@ -108,7 +108,7 @@ class ChatModule:
         self,
         input: str,
         decode_next_token: bool = True,
-        place_in_prompt: PlaceInPrompt = PlaceInPrompt.Whole,
+        place_in_prompt: PlaceInPrompt = PlaceInPrompt.All,
     ):
         r"""Run prefill stage for a given input and optionally decode the first output token.
         User can decide where to place the input in the prompt.
@@ -127,7 +127,7 @@ class ChatModule:
     def embed(
         self,
         input: str,
-        place_in_prompt: PlaceInPrompt = PlaceInPrompt.Whole,
+        place_in_prompt: PlaceInPrompt = PlaceInPrompt.All,
     ):
         r"""Given a text input, get the embedding of the tokenized prompt.
         User can decide where to place the input in the prompt.

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -1,13 +1,24 @@
 """Python runtime for MLC chat."""
-#! pylint: disable=unused-import
+#! pylint: disable=unused-import, invalid-name
 import ctypes
 import os
 import sys
+from enum import Enum
 
 import tvm
 import tvm._ffi.base
 
 from . import libinfo
+
+
+class PlaceInPrompt(Enum):
+    """The place of an input message in a prompt, at the beginning / in the middle / in the end
+    or as a whole."""
+
+    Whole = 0
+    Begin = 1
+    Middle = 2
+    End = 3
 
 
 def _load_mlc_llm_lib():
@@ -28,6 +39,7 @@ def quantization_keys():
     return [
         "q3f16_0",
         "q4f16_0",
+        "q4f16_1",
         "q4f32_0",
         "q8f16_0",
         "q8f32_0",
@@ -70,11 +82,12 @@ class ChatModule:
         self.reset_chat_func = chat_mod["reset_chat"]
         self.runtime_stats_text_func = chat_mod["runtime_stats_text"]
         self.reset_runtime_stats_func = chat_mod["reset_runtime_stats"]
+        self.process_system_prompts_func = chat_mod["process_system_prompts"]
         self.evaluate_func = chat_mod["evaluate"]
         self.get_role0 = chat_mod["get_role0"]
         self.get_role1 = chat_mod["get_role1"]
 
-    def reload(self, lib: str, model_path: str):
+    def reload(self, lib: str, model_path: str, app_config_json: str = ""):
         r"""Reload the chat module from the given library and model path.
 
         Parameters
@@ -83,38 +96,61 @@ class ChatModule:
             The library path.
         model_path : str
             The model path.
+        app_config_json: str
+            The partial config that is used to partially override the model configuration.
         """
-        self.reload_func(lib, model_path)
+        self.reload_func(lib, model_path, app_config_json)
 
-    def prefill(self, input: str):
-        r"""Run prefill stage for a given input and decode the first output token.
+    def prefill(
+        self,
+        input: str,
+        decode_next_token: bool = True,
+        place_in_prompt: PlaceInPrompt = PlaceInPrompt.Whole,
+    ):
+        r"""Run prefill stage for a given input and optionally decode the first output token.
+        User can decide where to place the input in the prompt.
 
         Parameters
         ----------
         input : str
             The user input string.
+        decode_next_token : bool
+            Whether to decode the next token after prefilling.
+        place_in_prompt: PlaceInPrompt
+            The place of the input message in the prompt.
         """
-        self.prefill_func(input)
+        self.prefill_func(input, decode_next_token, place_in_prompt.value)
 
-    def embed(self, input: str):
+    def embed(
+        self,
+        input: str,
+        place_in_prompt: PlaceInPrompt = PlaceInPrompt.Whole,
+    ):
         r"""Given a text input, get the embedding of the tokenized prompt.
+        User can decide where to place the input in the prompt.
 
         Parameters
         ----------
         input : str
             The user input string.
+        place_in_prompt: PlaceInPrompt
+            The place of the input message in the prompt.
         """
-        return self.embed_func(input)
+        return self.embed_func(input, place_in_prompt.value)
 
-    def prefill_with_embed(self, embedding: tvm.runtime.NDArray):
-        r"""Given an embedding, run the prefill stage and decode the first output token.
+    def prefill_with_embed(
+        self, embedding: tvm.runtime.NDArray, decode_next_token: bool = True
+    ):
+        r"""Given an embedding, run the prefill stage and optionally decode the first output token.
 
         Parameters
         ----------
         embedding : tvm.runtime.NDArray
             The embedding of user input.
+        decode_next_token : bool
+            Whether to decode the next token after prefilling.
         """
-        self.prefill_with_embed_func(embedding)
+        self.prefill_with_embed_func(embedding, decode_next_token)
 
     def decode(self):
         r"""Decode the next token, the decoding result is stored in a buffer and
@@ -168,6 +204,10 @@ class ChatModule:
     def reset_runtime_stats(self):
         r"""Reset the runtime stats."""
         self.reset_runtime_stats_func()
+
+    def process_system_prompts(self):
+        r"""Pre-process by prefilling the system prompts, running prior to any user input."""
+        self.process_system_prompts_func()
 
     def evaluate(self):
         self.evaluate_func()

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -12,12 +12,15 @@ from . import libinfo
 
 
 class PlaceInPrompt(Enum):
-    """The place of an input message in a prompt, at the beginning / in the middle / in the end
-    or as a whole."""
+    """The place of an input message in a prompt."""
 
+    # The input message should have role and/or sep appended at both the beginning and in the end.
     Whole = 0
+    # The input message is only the beginning part of a prompt, no role and sep should be appended in the end.
     Begin = 1
+    # The input message is in the middle of a prompt, nothing should be appended before or after the message.
     Middle = 2
+    # The input message is the ending part of a prompt, no role and sep should be appended before that.
     End = 3
 
 

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -14,13 +14,16 @@ from . import libinfo
 class PlaceInPrompt(Enum):
     """The place of an input message in a prompt."""
 
-    # The input message should have role and/or sep appended at both the beginning and in the end.
+    # The input message should have role names and corresponding seperators appended both prior to it and after it,
+    # making it a complete prompt.
     All = 0
-    # The input message is only the beginning part of a prompt, no role and sep should be appended in the end.
+    # The input message is only the beginning part of a prompt, no role name and separator should be appended after
+    # the message since there will be future messages appended after the message.
     Begin = 1
     # The input message is in the middle of a prompt, nothing should be appended before or after the message.
     Middle = 2
-    # The input message is the ending part of a prompt, no role and sep should be appended before that.
+    # The input message is the ending part of a prompt, no role name and separator should be appended prior to it
+    # since the message is concatenated to some prior messages.
     End = 3
 
 

--- a/python/mlc_chat/gradio.py
+++ b/python/mlc_chat/gradio.py
@@ -1,16 +1,16 @@
 """Gradio interface for MLC Chat."""
 
-
 import argparse
 import glob
 import os
 
 import gradio as gr
+import numpy as np
 import tvm
 
-from .chat_module import ChatModule
+from .chat_module import ChatModule, PlaceInPrompt
 
-model_local_ids = []
+# pylint-disable=import-error, import-outside-toplevel, invalid-name
 
 
 def _parse_args():
@@ -28,73 +28,179 @@ def _parse_args():
     return parsed
 
 
-def _check_model_dir(dir):
-    if not os.path.isdir(dir):
-        return False
-    params_exists, model_exists = False, False
-    for path in glob.glob(os.path.join(dir, "*")):
-        local_id = dir.split("/")[-1]
-        if path.split("/")[-1] == "params":
-            params_exists = True
-        if path.split("/")[-1].startswith(local_id):
-            model_exists = True
-    return params_exists and model_exists
-
-
-def get_local_ids(artifact_path):
-    for path in glob.glob(os.path.join(artifact_path, "*")):
-        if _check_model_dir(path):
-            local_id = path.split("/")[-1]
-            model_local_ids.append(local_id)
+llm_local_ids = []
+image_model_local_ids = []
 
 
 class GradioChatModule(ChatModule):
-    def __init__(self, ARGS):
-        super().__init__(ARGS.device_name, ARGS.device_id)
-        self.artifact_path = ARGS.artifact_path
-        self.device_name = ARGS.device_name
+    """The main Gradio chat module supporting a variety of functionalities such as model reloading, chatting etc."""
 
-    def reload_model(self, model_name, text_input, chat_state, img_list):
-        model_lib, model_dir = None, os.path.join(self.artifact_path, model_name)
-        for path in glob.glob(os.path.join(model_dir, "*")):
-            if path.split("/")[-1].startswith(model_name + "-" + self.device_name):
-                model_lib = path
-                break
-        assert model_lib is not None
-        lib = tvm.runtime.load_module(model_lib)
-        assert lib is not None
-        chat_mod.reload_func(lib, os.path.join(model_dir, "params"))
-        self.reset_runtime_stats_func()
-        if chat_state is not None:
-            chat_state.messages = []
-        if img_list is not None:
-            img_list = []
-        text_input = gr.update(interactive=True, placeholder="Type and press Enter")
+    def __init__(self, args):
+        super().__init__(args.device_name, args.device_id)
+        self.artifact_path = args.artifact_path
+        self.device_name = args.device_name
+        # vision-related attributes
+        self.vision_exec = None
+        self.vision_params = None
+        self.vision_embed = None
+        self.vision_dtype = None
+        # keep track of current llm
+        self.curr_llm_lib = None
+        self.curr_llm_dir = None
+        self.curr_llm_dtype = None
+        # handle first user text input after vision embed
+        self.is_first_input_after_vision = False
 
-        return (
+    def reload_llm(self, llm_model, chatbot, chat_state, img_list):
+        """Reload the language model."""
+        quantization_type = llm_model.split("-")[-1]
+        if quantization_type[3:5] == "16":
+            self.curr_llm_dtype = "float16"
+        elif quantization_type[3:5] == "32":
+            self.curr_llm_dtype = "float32"
+        else:
+            raise ValueError(f"LLM dtype is not supported")
+
+        # load the langauge model
+        model_dir = os.path.join(self.artifact_path, llm_model)
+        lib = load_model(model_dir, self.device_name)
+        chat_mod.reload(lib, os.path.join(model_dir, "params"))
+        print(f"loaded {llm_model}")
+
+        # reset environment and chatbot vars
+        self.vision_exec, self.vision_params, self.vision_embed = None, None, None
+        self.curr_llm_lib, self.curr_llm_dir = lib, model_dir
+        self.reset_runtime_stats()
+        self.process_system_prompts()
+        chatbot = None
+        chat_state = []
+        img_list = []
+        chatbot_vars = [chatbot, chat_state, img_list]
+
+        # change button visibility and state of being interactive
+        if llm_model.startswith("vicuna"):
+            image_model = gr.update(value=None, interactive=True, visible=True)
+        else:
+            image_model = gr.update(interactive=False, visible=False)
+        stream_interval = gr.update(interactive=True, visible=True)
+        reset_llm_button = gr.update(interactive=True, visible=True)
+        stats_button = gr.update(interactive=True, visible=True)
+        stats_output = gr.update(
+            placeholder="Click to get runtime statistics.", visible=True
+        )
+        text_input = gr.update(interactive=True, placeholder="Type and press enter")
+        llm_buttons = [
+            image_model,
+            stream_interval,
+            reset_llm_button,
+            stats_button,
+            stats_output,
             text_input,
-            gr.update(interactive=True),
-            gr.update(placeholder="Click to get runtime statistics."),
-            gr.update(interactive=True),
-            None,
-            chat_state,
-            img_list,
+        ]
+
+        return llm_buttons + chatbot_vars
+
+    def reload_image_model(self, image_model, chatbot, chat_state, img_list):
+        """Reload the image model."""
+        if image_model == "-None-" or image_model is None:
+            # reload the current llm with original conv template
+            if image_model == "-None-":
+                assert self.curr_llm_lib is not None and self.curr_llm_dir is not None
+                chat_mod.reload(
+                    self.curr_llm_lib, os.path.join(self.curr_llm_dir, "params")
+                )
+                self.reset_runtime_stats()
+                self.process_system_prompts()
+
+            # reset environment and chatbot vars
+            self.vision_exec, self.vision_params, self.vision_embed = None, None, None
+            chatbot = None
+            chat_state = []
+            img_list = []
+            chatbot_vars = [chatbot, chat_state, img_list]
+
+            # change button visibility and state of being interactive
+            image = gr.update(visible=False, interactive=False)
+            text_input = gr.update(interactive=True, placeholder="Type and press enter")
+            image_model_buttons = [image, text_input]
+
+            return image_model_buttons + chatbot_vars
+
+        # get image model dtype
+        quantization_type = image_model.split("-")[-1]
+        if quantization_type[3:5] == "16":
+            self.vision_dtype = "float16"
+        elif quantization_type[3:5] == "32":
+            self.vision_dtype = "float32"
+        else:
+            raise ValueError(f"image model dtype is not supported")
+
+        # reload image model
+        model_dir = os.path.join(self.artifact_path, image_model)
+        self.vision_exec = load_model(model_dir, self.device_name)
+        self.vision_params = load_params(model_dir, self.device)
+        print(f"loaded {image_model}")
+
+        # reload the current llm with MiniGPT's conv template
+        assert self.curr_llm_lib is not None and self.curr_llm_dir is not None
+        app_config_json = '{"conv_template":"minigpt"}'
+        chat_mod.reload(
+            self.curr_llm_lib,
+            os.path.join(self.curr_llm_dir, "params"),
+            app_config_json,
         )
 
-    def reset_model(self, chat_state, img_list):
+        # reset environment and chatbot vars
+        self.vision_embed = None
+        self.reset_runtime_stats()
+        self.process_system_prompts()
+        chatbot = None
+        chat_state = []
+        img_list = []
+        chatbot_vars = [chatbot, chat_state, img_list]
+
+        # change button visibility and state of being interactive
+        image = gr.update(value=None, visible=True, interactive=True)
+        text_input = gr.update(
+            interactive=False, placeholder="Upload an image to start chatting"
+        )
+        image_model_buttons = [image, text_input]
+
+        return image_model_buttons + chatbot_vars
+
+    def reset_llm(self, chatbot, chat_state, img_list):
+        """Reset the llm chat (and image)."""
         self.reset_chat()
-        if chat_state is not None:
-            chat_state.messages = []
-        if img_list is not None:
-            img_list = []
-        return None, chat_state, img_list
+        self.process_system_prompts()
+        self.vision_embed = None
+        if self.vision_exec is None:
+            image = gr.update(visible=False, interactive=False)
+            text_input = gr.update(interactive=True, placeholder="Type and press enter")
+        else:
+            image = gr.update(value=None, visible=True, interactive=True)
+            text_input = gr.update(
+                interactive=False, placeholder="Upload an image to start chatting"
+            )
+        chatbot = None
+        chat_state = []
+        img_list = []
+        return image, text_input, chatbot, chat_state, img_list
 
     def ask(self, text_input, chatbot):
-        self.prefill(text_input)
+        """Process user text input."""
+        if self.is_first_input_after_vision:
+            self.prefill(
+                text_input, decode_next_token=True, place_in_prompt=PlaceInPrompt.End
+            )
+            self.is_first_input_after_vision = False
+        else:
+            self.prefill(text_input)
         chatbot = chatbot + [[text_input, None]]
-        return "", chatbot
+        text_input = ""
+        return text_input, chatbot
 
     def answer(self, chatbot, stream_interval):
+        """Process the chatbot's text response."""
         i, cur_utf8_chars = 0, "".encode("utf-8")
         res = ""
         while not self.stopped():
@@ -113,42 +219,99 @@ class GradioChatModule(ChatModule):
                 chatbot[-1][1] = res
                 yield chatbot
 
+    def upload_image(self, image):
+        """Process user image input."""
+        from PIL import Image
+        from tvm import relax
+
+        img_list = []
+        if image is None:
+            text_input = gr.update(
+                placeholder="Upload an image to get started", interactive=False
+            )
+            return img_list, text_input
+
+        if not isinstance(image, Image.Image):
+            text_input = gr.update(
+                placeholder="Uploaded image type is not supported", interactive=False
+            )
+            return img_list, text_input
+
+        # generate vision embedding
+        image = transform_image(image, self.vision_dtype)
+        image_param = tvm.nd.array(image, self.device)
+        vm = relax.vm.VirtualMachine(self.vision_exec, self.device)["embed"]
+        self.vision_embed = vm(image_param, self.vision_params)
+        # convert to dtype of llm
+        self.vision_embed = self.vision_embed.numpy().astype(self.curr_llm_dtype)
+
+        # prefill with vision embedding
+        self.prefill(
+            "<Img>",
+            decode_next_token=False,
+            place_in_prompt=PlaceInPrompt.Begin,
+        )
+        self.prefill_with_embed(tvm.nd.array(self.vision_embed, self.device), False)
+        self.prefill(
+            "</Img> ",
+            decode_next_token=False,
+            place_in_prompt=PlaceInPrompt.Middle,
+        )
+        self.is_first_input_after_vision = True
+
+        # change button
+        text_input = gr.update(placeholder="Type and press enter", interactive=True)
+        return img_list, text_input
+
     def get_stats(self, stats_output):
+        """Get runtime statistics."""
         stats_output = self.runtime_stats_text()
         return stats_output
 
 
+# main function for the design of Gradio interface
+
+
 def launch_gradio(chat_mod, share_link=False):
-    title = """<h1 align="center">MLC Chat Demo</h1>"""
-    description = """<h3>Welcome to MLC Chat! Pick a model from your local models to get started!</h3>"""
+    title = """<h1 align="center">MLC Chat Gradio Interface</h1>"""
+    description = """<h3>Welcome to MLC Chat! Pick a model from your local ids to get started.</h3>"""
 
     with gr.Blocks() as demo:
         gr.Markdown(title)
         gr.Markdown(description)
-        with gr.Row():
-            model_choice = gr.Radio(
-                model_local_ids,
-                label="Model Name",
-                info="Choose a model from your local models",
-            )
 
         with gr.Row():
-            with gr.Column(scale=0.5):
-                reset_button = gr.Button("Reset chat", interactive=False)
+            with gr.Column(scale=0.3):
+                llm_model = gr.Dropdown(llm_local_ids, label="Language Model")
+                image_model = gr.Dropdown(
+                    ["-None-"] + image_model_local_ids,
+                    label="Do you wanna add an image model?",
+                    visible=False,
+                    interactive=False,
+                )
+                image = gr.Image(type="pil", interactive=False, visible=False)
                 stream_interval = gr.Slider(
                     minimum=1.0,
                     maximum=5.0,
                     value=2.0,
                     step=1.0,
                     interactive=True,
+                    visible=False,
                     label="Stream Interval",
                 )
-                stats_button = gr.Button("Get Runtime Statistics", interactive=False)
+                reset_llm_button = gr.Button(
+                    "Reset chat", visible=False, interactive=False
+                )
+                stats_button = gr.Button(
+                    "Get Runtime Statistics", interactive=False, visible=False
+                )
                 stats_output = gr.Textbox(
                     show_label=False,
                     placeholder="Click to get runtime statistics.",
                     interactive=False,
-                ).style(container=False)
+                    visible=False,
+                    container=False,
+                )
 
             with gr.Column():
                 chat_state = gr.State()
@@ -158,33 +321,108 @@ def launch_gradio(chat_mod, share_link=False):
                     show_label=False,
                     placeholder="Select a model to start chatting!",
                     interactive=False,
-                ).style(container=False)
+                    container=False,
+                )
 
-        model_choice.change(
-            chat_mod.reload_model,
-            [model_choice, text_input, chat_state, img_list],
-            [
-                text_input,
-                reset_button,
-                stats_output,
-                stats_button,
-                chatbot,
-                chat_state,
-                img_list,
-            ],
+        # buttons whose visibility change when llm reload
+        llm_buttons = [
+            image_model,
+            stream_interval,
+            reset_llm_button,
+            stats_button,
+            stats_output,
+            text_input,
+        ]
+        # buttons whose visibility change when image model reload
+        image_model_buttons = [image, text_input]
+        # chatbot state variables
+        chatbot_vars = [chatbot, chat_state, img_list]
+
+        # change of state controls
+        llm_model.change(
+            chat_mod.reload_llm,
+            [llm_model] + chatbot_vars,
+            llm_buttons + chatbot_vars,
             queue=False,
         )
-        reset_button.click(
-            chat_mod.reset_model,
-            [chat_state, img_list],
-            [chatbot, chat_state, img_list],
+        image_model.change(
+            chat_mod.reload_image_model,
+            [image_model] + chatbot_vars,
+            image_model_buttons + chatbot_vars,
+            queue=False,
         )
-        stats_button.click(chat_mod.get_stats, [stats_output], [stats_output])
         text_input.submit(
             chat_mod.ask, [text_input, chatbot], [text_input, chatbot]
         ).then(chat_mod.answer, [chatbot, stream_interval], [chatbot])
+        image.upload(chat_mod.upload_image, [image], [img_list, text_input])
+        image.clear(
+            chat_mod.reset_llm,
+            chatbot_vars,
+            image_model_buttons + chatbot_vars,
+        )
+        reset_llm_button.click(
+            chat_mod.reset_llm,
+            chatbot_vars,
+            image_model_buttons + chatbot_vars,
+        )
+        stats_button.click(chat_mod.get_stats, [stats_output], [stats_output])
 
     demo.launch(share=share_link, enable_queue=True, server_port=ARGS.port)
+
+
+# helper functions below
+
+
+def _check_model_dir(model_dir):
+    """Check the validity of model directory."""
+    if not os.path.isdir(model_dir):
+        return False
+    params_exists, model_exists = False, False
+    for path in glob.glob(os.path.join(model_dir, "*")):
+        local_id = model_dir.split("/")[-1]
+        if path.split("/")[-1] == "params":
+            params_exists = True
+        if path.split("/")[-1].startswith(local_id):
+            model_exists = True
+    return params_exists and model_exists
+
+
+def get_local_ids(artifact_path):
+    """Get all model ids in the artifact path, and categorize into llm and image models."""
+    for path in glob.glob(os.path.join(artifact_path, "*")):
+        if _check_model_dir(path):
+            local_id = path.split("/")[-1]
+            if local_id.startswith("minigpt"):
+                image_model_local_ids.append(local_id)
+            else:
+                llm_local_ids.append(local_id)
+    llm_local_ids.sort()
+    image_model_local_ids.sort()
+
+
+def load_params(model_dir, device):
+    """Load model parameters from the local directory."""
+    from tvm.contrib import tvmjs
+
+    params, meta = tvmjs.load_ndarray_cache(f"{model_dir}/params", device)
+    plist = []
+    size = meta["ParamSize"]
+    for i in range(size):
+        plist.append(params[f"param_{i}"])
+    return plist
+
+
+def load_model(model_dir, device_name):
+    """Load model executable from the local directory."""
+    model_lib, model_name = None, model_dir.split("/")[-1]
+    for path in glob.glob(os.path.join(model_dir, "*")):
+        if path.split("/")[-1].startswith(model_name + "-" + device_name):
+            model_lib = path
+            break
+    assert model_lib is not None, "compiled model does not exist"
+    lib = tvm.runtime.load_module(os.path.join(model_dir, model_lib))
+    assert lib is not None, "model executable cannot be loaded"
+    return lib
 
 
 def first_idx_mismatch(str1, str2):
@@ -193,6 +431,33 @@ def first_idx_mismatch(str1, str2):
         if char1 != char2:
             return i
     return min(len(str1), len(str2))
+
+
+def transform_image(image, dtype, image_size=224):
+    """Preprocess the user image"""
+    from torchvision import transforms
+    from torchvision.transforms.functional import InterpolationMode
+
+    mean = (0.48145466, 0.4578275, 0.40821073)
+    std = (0.26862954, 0.26130258, 0.27577711)
+    transform_fn = transforms.Compose(
+        [
+            transforms.Resize(
+                (image_size, image_size),
+                interpolation=InterpolationMode.BICUBIC,
+            ),
+            transforms.ToTensor(),
+            transforms.Normalize(mean, std),
+        ]
+    )
+    image = transform_fn(image).unsqueeze(0)
+    if dtype == "float16":
+        image = image.half()
+    elif dtype == "float32":
+        image = image.float()
+    else:
+        raise ValueError("image dtype not supported yet")
+    return image
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR tested and confirmed the quality of running minigpt from cli and massively polished the gradio interface. 

To build:
* make sure to compile vicuna models with `--sep-embed` flag
* it is recommended to download minigpt 7b weights from [https://drive.google.com/file/d/1RY9jV0dyqLX-o38LrumkKRh6Jtaop58R/view?usp=sharing](url) and store as a **single file** (no folders!) under artifact-path/models/

Features changed:
* add `PlaceInPrompt` enum class that allows the user to decide where to place a text input in a prompt, choices are "kBegin" / "kMiddle" / "kEnd" / "kAll" (default is "kAll").

Demo:

https://github.com/mlc-ai/mlc-llm/assets/65606304/78722672-b95b-4533-9400-e591b75f9762

