### PR TITLE
[Fix] Lib with small `max_seq_len` incompatible with prebuilt weight

### DIFF
--- a/mlc_llm/transform/fuse_split_rotary_embedding.py
+++ b/mlc_llm/transform/fuse_split_rotary_embedding.py
@@ -15,6 +15,7 @@ from tvm.script import relax as R
 
 def get_split_rotary(num_attention_heads, head_dim, max_sequence_length=2048):
     hidden_size = num_attention_heads * head_dim
+    max_sequence_length = max(max_sequence_length, 2048)
 
     @T.prim_func
     def split_rotary(
@@ -77,6 +78,7 @@ def get_split_rotary(num_attention_heads, head_dim, max_sequence_length=2048):
 
 def fuse_split_rotary_embedding(mod, num_attention_heads, hidden_size, max_sequence_length=2048):
     head_dim = hidden_size // num_attention_heads
+    max_sequence_length = max(max_sequence_length, 2048)
 
     mod["split_rotary"] = get_split_rotary(num_attention_heads, head_dim, max_sequence_length)
 


### PR DESCRIPTION
This PR fixes an issue introduced by #780, which broke our intended behavior to make the cos/sin shape independent of the max sequence length, so that no matter what max sequence length people use, they can always use a same set of prebuilt weight and do not need to clone different weight repositories. This intended behavior is broken by #780.

However, it is true that the needs for larger max sequence length are growing. Prior to #780, when the max sequence length is larger than 2048, the cached cos/sin do not work anymore and break. To be compatible as much as possible, this PR changes the behavior to "taking the maximum value of 2048 and the specified max sequence length when building the model lib".

With this fix, when the maximum sequence length is smaller than 2048, we are still able to use the prebuilt weights. And when it is larger than 2048, we will only be able to use the weight converted along the build.