### PR TITLE
[BugFix] Fix target type in transform_params

### DIFF
--- a/build.py
+++ b/build.py
@@ -314,7 +314,7 @@ def mod_transform_before_build(
     debug_dump_script(mod_transform, "mod_lift_params.py", args)
     debug_dump_script(mod_deploy, "mod_deploy.py", args)
 
-    new_params = utils.transform_params(mod_transform, param_manager, model_params)
+    new_params = utils.transform_params(mod_transform, param_manager, model_params, args.target)
     utils.save_params(new_params, args.artifact_path)
     return mod_deploy
 

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -113,8 +113,8 @@ def transform_params(
     mod_transform: tvm.IRModule,
     param_manager: param_manager.ParamManager,
     model_params: List[Optional[tvm.nd.NDArray]],
+    target: tvm.target.target.Target
 ) -> List[tvm.nd.NDArray]:
-    target = detect_local_target()
     print(f"Automatically using target for weight quantization: {target}")
     device = tvm.device(target.kind.default_keys[0])
     device_cpu = tvm.cpu()


### PR DESCRIPTION
Previously in `utils.transform_params()` the `detect_local_target()` function was called, even if the target was manually set from the command line. This fix changes it so that `utils.parse_target()` and `utils.transform_params()` use the same target.