### PR TITLE
[Doc] Announce Llama 2 70B CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Everything runs locally  with no server support and accelerated with local GPUs 
 
 **[Click here to join our Discord server!][discord-url]**
 
-<ins>**[Check out our instruction page to try out!](https://mlc.ai/mlc-llm/docs/get_started/try_out.html)**</ins>
+<ins>**[News] MLC LLM now supports 7B/13B/70B Llama-2 !! [Check out our instruction page to try out!](https://mlc.ai/mlc-llm/docs/get_started/try_out.html)**</ins>
+
 
 <p align="center">
   <img src="site/gif/ios-demo.gif" height="700">

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Everything runs locally  with no server support and accelerated with local GPUs 
 
 **[Click here to join our Discord server!][discord-url]**
 
-<ins>**[News] MLC LLM now supports 7B/13B/70B Llama-2 !! [Check out our instruction page to try out!](https://mlc.ai/mlc-llm/docs/get_started/try_out.html)**</ins>
+**[News] MLC LLM now supports 7B/13B/70B Llama-2 !!**
+
+<ins>**[Check out our instruction page to try out!](https://mlc.ai/mlc-llm/docs/get_started/try_out.html)**</ins>
 
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Everything runs locally  with no server support and accelerated with local GPUs 
 
 <ins>**[Check out our instruction page to try out!](https://mlc.ai/mlc-llm/docs/get_started/try_out.html)**</ins>
 
-
 <p align="center">
   <img src="site/gif/ios-demo.gif" height="700">
 </p>

--- a/docs/get_started/try_out.rst
+++ b/docs/get_started/try_out.rst
@@ -11,7 +11,7 @@ and you can try out prebuilt models on the following platforms:
 
   .. tab:: CLI (Linux/MacOS/Windows)
 
-    **MLC LLM now supports 7B/13B Llama-2.** *Follow the instructions below and try out the CLI!*
+    **MLC LLM now supports 7B/13B/70B Llama-2.** *Follow the instructions below and try out the CLI!*
 
     To run the models on your PC, you can try out the CLI version of MLC LLM.
 
@@ -34,11 +34,13 @@ and you can try out prebuilt models on the following platforms:
       mkdir -p dist/prebuilt
       git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt/lib
 
-      # Download prebuilt weights of Llama-2-7B or Llama-2-13B
+      # Download prebuilt weights of Llama-2-7B, Llama-2-13B or Llama-2-70B
       cd dist/prebuilt
       git clone https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1
       # or the 13B model
       # git clone https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f16_1
+      # or the 70B model (only supports Mac w/ Apple Silicon at the moment)
+      # git clone https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q4f16_1
       cd ../..
       mlc_chat_cli --local-id Llama-2-7b-chat-hf-q4f16_1
       # or the 13B model


### PR DESCRIPTION
W/ #567 get merged, MLC-LLM now supports Llama-2-70B-Chat, tested on Mac Station w/ M2 Ultra (decoding speed: 9.8 toks/s).

Weight: https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q4f16_1
Binary: https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-70b-chat-hf-q4f16_1-metal.so