### PR TITLE
Update Llama2 cached sin/cos to use max_sequence_length

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -530,7 +530,7 @@ def build_model_from_args(args: argparse.Namespace):
         os.makedirs(os.path.join(args.artifact_path, "debug"), exist_ok=True)
     cache_path = os.path.join(args.artifact_path, "mod_cache_before_build.pkl")
     args.raw_params_path = os.path.join(args.artifact_path, "raw_params")
-    use_cache = args.use_cache and os.path.isfile(cache_path)        
+    use_cache = args.use_cache and os.path.isfile(cache_path)
     if args.sep_embed and args.model_category != "llama":
         raise ValueError(f"separate embedding not supported on {args.model}")
     if args.model_category != "minigpt":

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -358,7 +358,10 @@ def mod_transform_before_build(
     )  # pylint: disable=not-callable
 
     if "num_attention_heads" in config and "hidden_size" in config:
-        mod = fuse_split_rotary_embedding(mod, config["num_attention_heads"], config["hidden_size"])
+        if args.max_seq_len:
+            mod = fuse_split_rotary_embedding(mod, config["num_attention_heads"], config["hidden_size"], args.max_seq_len)
+        else:
+            mod = fuse_split_rotary_embedding(mod, config["num_attention_heads"], config["hidden_size"])
 
     if args.target_kind == "cuda":
         patterns = []
@@ -527,7 +530,7 @@ def build_model_from_args(args: argparse.Namespace):
         os.makedirs(os.path.join(args.artifact_path, "debug"), exist_ok=True)
     cache_path = os.path.join(args.artifact_path, "mod_cache_before_build.pkl")
     args.raw_params_path = os.path.join(args.artifact_path, "raw_params")
-    use_cache = args.use_cache and os.path.isfile(cache_path)
+    use_cache = args.use_cache and os.path.isfile(cache_path)        
     if args.sep_embed and args.model_category != "llama":
         raise ValueError(f"separate embedding not supported on {args.model}")
     if args.model_category != "minigpt":

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -612,13 +612,13 @@ class LlamaForCausalLM(nn.Module):
         assert config.hidden_size % config.num_attention_heads == 0
         head_dim = config.hidden_size // config.num_attention_heads
 
-        # Hardcode the cached sin/cos for 2048.
+        # Set the cached sin/cos to the max seq len.
         # This will be eliminated further with online rotary embedding calculation.
         self.cos_cached = nn.Parameter(
-            (2048, head_dim), dtype=config.dtype, name="cos_cached"
+            (config.max_sequence_length, head_dim), dtype=config.dtype, name="cos_cached"
         )
         self.sin_cached = nn.Parameter(
-            (2048, head_dim), dtype=config.dtype, name="sin_cached"
+            (config.max_sequence_length, head_dim), dtype=config.dtype, name="sin_cached"
         )
         ############ End ############
 
@@ -957,7 +957,7 @@ def get_model(args, hf_config):
     )
     # Hardcode the cached sin/cos for 2048.
     # This will be eliminated further with online rotary embedding calculation.
-    t = np.arange(2048, dtype=inv_freq.dtype)
+    t = np.arange(config.max_sequence_length, dtype=inv_freq.dtype)
     freqs = np.einsum("i,j->ij", t, inv_freq)
     emb = np.concatenate((freqs, freqs), axis=-1)
     param_list[-2] = tvm.nd.array(np.cos(emb).astype(config.dtype), device)

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -955,7 +955,7 @@ def get_model(args, hf_config):
         config.position_embedding_base
         ** (np.arange(0, head_dim, 2).astype("float32") / head_dim)
     )
-    # Hardcode the cached sin/cos for 2048.
+    # Set the cached sin/cos to the max sequence length.
     # This will be eliminated further with online rotary embedding calculation.
     t = np.arange(config.max_sequence_length, dtype=inv_freq.dtype)
     freqs = np.einsum("i,j->ij", t, inv_freq)


### PR DESCRIPTION
… and cos functions.

Currently if you need to make the max sequence length of a llama2 model larger than 2048 it will run into issues actually handling more than 2048 tokens. The model would spit out garbage data or segfault if greater than 2048 tokens was sent in. The root cause I believe is due to this hardcoding of the sin and cos functions and I have been able to increase the max sequence length using these updates. 