### PR TITLE
[ChatModule] Raw text generation and benchmark

### DIFF
--- a/examples/python/benchmark.py
+++ b/examples/python/benchmark.py
@@ -7,4 +7,7 @@ from mlc_chat.chat_module import ChatModule
 
 # Create a ChatModule instance
 cm = ChatModule(model="Llama-2-7b-chat-hf-q4f16_1")
-cm.evaluate(prompt_len=1, generate_len=512)
+
+output = cm.benchmark_generate("What's the meaning of life?", generate_length=256)
+print(f"Generated text:\n{output}\n")
+print(f"Statistics: {cm.stats()}")


### PR DESCRIPTION
This PR introduces the `RawGenerate` function to ChatModule for benchmarking purpose, which generates text by taking the input prompt and target generation length. The raw text generation does not use system prompt and ignores the stop tokens of the conversation template.

Based on the raw generation, this PR also brings the `benchmark_generate` method to the Python ChatModule. The function first warms up and then invoke the raw generation. After `benchmark_generate`, we can use `stats()` to get the generation performance of the model.

The `benchmark_generate` methods replaces the previous public `evaluate` method in the Python ChatModule.