### PR TITLE
[Examples] Use stdout stream for Python API examples

### DIFF
--- a/docs/get_started/try_out.rst
+++ b/docs/get_started/try_out.rst
@@ -48,6 +48,7 @@ and you can try out prebuilt models on the following platforms:
     .. code:: python
 
       from mlc_chat import ChatModule
+      from mlc_chat.callback import StreamToStdout
 
       # From the mlc-llm directory, run
       # $ python sample_mlc_chat.py
@@ -57,15 +58,18 @@ and you can try out prebuilt models on the following platforms:
       # You can change to other models that you downloaded, for example,
       # cm = ChatModule(model="Llama-2-13b-chat-hf-q4f16_1")  # Llama2 13b model
 
-      # Generate a response for a given prompt
-      output = cm.generate(prompt="What is the meaning of life?")
-      print(f"Generated text:\n{output}\n")
+      output = cm.generate(
+          prompt="What is the meaning of life?",
+          progress_callback=StreamToStdout(callback_interval=2),
+      )
 
       # Print prefill and decode performance statistics
       print(f"Statistics: {cm.stats()}\n")
 
-      output = cm.generate(prompt="How many points did you list out?")
-      print(f"Followup generation:\n{output}\n")
+      output = cm.generate(
+          prompt="How many points did you list out?",
+          progress_callback=StreamToStdout(callback_interval=2),
+      )
 
       # Reset the chat module by
       # cm.reset_chat()

--- a/examples/python/sample_mlc_chat.py
+++ b/examples/python/sample_mlc_chat.py
@@ -1,4 +1,5 @@
 from mlc_chat import ChatModule
+from mlc_chat.callback import StreamToStdout
 
 # From the mlc-llm directory, run
 # $ python examples/python/sample_mlc_chat.py
@@ -9,14 +10,18 @@ cm = ChatModule(model="Llama-2-7b-chat-hf-q4f16_1")
 # cm = ChatModule(model="Llama-2-13b-chat-hf-q4f16_1")  # Llama2 13b model
 
 # Generate a response for a given prompt
-output = cm.generate(prompt="What is the meaning of life?")
-print(f"Generated text:\n{output}\n")
+output = cm.generate(
+    prompt="What is the meaning of life?",
+    progress_callback=StreamToStdout(callback_interval=2),
+)
 
 # Print prefill and decode performance statistics
 print(f"Statistics: {cm.stats()}\n")
 
-output = cm.generate(prompt="How many points did you list out?")
-print(f"Followup generation:\n{output}\n")
+output = cm.generate(
+    prompt="How many points did you list out?",
+    progress_callback=StreamToStdout(callback_interval=2),
+)
 
 # Reset the chat module by
 # cm.reset_chat()

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -476,19 +476,24 @@ class ChatModule:
     .. code:: python
 
         from mlc_chat import ChatModule
+        from mlc_chat.callback import StreamToStdout
 
         # Create a ChatModule instance
         cm = ChatModule(model="Llama-2-7b-chat-hf-q4f16_1")
 
         # Generate a response for a given prompt
-        output = cm.generate(prompt="What is the meaning of life?")
-        print(f"Generated text:\n{output}\n")
+        output = cm.generate(
+            prompt="What is the meaning of life?",
+            progress_callback=StreamToStdout(callback_interval=2),
+        )
 
         # Print prefill and decode performance statistics
         print(f"Statistics: {cm.stats()}\n")
 
-        output = cm.generate(prompt="How many points did you list out?")
-        print(f"Followup generation:\n{output}\n")
+        output = cm.generate(
+            prompt="How many points did you list out?",
+            progress_callback=StreamToStdout(callback_interval=2),
+        )
 
 
     Parameters


### PR DESCRIPTION
This PR uses the stdout stream for Python API examples so that the output will go to string which gives a smoother experience.