### PR TITLE
Add cublas offload

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -25,6 +25,7 @@ from tvm import relax
 from tvm.contrib.nvcc import parse_compute_version
 from tvm.relax.backend import get_patterns_with_prefix
 from tvm.relax.backend.contrib.cutlass import annotate_workspace
+import tvm.relax.backend.contrib.cublas as _
 
 
 @dataclass
@@ -143,6 +144,14 @@ class BuildArgs:
                 "Offload layer and RMS norm operations to CUTLASS when the target is CUDA"
                 "and TVM has been built with CUTLASS enabled."
             ),
+            "action": "store_true",
+        },
+    )
+    use_cublas: bool = field(
+        default=False,
+        metadata={
+            "help": ("Offload matmul to cuBLAS when target is CUDA and TVM has been built"
+                     "with cuBLAS enbaled."),
             "action": "store_true",
         },
     )
@@ -311,21 +320,26 @@ def mod_transform_before_build(
     if "num_attention_heads" in config and "hidden_size" in config:
         mod = fuse_split_rotary_embedding(mod, config["num_attention_heads"], config["hidden_size"])
 
-    if args.target_kind == "cuda" and tvm.get_global_func("relax.ext.cutlass", True):
-        # CUTLASS offloading
+    if args.target_kind == "cuda":
         patterns = []
 
-        if not args.no_cutlass_attn:
+        has_cutlass = tvm.get_global_func("relax.ext.cutlass", True)
+        has_cublas = tvm.get_global_func("relax.ext.cublas", True)
+
+        if has_cutlass and not args.no_cutlass_attn:
             mod["prefill"] = rewrite_attention(mod["prefill"])
             mod["decode"] = rewrite_attention(mod["decode"])
             patterns += get_patterns_with_prefix("cutlass.attention")
 
-        if not args.no_cutlass_norm:
+        if has_cutlass and not args.no_cutlass_norm:
             patterns += get_patterns_with_prefix("cutlass.layer_norm")
             patterns += get_patterns_with_prefix("cutlass.rms_norm")
 
-        if use_ft_quant:
+        if has_cutlass and use_ft_quant:
             patterns += get_patterns_with_prefix("cutlass.decode_matmul")
+
+        if has_cublas and args.use_cublas:
+            patterns += get_patterns_with_prefix("cublas")
 
         if len(patterns) > 0:
             os.makedirs("./tmp", exist_ok=True)


### PR DESCRIPTION
This PR upstreams the cuBLAS offload from https://github.com/octoml/mlc-llm/pull/8. It adds a flag `--use-cublas` to enable cublas offloading on CUDA target.

cc @masahi 