### PR TITLE
Update REST API to support new ChatModule API

### DIFF
--- a/examples/python/sample_chat_module.py
+++ b/examples/python/sample_chat_module.py
@@ -1,4 +1,4 @@
-from python.mlc_chat.chat_module  import ChatModule
+from mlc_chat.chat_module  import ChatModule
 
 # From the mlc-llm directory, run
 # $ python -m examples.python.sample_chat_module 

--- a/python/mlc_chat/callback.py
+++ b/python/mlc_chat/callback.py
@@ -29,3 +29,25 @@ class stream_to_stdout(object):
             print()
         else:
             print(message, end="", flush=True)
+
+
+class update_var(object):
+
+    def __init__(self):
+        r"""Initialize the callback class.
+        """
+        self.var = ""
+        self.interval = 0
+
+    def __call__(self, message: str = "", stopped: bool = False):
+        r"""Update `var` with the delta message.
+
+        Parameters
+        ----------
+        message : str
+            The new piece of message that has not been added to `var` yet.
+        stopped : bool
+            Whether streaming reaches the end.
+        """
+        if not stopped:
+            self.var += message

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -373,7 +373,7 @@ def _get_lib_module(
             f"{chat_config.model_lib}-{device_name}.dll",
         ]
 
-    # 3. Genereate possible model library paths
+    # 3. Generate possible model library paths
     candidate_paths = []
     for lib_name in candidate_lib_names:
         # Equivalent to {model_path}/../

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -243,7 +243,7 @@ async def read_stats():
     """
     Get the runtime stats.
     """
-    return session["chat_mod"].runtime_stats_text()
+    return session["chat_mod"].stats()
 
 
 ARGS = convert_args_to_argparser().parse_args()

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -104,22 +104,6 @@ def convert_args_to_argparser() -> argparse.ArgumentParser:
 
 session = {}
 
-def _shared_lib_suffix():
-    if sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
-        return ".so"
-    if sys.platform.startswith("win32"):
-        return ".dll"
-    if sys.platform.startswith("darwin"):
-        cpu_brand_string = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"]).decode("utf-8")
-        if cpu_brand_string.startswith("Apple"):
-            # Apple Silicon
-            return ".so"
-        else:
-            # Intel (x86)
-            return ".dylib"
-    return ".so"
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     chat_mod = ChatModule(


### PR DESCRIPTION
This PR updates the REST API to support the new ChatModule API. 

- The non-streaming `/v1/chat/completions` and `/v1/completions` endpoints have been updated to use the new `generate` API. 
- As far as I can tell, it doesn't seem possible for us to use the `generate` API for the streaming use case in the `/v1/chat/completions` endpoint. This is because the endpoint needs to return a `StreamingResponse` with an `AsyncGenerator`.  However, this does not currently seem possible with the way callbacks are defined for the API (please let me know if you think otherwise). I've therefore kept the usage of the internal API for the streaming use case.

I've tested all the sample scripts, and have confirmed that they are running successfully.