### PR TITLE
Suggest using `q4f16_1` than `q4f16_0`

### DIFF
--- a/android/MLCChat/app/src/main/assets/app-config.json
+++ b/android/MLCChat/app/src/main/assets/app-config.json
@@ -1,18 +1,17 @@
 {
   "model_libs": [
-    "vicuna-v1-7b-q4f16_0",
-    "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
+    "vicuna-v1-7b-q4f16_1",
+    "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
   ],
   "model_list": [
     {
       "model_url": "https://huggingface.co/mlc-ai/demo-vicuna-v1-7b-int4/",
-      "local_id": "vicuna-v1-7b-q4f16_0"
+      "local_id": "vicuna-v1-7b-q4f16_1"
     },
     {
-      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0/",
-      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
     }
   ],
-  "add_model_samples": [
-  ]
+  "add_model_samples": []
 }

--- a/docs/compilation/compile_models.rst
+++ b/docs/compilation/compile_models.rst
@@ -58,19 +58,19 @@ your personal computer.
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target metal --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target metal --quantization q4f16_1
 
         On Apple Silicon powered Mac, compile for x86 Mac:
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target metal_x86_64 --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target metal_x86_64 --quantization q4f16_1
 
     .. group-tab:: Linux - CUDA
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target cuda --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target cuda --quantization q4f16_1
 
     .. group-tab:: Vulkan
 
@@ -78,19 +78,19 @@ your personal computer.
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_1
 
         On Linux, compile for Windows: please first install the `LLVM-MinGW <https://github.com/mstorsjo/llvm-mingw>`_ toolchain, and substitute the ``path/to/llvm-mingw`` in the command with your LLVM-MinGW installation path.
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_0 --llvm-mingw path/to/llvm-mingw
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_1 --llvm-mingw path/to/llvm-mingw
 
     .. group-tab:: iOS/iPadOS
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target iphone --max-seq-len 768 --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target iphone --max-seq-len 768 --quantization q4f16_1
 
         .. note::
             If it runs into error
@@ -108,13 +108,13 @@ your personal computer.
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target android --max-seq-len 768 --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target android --max-seq-len 768 --quantization q4f16_1
 
     .. group-tab:: WebGPU
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target webgpu --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Chat-3B-v1 --target webgpu --quantization q4f16_1
 
 By executing the compile command above, we generate the model weights, model lib, and a chat config.
 We can check the output with the commands below:
@@ -125,12 +125,12 @@ We can check the output with the commands below:
 
         .. code:: shell
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0
-              RedPajama-INCITE-Chat-3B-v1-q4f16_0-metal.so     # ===> the model library
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1
+              RedPajama-INCITE-Chat-3B-v1-q4f16_1-metal.so     # ===> the model library
               mod_cache_before_build_metal.pkl                 # ===> a cached file for future builds
               params                                           # ===> containing the model weights, tokenizer and chat config
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params
               mlc-chat-config.json                             # ===> the chat config
               ndarray-cache.json                               # ===> the model weight info
               params_shard_0.bin                               # ===> the model weights
@@ -144,21 +144,21 @@ We can check the output with the commands below:
         .. code:: shell
 
             # Run CLI
-            mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_0
+            mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
-       The CLI will use the config file ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params/mlc-chat-config.json``
-       and model library ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_0-metal.so``.
+       The CLI will use the config file ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params/mlc-chat-config.json``
+       and model library ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/RedPajama-INCITE-Chat-3B-v1-q4f16_1-metal.so``.
 
     .. group-tab:: Linux - CUDA
 
         .. code:: shell
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0
-              RedPajama-INCITE-Chat-3B-v1-q4f16_0-cuda.so      # ===> the model library
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1
+              RedPajama-INCITE-Chat-3B-v1-q4f16_1-cuda.so      # ===> the model library
               mod_cache_before_build_cuda.pkl                  # ===> a cached file for future builds
               params                                           # ===> containing the model weights, tokenizer and chat config
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params
               mlc-chat-config.json                             # ===> the chat config
               ndarray-cache.json                               # ===> the model weight info
               params_shard_0.bin                               # ===> the model weights
@@ -173,21 +173,21 @@ We can check the output with the commands below:
         .. code:: shell
 
             # Run CLI
