### PR TITLE
FasterTransformer offloading integration

### DIFF
--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -5,7 +5,7 @@ from .quantization import QuantSpecUpdater
 from .group_quantization import GroupQuantizationSpec
 from .autogptq_quantization import AutogptqQuantizationSpec, load_autogptq_params
 from .rwkv_quantization import RWKVQuantizationSpec
-from .ft_rowwise_quantization import FTRowwiseQuantizationSpec
+from .ft_rowwise_quantization import FTRowwiseQuantizationSpec, FTQuantizeUpdater
 
 
 # The predefined quantization schemes.
@@ -115,6 +115,7 @@ quantization_schemes = {
             transpose=False,
         ),
         final_fc_weight="same_as_linear_weight",
+        qspec_updater_class=FTQuantizeUpdater,
     ),
     "q4f32_0": QuantizationScheme(
         name="q4f32_0",
@@ -169,5 +170,6 @@ quantization_schemes = {
             transpose=False,
         ),
         final_fc_weight="same_as_linear_weight",
+        qspec_updater_class=FTQuantizeUpdater,
     ),
 }

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -154,4 +154,20 @@ quantization_schemes = {
         linear_weight=RWKVQuantizationSpec(dtype="float16", mode="uint8", nbit=8),
         final_fc_weight="same_as_linear_weight",
     ),
+    "q8f16_ft": QuantizationScheme(
+        name="q8f16_ft",
+        linear_weight=FTRowwiseQuantizationSpec(
+            dtype="float16",
+            nbit=8,
+        ),
+        embedding_table=GroupQuantizationSpec(
+            dtype="float16",
+            mode="int8",
+            sym=True,
+            storage_nbit=32,
+            group_size=32,
+            transpose=False,
+        ),
+        final_fc_weight="same_as_linear_weight",
+    ),
 }

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -5,6 +5,7 @@ from .quantization import QuantSpecUpdater
 from .group_quantization import GroupQuantizationSpec
 from .autogptq_quantization import AutogptqQuantizationSpec, load_autogptq_params
 from .rwkv_quantization import RWKVQuantizationSpec
+from .ft_rowwise_quantization import FTRowwiseQuantizationSpec
 
 
 # The predefined quantization schemes.
@@ -97,6 +98,22 @@ quantization_schemes = {
             transpose=False,
         ),
         embedding_table="same_as_linear_weight",
