### PR TITLE
added cors to fast api

### DIFF
--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -9,6 +9,7 @@ import tvm
 import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
 
 from dataclasses import dataclass, field, fields
 from typing import Optional
@@ -112,6 +113,18 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+origins = [
+    "*",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 class AsyncChatCompletionStream:
     def __aiter__(self):


### PR DESCRIPTION
Currently getting this error when trying to call the rest api from the browser:

```
Access to XMLHttpRequest at 'http://127.0.0.1:8000/v1/chat/completions' from origin 'http://localhost:4000' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```