### PR TITLE
Update CLI to be more consistent with ChatModule

### DIFF
--- a/cpp/cli_main.cc
+++ b/cpp/cli_main.cc
@@ -160,8 +160,7 @@ struct ModelPaths {
    */
   std::filesystem::path lib;
 
-  static ModelPaths Find(const std::filesystem::path& artifact_path, const std::string& device_name,
-                         const std::string& local_id);
+  static ModelPaths Find(const std::string& device_name, const std::string& local_id);
 };
 
 /*!
@@ -301,13 +300,13 @@ class ChatModule {
   tvm::runtime::Module executable_;
 };
 
-std::optional<std::filesystem::path> TryInferMLCChatConfig(
-    const std::filesystem::path& artifact_path, const std::string& local_id) {
+std::optional<std::filesystem::path> TryInferMLCChatConfig(const std::string& local_id) {
   return FindFile(
       {
-          artifact_path / local_id / "params",
-          artifact_path / "prebuilt" / local_id,
-          artifact_path / "prebuilt" / ("mlc-chat-" + local_id),
+          local_id, // full path, or just the name
+          "dist/prebuilt/" + local_id, // Using prebuilt workflow
+          "dist/" + local_id + "/params", // Default directory after mlc_llm.build_model()
+          "dist/prebuilt/mlc-chat-" + local_id, // Also prebuilt workflow, but missed prefix
       },
       {"mlc-chat-config"}, {".json"});
 }
@@ -330,15 +329,14 @@ std::string ReadStringFromJSONFile(const std::filesystem::path& config_path,
   return config[key].get<std::string>();
 }
 
-ModelPaths ModelPaths::Find(const std::filesystem::path& artifact_path,
-                            const std::string& device_name, const std::string& local_id) {
+ModelPaths ModelPaths::Find(const std::string& device_name, const std::string& local_id) {
   // Step 1. Find config path
   std::filesystem::path config_path;
-  if (auto path = TryInferMLCChatConfig(artifact_path, local_id)) {
+  if (auto path = TryInferMLCChatConfig(local_id)) {
     config_path = path.value();
   } else {
-    std::cerr << "Cannot find \"mlc-chat-config.json\" in path \"" << artifact_path << "/"
-              << local_id;
+    // TODO: Add more descriptive error message.
+    std::cerr << "Cannot find \"mlc-chat-config.json\" in path" << local_id;
     exit(1);
   }
   std::cout << "Use MLC config: " << config_path << std::endl;
@@ -358,9 +356,10 @@ ModelPaths ModelPaths::Find(const std::filesystem::path& artifact_path,
   std::filesystem::path lib_path;
   if (auto path = FindFile(
           {
-              artifact_path / lib_local_id,              // Usually this is the candidate
-              artifact_path / "prebuilt" / "lib",        // prebuilt lib
-              artifact_path / "prebuilt" / lib_local_id  // For prebuilts
+              lib_local_id,
+              "dist/prebuilt/lib", // Using prebuilt workflow
+              "dist/" + local_id,
+              "dist/prebuilt/" + lib_local_id
           },
           {
               lib_name + GetArchSuffix(),
@@ -369,8 +368,9 @@ ModelPaths ModelPaths::Find(const std::filesystem::path& artifact_path,
           GetLibSuffixes())) {
     lib_path = path.value();
   } else {
+    // TODO: Fix error message
     std::cerr << "Cannot find library \"" << lib_name << GetLibSuffixes().back() << "\" in "
-              << artifact_path << "/prebuilt/lib or other search paths" << std::endl;
+              << "/prebuilt/lib or other search paths" << std::endl;
     exit(1);
   }
   std::cout << "Use model library: " << lib_path << std::endl;
@@ -409,9 +409,8 @@ void Converse(ChatModule* chat, const std::string& input, int stream_interval,
  * \param executable The model library to initialize the chat module.
  * \param model_path The model path with contains the model config, tokenizer and parameters.
  */
