### PR TITLE
Fix OPENCL variable in tvm.rst

### DIFF
--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -92,7 +92,7 @@ While it is generally recommended to always use the prebuilt TVM Unity, if you r
         echo "set(USE_CUDA   OFF)" >> config.cmake
         echo "set(USE_METAL  OFF)" >> config.cmake
         echo "set(USE_VULKAN OFF)" >> config.cmake
-        echo "set(USE_OpenCL OFF)" >> config.cmake
+        echo "set(USE_OPENCL OFF)" >> config.cmake
 
     .. note::
         ``HIDE_PRIVATE_SYMBOLS`` is a configuration option that enables the ``-fvisibility=hidden`` flag. This flag helps prevent potential symbol conflicts between TVM and PyTorch. These conflicts arise due to the frameworks shipping LLVMs of different versions.


### PR DESCRIPTION
## Description

In the build instructions of TVM-unity, there is an issue with the variable "USE_OpenCL" in cmake additions, which should be capitalised (i.e. `USE_OPENCL`). 

If someone follows the guide and copies the instructions, they will not be compiling with support for OpenCL, unless they set the proper variable to ON.