### PR TITLE
[Fix][Python] Reset chat before benchmark warmup

### DIFF
--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -739,6 +739,7 @@ class ChatModule:
             )
 
         # warmup run
+        self.reset_chat()
         self._prefill(prompt)
         self._decode()
 


### PR DESCRIPTION
Previously the `benchmark_warmup` method does not reset chat before warming up.