### PR TITLE
[Fix] FuseDecodeTranspose pass with PrimFunc deep copy

### DIFF
--- a/mlc_llm/transform/decode_transpose.py
+++ b/mlc_llm/transform/decode_transpose.py
@@ -95,6 +95,9 @@ class FuseDecodeTranspose:
                         ),
                     ),
                 )
+                # Call `renew_defs` for deep-copy to avoid IR node duplication in
+                # different PrimFuncs of an IRModule.
+                new_func = tir.stmt_functor.renew_defs(new_func)
                 gv = self.builder_.add_func(new_func, func_name="decode")
                 decoded_matmul_rhs = self.builder_.emit(
                     relax.call_tir(


### PR DESCRIPTION
Prior to this PR, the FuseDecodeTranspose pass creates the fused PrimFunc which directly reuses the blocks in the functions being fused. This lead to tir.Schedule error when a Schedule is constructed on an IRModule which contains both the post-fusion and pre-fusion functions.

This PR calls `tir.stmt_functor.renew_defs` on the fused PrimFunc for the purpose of simple deep copy.

Other fusion passes are confirmed with no similar issue.