### PR TITLE
[Docs] Update with RedPajama `q4f16_1` quantization

### DIFF
--- a/docs/compilation/compile_models.rst
+++ b/docs/compilation/compile_models.rst
@@ -300,8 +300,8 @@ In other cases you need to specify the model via ``--model``.
 --model MODEL_NAME_OR_PATH  The name or local path of the model to compile.
                             We will search for the model on your disk in the following two candidates:
 
-                            - ``dist/models/MODEL_NAME_OR_PATH`` (e.g., ``--model vicuna-v1-7b``),
-                            - ``MODEL_NAME_OR_PATH`` (e.g., ``--model /my-model/vicuna-v1-7b``).
+                            - ``dist/models/MODEL_NAME_OR_PATH`` (e.g., ``--model Llama-2-7b-chat-hf``),
+                            - ``MODEL_NAME_OR_PATH`` (e.g., ``--model /my-model/Llama-2-7b-chat-hf``).
 
                             When running the compile command using ``--model``, please make sure you have placed the model to compile under ``dist/models/`` or other location on the disk.
 
@@ -394,6 +394,12 @@ This section lists compile commands for more models that you can try out.
 
                     python3 -m mlc_llm.build --model Llama-2-7b-chat-hf --target vulkan --quantization q4f16_1 --llvm-mingw path/to/llvm-mingw
 
+            .. tab:: WebGPU
+
+                .. code:: shell
+
+                    python3 -m mlc_llm.build --model Llama-2-7b-chat-hf --target webgpu --quantization q4f32_1
+
             .. tab:: iPhone/iPad
 
                 .. code:: shell
@@ -410,7 +416,7 @@ This section lists compile commands for more models that you can try out.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target cuda --quantization q3f16_0
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target cuda --quantization q4f16_1
 
             .. tab:: Metal
 
@@ -418,13 +424,13 @@ This section lists compile commands for more models that you can try out.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target metal --quantization q3f16_0
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target metal --quantization q4f16_1
 
                 On Apple Silicon powered Mac, compile for x86 Mac:
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target metal_x86_64 --quantization q3f16_0
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target metal_x86_64 --quantization q4f16_1
 
             .. tab:: Vulkan
 
@@ -432,31 +438,31 @@ This section lists compile commands for more models that you can try out.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target vulkan --quantization q3f16_0
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target vulkan --quantization q4f16_1
 
                 On Linux, compile for Windows: please first install the `LLVM-MinGW <https://github.com/mstorsjo/llvm-mingw>`_ toolchain, and substitute the ``path/to/llvm-mingw`` in the command with your LLVM-MinGW installation path.
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target vulkan --quantization q3f16_0 --llvm-mingw path/to/llvm-mingw
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target vulkan --quantization q4f16_1 --llvm-mingw path/to/llvm-mingw
 
             .. tab:: WebGPU
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target webgpu --quantization q4f32_0
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target webgpu --quantization q4f32_1
 
             .. tab:: iPhone/iPad
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target iphone --max-seq-len 768 --quantization q3f16_0
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target iphone --max-seq-len 768 --quantization q3f16_1
 
             .. tab:: Android
 
                 .. code:: shell
 
-                    python3 -m mlc_llm.build --model vicuna-v1-7b --target android --max-seq-len 768 --quantization q4f16_1
+                    python3 -m mlc_llm.build --model vicuna-v1-7b --target android --max-seq-len 768 --quantization q4f16_0
 
     .. tab:: RedPajama-v1-3B
 

--- a/docs/compilation/distribute_compiled_models.rst
+++ b/docs/compilation/distribute_compiled_models.rst
@@ -8,13 +8,6 @@ This page describes how to distribute the model you compiled so others can use t
 For demonstration purposes, we show how to compile the `RedPajama-3B instruct model <https://huggingface.co/togethercomputer/RedPajama-INCITE-Instruct-3B-v1>`_
 (which has different weights from the RedPajama chat model).
 
-.. note::
-
-    We use the quantization option `q4f16_0` here throughout the example
-    because that was what came with the existing prebuilt (we are upgrading prebuilt for `q4f16_1`).
-    If you do not need to try out prebuilt and would like to compile the library
-    from scratch, we recommend `q4f16_1`.
-
 
 If you have not compiled the RedPajama-3B instruct model,
 you can use the following command to compile it:
