### PR TITLE
Add PrimFunc Benchmark Script Dump in Debug Dump Mode

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -420,6 +420,10 @@ def build(mod_deploy: tvm.IRModule, args: argparse.Namespace) -> None:
         mod_deploy = mod_deploy.with_attrs({"system_lib_prefix": args.system_lib_prefix})
 
     utils.debug_dump_script(mod_deploy, "mod_before_build.py", args)
+    utils.debug_dump_benchmark_script(
+        mod_deploy, f"{args.model}_{args.quantization.name}".replace("-", "_"), args
+    )
+
     if target_kind != "cpu":
         dispatch_target = (
             args.target


### PR DESCRIPTION
This PR will add a script dumped in debug dump mode for dlight bench benchmarking. Example see https://github.com/mlc-ai/dlight-bench/pull/6. An example of generated script can be found [here](https://gist.github.com/zxybazh/a74ebfd46393eed65a112b39f022a76c).

With this PR it would be easy to extract PrimFuncs from llm models and port to later development benchmarking.

CC: @sunggg 