-void Chat(ChatModule* chat, const std::filesystem::path& artifact_path,
-          const std::string& device_name, std::string local_id, int stream_interval = 2) {
-  ModelPaths model = ModelPaths::Find(artifact_path, device_name, local_id);
+void Chat(ChatModule* chat, const std::string& device_name, std::string local_id, int stream_interval = 2) {
+  ModelPaths model = ModelPaths::Find(device_name, local_id);
   PrintSpecialCommands();
   chat->Reload(model);
   chat->ProcessSystemPrompts();
@@ -430,18 +429,19 @@ void Chat(ChatModule* chat, const std::filesystem::path& artifact_path,
     } else if (input.substr(0, 6) == "/stats") {
       std::cout << chat->RuntimeStatsText() << std::endl << std::flush;
     } else if (input.substr(0, 7) == "/reload") {
-      std::string new_local_id;
-      {
-        std::string reload_prompt;
-        std::istringstream is(input);
-        is >> reload_prompt >> new_local_id;
-      }
-      if (new_local_id.empty()) {
-        new_local_id = local_id;
-      }
-      model = ModelPaths::Find(artifact_path, device_name, new_local_id);
-      chat->Reload(model);
-      local_id = new_local_id;
+      // TODO: Handle reload path
+    //   std::string new_local_id;
+    //   {
+    //     std::string reload_prompt;
+    //     std::istringstream is(input);
+    //     is >> reload_prompt >> new_local_id;
+    //   }
+    //   if (new_local_id.empty()) {
+    //     new_local_id = local_id;
+    //   }
+    //   model = ModelPaths::Find(artifact_path, device_name, new_local_id);
+    //   chat->Reload(model);
+    //   local_id = new_local_id;
     } else if (input.substr(0, 5) == "/help") {
       PrintSpecialCommands();
     } else {
@@ -450,34 +450,34 @@ void Chat(ChatModule* chat, const std::filesystem::path& artifact_path,
   }
 }
 
-std::string GuessLocalId(const std::filesystem::path& artifact_path, const std::string& model,
-                         const std::string& quantization) {
-  std::vector<std::string> local_id_candidates;
-  std::vector<std::string> quantization_candidates =
-      (quantization == "auto") ? quantization_presets : std::vector<std::string>{quantization};
-  for (std::string quantization_candidate : quantization_candidates) {
-    local_id_candidates.push_back(model + "-" + quantization_candidate);
-  }
-  for (const std::string& guess_local_id : local_id_candidates) {
-    if (std::optional<std::filesystem::path> config_path =
-            TryInferMLCChatConfig(artifact_path, guess_local_id)) {
-      return guess_local_id;
-    }
-  }
-  std::cerr << "Cannot find \"mlc-chat-config.json\" in path \"" << artifact_path << "/"
-            << local_id_candidates[0] << "/params/\", \"" << artifact_path
-            << "/prebuilt/" + local_id_candidates[0] << "\" or other candidate paths.";
-  exit(1);
-}
+// std::string GuessLocalId(const std::filesystem::path& artifact_path, const std::string& model,
+//                          const std::string& quantization) {
+//   std::vector<std::string> local_id_candidates;
+//   std::vector<std::string> quantization_candidates =
+//       (quantization == "auto") ? quantization_presets : std::vector<std::string>{quantization};
+//   for (std::string quantization_candidate : quantization_candidates) {
+//     local_id_candidates.push_back(model + "-" + quantization_candidate);
+//   }
+//   for (const std::string& guess_local_id : local_id_candidates) {
+//     if (std::optional<std::filesystem::path> config_path =
+//             TryInferMLCChatConfig(artifact_path, guess_local_id)) {
+//       return guess_local_id;
+//     }
+//   }
+//   std::cerr << "Cannot find \"mlc-chat-config.json\" in path \"" << artifact_path << "/"
+//             << local_id_candidates[0] << "/params/\", \"" << artifact_path
+//             << "/prebuilt/" + local_id_candidates[0] << "\" or other candidate paths.";
+//   exit(1);
+// }
 
 int main(int argc, char* argv[]) {
   argparse::ArgumentParser args("mlc_chat");
 
   args.add_argument("--local-id").default_value("");
-  args.add_argument("--model").default_value("vicuna-v1-7b");
-  args.add_argument("--quantization").default_value("auto");
+//   args.add_argument("--model").default_value("vicuna-v1-7b");
+//   args.add_argument("--quantization").default_value("auto");
   args.add_argument("--device").default_value("auto");
-  args.add_argument("--artifact-path").default_value("dist");
+//   args.add_argument("--artifact-path").default_value("dist");
   args.add_argument("--evaluate").default_value(false).implicit_value(true);
   args.add_argument("--eval-prompt-len").default_value(128).scan<'i', int>();
   args.add_argument("--eval-gen-len").default_value(1024).scan<'i', int>();
@@ -491,30 +491,31 @@ int main(int argc, char* argv[]) {
   }
 
   std::string local_id = args.get<std::string>("--local-id");
-  std::string model = args.get<std::string>("--model");
-  std::string quantization = args.get<std::string>("--quantization");
+//   std::string model = args.get<std::string>("--model");
+//   std::string quantization = args.get<std::string>("--quantization");
   auto [device_name, device_id] = DetectDevice(args.get<std::string>("--device"));
-  std::string artifact_path = args.get<std::string>("--artifact-path");
+//   std::string artifact_path = args.get<std::string>("--artifact-path");
 
-  if (local_id.empty()) {
-    local_id = GuessLocalId(artifact_path, model, quantization);
-  }
+//   if (local_id.empty()) {
+//     local_id = GuessLocalId(artifact_path, model, quantization);
+//   }
 
   try {
     ChatModule chat(GetDevice(device_name, device_id));
     if (args.get<bool>("--evaluate")) {
       // `--evaluate` is only used for performance debugging, and thus will call low-level APIs
       // that are not supposed to be used in chat app setting
-      int prompt_len = args.get<int>("--eval-prompt-len");
-      int gen_len = args.get<int>("--eval-gen-len");
-      ModelPaths model = ModelPaths::Find(artifact_path, device_name, local_id);
-      tvm::runtime::Module chat_mod = mlc::llm::CreateChatModule(GetDevice(device_name, device_id));
-      std::string model_path = model.config.parent_path().string();
-      tvm::runtime::Module lib = tvm::runtime::Module::LoadFromFile(model.lib.string());
-      chat_mod.GetFunction("reload")(lib, tvm::String(model_path));
-      chat_mod.GetFunction("evaluate")(prompt_len, gen_len);
+      // TODO: Handle evaluate path
+    //   int prompt_len = args.get<int>("--eval-prompt-len");
+    //   int gen_len = args.get<int>("--eval-gen-len");
+    //   ModelPaths model = ModelPaths::Find(artifact_path, device_name, local_id);
+    //   tvm::runtime::Module chat_mod = mlc::llm::CreateChatModule(GetDevice(device_name, device_id));
+    //   std::string model_path = model.config.parent_path().string();
+    //   tvm::runtime::Module lib = tvm::runtime::Module::LoadFromFile(model.lib.string());
+    //   chat_mod.GetFunction("reload")(lib, tvm::String(model_path));
+    //   chat_mod.GetFunction("evaluate")(prompt_len, gen_len);
     } else {
-      Chat(&chat, artifact_path, device_name, local_id);
+      Chat(&chat, device_name, local_id);
     }
   } catch (const std::runtime_error& err) {
     std::cerr << err.what() << std::endl;

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -524,7 +524,7 @@ class ChatModule:
     ):
         device_err_msg = (
             f"Invalid device name: {device}. Please enter the device in the form "
-            "'device_name:device_id' or 'device_name', where 'device_name' need to be "
+            "'device_name:device_id' or 'device_name', where 'device_name' needs to be "
             "one of 'cuda', 'metal', 'vulkan', 'rocm', 'opencl', 'auto'."
         )
 

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -18,25 +18,6 @@ _PYTHON_GET_STARTED_TUTORIAL_URL = "https://github.com/mlc-ai/notebooks/blob/mai
 # pylint: enable=line-too-long
 
 
-def quantization_keys():
-    r"""Get the keys of all quantization schemes."""
-    return [
-        "autogptq_llama_q4f16_0",
-        "q0f16",
-        "q0f32",
-        "q3f16_0",
-        "q3f16_1",
-        "q4f16_0",
-        "q4f16_1",
-        "q4f16_2",
-        "q4f16_ft",
-        "q4f32_0",
-        "q4f32_1",
-        "q8f16_0",
-        "q8f16_ft",
-    ]
-
-
 @dataclass
 class ConvConfig:
     r"""A dataclass that represents user-defined partial configuration for conversation template.


### PR DESCRIPTION
This PR updates the CLI interface to be more consistent with the ChatModule interface. Apart from updating the input args, the PR also aligns the error messages. Some examples below.

**Invalid model folder:**
```shell
./build/mlc_chat_cli --model hello-world-model
[18:37:21] /home/sudeepag/cli/mlc-llm/cpp/cli_main.cc:339: The model folder provided does not seem to refer to a valid mlc-llm model folder. Specifically, we cannot find `mlc-chat-config.json`, a required file. You should provide a path that contains the file. According to your input `hello-world-model`, we looked at folder(s):
- hello-world-model
- dist/prebuilt/hello-world-model
- dist/hello-world-model/params
- dist/prebuilt/mlc-chat-hello-world-model
```

**Invalid lib:**
```shell
$ ./build/mlc_chat_cli --model Llama-2-7b-chat-hf-q4f16_1
Use MLC config: "/home/sudeepag/cli/mlc-llm/dist/prebuilt/mlc-chat-Llama-2-7b-chat-hf-q4f16_1/mlc-chat-config.json"
Use model weights: "/home/sudeepag/cli/mlc-llm/dist/prebuilt/mlc-chat-Llama-2-7b-chat-hf-q4f16_1/ndarray-cache.json"
[18:42:41] /home/sudeepag/cli/mlc-llm/cpp/cli_main.cc:377: Cannot find the model library that corresponds to `Llama-2-7b-chat-hf-q4f16_1`.
We searched over the following possible paths: 
- Llama-2-7b-chat-hf-q4f16_1
- dist/prebuilt/lib 
- dist/Llama-2-7b-chat-hf-q4f16_1
- dist/prebuilt/Llama-2-7b-chat-hf-q4f16_1
Stack trace:
  [bt] (0) /home/sudeepag/cli/mlc-llm/build/tvm/libtvm_runtime.so(tvm::runtime::Backtrace[abi:cxx11]()+0x2c) [0x7f27bea009ec]
  [bt] (1) ./build/mlc_chat_cli(tvm::runtime::detail::LogFatal::Entry::Finalize()+0x3d) [0x5599ce9d650d]
  [bt] (2) ./build/mlc_chat_cli(+0xd7c7) [0x5599ce9cf7c7]
  [bt] (3) ./build/mlc_chat_cli(+0xdbc7) [0x5599ce9cfbc7]
  [bt] (4) ./build/mlc_chat_cli(+0x9b69) [0x5599ce9cbb69]
  [bt] (5) /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7f27be466083]
  [bt] (6) ./build/mlc_chat_cli(+0x9d6e) [0x5599ce9cbd6e]
```
