### PR TITLE
Disable decoding for system prompts

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -909,7 +909,9 @@ class LLMChat {
   // Clear kv cache
   void ResetKVCache() { reset_kv_cache_func_(kv_cache_); }
 
-  void ProcessSystemPrompts() { this->PrefillStep(/*inp=*/"", /*append_conversation=*/false); }
+  void ProcessSystemPrompts() {
+    this->PrefillStep(/*inp=*/"", /*append_conversation=*/false, /*decode_next_token=*/false);
+  }
 
   // Utils
   static double GetRandomNumber() {


### PR DESCRIPTION
In some cases, the model may produce a single EOS token for system prompt and cause assertion errors in https://github.com/mlc-ai/mlc-llm/blob/main/cpp/conversation.h#L198. It is actually not necessary to decode the system prompts since it is followed by users inputs.