### PR TITLE
[Fix] Rest API: Update system platform checks for Apple Silicon (#608)

### DIFF
--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import os
+import subprocess
 import sys
 from contextlib import asynccontextmanager
 
@@ -21,7 +22,13 @@ def _shared_lib_suffix():
     if sys.platform.startswith("win32"):
         return ".dll"
     if sys.platform.startswith("darwin"):
-        return ".dylib"
+        cpu_brand_string = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"]).decode("utf-8")
+        if cpu_brand_string.startswith("Apple"):
+            # Apple Silicon
+            return ".so"
+        else:
+            # Intel (x86)
+            return ".dylib"
     return ".so"
 
 


### PR DESCRIPTION
## Description

As described in issue #608, currently the Rest API incorrectly reads `.dylib` files instead of `.so` files on Apple Silicon macOS.

This PR fixes this problem. If `sys.platform` is `darwin` (macOS), it will additionally judge the CPU brand string through `sysctl -n machdep.cpu.brand_string` to confirm whether it is Apple Silicon or Intel (x86) architecture.

Note: Using `platform.processor()` to confirm the macOS architecture may lead to misjudgment under Rosetta or different Python version, so the relatively stable `machdep.cpu.brand_string` is used for judgment.
