### PR TITLE
[PYTHON] Use abspath for dll module

### DIFF
--- a/python/mlc_chat/libinfo.py
+++ b/python/mlc_chat/libinfo.py
@@ -36,7 +36,7 @@ def get_dll_directories():
     elif sys.platform.startswith("win32"):
         dll_path.extend(get_env_paths("PATH", ";"))
 
-    return [p for p in dll_path if os.path.isdir(p)]
+    return [os.path.abspath(p) for p in dll_path if os.path.isdir(p)]
 
 
 def find_lib_path(name, optional=False):


### PR DESCRIPTION
Always use abspath for all module in case
there are wrong directories.