### PR TITLE
[bugfix] quick fix of convert_build_args_to_argparser

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -130,7 +130,7 @@ def convert_build_args_to_argparser() -> argparse.ArgumentParser:
             # boolean arguments do not need to specify `type`
             args.add_argument(field_name, default=field.default, **kwargs)
         else:
-            args.add_argument(field_name, field.type, default=field.default, **kwargs)
+            args.add_argument(field_name, type=field.type, default=field.default, **kwargs)
     return args
 
 


### PR DESCRIPTION
A fix, PR https://github.com/mlc-ai/mlc-llm/pull/626 has a simple typo which accidentally deleted type= of add_arguments.


https://github.com/mlc-ai/mlc-llm/blob/9c77d19a4212323d05033cd077d6a9b9b62ddc50/mlc_llm/core.py#L121-L134

the line of 133 should be 

`args.add_argument(field_name, type=field.type, default=field.default, **kwargs)`

as the params of add_arguments are:

```
def add_argument(
    *name_or_flags: str,
    action: _ActionStr | type[Action] = ...,
    nargs: int | _NArgsStr | _SUPPRESS_T = ...,
    const: Any = ...,
    default: Any = ...,
    type: ((str) -> _T@add_argument) | FileType = ...,
    choices: Iterable[_T@add_argument] | None = ...,
    required: bool = ...,
    help: str | None = ...,
    metavar: str | tuple[str, ...] | None = ...,
```