-            mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_0
+            mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
-        The CLI app using config file ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params/mlc-chat-config.json``
-        and model library ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_0-cuda.so``.
+        The CLI app using config file ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params/mlc-chat-config.json``
+        and model library ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/RedPajama-INCITE-Chat-3B-v1-q4f16_1-cuda.so``.
 
     .. group-tab:: Vulkan
 
         .. code:: shell
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0
-              RedPajama-INCITE-Chat-3B-v1-q4f16_0-vulkan.so    # ===> the model library (will be .dll when built for Windows)
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1
+              RedPajama-INCITE-Chat-3B-v1-q4f16_1-vulkan.so    # ===> the model library (will be .dll when built for Windows)
               mod_cache_before_build_vulkan.pkl                # ===> a cached file for future builds
               params                                           # ===> containing the model weights, tokenizer and chat config
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params
               mlc-chat-config.json                             # ===> the chat config
               ndarray-cache.json                               # ===> the model weight info
               params_shard_0.bin                               # ===> the model weights
@@ -201,21 +201,21 @@ We can check the output with the commands below:
         .. code:: shell
 
             # Run CLI
-            mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_0
+            mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
-        CLI app will use config file ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params/mlc-chat-config.json``
-        and model library ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_0-vulkan.so`` (or ``.dll``).
+        CLI app will use config file ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params/mlc-chat-config.json``
+        and model library ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/RedPajama-INCITE-Chat-3B-v1-q4f16_1-vulkan.so`` (or ``.dll``).
 
     .. group-tab:: iOS/iPadOS
 
         .. code:: shell
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0
-              RedPajama-INCITE-Chat-3B-v1-q4f16_0-iphone.tar   # ===> the model library
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1
+              RedPajama-INCITE-Chat-3B-v1-q4f16_1-iphone.tar   # ===> the model library
               mod_cache_before_build_iphone.pkl                # ===> a cached file for future builds
               params                                           # ===> containing the model weights, tokenizer and chat config
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params
               mlc-chat-config.json                             # ===> the chat config
               ndarray-cache.json                               # ===> the model weight info
               params_shard_0.bin                               # ===> the model weights
@@ -224,19 +224,19 @@ We can check the output with the commands below:
               tokenizer.json                                   # ===> the tokenizer files
               tokenizer_config.json
 
-        The model lib ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_0-iphone.tar``
+        The model lib ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/RedPajama-INCITE-Chat-3B-v1-q4f16_1-iphone.tar``
         will be packaged as a static library into the iOS app. Checkout :ref:`deploy-ios` for more details.
 
     .. group-tab:: Android
 
         .. code:: shell
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0
-              RedPajama-INCITE-Chat-3B-v1-q4f16_0-android.tar  # ===> the model library
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1
+              RedPajama-INCITE-Chat-3B-v1-q4f16_1-android.tar  # ===> the model library
               mod_cache_before_build_android.pkl               # ===> a cached file for future builds
               params                                           # ===> containing the model weights, tokenizer and chat config
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params
               mlc-chat-config.json                             # ===> the chat config
               ndarray-cache.json                               # ===> the model weight info
               params_shard_0.bin                               # ===> the model weights
@@ -245,19 +245,19 @@ We can check the output with the commands below:
               tokenizer.json                                   # ===> the tokenizer files
               tokenizer_config.json
 
-        The model lib ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_0-android.tar``
+        The model lib ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/RedPajama-INCITE-Chat-3B-v1-q4f16_1-android.tar``
         will be packaged as a static library into the android app. Checkout :ref:`deploy-android` for more details.
 
     .. group-tab:: WebGPU
 
         .. code:: shell
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0
-              RedPajama-INCITE-Chat-3B-v1-q4f16_0-webgpu.wasm  # ===> the model library
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1
+              RedPajama-INCITE-Chat-3B-v1-q4f16_1-webgpu.wasm  # ===> the model library
               mod_cache_before_build_webgpu.pkl                # ===> a cached file for future builds
               params                                           # ===> containing the model weights, tokenizer and chat config
 
-            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/params
+            ~/mlc-llm > ls dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/params
               mlc-chat-config.json                             # ===> the chat config
               ndarray-cache.json                               # ===> the model weight info
               params_shard_0.bin                               # ===> the model weights
