### PR TITLE
Stop-str for Llama-2, and `q4f32_1` for web

### DIFF
--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -49,7 +49,7 @@ Conversation Llama2() {
   conv.role_msg_sep = " ";
   conv.role_empty_sep = " ";
   conv.stop_tokens = {2};
-  conv.stop_str = "";
+  conv.stop_str = "[INST]";
   conv.add_bos = true;
   return conv;
 }

--- a/mlc_llm/build.py
+++ b/mlc_llm/build.py
@@ -370,12 +370,13 @@ def build(mod_deploy: tvm.IRModule, args: argparse.Namespace) -> None:
                 mod_deploy = mlc_llm.dispatch.DispatchTIROperatorAdreno()(  # pylint: disable=not-callable
                     mod_deploy
                 )
-            mod_deploy = relax.transform.MetaScheduleApplyDatabase()(mod_deploy)
-            mod_deploy = (
-                mlc_llm.dispatch.DispatchTIROperator(  # pylint: disable=not-callable
+            if args.target_kind != "cuda":
+                mod_deploy = relax.transform.MetaScheduleApplyDatabase()(mod_deploy)
+                mod_deploy = mlc_llm.dispatch.DispatchTIROperator(  # pylint: disable=not-callable
                     args.model_category
-                )(mod_deploy)
-            )
+                )(
+                    mod_deploy
+                )
             mod_deploy = dl.ApplyDefaultSchedule(dl.gpu.Matmul())(mod_deploy)
             mod_deploy = dl.ApplyDefaultSchedule(dl.gpu.DecodeGEMV())(mod_deploy)
             mod_deploy = dl.ApplyDefaultSchedule(dl.gpu.Reduction())(mod_deploy)

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -118,6 +118,19 @@ quantization_schemes = {
         ),
         final_fc_weight="same_as_linear_weight",
     ),
+    "q4f32_1": QuantizationScheme(
+        name="q4f32_1",
+        linear_weight=GroupQuantizationSpec(
+            dtype="float32",
+            mode="int4",
+            sym=False,
+            storage_nbit=32,
+            group_size=32,
+            transpose=False,
+        ),
+        embedding_table="same_as_linear_weight",
+        final_fc_weight="same_as_linear_weight",
+    ),
     "q8f16_0": QuantizationScheme(
         name="q8f16_0",
         linear_weight=RWKVQuantizationSpec(dtype="float16", mode="uint8", nbit=8),


### PR DESCRIPTION
This PR adds a stop string for the Llama-2 conversation, adds the `q4f32_1` quantization for web.