### PR TITLE
Make max_sequence_length config check optional.

### DIFF
--- a/mlc_llm/relax_model/chatglm.py
+++ b/mlc_llm/relax_model/chatglm.py
@@ -800,7 +800,7 @@ def get_model(args: argparse.Namespace, hf_config):
                 )
 
         if args.build_model_only:
-            return mod, param_manager, None
+            return mod, param_manager, None, config
 
         def f_convert_pname_fwd(pname: str) -> List[str]:
             if "transformer.embedding" in pname:
@@ -829,6 +829,6 @@ def get_model(args: argparse.Namespace, hf_config):
         param_manager.set_param_loading_func(
             args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
         )
-        return mod, param_manager, [None] * len(param_manager.param_names)
+        return mod, param_manager, [None] * len(param_manager.param_names), config
 
     raise ValueError(f"Unsupported model {model}")

--- a/mlc_llm/relax_model/gpt_bigcode.py
+++ b/mlc_llm/relax_model/gpt_bigcode.py
@@ -667,7 +667,7 @@ def get_model(args: argparse.Namespace, hf_config):
                 )
 
         if args.build_model_only:
-            return mod, param_manager, None
+            return mod, param_manager, None, config
 
         param_manager.set_param_loading_func(
             args.model_path,
@@ -676,6 +676,6 @@ def get_model(args: argparse.Namespace, hf_config):
                 (torch_pname, torch_param.astype(dtype))
             ],
         )
-        return mod, param_manager, [None] * len(param_manager.param_names)
+        return mod, param_manager, [None] * len(param_manager.param_names), config
 
     raise ValueError(f"Unsupported model {model}")

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -716,7 +716,7 @@ def get_model(
             )
 
     if args.build_model_only:
-        return mod, param_manager, None
+        return mod, param_manager, None, config
 
     def f_convert_pname_fwd(pname: str) -> List[str]:
         return [pname]
@@ -733,4 +733,4 @@ def get_model(
     param_manager.set_param_loading_func(
         args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
-    return mod, param_manager, [None] * len(param_manager.param_names)
+    return mod, param_manager, [None] * len(param_manager.param_names), config

--- a/mlc_llm/relax_model/gptj.py
+++ b/mlc_llm/relax_model/gptj.py
@@ -671,7 +671,7 @@ def get_model(args, hf_config):
             )
 
     if args.build_model_only:
-        return mod, param_manager, None
+        return mod, param_manager, None, config
 
     def f_convert_pname_fwd(pname: str) -> List[str]:
         import re
@@ -708,4 +708,4 @@ def get_model(args, hf_config):
     param_manager.set_param_loading_func(
         args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
-    return mod, param_manager, [None] * len(param_manager.param_names)
+    return mod, param_manager, [None] * len(param_manager.param_names), config

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -877,7 +877,7 @@ def get_model(args, hf_config):
             )
 
     if args.build_model_only:
-        return mod, param_manager, None
+        return mod, param_manager, None, config
 
     def f_convert_pname_fwd(pname: str) -> List[str]:
         if not config.combine_matmul:
@@ -963,4 +963,4 @@ def get_model(args, hf_config):
     param_list[-2] = tvm.nd.array(np.cos(emb).astype(config.dtype), device)
     param_list[-1] = tvm.nd.array(np.sin(emb).astype(config.dtype), device)
 
-    return mod, param_manager, param_list
+    return mod, param_manager, param_list, config

--- a/mlc_llm/relax_model/minigpt.py
+++ b/mlc_llm/relax_model/minigpt.py
@@ -516,7 +516,7 @@ def get_model(args):
         mod = bb.get()
 
         if args.build_model_only:
-            return mod, param_manager, None
+            return mod, param_manager, None, config
 
         param_manager.set_param_loading_func(
             args.model_path, args.use_safetensors, no_lazy_param_loading=True
@@ -577,7 +577,7 @@ def get_model(args):
                 tvm.nd.array(llama_state_dict[key].numpy().astype(config.dtype), device)
             )
 
-        return mod, param_manager, param_list
+        return mod, param_manager, param_list, config
 
     raise ValueError(f"Unsupported model: {model_name}")
 


### PR DESCRIPTION
This does not seem to get set for most cases since the config constructed by the model creation is never actually passed back out and therefore this value does not get set for llama models. 

Was getting while building my llama model
```
Traceback (most recent call last):
  File "/home/noah/anaconda3/envs/tvm-build-venv/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/noah/anaconda3/envs/tvm-build-venv/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/noah/workplace/mlc-llm/mlc_llm/build.py", line 13, in <module>
    main()
  File "/home/noah/workplace/mlc-llm/mlc_llm/build.py", line 10, in main
    core.build_model_from_args(parsed_args)
  File "/home/noah/workplace/mlc-llm/mlc_llm/core.py", line 578, in build_model_from_args
    mod = mod_transform_before_build(mod, param_manager, args, config)
  File "/home/noah/workplace/mlc-llm/mlc_llm/core.py", line 361, in mod_transform_before_build
    max_seq_len = config["max_sequence_length"]
KeyError: 'max_sequence_length'
```