@@ -266,7 +266,7 @@ We can check the output with the commands below:
               tokenizer.json                                   # ===> the tokenizer files
               tokenizer_config.json
 
-        The model lib ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_0-webgpu.wasm``
+        The model lib ``dist/RedPajama-INCITE-Chat-3B-v1-q4f16_1/RedPajama-INCITE-Chat-3B-v1-q4f16_1-webgpu.wasm``
         can be uploaded to internet. You can pass a ``model_lib_map`` field to WebLLM app config to use this library.
 
 
@@ -317,7 +317,7 @@ Another two necessary arguments for the compile command are the target and the q
                                     ``vulkan``, ``cuda``, ``webgpu``, ``android``, and ``opencl``.
 --quantization QUANTIZATION_MODE    The quantization mode we use to compile.
                                     The format of the code is ``qAfB(_0)``, where ``A`` represents the number of bits for storing weights and ``B`` represents the number of bits for storing activations.
-                                    Available options are: ``q3f16_0``, ``q4f16_0``, ``q4f32_0``, ``q0f32``, ``q0f16``, and ``q8f16_0`` (``q8f16_0`` is mainly designed for RWKV).
+                                    Available options are: ``q3f16_0``, ``q4f16_1``, ``q4f32_0``, ``q0f32``, ``q0f16``, and ``q8f16_0`` (``q8f16_0`` is mainly designed for RWKV).
                                     We encourage you to use 4-bit quantization, as the text generated by 3-bit quantized models may have bad quality depending on the model.
 
 The following arguments are optional:
@@ -455,7 +455,7 @@ This section lists compile commands for more models that you can try out.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target android --max-seq-len 768 --quantization q4f16_0
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target android --max-seq-len 768 --quantization q4f16_1
 
     .. tab:: RedPajama-v1-3B
 
@@ -465,7 +465,7 @@ This section lists compile commands for more models that you can try out.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target cuda --quantization q4f16_0
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target cuda --quantization q4f16_1
 
             .. tab:: Metal
 
@@ -473,13 +473,13 @@ This section lists compile commands for more models that you can try out.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target metal --quantization q4f16_0
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target metal --quantization q4f16_1
 
                 On Apple Silicon powered Mac, compile for x86 Mac:
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target metal_x86_64 --quantization q4f16_0
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target metal_x86_64 --quantization q4f16_1
 
             .. tab:: Vulkan
 
@@ -487,31 +487,31 @@ This section lists compile commands for more models that you can try out.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_0
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_1
 
                 On Linux, compile for Windows: please first install the `LLVM-MinGW <https://github.com/mstorsjo/llvm-mingw>`_ toolchain, and substitute the ``path/to/llvm-mingw`` in the command with your LLVM-MinGW installation path.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_0 --llvm-mingw path/to/llvm-mingw
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target vulkan --quantization q4f16_1 --llvm-mingw path/to/llvm-mingw
 
             .. tab:: WebGPU
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target webgpu --quantization q4f16_0
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target webgpu --quantization q4f16_1
 
             .. tab:: iPhone/iPad
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target iphone --max-seq-len 768 --quantization q4f16_0
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target iphone --max-seq-len 768 --quantization q4f16_1
 
             .. tab:: Android
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target android --max-seq-len 768 --quantization q4f16_0
+                    python3 -m mlc_llm.build --model RedPajama-INCITE-Chat-3B-v1 --target android --max-seq-len 768 --quantization q4f16_1
 
     .. tab:: rwkv-raven-1b5/3b/7b
 
@@ -596,7 +596,7 @@ This section lists compile commands for more models that you can try out.
                 .. code:: shell
 
                     # Download and put the model to `dist/models/MODEL_NAME`, and then run
-                    python3 -m mlc_llm.build --model MODEL_NAME --target cuda --quantization q4f16_0
+                    python3 -m mlc_llm.build --model MODEL_NAME --target cuda --quantization q4f16_1
 
             .. tab:: Metal
 
@@ -605,14 +605,14 @@ This section lists compile commands for more models that you can try out.
                 .. code:: shell
 
                     # Download and put the model to `dist/models/MODEL_NAME`, and then run
