### PR TITLE
[Doc]  fix-missing-code-block of `Download OpenCL ICD loader and manually add libmali to ICD` section

### DIFF
--- a/docs/install/gpu.rst
+++ b/docs/install/gpu.rst
@@ -157,6 +157,7 @@ Installation
 * Download OpenCL ICD loader and manually add libmali to ICD
 
 .. code-block:: bash
+
    sudo apt update
    sudo apt install mesa-opencl-icd
    sudo mkdir -p /etc/OpenCL/vendors


### PR DESCRIPTION
fix typo of #784

the view of document

<img width="876" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/9634619/d689c1a6-0b62-4054-9c79-219979886faa">

the Origininal rst

<img width="739" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/9634619/5523e8c6-2366-4627-bb07-6da2b2526380">
