### PR TITLE
Add Python build api

### DIFF
--- a/mlc_llm/__init__.py
+++ b/mlc_llm/__init__.py
@@ -3,3 +3,4 @@ from . import quantization
 from . import relax_model
 from . import transform
 from . import utils
+from .build import build_model

--- a/mlc_llm/build.py
+++ b/mlc_llm/build.py
@@ -399,7 +399,7 @@ def build(mod_deploy: tvm.IRModule, args: argparse.Namespace) -> None:
     print(f"Finish exporting to {args.lib_path}")
 
 
-def main(args):
+def run(args):
     os.makedirs(args.artifact_path, exist_ok=True)
     if args.debug_dump:
         os.makedirs(os.path.join(args.artifact_path, "debug"), exist_ok=True)
@@ -514,11 +514,14 @@ def build_model(model: str=None,
     args = empty_args.parse_args(arg_list)
     args = _parse_args(args)  # pylint: disable=protected-access
 
-    main(args)
+    run(args)
     return args.lib_path, args.params_path, args.chat_config_path
 
-if __name__ == "__main__":
+def main():
     empty_args = make_args()  # Create new ArgumentParser with arguments added
     parsed_args = empty_args.parse_args()  # Parse through command line
     parsed_args = _parse_args(parsed_args)  # Post-processing of args
-    main(parsed_args)
+    run(parsed_args)
+
+if __name__ == "__main__":
+    main()

--- a/python/mlc_chat/utils.py
+++ b/python/mlc_chat/utils.py
@@ -1,4 +1,0 @@
-"""Common utils used in Python runtime for MLC chat."""
-
-import tvm
-import tvm._ffi.base


### PR DESCRIPTION
Collaborator: @sbelcmu 

This PR adds a Python API `build_model()` in the `mlc_llm` package so that users can compile models in a Python script. 

After cloning the repo, installing `mlc-ai` and `mlc-chat`, and downloading the weights, the users can:
```python
import mlc_llm, mlc_chat, tvm
lib_path, model_path, chat_config_path = mlc_llm.build_model(model="RedPajama-INCITE-Chat-3B-v1", target="cuda", quantization="q4f16_0")

# They can directly use the returned paths to launch `ChatModule`:
lib = tvm.runtime.load_module(lib_path)
chat_mod = mlc_chat.ChatModule(target="cuda", device_id=0)
chat_mod.reload(lib=lib, model_path=model_path)
```

Tested:
- The code block above
- Tried the API in other directory after installing the package through `pip install -e .` 
- Ensured the original methods mentioned in [PR 525](https://github.com/mlc-ai/mlc-llm/pull/525) still work