### PR TITLE
Add support for Pydantic v2

### DIFF
--- a/examples/rest/sample_client.py
+++ b/examples/rest/sample_client.py
@@ -13,9 +13,6 @@ class color:
    UNDERLINE = '\033[4m'
    END = '\033[0m'
 
-# To launch the server, run
-# $ python -m mlc_chat.rest
-
 # Get a response using a prompt without streaming
 payload = {
     "model": "vicuna-v1-7b",

--- a/examples/rest/sample_langchain.py
+++ b/examples/rest/sample_langchain.py
@@ -10,6 +10,10 @@ from langchain.llms import OpenAI
 # export OPENAI_API_BASE=http://127.0.0.1:8000/v1
 # export OPENAI_API_KEY=EMPTY
 
+# Note that Langchain does not currently support Pydantic v2:
+# https://github.com/langchain-ai/langchain/issues/6841
+# Please ensure that your `pydantic` version is < 2.0
+
 class color:
    PURPLE = '\033[95m'
    CYAN = '\033[96m'

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -2,7 +2,7 @@
 Adapted from FastChat's OpenAI protocol: https://github.com/lm-sys/FastChat/blob/main/fastchat/protocol/openai_api_protocol.py
 """
 
-from typing import Literal, Optional, List, Dict, Any, Union
+from typing import Literal, Dict, Any
 from pydantic import BaseModel, Field
 import shortuuid
 import time
@@ -11,11 +11,12 @@ import time
 class ChatMessage(BaseModel):
     role: str
     content: str
+    name: str | None = None
 
 class ChatCompletionRequest(BaseModel):
     model: str
     messages: list[ChatMessage]
-    stream: Optional[bool] = False
+    stream: bool | None = False
     # TODO: Implement support for the following fields
     # temperature: Optional[float] = 1.0
     # top_p: Optional[float] = 1.0
@@ -28,61 +29,61 @@ class ChatCompletionRequest(BaseModel):
 
 class UsageInfo(BaseModel):
     prompt_tokens: int = 0
-    completion_tokens: Optional[int] = 0
+    completion_tokens: int | None = 0
     total_tokens: int = 0
 
 class ChatCompletionResponseChoice(BaseModel):
     index: int
     message: ChatMessage
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Literal["stop", "length"] | None = None
 
 class ChatCompletionResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"chatcmpl-{shortuuid.random()}")
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
-    choices: List[ChatCompletionResponseChoice]
+    choices: list[ChatCompletionResponseChoice]
     # TODO: Implement support for the following fields
-    usage: Optional[UsageInfo]
+    usage: UsageInfo | None = None
 
 class DeltaMessage(BaseModel):
-    role: Optional[str] = None
-    content: Optional[str] = None
+    role: str | None = None
+    content: str | None = None
 
 class ChatCompletionResponseStreamChoice(BaseModel):
     index: int
     delta: DeltaMessage
-    finish_reason: Optional[Literal["stop", "length"]]
+    finish_reason: Literal["stop", "length"] | None = None
 
 class ChatCompletionStreamResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"chatcmpl-{shortuuid.random()}")
     object: str = "chat.completion.chunk"
     created: int = Field(default_factory=lambda: int(time.time()))
-    choices: List[ChatCompletionResponseStreamChoice]
+    choices: list[ChatCompletionResponseStreamChoice]
 
 class CompletionRequest(BaseModel):
     model: str
-    prompt: Union[str, List[Any]]
+    prompt: str | list[str]
 
 class CompletionResponseChoice(BaseModel):
     index: int
     text: str
-    logprobs: Optional[int] = None
-    finish_reason: Optional[Literal["stop", "length"]]
+    logprobs: int | None = None
+    finish_reason: Literal["stop", "length"] | None = None
 
 class CompletionResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"cmpl-{shortuuid.random()}")
     object: str = "text_completion"
     created: int = Field(default_factory=lambda: int(time.time()))
-    choices: List[CompletionResponseChoice]
+    choices: list[CompletionResponseChoice]
     usage: UsageInfo
 
 class EmbeddingsRequest(BaseModel):
-    model: Optional[str] = None
-    input: Union[str, List[Any]]
-    user: Optional[str] = None
+    model: str
+    input: str
+    user: str | None = None
 
 class EmbeddingsResponse(BaseModel):
     object: str = "list"
-    data: List[Dict[str, Any]]
-    model: Optional[str] = None
+    data: list[Dict[str, Any]]
+    model: str | None = None
     usage: UsageInfo

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -155,7 +155,11 @@ async def request_completion(request: CompletionRequest):
     Creates a completion for a given prompt.
     """
     session["chat_mod"].reset_chat()
-    prompt = request.prompt[0]
+    # Langchain's load_qa_chain.run expects the input to be a list with the query
+    if isinstance(request.prompt, list):
+        prompt = request.prompt[0]
+    else:
+        prompt = request.prompt
     session["chat_mod"].prefill(input=prompt)
 
     msg = None


### PR DESCRIPTION
 `pydantic` made a [breaking change](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields) in their major version update to how `Optional` fields work with FastAPI. This PR updates the OpenAI interface to reflect this change, while ensuring backward compatibility with Pydantic v1.

A few things worth calling out:

- `sample_client` and `sample_openai` have both been tested with `pydantic` v1 and `pydantic` v2, and are expected to run successfully.
- `langchain` has a dependency on `pydantic` v1, so `sample_langchain` will not work with `pydantic` v2. This is reflected in [inline comments](https://github.com/mlc-ai/mlc-llm/pull/592/files#diff-e9e785f066c79b626e8c3c6220b1b6d4fe763cf0488767c93347b7c9fafee5b8R13-R15) within the sample code. However, it is expected to run successfully with `pydantic` v1.
- There is now a dependency on Python 3.10 for the REST API to run successfully.

Fixes https://github.com/mlc-ai/mlc-llm/issues/590 and https://github.com/mlc-ai/mlc-llm/issues/581.