### PR TITLE
[Bug fix] Small fix on RestAPIArgs

### DIFF
--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -35,7 +35,7 @@ class RestAPIArgs:
         }
     )
     lib_path: str = field(
-        default="None",
+        default=None,
         metadata={
             "help": (
                 """


### PR DESCRIPTION
Small fix to change from `"None"` to `None`. The former is treated as a string and considers the user passing in a path.