### PR TITLE
Automatically set 'offset' parameter if 'messages' parameter is set

### DIFF
--- a/cpp/conversation.cc
+++ b/cpp/conversation.cc
@@ -58,6 +58,7 @@ void Conversation::LoadJSONOverride(const picojson::value& config_json, bool par
     this->offset = config["offset"].get<int64_t>();
   } else {
     CHECK(partial_update) << "Key \"offset\" not found.";
+    this->offset = this->messages.size();
   }
   if (config.count("separator_style")) {
     CHECK(config["separator_style"].is<int64_t>()) << "Invalid separator style" << err_templ;

--- a/cpp/conversation.cc
+++ b/cpp/conversation.cc
@@ -57,7 +57,6 @@ void Conversation::LoadJSONOverride(const picojson::value& config_json, bool par
     CHECK(config["offset"].is<int64_t>()) << "Invalid offset" << err_templ;
     this->offset = config["offset"].get<int64_t>();
   } else {
-    CHECK(partial_update) << "Key \"offset\" not found.";
     this->offset = this->messages.size();
   }
   if (config.count("separator_style")) {

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -84,7 +84,7 @@ class ConvConfig:
     name: Optional[str] = None
     system: Optional[str] = None
     roles: Optional[List[str]] = None
-    messages: Optional[List[str]] = None
+    messages: Optional[List[List[str]]] = None
     offset: Optional[str] = None
     separator_style: Optional[int] = None
     seps: Optional[List[str]] = None
@@ -94,6 +94,9 @@ class ConvConfig:
     stop_tokens: Optional[List[int]] = None
     add_bos: Optional[bool] = None
 
+    def __post_init__(self):
+        if self.messages is not None and self.offset is None:
+            self.offset = len(self.messages)
 
 @dataclass
 class ChatConfig:


### PR DESCRIPTION
This change will automatically set the `offset` parameter if the `messages` parameter is set while still allowing the user to override the offset if necessary.