### PR TITLE
[Fix] Correcting num-kv-heads in Llama kv-cache creation func

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -790,10 +790,15 @@ def create_decoding_func(
 
 
 def create_kv_cache_func(bb: relax.BlockBuilder, config: LlamaConfig) -> None:
+    num_key_value_heads = (
+        config.num_attention_heads
+        if config.num_key_value_heads is None
+        else config.num_key_value_heads
+    )
     init_shape = relax.ShapeExpr(
         (
             config.max_sequence_length,
-            config.num_key_value_heads,
+            num_key_value_heads,
             config.hidden_size // config.num_attention_heads,  # head_dim
         )
     )


### PR DESCRIPTION
This PR fixes a minor bug introduced by the grouped query attention PR, and sets the correct number-of-heads value in the kv-cache creation function.