-                    python3 -m mlc_llm.build --model MODEL_NAME --target metal --quantization q4f16_0
+                    python3 -m mlc_llm.build --model MODEL_NAME --target metal --quantization q4f16_1
 
                 On Apple Silicon powered Mac, compile for x86 Mac:
 
                 .. code:: shell
 
                     # Download and put the model to `dist/models/MODEL_NAME`, and then run
-                    python3 -m mlc_llm.build --model MODEL_NAME --target metal_x86_64 --quantization q4f16_0
+                    python3 -m mlc_llm.build --model MODEL_NAME --target metal_x86_64 --quantization q4f16_1
 
             .. tab:: Vulkan
 
@@ -621,14 +621,14 @@ This section lists compile commands for more models that you can try out.
                 .. code:: shell
 
                     # Download and put the model to `dist/models/MODEL_NAME`, and then run
-                    python3 -m mlc_llm.build --model MODEL_NAME --target vulkan --quantization q4f16_0
+                    python3 -m mlc_llm.build --model MODEL_NAME --target vulkan --quantization q4f16_1
 
                 On Linux, compile for Windows: please first install the `LLVM-MinGW <https://github.com/mstorsjo/llvm-mingw>`_ toolchain, and substitute the ``path/to/llvm-mingw`` in the command with your LLVM-MinGW installation path.
 
                 .. code:: shell
 
                     # Download and put the model to `dist/models/MODEL_NAME`, and then run
-                    python3 -m mlc_llm.build --model MODEL_NAME --target vulkan --quantization q4f16_0 --llvm-mingw path/to/llvm-mingw
+                    python3 -m mlc_llm.build --model MODEL_NAME --target vulkan --quantization q4f16_1 --llvm-mingw path/to/llvm-mingw
 
             .. tab:: WebGPU
 
@@ -642,14 +642,14 @@ This section lists compile commands for more models that you can try out.
                 .. code:: shell
 
                     # Download and put the model to `dist/models/MODEL_NAME`, and then run
-                    python3 -m mlc_llm.build --model MODEL_NAME --target iphone --max-seq-len 768 --quantization q4f16_0
+                    python3 -m mlc_llm.build --model MODEL_NAME --target iphone --max-seq-len 768 --quantization q4f16_1
 
             .. tab:: Android
 
                 .. code:: shell
 
                     # Download and put the model to `dist/models/MODEL_NAME`, and then run
-                    python3 -m mlc_llm.build --model MODEL_NAME --target android --max-seq-len 768 --quantization q4f16_0
+                    python3 -m mlc_llm.build --model MODEL_NAME --target android --max-seq-len 768 --quantization q4f16_1
 
 
 For each model and each backend, the above only provides the most recommended build command (which is the most optimized). You can also try with different argument values (e.g., different quantization modes), whose build results may not run as fast and robustly as the provided one when running the model.

--- a/docs/compilation/configure_quantization.rst
+++ b/docs/compilation/configure_quantization.rst
@@ -16,4 +16,4 @@ In MLC-LLM we use a short code that indicates the quantization mode to use.
 The format of the code is ``qAfB(_id)``, where ``A`` represents the number
 of bits for storing weights and ``B`` represents the number of bits for storing activations. The ``_id`` is an integer identifier to distinguish different quantization algorithms (e.g. symmetric, non-symmetric, GPTQ, etc).
 
-Currently, the available options are: ``q3f16_0``, ``q4f16_0``, ``q4f32_0``, ``q0f32``, ``q0f16``, and ``q8f16_0`` (``q8f16_0`` is mainly designed for RWKV).
+Currently, the available options are: ``q3f16_0``, ``q4f16_1``, ``q4f32_0``, ``q0f32``, ``q0f16``, and ``q8f16_0`` (``q8f16_0`` is mainly designed for RWKV).

--- a/docs/compilation/distribute_compiled_models.rst
+++ b/docs/compilation/distribute_compiled_models.rst
@@ -18,19 +18,19 @@ you can use the following command to compile it:
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target metal --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target metal --quantization q4f16_1
 
     .. group-tab:: Linux - CUDA
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target cuda --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target cuda --quantization q4f16_1
 
     .. group-tab:: Vulkan
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target vulkan --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target vulkan --quantization q4f16_1
 
 
 .. contents:: Table of Contents
