### PR TITLE
[Build][Debug] Implemented DumpBeforeAfter and debugging features

### DIFF
--- a/mlc_llm/build.py
+++ b/mlc_llm/build.py
@@ -1,13 +1,46 @@
 """Script for building/compiling models."""
+import contextlib
+import sys
+
 from mlc_llm import core
+
+
+@contextlib.contextmanager
+def debug_on_except():
+    try:
+        yield
+    finally:
+        if sys.exc_info() == (None, None, None):
+            return
+
+        import traceback
+
+        try:
+            import ipdb as pdb
+        except ImportError:
+            import pdb
+
+        traceback.print_exc()
+        pdb.post_mortem()
+
 
 def main():
     """Main method for building model from command line."""
     empty_args = core.convert_build_args_to_argparser()  # Create new ArgumentParser
     parsed_args = empty_args.parse_args()  # Parse through command line
-    # Post processing of arguments
-    parsed_args = core._parse_args(parsed_args)  # pylint: disable=protected-access
-    core.build_model_from_args(parsed_args)
+
+    with contextlib.ExitStack() as stack:
+        # Enter an exception-catching context before post-processing
+        # the arguments, in case the post-processing itself raises an
+        # exception.
+        if parsed_args.pdb:
+            stack.enter_context(debug_on_except())
+
+        # Post processing of arguments
+        parsed_args = core._parse_args(parsed_args)  # pylint: disable=protected-access
+
+        core.build_model_from_args(parsed_args)
+
 
 if __name__ == "__main__":
     main()

--- a/mlc_llm/build.py
+++ b/mlc_llm/build.py
@@ -2,7 +2,9 @@
 import contextlib
 import sys
 
+import tvm
 from mlc_llm import core
+from tvm.relax.ir.instrument import WellFormedInstrument
 
 
 @contextlib.contextmanager
@@ -38,6 +40,10 @@ def main():
 
         # Post processing of arguments
         parsed_args = core._parse_args(parsed_args)  # pylint: disable=protected-access
+
+        # Enter any additional debug contexts
+        if parsed_args.assert_well_formed:
+            stack.enter_context(tvm.transform.PassContext(instruments=[WellFormedInstrument()]))
 
         core.build_model_from_args(parsed_args)
 

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -136,6 +136,17 @@ class BuildArgs:
             "action": "store_true",
         },
     )
+    black_format: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to use the black autoformatter "
+                "to format the debug dumps.  "
+                "Disabled by default, as black can be very slow on large files."
+            ),
+            "action": "store_true",
+        },
+    )
     debug_load_script: bool = field(
         default=False,
         metadata={

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -224,6 +224,13 @@ class BuildArgs:
             "action": "store_true",
         },
     )
+    assert_well_formed: bool = field(
+        default=False,
+        metadata={
+            "help": "If set, check for well-formed-ness before/after each ir.transform.Pass",
+            "action": "store_true",
+        },
+    )
 
 
 def convert_build_args_to_argparser() -> argparse.ArgumentParser:

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -103,7 +103,7 @@ def debug_dump_script(
     if black_format is None:
         black_format = args.black_format
 
-    def format_script(script, dump_path: pathlib.Path):
+    def format_script(script):
         try:
             import black
         except ImportError:
@@ -125,7 +125,7 @@ def debug_dump_script(
 
     script = mod.script(show_meta=True)
     if black_format:
-        script = format_script(script, dump_path)
+        script = format_script(script)
 
     with open(dump_path, "w", encoding="utf-8") as outfile:
         outfile.write(script)


### PR DESCRIPTION
This PR introduces the following features:

- It implements dumping mod before and after each transform passes. It does excludes dumping before/after of TIR passes. 
       - Optional --black-format as command-line argument
       - Includes step number in filename
- Use contextlib for breaking into pdb on error
- Added an --assert-well-formed flag

authored-by: Eric Lunderberg <elunderberg@octoml.ai>