### PR TITLE
[Android] Move model download path

### DIFF
--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/AppViewModel.kt
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/AppViewModel.kt
@@ -148,10 +148,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             try {
                 val url = URL("${modelUrl}${ModelUrlSuffix}${ModelConfigFilename}")
                 val tempId = UUID.randomUUID().toString()
-                val tempFile = File(
-                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-                    tempId
-                )
+                val tempFile = File(application.externalCacheDir, tempId)
                 url.openStream().use {
                     Channels.newChannel(it).use { src ->
                         FileOutputStream(tempFile).use { fileOutputStream ->


### PR DESCRIPTION
The path `Environment.getExternalStoragePublicDirectory` is an external path out of app, according to https://developer.android.com/about/versions/11/privacy/storage, it requires APP to request runtime permission and declare in AndroidManifest.xml. But actually it doesn't make sense, considering it's just a temp path and in fact users are not expected to share the files(cause the finally path is APP internal), moving to cache dir is more reasonable and will be permission free, also fixes the permission issue over Android Q