@@ -44,12 +44,12 @@ To begin with, we can check that we have the compilation artifact ready on the d
 
 .. code:: shell
 
-    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0
-        RedPajama-INCITE-Instruct-3B-v1-q4f16_0-metal.so  # ===> the model library
+    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1
+        RedPajama-INCITE-Instruct-3B-v1-q4f16_1-metal.so  # ===> the model library
         mod_cache_before_build_metal.pkl                  # ===> a cached file for future builds
         params                                            # ===> containing the model weights, tokenizer and chat config
 
-    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params
+    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params
         mlc-chat-config.json                              # ===> the chat config
         ndarray-cache.json                                # ===> the model weight info
         params_shard_0.bin                                # ===> the model weights
@@ -64,7 +64,7 @@ Step 2. Update MLC Chat Configuration JSON
 ------------------------------------------
 
 You can **optionally** customize the chat config file
-``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params/mlc-chat-config.json`` (checkout :ref:`configure-mlc-chat-json` for more detailed instructions).
+``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params/mlc-chat-config.json`` (checkout :ref:`configure-mlc-chat-json` for more detailed instructions).
 You can also simply use the default configuration and skip this step.
 
 For demonstration purpose, we update ``mean_gen_len`` to 32 and ``max_gen_len`` to 64.
@@ -79,8 +79,8 @@ Step 3. Specify the Model Lib
 An MLC chat app needs to look for the model library to run the model.
 In the case of RedPajama-3B instruct model, we already have a prebuilt model lib for RedPajama-3B chat model that shares the
 same model architecture and quantization mode as the instruct model.
-We can edit ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params/mlc-chat-config.json``
-and update the value of field ``model_lib`` to ``"RedPajama-INCITE-Chat-3B-v1-q4f16_0"``.
+We can edit ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params/mlc-chat-config.json``
+and update the value of field ``model_lib`` to ``"RedPajama-INCITE-Chat-3B-v1-q4f16_1"``.
 
 .. note::
 
@@ -93,17 +93,17 @@ and update the value of field ``model_lib`` to ``"RedPajama-INCITE-Chat-3B-v1-q4
 
     .. code:: shell
 
-        python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --reuse-lib RedPajama-INCITE-Chat-3B-v1-q4f16_0 --target [your target] --quantization q4f16_0
+        python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --reuse-lib RedPajama-INCITE-Chat-3B-v1-q4f16_1 --target [your target] --quantization q4f16_1
     
     In this way, `mlc_llm.build` does not produce the model library for the instruct model, and in `mlc-chat-config.json`
-    the ``model_lib`` field is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_0``.
+    the ``model_lib`` field is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_1``.
 
     Please note that only models with same architecture and compiled with same quantization modes can reuse and share model library.
 
 
 We should distribute the generated model lib if we want to build a new model architecture or try out customized compilation optimizations.
-In this case, we should keep the ``model_lib`` field as ``"RedPajama-INCITE-Instruct-3B-v1-q4f16_0"``.
-You can upload the model library ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/RedPajama-INCITE-Instruct-3B-v1-q4f16_0-metal.so``
+In this case, we should keep the ``model_lib`` field as ``"RedPajama-INCITE-Instruct-3B-v1-q4f16_1"``.
+You can upload the model library ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/RedPajama-INCITE-Instruct-3B-v1-q4f16_1-metal.so``
 and ask others to download it to  `dist/prebuilt/lib` directory so the CLI app can pick it up.
 
 
@@ -111,7 +111,7 @@ Step 4. Upload the Compiled Model Weights
 -----------------------------------------
 
 As a next step, we need to upload the model weights.
-We only need to upload the files in ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params``.
+We only need to upload the files in ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params``.
 If you also want to host the compiled models on Hugging Face, you can follow the instructions below:
 
 .. code:: shell
@@ -121,11 +121,11 @@ If you also want to host the compiled models on Hugging Face, you can follow the
     git lfs install
     git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo
     cd my-redpajama3b-weight-huggingface-repo
