### PR TITLE
Improve code completion experience

### DIFF
--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -290,6 +290,44 @@ Conversation StableLM() {
   return conv;
 }
 
+Conversation StableCodeCompletion() {
+  Conversation conv;
+  conv.name = "stablecode_completion";
+  conv.system = "";
+  conv.roles = {"Prompt", "Code"};
+  conv.messages = {};
+  conv.offset = 0;
+  conv.separator_style = SeparatorStyle::kCodeCompletion;
+  conv.seps = {""};
+  conv.role_msg_sep = "";
+  conv.role_empty_sep = "";
+  // TODO(mlc-team): add eos to mlc-chat-config
+  // and remove eos from stop token setting.
+  conv.stop_tokens = {0};
+  conv.stop_str = "<|endoftext|>";
+  conv.add_bos = false;
+  return conv;
+}
+
+Conversation StableCodeInstruct() {
+  Conversation conv;
+  conv.name = "stablecode_instruct";
+  conv.system = "";
+  conv.roles = {"###Instruction", "###Response"};
+  conv.messages = {};
+  conv.offset = 0;
+  conv.separator_style = SeparatorStyle::kSepRoleMsg;
+  conv.seps = {""};
+  conv.role_msg_sep = "\n";
+  conv.role_empty_sep = "\n";
+  // TODO(mlc-team): add eos to mlc-chat-config
+  // and remove eos from stop token setting.
+  conv.stop_tokens = {0};
+  conv.stop_str = "<|endoftext|>";
+  conv.add_bos = false;
+  return conv;
+}
+
 Conversation MiniGPT() {
   Conversation conv;
   conv.name = "minigpt";
@@ -366,22 +404,22 @@ Conversation VanillaLM() {
   return conv;
 }
 
-Conversation CodeGPT() {
+Conversation GPTBigCode() {
   Conversation conv;
-  conv.name = "code_gpt";
+  conv.name = "gpt_bigcode";
   conv.system = "";
   conv.roles = {"Prompt", "Code"};
   conv.messages = {};
   conv.offset = 0;
-  conv.separator_style = SeparatorStyle::kSepRoleMsg;
-  conv.seps = {"\n\n", "### End\n"};
-  conv.role_msg_sep = ":\n";
-  conv.role_empty_sep = ":\n";
+  conv.separator_style = SeparatorStyle::kCodeCompletion;
+  conv.seps = {""};
+  conv.role_msg_sep = "";
+  conv.role_empty_sep = "";
   // TODO(mlc-team): add eos to mlc-chat-config
   // and remove eos from stop token setting.
   conv.stop_tokens = {0};
-  conv.stop_str = "### End";
-  conv.add_bos = true;
+  conv.stop_str = "<|endoftext|>";
+  conv.add_bos = false;
   return conv;
 }
 
@@ -464,10 +502,12 @@ Conversation Conversation::FromTemplate(const std::string& name) {
       {"dolly", Dolly},
       {"oasst", Oasst},
       {"stablelm", StableLM},
+      {"stablecode_completion", StableCodeCompletion},
+      {"stablecode_instruct", StableCodeInstruct},
       {"minigpt", MiniGPT},
       {"moss", MOSS},
       {"LM", VanillaLM},
-      {"code_gpt", CodeGPT},
+      {"gpt_bigcode", GPTBigCode},
       {"wizardlm_7b", WizardLM7B},
       {"wizard_coder_or_math", WizardCoderOrMATH},
       {"glm", GLM},

--- a/cpp/conversation.h
+++ b/cpp/conversation.h
@@ -17,6 +17,8 @@ namespace llm {
 enum class SeparatorStyle {
   /*! \brief Add separator between role and message. */
   kSepRoleMsg,
+  /*! \brief Code completion without separators or roles. No memory. */
+  kCodeCompletion,
   /*! \brief raw language model style, always only returns last message. */
   kLM,
 };
@@ -280,7 +282,8 @@ class Conversation {
           /* fproc_message= */ Identity,
           /* place_in_prompt= */ place_in_prompt);
     } else {
-      ICHECK(this->separator_style == SeparatorStyle::kLM) << "Unsupported separator_style";
+      ICHECK(this->separator_style == SeparatorStyle::kLM ||
+        this->separator_style == SeparatorStyle::kCodeCompletion) << "Unsupported separator_style";
       // special handle LM, LM mode have no memory
       // and only returns last one
       if (this->messages.size() >= 2) {

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -501,7 +501,8 @@ class LLMChat {
 
   std::vector<int32_t> PrepareBeforeEmbedding(std::string inp, bool append_conversation = true,
                                               PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
-    if (conversation_.name == "LM") {
+    if (conversation_.separator_style == SeparatorStyle::kLM ||
+        conversation_.separator_style == SeparatorStyle::kCodeCompletion) {
       this->ResetChat();
     }
     if (reset_stats_per_prefill_) {

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -253,6 +253,7 @@ MLC-LLM supports the following model architectures:
     - * `RedPajama <https://www.together.xyz/blog/redpajama>`__
       * `Dolly <https://github.com/databrickslabs/dolly>`__
       * `Pythia <https://huggingface.co/EleutherAI/pythia-1.4b>`__
+      * `StableCode <https://huggingface.co/stabilityai/stablecode-instruct-alpha-3b>`__
   * - ``gptj``
     - `GPT-J <https://huggingface.co/EleutherAI/gpt-j-6b>`__
     - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gptj.py>`__
@@ -271,6 +272,12 @@ MLC-LLM supports the following model architectures:
     - * `StarCoder <https://huggingface.co/bigcode/starcoder>`__
       * `WizardCoder <https://huggingface.co/WizardLM/WizardCoder-15B-V1.0>`__
       * `SantaCoder <https://huggingface.co/bigcode/gpt_bigcode-santacoder>`__
+  * - ``chatglm``
+    - `ChatGLM <https://github.com/THUDM/ChatGLM-6B/blob/main/README_en.md>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/chatglm.py>`__
+    - * `ChatGLM2 <https://huggingface.co/THUDM/chatglm2-6b>`__
+      * `CodeGeeX2 <https://huggingface.co/THUDM/codegeex2-6b>`__
+
 
 For models structured in these model architectures, you can check the :doc:`model compilation page </compilation/compile_models>` on how to compile models.
 Please `create a new issue <https://github.com/mlc-ai/mlc-llm/issues/new/choose>`_ if you want to request a new model architecture.

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -674,6 +674,8 @@ def get_model(
     elif model.startswith("stablelm-"):
         stop_tokens = [50278, 50279, 50277, 1, 0]
         ffn_out_dtype = "float16"
+    elif model.lower().startswith("stablecode-"):
+        stop_tokens = [0]
     elif model.lower().startswith("redpajama-"):
         stop_tokens = [0]
     else:

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -65,12 +65,14 @@ def argparse_postproc_common(args: argparse.Namespace) -> None:
         "rwkv-": "rwkv",
         "gorilla-": "gorilla",
         "guanaco": "guanaco",
-        "starcoder": "code_gpt",
         "wizardlm-7b": "wizardlm_7b",  # first get rid of 7b
         "wizardlm-": "vicuna_v1.1",  # all others use vicuna template
         "wizardmath-": "wizard_coder_or_math",
         "wizardcoder-": "wizard_coder_or_math",
-        "gpt_bigcode-santacoder": "code_gpt",
+        "starcoder": "gpt_bigcode",
+        "gpt_bigcode-santacoder": "gpt_bigcode",
+        "stablecode-completion": "stablecode_completion",
+        "stablecode-instruct": "stablecode_instruct",
         "chatglm2": "glm",
         "codegeex2": "glm",
     }


### PR DESCRIPTION
This PR refines the code completion support for MLC LLM. Previously, these code completion models used inappropriate templates, that were harming the completion task. This template was changed to execute the LM without memory, and also to ignore roles and separators. Code instruct models still use the normal conversational templates, since were trained for this purpose (e.g., CodeGeeX2, StableCode-Instruct). I was able to test it with the vscode hf code completion extension (solves #748, concludes #761). For this extension, models trained using the Fill-in-the-Middle objective are the most suitable (e.g., StarCoder). If you try others than these you may get worse results.

Additionaly this PR adds support for [StableCode-Instruct](https://huggingface.co/stabilityai/stablecode-instruct-alpha-3b) and [StableCode-Completion](https://huggingface.co/stabilityai/stablecode-completion-alpha-3b).

![image](https://github.com/mlc-ai/mlc-llm/assets/61968959/8ac172be-0532-4548-97a5-901da23f9139)