@@ -25,19 +18,19 @@ you can use the following command to compile it:
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target metal --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target metal --quantization q4f16_1
 
     .. group-tab:: Linux - CUDA
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target cuda --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target cuda --quantization q4f16_1
 
     .. group-tab:: Vulkan
 
         .. code:: shell
 
-            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target vulkan --quantization q4f16_0
+            python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --target vulkan --quantization q4f16_1
 
 
 .. contents:: Table of Contents
@@ -51,12 +44,12 @@ To begin with, we can check that we have the compilation artifact ready on the d
 
 .. code:: shell
 
-    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0
-        RedPajama-INCITE-Instruct-3B-v1-q4f16_0-metal.so  # ===> the model library
+    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1
+        RedPajama-INCITE-Instruct-3B-v1-q4f16_1-metal.so  # ===> the model library
         mod_cache_before_build_metal.pkl                  # ===> a cached file for future builds
         params                                            # ===> containing the model weights, tokenizer and chat config
 
-    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params
+    ~/mlc-llm > ls dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params
         mlc-chat-config.json                              # ===> the chat config
         ndarray-cache.json                                # ===> the model weight info
         params_shard_0.bin                                # ===> the model weights
@@ -71,7 +64,7 @@ Step 2. Update MLC Chat Configuration JSON
 ------------------------------------------
 
 You can **optionally** customize the chat config file
-``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params/mlc-chat-config.json`` (checkout :ref:`configure-mlc-chat-json` for more detailed instructions).
+``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params/mlc-chat-config.json`` (checkout :ref:`configure-mlc-chat-json` for more detailed instructions).
 You can also simply use the default configuration and skip this step.
 
 For demonstration purpose, we update ``mean_gen_len`` to 32 and ``max_gen_len`` to 64.
@@ -86,8 +79,8 @@ Step 3. Specify the Model Lib
 An MLC chat app needs to look for the model library to run the model.
 In the case of RedPajama-3B instruct model, we already have a prebuilt model lib for RedPajama-3B chat model that shares the
 same model architecture and quantization mode as the instruct model.
-We can edit ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params/mlc-chat-config.json``
-and update the value of field ``model_lib`` to ``"RedPajama-INCITE-Chat-3B-v1-q4f16_0"``.
+We can edit ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params/mlc-chat-config.json``
+and update the value of field ``model_lib`` to ``"RedPajama-INCITE-Chat-3B-v1-q4f16_1"``.
 
 .. note::
 
@@ -100,17 +93,17 @@ and update the value of field ``model_lib`` to ``"RedPajama-INCITE-Chat-3B-v1-q4
 
     .. code:: shell
 
-        python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --reuse-lib RedPajama-INCITE-Chat-3B-v1-q4f16_0 --target [your target] --quantization q4f16_0
+        python3 -m mlc_llm.build --hf-path togethercomputer/RedPajama-INCITE-Instruct-3B-v1 --reuse-lib RedPajama-INCITE-Chat-3B-v1-q4f16_1 --target [your target] --quantization q4f16_1
 
     In this way, `mlc_llm.build` does not produce the model library for the instruct model, and in `mlc-chat-config.json`
-    the ``model_lib`` field is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_0``.
+    the ``model_lib`` field is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_1``.
 
     Please note that only models with same architecture and compiled with same quantization modes can reuse and share model library.
 
 
 We should distribute the generated model lib if we want to build a new model architecture or try out customized compilation optimizations.
-In this case, we should keep the ``model_lib`` field as ``"RedPajama-INCITE-Instruct-3B-v1-q4f16_0"``.
-You can upload the model library ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/RedPajama-INCITE-Instruct-3B-v1-q4f16_0-metal.so``
+In this case, we should keep the ``model_lib`` field as ``"RedPajama-INCITE-Instruct-3B-v1-q4f16_1"``.
+You can upload the model library ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/RedPajama-INCITE-Instruct-3B-v1-q4f16_1-metal.so``
 and ask others to download it to  `dist/prebuilt/lib` directory so the CLI app can pick it up.
 
 
@@ -118,7 +111,7 @@ Step 4. Upload the Compiled Model Weights
 -----------------------------------------
 
 As a next step, we need to upload the model weights.
-We only need to upload the files in ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params``.
+We only need to upload the files in ``dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params``.
 If you also want to host the compiled models on Hugging Face, you can follow the instructions below:
 
 .. code:: shell
