### PR TITLE
fix a small bug in mod_transform_before_build

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -349,7 +349,7 @@ def mod_transform_before_build(
         ]
         if args.sep_embed:
             model_names = ["embed", "prefill_with_embed"] + model_names[1:]
-        if args.model.startswith("rwkv-"):
+        if args.model.lower().startswith("rwkv-"):
             model_names += ["reset_kv_cache"]
 
     mod = param_manager.transform_dequantize(mod)
@@ -359,7 +359,8 @@ def mod_transform_before_build(
         mod
     )  # pylint: disable=not-callable
 
-    if "num_attention_heads" in config and "hidden_size" in config:
+
+    if hasattr(config, "num_attention_heads") and hasattr(config, "hidden_size"):
         max_seq_len = None
         if args.max_seq_len > 0:
             max_seq_len = args.max_seq_len

--- a/mlc_llm/relax_model/rwkv.py
+++ b/mlc_llm/relax_model/rwkv.py
@@ -569,7 +569,7 @@ def get_model(args, hf_config):
     max_seq_len = args.max_seq_len
     dtype = args.quantization.model_dtype
 
-    if not model_name.startswith("rwkv-"):
+    if not model_name.lower().startswith("rwkv-"):
         raise ValueError(f"Unsupported model name: {model_name}")
 
     config = RWKVConfig(**hf_config, dtype=dtype)


### PR DESCRIPTION
core.py:362引起报错：

![1693294551532的副本](https://github.com/mlc-ai/mlc-llm/assets/35585791/3d11eab8-9048-4156-b8ba-5906683b9f18)

把in改成hasattr修复。另外rwkv的world系列模型在hf是以大写开头的，这里把rwkv的只判断小写开头也顺手改掉。