### PR TITLE
Add support for safetensors

### DIFF
--- a/docs/compilation/compile_models.rst
+++ b/docs/compilation/compile_models.rst
@@ -290,7 +290,8 @@ Generally, the model compile command is specified by a sequence of arguments and
         [--max-seq-len MAX_ALLOWED_SEQUENCE_LENGTH] \
         [--reuse-lib LIB_NAME] \
         [--use-cache=0] \
-        [--debug-dump]
+        [--debug-dump] \
+        [--use-safetensors]
 
 This command first goes with ``--model`` or ``--hf-path``.
 **Only one of them needs to be specified**: when the model is publicly available on Hugging Face, you can use ``--hf-path`` to specify the model.
@@ -333,7 +334,7 @@ The following arguments are optional:
                                             and will compile the model from the very start.
                                             Using cache can help reduce the time needed to compile.
 --debug-dump                                Specifies whether to dump debugging files during compilation.
-
+--use-safetensors                           Specifies whether to use ``.safetensors`` instead of the default ``.bin`` when loading in model weights.
 
 More Model Compile Commands
 ---------------------------

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -123,6 +123,16 @@ class BuildArgs:
             "action": "store_true",
         },
     )
+    use_safetensors: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Use ``.safetensors`` instead of the default ``.bin`` when loading "
+                "model weights."
+            ),
+            "action": "store_true",
+        },
+    )
 
 
 def convert_build_args_to_argparser() -> argparse.ArgumentParser:

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -127,8 +127,8 @@ class BuildArgs:
         default=False,
         metadata={
             "help": (
-                "Use ``.safetensors`` instead of the default ``.bin`` when loading "
-                "model weights."
+                "Specifies whether to use ``.safetensors`` instead of the default "
+                "``.bin`` when loading in model weights."
             ),
             "action": "store_true",
         },

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -155,6 +155,13 @@ def convert_build_args_to_argparser() -> argparse.ArgumentParser:
 
 def _parse_args(parsed) -> argparse.Namespace:
     assert parsed.max_seq_len == -1 or parsed.max_seq_len > 0
+    if parsed.use_safetensors:
+        try:
+            import safetensors  # pylint: disable=import-outside-toplevel, unused-import
+        except ImportError as error:
+            raise ImportError(
+                "`use_safetensors` option is toggled, please install safetensors package."
+            ) from error
 
     parsed.export_kwargs = {}
     parsed.lib_format = "so"

--- a/mlc_llm/quantization/autogptq_quantization.py
+++ b/mlc_llm/quantization/autogptq_quantization.py
@@ -12,6 +12,7 @@ from .quantization import FQuantize, FTEDequantize, convert_TE_func
 
 def load_autogptq_params(
     model_path: str,
+    use_safetensors: bool,
     param_list: List[relax.Var],
     pidx2pname: Dict[int, str],
     device: Device,
@@ -26,7 +27,9 @@ def load_autogptq_params(
 
     from auto_gptq import AutoGPTQForCausalLM
 
-    model = AutoGPTQForCausalLM.from_quantized(model_path).cpu()
+    model = AutoGPTQForCausalLM.from_quantized(
+        model_path, use_safetensors=use_safetensors
+    ).cpu()
     param_dict = model.state_dict()
     for pidx, pname in pidx2pname.items():
         if any(excluded_param in pname for excluded_param in excluded_params):

--- a/mlc_llm/relax_model/gpt_bigcode.py
+++ b/mlc_llm/relax_model/gpt_bigcode.py
@@ -671,6 +671,7 @@ def get_model(args: argparse.Namespace, hf_config):
 
         param_manager.set_param_loading_func(
             args.model_path,
+            args.use_safetensors,
             f_convert_param_bkwd=lambda torch_pname, torch_param: [
                 (torch_pname, torch_param.astype(dtype))
             ],

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -785,6 +785,6 @@ def get_model(
             return [(torch_pname, torch_param.astype(dtype))]
 
     param_manager.set_param_loading_func(
-        args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
+        args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
     return mod, param_manager, [None] * len(param_manager.param_names)

--- a/mlc_llm/relax_model/gptj.py
+++ b/mlc_llm/relax_model/gptj.py
@@ -706,6 +706,6 @@ def get_model(args, hf_config):
             return [(torch_pname, torch_param.astype(dtype))]
 
     param_manager.set_param_loading_func(
-        args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
+        args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
     return mod, param_manager, [None] * len(param_manager.param_names)

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -932,6 +932,7 @@ def get_model(args, hf_config):
 
     param_manager.set_param_loading_func(
         args.model_path,
+        args.use_safetensors,
         f_convert_pname_fwd,
         f_convert_param_bkwd,
         f_compute_relax_param,
@@ -942,6 +943,7 @@ def get_model(args, hf_config):
     if args.quantization.pre_quantized:
         param_list = args.quantization.load_quantized_params(
             args.model_path,
+            args.use_safetensors,
             param_list,
             param_manager.pidx2pname,
             device,

--- a/mlc_llm/relax_model/minigpt.py
+++ b/mlc_llm/relax_model/minigpt.py
@@ -519,7 +519,7 @@ def get_model(args):
             return mod, param_manager, None
 
         param_manager.set_param_loading_func(
-            args.model_path, no_lazy_param_loading=True
+            args.model_path, args.use_safetensors, no_lazy_param_loading=True
         )
 
         # load visual encoder weights

--- a/mlc_llm/relax_model/rwkv.py
+++ b/mlc_llm/relax_model/rwkv.py
@@ -552,6 +552,6 @@ def get_model(args, hf_config):
             return [(pname, torch_param.astype(config.dtype))]
 
     param_manager.set_param_loading_func(
-        args.model_path, f_convert_pname_fwd, f_convert_param_bkwd
+        args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
     return mod, param_manager, [None] * len(param_manager.param_names)


### PR DESCRIPTION
As brought up in Issue #585, it would be great to include support for `.safetensors` files. 

This PR allows users to use `.safetensors` instead of the default `.bin` to compile their model. To trigger this, users would specify `use_safetensors=True` in `BuildArgs`, or equivalently `--use-safetensors` in CLI.

Updated docs correspondingly.

Tested:
- Building Llama-2-7b-chat-hf with `.safetensors`
- Building Llama-2-7b-chat-hf with `.bin` 