### PR TITLE
[Bug fix] Remove potential trailing backslash

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -220,6 +220,7 @@ def _setup_model_path(args: argparse.Namespace):  # pylint: disable=too-many-bra
         validate_config(args.model_path)
     elif args.model != "auto":
         if os.path.isdir(args.model):
+            args.model = os.path.normpath(args.model)  # Remove potential trailing `/`
             args.model_path = args.model
             args.model = os.path.basename(args.model)
         else:


### PR DESCRIPTION
The behavior of [os.path.basename()](https://docs.python.org/3/library/os.path.html#os.path.basename):

```python
# Without trailing `/`
os.path.basename("/models/Llama-2-7b-chat-hf")
>>> Llama-2-7b-chat-hf

# With trailing `/`
os.path.basename("/models/Llama-2-7b-chat-hf/")
>>> ""
```

This method can remove potential trailing `/`: [os.path.normpath()](https://docs.python.org/3/library/os.path.html#os.path.normpath)

```python
os.path.normpath("/models/Llama-2-7b-chat-hf/")
>>> /models/Llama-2-7b-chat-hf
```

There aren't many places in the repo where we use os.path.basename. For those that do, they seem to be fine except in this case.

cc @junrushao 