### PR TITLE
Enable offloading attention and layer / RMS norm to CUTLASS

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 import mlc_llm
 import tvm
 from mlc_llm import utils
+from mlc_llm.transform import rewrite_attention
 from mlc_llm.relax_model import (
     gpt_bigcode,
     gpt_neox,
@@ -18,9 +19,12 @@ from mlc_llm.relax_model import (
     param_manager,
     rwkv,
 )
+
 from tvm import dlight as dl
 from tvm import meta_schedule as ms
 from tvm import relax
+from tvm.relax.backend import get_patterns_with_prefix
+from tvm.relax.backend.contrib.cutlass import annotate_workspace
 
 
 @dataclass
@@ -122,6 +126,16 @@ class BuildArgs:
             "help": (
                 "Specifies whether to use ``.safetensors`` instead of the default "
                 "``.bin`` when loading in model weights."
+            ),
+            "action": "store_true",
+        },
+    )
+    use_cutlass_attn: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Offload attention operations to CUTLASS when the target is CUDA"
+                "and TVM has been built with CUTLASS enabled."
             ),
             "action": "store_true",
         },
@@ -300,6 +314,30 @@ def mod_transform_before_build(
 
     mod = param_manager.transform_dequantize(mod)
     mod = mlc_llm.transform.FuseDecodeTranspose()(mod)  # pylint: disable=not-callable
+
+    if (
+        args.use_cutlass_attn
+        and args.target_kind == "cuda"
+        and tvm.get_global_func("relax.ext.cutlass", True)
+    ):
+        mod["prefill"] = rewrite_attention(mod["prefill"])
+        mod["decode"] = rewrite_attention(mod["decode"])
+
+        partition_pass = relax.transform.FuseOpsByPattern(
+            get_patterns_with_prefix("cutlass.attention"),
+            bind_constants=False,
+            annotate_codegen=True,
+        )
+        mod = partition_pass(mod)
+        mod = annotate_workspace(mod)
+        mod = relax.transform.AllocateWorkspace()(mod)
+
+        os.makedirs("./tmp", exist_ok=True)
+        mod = relax.transform.RunCodegen(
+            {"cutlass": {"sm": 80, "find_first_valid": False}},
+            entry_functions=model_names,
+        )(mod)
+
     mod = mlc_llm.transform.FuseTransposeMatmul()(mod)  # pylint: disable=not-callable
     mod = relax.pipeline.get_pipeline()(mod)  # pylint: disable=no-value-for-parameter
     mod = mlc_llm.transform.FuseDecodeMatmulEwise(  # pylint: disable=not-callable

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -140,6 +140,16 @@ class BuildArgs:
             "action": "store_true",
         },
     )
+    use_cutlass_norm: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Offload layer and RMS norm operations to CUTLASS when the target is CUDA"
+                "and TVM has been built with CUTLASS enabled."
+            ),
+            "action": "store_true",
+        },
+    )
 
 
 def convert_build_args_to_argparser() -> argparse.ArgumentParser:
@@ -323,6 +333,10 @@ def mod_transform_before_build(
             mod["prefill"] = rewrite_attention(mod["prefill"])
             mod["decode"] = rewrite_attention(mod["decode"])
             patterns += get_patterns_with_prefix("cutlass.attention")
+
+        if args.use_cutlass_norm:
+            patterns += get_patterns_with_prefix("cutlass.layer_norm")
+            patterns += get_patterns_with_prefix("cutlass.rms_norm")
 
         if len(patterns) > 0:
             os.makedirs("./tmp", exist_ok=True)

--- a/mlc_llm/transform/__init__.py
+++ b/mlc_llm/transform/__init__.py
@@ -4,4 +4,5 @@ from .decode_take import FuseDecodeTake
 from .decode_transpose import FuseDecodeTranspose
 from .lift_tir_global_buffer_alloc import LiftTIRGlobalBufferAlloc
 from .reorder_transform_func import ReorderTransformFunc
+from .rewrite_attention import rewrite_attention
 from .transpose_matmul import FuseTransposeMatmul

--- a/mlc_llm/transform/rewrite_attention.py
+++ b/mlc_llm/transform/rewrite_attention.py
@@ -1,0 +1,30 @@
+from tvm.relax.dpl import PatternContext, is_const, is_op, rewrite_call, wildcard
+from tvm.script import relax as R
+
+
+def rewrite_attention(f):
+    Q = wildcard()
+    K = wildcard()
+    V = wildcard()
+
+    Q_BNSH = is_op("relax.permute_dims")(Q)
+    K_BNSH = is_op("relax.permute_dims")(K)
+    V_BNSH = is_op("relax.permute_dims")(V)
+
+    K_BNSH_T = is_op("relax.permute_dims")(K_BNSH)
+
+    matmul1 = is_op("relax.matmul")(Q_BNSH, K_BNSH_T)
+    divide = is_op("relax.divide")(matmul1, is_const())
+    max = is_op("relax.maximum")(divide, is_const())
+    min = is_op("relax.minimum")(max, wildcard())
+    softmax = is_op("relax.nn.softmax")(is_op("relax.astype")(min))
+    matmul2 = is_op("relax.matmul")(is_op("relax.astype")(softmax), V_BNSH)
+
+    pattern = is_op("relax.permute_dims")(matmul2)
+
+    def callback(_, matchings):
+        return R.nn.attention(
+            matchings[Q], matchings[K], matchings[V], causal_mask="BottomRight"
+        )
+
+    return rewrite_call(pattern, callback, f)


### PR DESCRIPTION
With TVM built with `USE_CUTLASS`, adding `--use-cutlass-attn --use-cutlass-norm` enables offloading attention and layer / RMS norm to CUTLASS.

On RTX 4080 and Vicuna 7B, attention offload brings 12-15 tok / s improvement, and RMS norm offload adds another 4-5 tok / sec.  