### PR TITLE
[General] Correct processing of bfloat16 weights

### DIFF
--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -206,10 +206,15 @@ def transform_params(
             torch_param_names = list(torch_params.keys())
             for torch_param_name in torch_param_names:
                 if str(torch_params[torch_param_name].dtype) == "torch.bfloat16":
-                    # Convert to float32 first.
-                    raw_param = (
-                        torch_params[torch_param_name].detach().cpu().float().numpy()
-                    )
+                    if args.quantization.mode == "no" and args.quantization.model_dtype == "float16":
+                        raw_param = (
+                            torch_params[torch_param_name].detach().cpu().to(dtype=torch.float16).numpy()
+                        )
+                    else:
+                        # Convert to float32 first.
+                        raw_param = (
+                            torch_params[torch_param_name].detach().cpu().float().numpy()
+                        )
                 else:
                     raw_param = torch_params[torch_param_name].detach().cpu().numpy()
                 del torch_params[torch_param_name]


### PR DESCRIPTION
It is variant of resolution of issue #458. I'm not sure that it is ideal, see my thoughts below.

Quantization tag `qMfN` (e.g. "q3f16") can be splitted on two parts: `M` defines number of bits for low-precision quantization of weights; `N` defines size of floating point type for calculation. But there is white spot: if M = 0 the weights are not quantized and `N` value does not influence on storage data type. Additionally if the original weigth data is "bfloat16" it is converted to "float32" that affects memory usage (#458). Thus we do not control data type for M = 0 in good way.
Just now I propose to convert "bfloat16" to N-bits floating point during transfer torch weights to numpy. There are two obvious options more: 1. convert "bfloat16" to "float16" immediately to effectively use memory, but I'm not sure that calculation will be with N-bits floating point in correct way; 2. convert "bfloat16" to "float32" as it makes now and reconvert weights to needed data type on quantization pass side.
Alternative way is to extend the quantization tag format to `fMfN` (e.g. "f16f32") which will cover the white spot.

cc @yzh119 @tqchen 