### PR TITLE
[Bug fix] Fix build model api return value

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field, fields, asdict
 import json
 import os
 import pickle
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import tvm
 from tvm import dlight as dl
@@ -449,7 +449,7 @@ def build_model_from_args(args: argparse.Namespace):
         print("Reuse existing prebuilt lib {ARGS.reuse_lib}...")
 
 
-def build_model(args: BuildArgs):
+def build_model(args: BuildArgs) -> (Optional[str], Optional[str], Optional[str]):
     r"""Builds/compiles a model.
 
     Parameters
@@ -459,11 +459,11 @@ def build_model(args: BuildArgs):
 
     Returns
     ----------
-    lib_path: str
+    lib_path: Optional[str]
         The path to the model library file. Return ``None`` if not applicable.
-    model_path: str
+    model_path: Optional[str]
         The path to the folder of the model's parameters. Return ``None`` if not applicable.
-    chat_config_path: str
+    chat_config_path: Optional[str]
         The path to the chat config `.json` file. Return ``None`` if not applicable.
     """
     # Convert BuildArgs to argparse.Namespace so that we can share the rest

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -460,11 +460,11 @@ def build_model(args: BuildArgs):
     Returns
     ----------
     lib_path: str
-        The path to the `.so` library file.
+        The path to the model library file. Return ``None`` if not applicable.
     model_path: str
-        The path to the folder of the model's parameters.
+        The path to the folder of the model's parameters. Return ``None`` if not applicable.
     chat_config_path: str
-        The path to the chat config `.json` file.
+        The path to the chat config `.json` file. Return ``None`` if not applicable.
     """
     # Convert BuildArgs to argparse.Namespace so that we can share the rest
     # of the code with the command line workflow
@@ -473,4 +473,11 @@ def build_model(args: BuildArgs):
     args = _parse_args(build_args_namespace)
     build_model_from_args(args)
 
-    return args.lib_path, args.params_path, args.chat_config_path
+    # Prepare output; some workflows may or may not have the paths to return
+    lib_path = args.lib_path if hasattr(args, "lib_path") else None
+    model_path = args.params_path if hasattr(args, "params_path") else None
+    chat_config_path = (
+        args.chat_config_path if hasattr(args, "chat_config_path") else None
+    )
+
+    return lib_path, model_path, chat_config_path


### PR DESCRIPTION
Currently, if the specific workflow does not produce a corresponding path, the `build_model` API would run into an error.

For instance, if we are reusing the cache, we would not need `args.params_path`, hence running into error when returning at `build_model`: 
```
AttributeError: 'Namespace' object has no attribute 'params_path'
```

Similarly, depending on the arguments when building, the paths we want to return may or may not apply.