+        final_fc_weight="same_as_linear_weight",
+    ),
+    "q4f16_ft": QuantizationScheme(
+        name="q4f16_ft",
+        linear_weight=FTRowwiseQuantizationSpec(
+            dtype="float16",
+            nbit=4,
+        ),
+        embedding_table=GroupQuantizationSpec(
+            dtype="float16",
+            mode="int4",
+            sym=True,
+            storage_nbit=32,
+            group_size=32,
+            transpose=False,
+        ),
         final_fc_weight="same_as_linear_weight",
     ),
     "q4f32_0": QuantizationScheme(

--- a/mlc_llm/quantization/ft_rowwise_quantization.py
+++ b/mlc_llm/quantization/ft_rowwise_quantization.py
@@ -165,6 +165,10 @@ class FTQuantizeUpdater(QuantSpecUpdater._cls):
         param = self.param_map[rhs.args[0]]
 
         if call.struct_info.dtype == "float32" or rhs.struct_info.shape[-1] % 8 != 0:
+            # FT requires N to be a multiple of 8
+            # FT does not support fp32 output dtype
+            # TODO(masahi): If `matmul(..., out_dtype="float32")` is immediately followed
+            # by `cast(..., "float16")`, `matmul -> cast` can be offloaded.
             param.quant_spec = GroupQuantizationSpec(param.param_info.dtype,
                                                      mode="int4",
                                                      sym=True,

--- a/mlc_llm/quantization/ft_rowwise_quantization.py
+++ b/mlc_llm/quantization/ft_rowwise_quantization.py
@@ -1,0 +1,142 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from tvm import relax, te, tir, topi
+from tvm.script import tir as T
+
+from . import tir_utils
+from .quantization import QuantizationSpec
+from .quantization import FQuantize, convert_TE_func
+
+
+@dataclass
+class FTRowwiseQuantizationSpec(QuantizationSpec):
+    """The quantization specification for the FasterTransformer kernel."""
+
+    nbit: int
+
+    def get_quantize_func(self, param_info: relax.TensorStructInfo) -> Optional[FQuantize]:
+        def f_quantize(bb: relax.BlockBuilder, inputs: List[relax.Expr]):
+            encoded_data = bb.emit_te(
+                encoding_func(
+                    self.nbit,
+                    8,
+                    dtype=self.dtype,
+                ),
+                inputs[0],
+                primfunc_name_hint="encode",
+            )
+            packed_weight = bb.normalize(encoded_data[0])
+            encoded_weight = bb.emit(
+                relax.call_pure_packed(
+                    "cutlass.ft_preprocess_weight",
+                    packed_weight,
+                    80,
+                    self.nbit == 4,
+                    sinfo_args=packed_weight.struct_info,
+                )
+            )
+            return bb.emit(relax.Tuple([encoded_weight, encoded_data[1]]))
+
+        return f_quantize
+
+    def get_dequantize_func(
+        self,
+        param_info: relax.TensorStructInfo,
+        qparam_info: List[relax.TensorStructInfo],
+    ) -> Optional[FQuantize]:
+        return convert_TE_func(
+            decoding_func(
+                self.nbit,
+                storage_nbit=8,
+            ),
+            func_name="decode",
+        )
+
+
+def encoding_func(nbit: int, storage_nbit: int, dtype: str = "float32"):
+    def te_encode_sym(weight: te.Tensor):
+        n_float_per_int = storage_nbit // nbit
+        max_int_value = (1 << (nbit - 1)) - 1
+
+        scale_min_shape = (weight.shape[0],)
+        k = te.reduce_axis((0, weight.shape[1]), name="k")
+        max_abs_value = te.compute(
+            shape=scale_min_shape,
+            fcompute=lambda i: te.max(te.abs(weight[i, k]), axis=k),
+            name="max_abs_value",
+        )
+
+        def f_compute_scale(i):
+            max_value = tir.max(tir.Cast(dtype, max_abs_value[i]), tir.const(1e-4, dtype))
+            return max_value / tir.const(max_int_value + 1, dtype)
+
+        scale = te.compute(shape=scale_min_shape, fcompute=f_compute_scale, name="scale")
+        storage_dtype = "int" + str(storage_nbit)
+
+        def f_scale_weight(i, j):
+            w_scaled = tir.round(tir.Cast(dtype, weight[i, j]) / scale[i])
+            w_scaled = T.min(
+                T.max(w_scaled, tir.const(-max_int_value - 1, dtype)),
+                tir.const(max_int_value, dtype),
+            ).astype(storage_dtype)
+            if n_float_per_int == 1:
+                return w_scaled
+            return w_scaled & tir.const((1 << nbit) - 1, storage_dtype)
+
+        n_i32 = tir.ceildiv(weight.shape[0], n_float_per_int)
+
+        if n_float_per_int == 1:
+            w_gathered = te.compute(
+                shape=(weight.shape[1], n_i32),
+                fcompute=lambda j, i: f_scale_weight(i, j),
+                name="w_gathered",
+            )
+        else:
+            k = te.reduce_axis((0, n_float_per_int), name="k")
+            reducer = te.comm_reducer(
+                fcombine=lambda x, y: tir.bitwise_or(x, y),
+                fidentity=lambda dtype: tir.const(0, storage_dtype),
+                name="bitwise_or",
+            )
+            w_gathered = te.compute(
+                shape=(weight.shape[1], n_i32),
+                fcompute=lambda j, i: reducer(
+                    tir.if_then_else(
+                        i * n_float_per_int + k < weight.shape[0],
+                        f_scale_weight(i * n_float_per_int + k, j)
+                        << (k.astype(storage_dtype) * tir.const(nbit, storage_dtype)),
+                        tir.const(0, storage_dtype),
+                    ),
+                    axis=k,
+                ),
+                name="w_gathered",
+            )
+
+        return w_gathered, topi.cast(scale, "float16")
+
+    return te_encode_sym
+
+
+def decoding_func(nbit: int, storage_nbit: int):
+    def te_decode_sym(data, scale):
+        n_float_per_int = storage_nbit // nbit
+
+        def f_decode_sym(i, j):
+            if n_float_per_int == 1:
+                data_float = tir.Cast("float16", data[i, j])
+            else:
+                f_convert = tir_utils._tir_packed_int_to_int_to_float(storage_nbit)
+                data_float = f_convert(
+                    nbit, data[i, j // n_float_per_int], j % n_float_per_int, dtype="float16"
+                )
+
+            scale_float = scale[j]
+            return data_float * scale_float
+
+        shape = (data.shape[0], data.shape[1] * n_float_per_int)
+        w = te.compute(shape=shape, fcompute=f_decode_sym, name="decode")
+        # Dummy transpose for FuseDecodeTranspose
+        return topi.transpose(w)
+
+    return te_decode_sym

--- a/mlc_llm/quantization/ft_rowwise_quantization.py
+++ b/mlc_llm/quantization/ft_rowwise_quantization.py
@@ -169,9 +169,11 @@ class FTQuantizeUpdater(QuantSpecUpdater._cls):
             # FT does not support fp32 output dtype
             # TODO(masahi): If `matmul(..., out_dtype="float32")` is immediately followed
             # by `cast(..., "float16")`, `matmul -> cast` can be offloaded.
-            param.quant_spec = GroupQuantizationSpec(param.param_info.dtype,
-                                                     mode="int4",
-                                                     sym=True,
-                                                     storage_nbit=32,
-                                                     group_size=32,
-                                                     transpose=False)
+            param.quant_spec = GroupQuantizationSpec(
+                param.param_info.dtype,
+                mode="int4",
+                sym=True,
+                storage_nbit=32,
+                group_size=32,
+                transpose=False,
+            )

--- a/mlc_llm/quantization/ft_rowwise_quantization.py
+++ b/mlc_llm/quantization/ft_rowwise_quantization.py
@@ -164,7 +164,7 @@ class FTQuantizeUpdater(QuantSpecUpdater._cls):
 
         param = self.param_map[rhs.args[0]]
 
-        if call.struct_info.dtype == "float32" or rhs.struct_info[-1] % 8 != 0:
+        if call.struct_info.dtype == "float32" or rhs.struct_info.shape[-1] % 8 != 0:
             param.quant_spec = GroupQuantizationSpec(param.param_info.dtype,
                                                      mode="int4",
                                                      sym=True,

--- a/mlc_llm/quantization/tir_utils.py
+++ b/mlc_llm/quantization/tir_utils.py
@@ -40,6 +40,18 @@ def _tir_packed_uint_to_uint_to_float(storage_nbit: int):
     return f_convert
 
 
+def _tir_packed_int_to_int_to_float(storage_nbit: int):
+    storage_dtype = "int" + str(storage_nbit)
+
+    def f_convert(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, dtype: str):
+        assert val.dtype == storage_dtype
+        mask = tir.const((1 << nbit) - 1, "int32")
+        unextended = (val >> (pos.astype("int32") * tir.const(nbit, "int32"))) & mask
+        return tir.Cast(dtype, (unextended << tir.const(32 - nbit, "int32")) >> tir.const(32 - nbit, "int32"))
+
+    return f_convert
+
+
 def _tir_f32_to_uint_to_f4(val: tir.PrimExpr):
     assert val.dtype == "float32"
     val_u32 = tir.reinterpret("uint32", val)


### PR DESCRIPTION
This adds two Q schemes, `q4f16_ft` and `q8f16_ft`, for quantizing weights in the format as expected by the FT fp16 A - int B kernel. The resulting `decode -> matmul` sequences are offloaded to the FT kernel via CUTLASS BYOC.

The new Q scheme is a simple symmetric one where each column of `(K, N)` matrix is scaled by the corresponding element from a scale vector of shape `(N,)`. Each scale is calculated over the `K` axis. For int4, the weight matrix needs to be packed into int8 storage with shape `(K, N / 2)`. 

The quantized weight is further preprocessed by relax `cutlass.ft_preprocess_weight` packed call, which is made possible by the recent improvement https://github.com/mlc-ai/mlc-llm/pull/622. Moreover, based on the attributes of the consumer matmul or weight shape, we may need to fallback to other Q scheme. I use `GroupQuantizationSpec` when the FT Q is not applicable. This fallback mechanism is made possible by another recent improvement, https://github.com/mlc-ai/mlc-llm/pull/657. Thanks @MasterJH5574 for your help in making these improvements. 

@tqchen @sunggg @junrushao @yzh119 