-    cp path/to/mlc-llm/dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params/* .
+    cp path/to/mlc-llm/dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params/* .
     git add . && git commit -m "Add redpajama-3b instruct model weights"
     git push origin main
 
-Here we provide an `example distributed RedPajama-3B instruct model repository <https://huggingface.co/mlc-ai/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/tree/main>`_ which you can refer to.
+Here we provide an `example distributed RedPajama-3B instruct model repository <https://huggingface.co/mlc-ai/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/tree/main>`_ which you can refer to.
 
 ---------------------------------
 
@@ -150,10 +150,10 @@ The steps needed to run models in CLI are similar to the steps to download the p
 
     # Download the model weights
     cd dist/prebuilt
-    git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo RedPajama-INCITE-Instruct-3B-v1-q4f16_0
+    git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo RedPajama-INCITE-Instruct-3B-v1-q4f16_1
     cd ../..
     # Run CLI
-    mlc_chat_cli --local-id RedPajama-INCITE-Instruct-3B-v1-q4f16_0
+    mlc_chat_cli --local-id RedPajama-INCITE-Instruct-3B-v1-q4f16_1
 
 
 Download the Distributed Models and Run in iOS App
@@ -163,8 +163,8 @@ For iOS app, model libraries are statically packed into the app at the time of a
 Therefore, the iOS app supports running any models whose model libraries are integrated into the app.
 You can check the :ref:`list of supported model libraries <prebuilt-models-ios>`.
 
-To download and run the compiled RedPajama-3B instruct model on iPhone, we need to reuse the integrated ``RedPajama-INCITE-Chat-3B-v1-q4f16_0`` model library.
-Please revisit :ref:`distribute-model-step3-specify-model-lib` and make sure the ``model_lib`` field of `mlc-chat-config.json` is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_0``.
+To download and run the compiled RedPajama-3B instruct model on iPhone, we need to reuse the integrated ``RedPajama-INCITE-Chat-3B-v1-q4f16_1`` model library.
+Please revisit :ref:`distribute-model-step3-specify-model-lib` and make sure the ``model_lib`` field of `mlc-chat-config.json` is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_1``.
 
 Now we can download the model weights in iOS app and run the model by following the steps below:
 

--- a/docs/deploy/android.rst
+++ b/docs/deploy/android.rst
@@ -35,34 +35,34 @@ App Build Instructions
    .. code:: shell
 
       # From mlc-llm project directory
-      python3 build.py --model path/to/vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
+      python3 build.py --model path/to/vicuna-v1-7b --quantization q4f16_1 --target android --max-seq-len 768
 
       # If the model path is `dist/models/vicuna-v1-7b`,
       # we can simplify the build command to
-      # python build.py --model vicuna-v1-7b --quantization q4f16_0 --target android --max-seq-len 768
+      # python build.py --model vicuna-v1-7b --quantization q4f16_1 --target android --max-seq-len 768
 
 2. Configure the ``model_libs`` in ``android/MLCChat/app/src/main/assets/app-config.json``:
    
    If there is a ``local_id`` in ``model_libs`` list, then there should be a ``local_id-target.tar`` in ``dist/local_id`` compiled in Step 1.
 
-   For example, if you have ``vicuna-v1-7b-q4f16_0`` in the ``model_libs``:
+   For example, if you have ``vicuna-v1-7b-q4f16_1`` in the ``model_libs``:
 
    .. code:: bash
 
       cat android/MLCChat/app/src/main/assets/app-config.json
       # "model_libs": [
       #   ...
-      #   "vicuna-v1-7b-q4f16_0",
+      #   "vicuna-v1-7b-q4f16_1",
       #   ...
       # ],
    
-   then there should be a ``dist/vicuna-v1-7b-q4f16_0/vicuna-v1-7b-q4f16_0-android.tar`` file:
+   then there should be a ``dist/vicuna-v1-7b-q4f16_1/vicuna-v1-7b-q4f16_1-android.tar`` file:
 
    .. code:: bash
 
-      ls dist/vicuna-v1-7b-q4f16_0
+      ls dist/vicuna-v1-7b-q4f16_1
       # ...
-      # vicuna-v1-7b-q4f16_0-android.tar,
+      # vicuna-v1-7b-q4f16_1-android.tar,
       # ...
 
 3. Download `Android Studio <https://developer.android.com/studio>`_, install the ``NDK`` and ``CMake`` via `SDK Manager <https://developer.android.com/studio/projects/install-ndk>`_.

--- a/docs/deploy/ios.rst
+++ b/docs/deploy/ios.rst
@@ -54,7 +54,7 @@ in the root of the MLC-LLM.
 
    cd dist/prebuilt
    git lfs install
-   git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
+   git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1
    cd ../..
 
 Validate that the files and directories exist:
@@ -62,10 +62,10 @@ Validate that the files and directories exist:
 .. code:: bash
 
    >>> ls -l ./dist/prebuilt/lib/*-iphone.tar
-   ./dist/prebuilt/lib/RedPajama-INCITE-Chat-3B-v1-q4f16_0-iphone.tar
+   ./dist/prebuilt/lib/RedPajama-INCITE-Chat-3B-v1-q4f16_1-iphone.tar
    ./dist/prebuilt/lib/vicuna-v1-7b-q3f16_0-iphone.tar
 
-   >>> ls -l ./dist/prebuilt/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
+   >>> ls -l ./dist/prebuilt/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1
    # chat config:
    mlc-chat-config.json
    # model weights:
@@ -107,7 +107,7 @@ run the following command under the ``./ios`` directory:
 .. code:: bash
 
    cd ./ios
-   open ./prepare_params.sh # make sure builtin_list only contains "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
+   open ./prepare_params.sh # make sure builtin_list only contains "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
    ./prepare_params.sh
 
 The outcome should be as follows:
@@ -115,7 +115,7 @@ The outcome should be as follows:
 .. code:: bash
 
    >>> ls ./dist/
-   RedPajama-INCITE-Chat-3B-v1-q4f16_0
+   RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
 Step 4. Build iOS App
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/get_started/mlc_chat_config.rst
+++ b/docs/get_started/mlc_chat_config.rst
@@ -6,7 +6,7 @@ Configure MLCChat in JSON
 This page explains the components of a chat configuration and how to customize them for your own purposes.
 
 Each MLC Chat runtime can be configured via an ``mlc-chat-config.json`` file under the directory of each compiled model (e.g.
-`RedPajama chat config <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0/blob/main/mlc-chat-config.json>`__)
+`RedPajama chat config <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/blob/main/mlc-chat-config.json>`__)
 which contains the chat configuration. You can customize the chat configuration by modifying this file.
 Additionally, the runtimes also provide APIs to optionally override some of the configurations.
 

--- a/docs/get_started/try_out.rst
+++ b/docs/get_started/try_out.rst
@@ -51,9 +51,9 @@ and you can try out prebuilt models on the following platforms:
       # You can try more models, for example:
       # download prebuilt weights of RedPajama-3B
       cd dist/prebuilt
-      git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
+      git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1
       cd ../..
-      mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_0
+      mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
     .. note::
       If you are using Windows or Linux. Make sure you have the latest Vulkan driver installed.

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -40,12 +40,12 @@ Prebuilt Models for CLI
       * Running data type: float16
       * Symmetric quantization
     - `link <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_0`
+  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
     - `RedPajama <https://www.together.xyz/blog/redpajama>`__
     - * Weight storage data type: int4
       * Running data type: float16
       * Symmetric quantization
-    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
+    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
   * - `rwkv-raven-1b5-q8f16_0`
     - `RWKV <https://github.com/BlinkDL/RWKV-LM>`__
     - * Weight storage data type: uint8
@@ -117,12 +117,12 @@ Prebuilt Models for iOS
       * Running data type: float16
       * Symmetric quantization
     - `link <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_0`
+  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
     - `RedPajama <https://www.together.xyz/blog/redpajama>`__
     - * Weight storage data type: int4
       * Running data type: float16
       * Symmetric quantization
-    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
+    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
 
 The `downloadable iOS app <https://apps.apple.com/us/app/mlc-chat/id6448482937>`_ has builtin RedPajama-3B model support.
 To add a model to the iOS app, follow the steps below:
@@ -184,7 +184,7 @@ For example, if you compile `OpenLLaMA-7B <https://github.com/openlm-research/op
     - * Weight storage data type: int3
       * Running data type: float16
       * Symmetric quantization
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_0`
+  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
     - GPT-NeoX
     - * Weight storage data type: int4
       * Running data type: float16
@@ -204,18 +204,18 @@ Prebuilt Models for Android
     - Model Series
     - Quantization Mode
     - Hugging Face repo
-  * - `vicuna-v1-7b-q4f16_0`
+  * - `vicuna-v1-7b-q4f16_1`
     - `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
     - * Weight storage data type: int4
       * Running data type: float16
       * Symmetric quantization
     - `link <https://huggingface.co/mlc-ai/demo-vicuna-v1-7b-int4>`__
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_0`
+  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
     - `RedPajama <https://www.together.xyz/blog/redpajama>`__
     - * Weight storage data type: int4
       * Running data type: float16
       * Symmetric quantization
-    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
+    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
 
 ------------------
 

--- a/ios/MLCChat/app-config.json
+++ b/ios/MLCChat/app-config.json
@@ -1,18 +1,18 @@
 {
-    "model_libs": [
-        "Llama-2-7b-chat-hf-q3f16_1",
-        "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
-    ],
-    "model_list": [
-        {
-            "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0/",
-            "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
-        }
-    ],
-    "add_model_samples": [
-        {
-            "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0/",
-            "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
-        }
-    ]
+  "model_libs": [
+    "Llama-2-7b-chat-hf-q3f16_1",
+    "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+  ],
+  "model_list": [
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+    }
+  ],
+  "add_model_samples": [
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+    }
+  ]
 }

--- a/ios/prepare_params.sh
+++ b/ios/prepare_params.sh
@@ -6,25 +6,23 @@ rm -rf dist
 mkdir -p dist
 
 declare -a builtin_list=(
-    "Llama-2-7b-chat-hf-q3f16_1"
-    # "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
-    # "vicuna-v1-7b-q3f16_0"
-    # "rwkv-raven-1b5-q8f16_0"
-    # "rwkv-raven-3b-q8f16_0"
-    # "rwkv-raven-7b-q8f16_0"
+	"Llama-2-7b-chat-hf-q3f16_1"
+	# "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+	# "vicuna-v1-7b-q3f16_0"
+	# "rwkv-raven-1b5-q8f16_0"
+	# "rwkv-raven-3b-q8f16_0"
+	# "rwkv-raven-7b-q8f16_0"
 )
 
-for model in "${builtin_list[@]}"
-do
-    if [ -d  ../dist/$model/params ]; then
-        cp -r ../dist/$model/params dist/$model
-    elif [ -d  ../dist/prebuilt/$model ]; then
-        cp -r ../dist/prebuilt/$model dist/$model
-    elif [ -d  ../dist/prebuilt/mlc-chat-$model ]; then
-        cp -r ../dist/prebuilt/mlc-chat-$model dist/$model
-    else
-        echo "Cannot find prebuilt weights for " $model
-        exit 1
-    fi
+for model in "${builtin_list[@]}"; do
+	if [ -d ../dist/$model/params ]; then
+		cp -r ../dist/$model/params dist/$model
+	elif [ -d ../dist/prebuilt/$model ]; then
+		cp -r ../dist/prebuilt/$model dist/$model
+	elif [ -d ../dist/prebuilt/mlc-chat-$model ]; then
+		cp -r ../dist/prebuilt/mlc-chat-$model dist/$model
+	else
+		echo "Cannot find prebuilt weights for " $model
+		exit 1
+	fi
 done
-

--- a/site/index.md
+++ b/site/index.md
@@ -82,9 +82,9 @@ mlc_chat_cli --local-id vicuna-v1-7b-q3f16_0
 
 # Download prebuilt weights of RedPajama-3B
 cd dist/prebuilt
-git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
+git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1
 cd ../..
-mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_0
+mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
 # Download prebuilt weights of RWKV-raven-1.5B/3B/7B
 cd dist/prebuilt


### PR DESCRIPTION
`q4f16_0` has been widely used in documentation, tutorials and command line default values since the beginning.

With the latest push, we have introduced `q4f16_1`, which is faster and has arithmetically equivalent precision.

Therefore, this PR aims to remind that `q4f16_1` is more preferrable than `q4f16_0` in case of any potential issues.