### PR TITLE
[Android] Add libOpenCL-pixel for supporintg Pixel phones.

### DIFF
--- a/android/MLCChat/app/src/main/AndroidManifest.xml
+++ b/android/MLCChat/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
         <uses-native-library
             android:name="libOpenCL.so"
             android:required="false"/>
+
+        <uses-native-library
+            android:name="libOpenCL-pixel.so"
+            android:required="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
Add the libOpenCL-pixel.so library as a dependency so it can be used on pixel phones. 
This depends on: https://github.com/mlc-ai/relax/pull/282 to be merged to be useful.