### PR TITLE
[Refactor] Param loading integration into ParamManager

### DIFF
--- a/mlc_llm/relax_model/minigpt.py
+++ b/mlc_llm/relax_model/minigpt.py
@@ -511,7 +511,9 @@ def get_model(args):
         bb = relax.BlockBuilder()
         create_embed_func(bb, param_manager, config, args.quantization)
         mod = bb.get()
-        mod, _ = param_manager.quantization_transform(mod)
+        mod = param_manager.transform_module(
+            mod, args.model_path, no_lazy_param_loading=True
+        )
 
         # load visual encoder weights
         visual_encoder_url = "https://storage.googleapis.com/sfr-vision-language-research/LAVIS/models/BLIP2/eva_vit_g.pth"
@@ -568,7 +570,7 @@ def get_model(args):
                 tvm.nd.array(llama_state_dict[key].numpy().astype(config.dtype), device)
             )
 
-        return mod, param_list
+        return mod, param_manager, param_list
 
     raise ValueError(f"Unsupported model: {model_name}")
 

--- a/mlc_llm/transform/reorder_transform_func.py
+++ b/mlc_llm/transform/reorder_transform_func.py
@@ -209,12 +209,12 @@ class ReorderTransformFunc:
         self,
         pidx2pname: Dict[int, str],
         pname2binname: Dict[str, str],
-        f_convert_pname_fwd: Callable[[str], str],
+        f_convert_pname_fwd: Callable[[str], List[str]],
     ) -> None:
         self.pidx2binname: Dict[int, str] = {
-            pidx: pname2binname[f_convert_pname_fwd(pname)]
+            pidx: pname2binname[f_convert_pname_fwd(pname)[0]]
             for pidx, pname in pidx2pname.items()
-            if f_convert_pname_fwd(pname) in pname2binname
+            if f_convert_pname_fwd(pname)[0] in pname2binname
         }
 
     def transform_module(


### PR DESCRIPTION
This PR refactors the lazy parameter loading logic, integrating it into the ParamManager so that the concept of ParamManager is more self-contained.

On top of this, this PR supports the lazy parameter loading with an additional functionality. Prior to this PR, the lazy parameter loading only supports the case of "one Relax parameter comes from one torch parameter". In this setting, we can support "the torch nn.Module has combined QKV while our Relax nn.Module separates them". However, we did not support the reverse - we did not support "the torch nn.Module separates Q, K, V, and the Relax nn.Module combines them together".

This PR now supports this. It opens the floor for the QKV combination for models like LLaMA (whose PyTorch nn.Module implementation does not combine Q, K, V together).

Verified the build on all models.