@@ -128,11 +121,11 @@ If you also want to host the compiled models on Hugging Face, you can follow the
     git lfs install
     git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo
     cd my-redpajama3b-weight-huggingface-repo
-    cp path/to/mlc-llm/dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/params/* .
+    cp path/to/mlc-llm/dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/params/* .
     git add . && git commit -m "Add redpajama-3b instruct model weights"
     git push origin main
 
-Here we provide an `example distributed RedPajama-3B instruct model repository <https://huggingface.co/mlc-ai/RedPajama-INCITE-Instruct-3B-v1-q4f16_0/tree/main>`_ which you can refer to.
+Here we provide an `example distributed RedPajama-3B instruct model repository <https://huggingface.co/mlc-ai/RedPajama-INCITE-Instruct-3B-v1-q4f16_1/tree/main>`_ which you can refer to.
 
 ---------------------------------
 
@@ -157,10 +150,10 @@ The steps needed to run models in CLI are similar to the steps to download the p
 
     # Download the model weights
     cd dist/prebuilt
-    git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo RedPajama-INCITE-Instruct-3B-v1-q4f16_0
+    git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo RedPajama-INCITE-Instruct-3B-v1-q4f16_1
     cd ../..
     # Run CLI
-    mlc_chat_cli --local-id RedPajama-INCITE-Instruct-3B-v1-q4f16_0
+    mlc_chat_cli --local-id RedPajama-INCITE-Instruct-3B-v1-q4f16_1
 
 
 Download the Distributed Models and Run in iOS App
@@ -170,8 +163,8 @@ For iOS app, model libraries are statically packed into the app at the time of a
 Therefore, the iOS app supports running any models whose model libraries are integrated into the app.
 You can check the :ref:`list of supported model libraries <prebuilt-models-ios>`.
 
-To download and run the compiled RedPajama-3B instruct model on iPhone, we need to reuse the integrated ``RedPajama-INCITE-Chat-3B-v1-q4f16_0`` model library.
-Please revisit :ref:`distribute-model-step3-specify-model-lib` and make sure the ``model_lib`` field of `mlc-chat-config.json` is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_0``.
+To download and run the compiled RedPajama-3B instruct model on iPhone, we need to reuse the integrated ``RedPajama-INCITE-Chat-3B-v1-q4f16_1`` model library.
+Please revisit :ref:`distribute-model-step3-specify-model-lib` and make sure the ``model_lib`` field of `mlc-chat-config.json` is set to ``RedPajama-INCITE-Chat-3B-v1-q4f16_1``.
 
 Now we can download the model weights in iOS app and run the model by following the steps below:
 

--- a/docs/deploy/cli.rst
+++ b/docs/deploy/cli.rst
@@ -98,7 +98,7 @@ and the cli. Please click the details below to see the instruction.
 Run Models through MLCChat CLI
 ------------------------------
 
-Once ``mlc_chat_cli`` is installed, you are able to run any MLC-compiled model on comamnd line.
+Once ``mlc_chat_cli`` is installed, you are able to run any MLC-compiled model on command line.
 
 **Ensure Model Exists.** As the input to ``mlc_chat_cli``, it is always good to double check if the compiled model exists.
 
@@ -118,10 +118,10 @@ Once ``mlc_chat_cli`` is installed, you are able to run any MLC-compiled model o
           .. code:: shell
 
             >>> ls -l ./dist/prebuilt/lib
-            vicuna-v1-7b-q3f16_0-metal.so  # Format: $(local_id)-$(arch).$(suffix)
-            vicuna-v1-7b-q3f16_0-vulkan.so
+            Llama-2-7b-chat-hf-q4f16_1-metal.so  # Format: $(local_id)-$(arch).$(suffix)
+            Llama-2-7b-chat-hf-q4f16_1-vulkan.so
             ...
-            >>> ls -l ./dist/prebuilt/mlc-chat-vicuna-v1-7b-q3f16_0  # Format: ./dist/prebuilt/mlc-chat-$(local_id)/
+            >>> ls -l ./dist/prebuilt/mlc-chat-Llama-2-7b-chat-hf-q4f16_1  # Format: ./dist/prebuilt/mlc-chat-$(local_id)/
             # chat config:
             mlc-chat-config.json
             # model weights:
@@ -140,10 +140,10 @@ Once ``mlc_chat_cli`` is installed, you are able to run any MLC-compiled model o
 
           .. code:: shell
 
-            >>> ls -l ./dist/vicuna-v1-7b-q3f16_0/ # Format: ./dist/$(local_id)/
-            vicuna-v1-7b-q3f16_0-metal.so  # Format: $(local_id)-$(arch).$(suffix)
+            >>> ls -l ./dist/Llama-2-7b-chat-hf-q4f16_1/ # Format: ./dist/$(local_id)/
+            Llama-2-7b-chat-hf-q4f16_1-metal.so  # Format: $(local_id)-$(arch).$(suffix)
             ...
-            >>> ls -l ./dist/vicuna-v1-7b-q3f16_0/params  # Format: ``./dist/$(local_id)/params/``
+            >>> ls -l ./dist/Llama-2-7b-chat-hf-q4f16_1/params  # Format: ``./dist/$(local_id)/params/``
             # chat config:
             mlc-chat-config.json
             # model weights:
@@ -158,11 +158,11 @@ Once ``mlc_chat_cli`` is installed, you are able to run any MLC-compiled model o
 .. code:: shell
 
   # `local_id` is `$(model_name)-$(quantize_mode)`
-  # In this example, `model_name` is `vicuna-v1-7b`, and `quantize_mode` is `q3f16_0`
-  >>> mlc_chat_cli --local-id vicuna-v1-7b-q3f16_0
+  # In this example, `model_name` is `Llama-2-7b-chat-hf`, and `quantize_mode` is `q4f16_1`
+  >>> mlc_chat_cli --local-id Llama-2-7b-chat-hf-q4f16_1
   Use MLC config: "....../mlc-chat-config.json"
   Use model weights: "....../ndarray-cache.json"
-  Use model library: "....../vicuna-v1-7b-q3f16_0-metal.so"
+  Use model library: "....../Llama-2-7b-chat-hf-q4f16_1-metal.so"
   ...
 
 Have fun chatting with MLC-compiled LLM!

--- a/docs/deploy/ios.rst
+++ b/docs/deploy/ios.rst
@@ -28,6 +28,8 @@ This section shows how we can build the app from source.
 Step 1. Install Build Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+First and foremost, please clone the `MLC LLM GitHub repository <https://github.com/mlc-ai/mlc-llm>`_.
+
 Please follow :doc:`/install/tvm` to install TVM Unity.
 Note that we **do not** have to run `build.py` since we can use prebuilt weights.
 We only need TVM Unity's utility to combine the libraries (`local-id-iphone.tar`) into a single library.
@@ -42,10 +44,11 @@ We also need to have the following build dependencies:
 Step 2. Download Prebuilt Weights and Library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You also need to obtain a copy of the MLC-LLM source code.
+You also need to obtain a copy of the MLC-LLM source code
+by cloning the `MLC LLM GitHub repository <https://github.com/mlc-ai/mlc-llm>`_.
 To simplify the build, we will use prebuilt model
 weights and libraries here. Run the following command
-in the root of the MLC-LLM.
+in the root directory of the MLC-LLM.
 
 .. code:: bash
 
@@ -54,7 +57,7 @@ in the root of the MLC-LLM.
 
    cd dist/prebuilt
    git lfs install
-   git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
+   git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1
    cd ../..
 
 Validate that the files and directories exist:
@@ -62,10 +65,11 @@ Validate that the files and directories exist:
 .. code:: bash
 
    >>> ls -l ./dist/prebuilt/lib/*-iphone.tar
-   ./dist/prebuilt/lib/RedPajama-INCITE-Chat-3B-v1-q4f16_0-iphone.tar
-   ./dist/prebuilt/lib/vicuna-v1-7b-q3f16_0-iphone.tar
+   ./dist/prebuilt/lib/RedPajama-INCITE-Chat-3B-v1-q4f16_1-iphone.tar
+   ./dist/prebuilt/lib/Llama-2-7b-chat-hf-q3f16_1-iphone.tar
+   ...
 
-   >>> ls -l ./dist/prebuilt/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
+   >>> ls -l ./dist/prebuilt/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1
    # chat config:
    mlc-chat-config.json
    # model weights:
@@ -85,10 +89,12 @@ components by following these steps:
 
 .. code:: bash
 
+   git submodule update --init --recursive
    cd ./ios
    ./prepare_libs.sh
 
-This will create a ``./build`` folder that contains the following files:
+This will create a ``./build`` folder that contains the following files.
+Please make sure all the following files exist in ``./build/``.
 
 .. code:: bash
 
@@ -101,13 +107,13 @@ This will create a ``./build`` folder that contains the following files:
 
 **Add prepackage model**
 
-We can also optionally add prepackage weights into the app,
+We can also *optionally* add prepackage weights into the app,
 run the following command under the ``./ios`` directory:
 
 .. code:: bash
 
    cd ./ios
-   open ./prepare_params.sh # make sure builtin_list only contains "RedPajama-INCITE-Chat-3B-v1-q4f16_0"
+   open ./prepare_params.sh # make sure builtin_list only contains "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
    ./prepare_params.sh
 
 The outcome should be as follows:
@@ -115,7 +121,7 @@ The outcome should be as follows:
 .. code:: bash
 
    >>> ls ./dist/
-   RedPajama-INCITE-Chat-3B-v1-q4f16_0
+   RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
 Step 4. Build iOS App
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/get_started/mlc_chat_config.rst
+++ b/docs/get_started/mlc_chat_config.rst
@@ -6,7 +6,7 @@ Configure MLCChat in JSON
 This page explains the components of a chat configuration and how to customize them for your own purposes.
 
 Each MLC Chat runtime can be configured via an ``mlc-chat-config.json`` file under the directory of each compiled model (e.g.
-`RedPajama chat config <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0/blob/main/mlc-chat-config.json>`__)
+`RedPajama chat config <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/blob/main/mlc-chat-config.json>`__)
 which contains the chat configuration. You can customize the chat configuration by modifying this file.
 Additionally, the runtimes also provide APIs to optionally override some of the configurations.
 
@@ -15,30 +15,36 @@ Additionally, the runtimes also provide APIs to optionally override some of the 
 Structure of MLCChat Configuration
 ----------------------------------
 
-Below is the ``mlc-chat-config.json`` file corresponding to Vicuna model:
+Below is the ``mlc-chat-config.json`` file corresponding to Llama2 model:
 
 .. code:: json
 
   // mlc-chat-config.json
   {
-    "model_lib": "vicuna-v1-7b-q4f32_0",
-    "local_id": "vicuna-v1-7b-q4f32_0",
-    "conv_template": "vicuna_v1.1",
+    "model_lib": "Llama-2-7b-chat-hf-q4f16_1",
+    "local_id": "Llama-2-7b-chat-hf-q4f16_1",
+    "conv_template": "llama-2",
     "temperature": 0.7,
     "repetition_penalty": 1.0,
     "top_p": 0.95,
     "mean_gen_len": 128,
+    "max_gen_len": 512,
     "shift_fill_factor": 0.3,
     "tokenizer_files": [
+        "added_tokens.json",
+        "tokenizer.json",
         "tokenizer.model"
-    ]
+    ],
+    "model_category": "llama",
+    "model_name": "Llama-2-7b-chat-hf"
   }
 
 The following fields contain the meta-data which affect system behaviors.
 
 ``model_lib``
   The necessary model library to launch this model architecture. We recommend reuse model library when possible.
-  For example, all LLaMA-7B models can use `vicuna-v1-7b-q4f32_0`. So you can distribute LLaMA-7B
+  For example, all LLaMA-7B models compiled under ``q4f16_1`` quantization
+  can use `Llama-2-7b-chat-hf-q4f16_1`. So you can distribute LLaMA-7B
   weight variants and still use them in prebuilt MLC chat apps.
 
 ``local_id``
@@ -85,6 +91,7 @@ Load from Pre-defined Conversation Templates
 
 MLC-LLM provided a set of pre-defined conversation templates, which you can directly use by specifying the template name in ``conv_template`` field in the ``mlc-chat-config.json``, below is a list (not complete) of supported conversation templates:
 
+- ``llama-2``
 - ``vicuna_v1.1``
 - ``redpajama_chat``
 - ``rwkv``

--- a/docs/get_started/project_overview.rst
+++ b/docs/get_started/project_overview.rst
@@ -13,7 +13,7 @@ The MLC-LLM project consists of three distinct submodules: model definition, mod
 
    Three independent submodules in MLC LLM
 
-**➀ Model definition in Python.** MLC offers a variety of pre-defined architectures, such as Llama (e.g., Vicuna, OpenLlama, Llama, Wizard), GPT-NeoX (e.g., RedPajama, Dolly), RNNs (e.g., RWKV), and GPT-J (e.g., MOSS). Model developers could solely define the model in pure Python, without having to touch code generation and runtime.
+**➀ Model definition in Python.** MLC offers a variety of pre-defined architectures, such as Llama (e.g., Llama2, Vicuna, OpenLlama, Wizard), GPT-NeoX (e.g., RedPajama, Dolly), RNNs (e.g., RWKV), and GPT-J (e.g., MOSS). Model developers could solely define the model in pure Python, without having to touch code generation and runtime.
 
 **➁ Model compilation in Python.** Models are compiled by :doc:`TVM Unity </install/tvm>` compiler, where the compilation is configured in pure Python. MLC LLM quantizes and exports the Python-based model to a model library and quantized model weights. Quantization and optimization algorithms can be developed in pure Python to compress and accelerate LLMs for specific usecases.
 

--- a/docs/get_started/try_out.rst
+++ b/docs/get_started/try_out.rst
@@ -51,9 +51,9 @@ and you can try out prebuilt models on the following platforms:
       # You can try more models, for example:
       # download prebuilt weights of RedPajama-3B
       cd dist/prebuilt
-      git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
+      git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1
       cd ../..
-      mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_0
+      mlc_chat_cli --local-id RedPajama-INCITE-Chat-3B-v1-q4f16_1
 
     .. note::
       If you are using Windows or Linux. Make sure you have the latest Vulkan driver installed.
@@ -100,7 +100,7 @@ and you can try out prebuilt models on the following platforms:
 
     Once the app is installed, you can download the models and then engage in chat with the model without requiring an internet connection.
 
-    Memory requirements vary across different models. The Vicuna-7B model necessitates an iPhone device with a minimum of 6GB RAM, whereas the RedPajama-3B model can run on an iPhone with at least 4GB RAM.
+    Memory requirements vary across different models. The Llama2-7B model necessitates an iPhone device with a minimum of 6GB RAM, whereas the RedPajama-3B model can run on an iPhone with at least 4GB RAM.
 
     .. figure:: https://mlc.ai/blog/img/redpajama/ios.gif
       :width: 300

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -40,12 +40,12 @@ Prebuilt Models for CLI
       * Running data type: float16
       * Symmetric quantization
     - `link <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_0`
+  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
     - `RedPajama <https://www.together.xyz/blog/redpajama>`__
     - * Weight storage data type: int4
       * Running data type: float16
       * Symmetric quantization
-    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
+    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
   * - `rwkv-raven-1b5-q8f16_0`
     - `RWKV <https://github.com/BlinkDL/RWKV-LM>`__
     - * Weight storage data type: uint8
@@ -117,12 +117,12 @@ Prebuilt Models for iOS
       * Running data type: float16
       * Symmetric quantization
     - `link <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_0`
+  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
     - `RedPajama <https://www.together.xyz/blog/redpajama>`__
     - * Weight storage data type: int4
       * Running data type: float16
       * Symmetric quantization
-    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
+    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
 
 The `downloadable iOS app <https://apps.apple.com/us/app/mlc-chat/id6448482937>`_ has builtin RedPajama-3B model support.
 To add a model to the iOS app, follow the steps below:
@@ -184,7 +184,7 @@ For example, if you compile `OpenLLaMA-7B <https://github.com/openlm-research/op
     - * Weight storage data type: int3
       * Running data type: float16
       * Symmetric quantization
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_0`
+  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
     - GPT-NeoX
     - * Weight storage data type: int4
       * Running data type: float16

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -47,7 +47,7 @@ class BuildArgs:
         metadata={"help": "Hugging Face path from which to download params, tokenizer, and config"},
     )
     quantization: str = field(
-        default=list(utils.quantization_schemes.keys())[0],
+        default="q4f16_1",
         metadata={
             "help": "The quantization mode we use to compile.",
             "choices": [*utils.quantization_schemes.keys()],


### PR DESCRIPTION
This PR updates the documentation in the following aspects:
* (mainly) switch the quantization mode for RedPajama from `q4f16_0` to `q4f16_1`,
* add the WebGPU compilation commands for Llama2,
* update the iOS documentation page per latest changes,
* switch the model compilation commands for Vicuna-7B from `q3f16_0` to `q4f16_1`,
* switch some other occurrences of Vicuna-q3f16_0 to Llama2-q4f16_1.