### PR TITLE
Lift weight conversion to an early stage

### DIFF
--- a/mlc_llm/relax_model/gpt_bigcode.py
+++ b/mlc_llm/relax_model/gpt_bigcode.py
@@ -666,8 +666,10 @@ def get_model(args: argparse.Namespace, hf_config):
                     },
                 )
 
-        mod = param_manager.transform_module(
-            mod,
+        if args.build_model_only:
+            return mod, param_manager, None
+
+        param_manager.set_param_loading_func(
             args.model_path,
             f_convert_param_bkwd=lambda torch_pname, torch_param: [
                 (torch_pname, torch_param.astype(dtype))

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -729,6 +729,9 @@ def get_model(
                 },
             )
 
+    if args.build_model_only:
+        return mod, param_manager, None
+
     def f_convert_pname_fwd(pname: str) -> List[str]:
         import re  # pylint: disable=import-outside-toplevel
 
@@ -781,7 +784,7 @@ def get_model(
         else:
             return [(torch_pname, torch_param.astype(dtype))]
 
-    mod = param_manager.transform_module(
-        mod, args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
+    param_manager.set_param_loading_func(
+        args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
     )
     return mod, param_manager, [None] * len(param_manager.param_names)

--- a/mlc_llm/relax_model/gptj.py
+++ b/mlc_llm/relax_model/gptj.py
@@ -670,6 +670,9 @@ def get_model(args, hf_config):
                 },
             )
 
+    if args.build_model_only:
+        return mod, param_manager, None
+
     def f_convert_pname_fwd(pname: str) -> List[str]:
         import re
 
@@ -702,7 +705,7 @@ def get_model(args, hf_config):
         else:
             return [(torch_pname, torch_param.astype(dtype))]
 
-    mod = param_manager.transform_module(
-        mod, args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
+    param_manager.set_param_loading_func(
+        args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
     )
     return mod, param_manager, [None] * len(param_manager.param_names)

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -876,6 +876,9 @@ def get_model(args, hf_config):
                 },
             )
 
+    if args.build_model_only:
+        return mod, param_manager, None
+
     def f_convert_pname_fwd(pname: str) -> List[str]:
         if not config.combine_matmul:
             return [pname]
@@ -927,8 +930,7 @@ def get_model(args, hf_config):
             raise ValueError("Unexpected param loading")
         return np.concatenate(torch_params, axis=0).astype(dtype)
 
-    mod = param_manager.transform_module(
-        mod,
+    param_manager.set_param_loading_func(
         args.model_path,
         f_convert_pname_fwd,
         f_convert_param_bkwd,

--- a/mlc_llm/relax_model/minigpt.py
+++ b/mlc_llm/relax_model/minigpt.py
@@ -514,8 +514,12 @@ def get_model(args):
         bb = relax.BlockBuilder()
         create_embed_func(bb, param_manager, config, args.quantization)
         mod = bb.get()
-        mod = param_manager.transform_module(
-            mod, args.model_path, no_lazy_param_loading=True
+
+        if args.build_model_only:
+            return mod, param_manager, None
+
+        param_manager.set_param_loading_func(
+            args.model_path, no_lazy_param_loading=True
         )
 
         # load visual encoder weights

--- a/mlc_llm/relax_model/rwkv.py
+++ b/mlc_llm/relax_model/rwkv.py
@@ -499,6 +499,9 @@ def get_model(args, hf_config):
     create_kv_cache_reset_func(bb, config)
     mod = bb.get()
 
+    if args.build_model_only:
+        return mod, param_manager, None
+
     def f_convert_pname_fwd(pname: str) -> List[str]:
         if (
             "key_weight" in pname
@@ -548,7 +551,7 @@ def get_model(args, hf_config):
         else:
             return [(pname, torch_param.astype(config.dtype))]
 
-    mod = param_manager.transform_module(
-        mod, args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
+    param_manager.set_param_loading_func(
+        args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
     )
     return mod, param_manager, [None] * len(param_manager.param_names)


### PR DESCRIPTION
This main part of this PR separates the weight conversion func construction from the model IRModule transformation, so that we can now choose to only convert the model weights or only to build the model library, by specifying corresponding build arguments.

With this PR, the `mod_transform_before_build` function no longer has anything to do with the weight conversion computation.

Besides, this PR also
* removes some dump functions to utils,
* making the dumped `.pkl` IRModule independent of the architecture.