### PR TITLE
[Quantization] QuantSpecUpdator visitor

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -421,6 +421,10 @@ def build_model_from_args(args: argparse.Namespace):
         else:
             raise ValueError(f"Model {args.model} not supported")
 
+        for qspec_updater_class in param_manager.qspec_updater_classes:
+            qspec_updater = qspec_updater_class(param_manager)
+            qspec_updater.visit_module(mod)
+
         if not args.build_model_only:
             new_params = utils.convert_weights(param_manager, params, args)
             utils.save_params(new_params, args.artifact_path)
@@ -445,7 +449,7 @@ def build_model_from_args(args: argparse.Namespace):
     if not args.reuse_lib:
         build(mod, args)
     else:
-        print("Reuse existing prebuilt lib {ARGS.reuse_lib}...")
+        print(f"Reuse existing prebuilt lib {args.reuse_lib}...")
 
 
 def build_model(args: BuildArgs) -> (Optional[str], Optional[str], Optional[str]):

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -1,6 +1,7 @@
 from .quantization import FQuantize
 from .quantization import QuantizationScheme
 from .quantization import QuantizationSpec, NoQuantizationSpec, ParamQuantKind
+from .quantization import QuantSpecUpdater
 from .group_quantization import GroupQuantizationSpec
 from .autogptq_quantization import AutogptqQuantizationSpec, load_autogptq_params
 from .rwkv_quantization import RWKVQuantizationSpec


### PR DESCRIPTION
This PR introduces QuantSpecUpdator, which is a subclass of Relax's PyExprVisitor. The QuantSpecUpdator takes a ParamManager instance as the constructor input. It has the capability to update the QuantizationSpec for the parameters in this ParamManager.

We can inherit the QuantSpecUpdator to write the update logic in the subclass.

Each QuantizationScheme now optionally takes a QuantSpecUpdator class as input. In the model build flow, after the IRModule is constructed, we will use all the registered QuantSpecUpdator to go through the IRModule, and update the QuantizationSpec accordingly.

This PR also provides a demo example of inheriting QuantSpecUpdator (GroupQuantDemoUpdater in `group_quantization.py`). The demo's functionality is validated on RedPajama (by disabling the Matmul and GeneralReduction dlight rules which are broken for RedPajama).