### PR TITLE
Support build-time multi-gpu parameter sharding

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -219,6 +219,12 @@ class BuildArgs:
             "choices": ["pre-fusion", "post-fusion"],
         },
     )
+    num_gpus: int = field(
+        default=1,
+        metadata={
+            "help": "The number of GPUs to use.  If greater than 1, muiltigpu must not be None."
+        },
+    )
 
 
 def convert_build_args_to_argparser() -> argparse.ArgumentParser:

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -616,11 +616,8 @@ def build_model_from_args(args: argparse.Namespace):
         # calls `func(activations, preprocess(weights))`.
         mod = relax.transform.LiftTransformParams()(mod)
         mod_transform, mod = utils.split_transform_deploy_mod(mod)
-<<<<<<< HEAD
         mod = finalizer(mod)
-=======
         mod = relax.transform.BundleModelParams()(mod)
->>>>>>> 5b13b42... Split out parameter bundling from ParamManager.transform_quantize
 
         utils.save_lifted_params(mod_transform, param_manager, params, args)
 

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -616,7 +616,11 @@ def build_model_from_args(args: argparse.Namespace):
         # calls `func(activations, preprocess(weights))`.
         mod = relax.transform.LiftTransformParams()(mod)
         mod_transform, mod = utils.split_transform_deploy_mod(mod)
+<<<<<<< HEAD
         mod = finalizer(mod)
+=======
+        mod = relax.transform.BundleModelParams()(mod)
+>>>>>>> 5b13b42... Split out parameter bundling from ParamManager.transform_quantize
 
         utils.save_lifted_params(mod_transform, param_manager, params, args)
 

--- a/mlc_llm/relax_model/chatglm.py
+++ b/mlc_llm/relax_model/chatglm.py
@@ -829,6 +829,6 @@ def get_model(args: argparse.Namespace, hf_config):
         param_manager.set_param_loading_func(
             args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
         )
-        return mod, param_manager, [None] * len(param_manager.param_names), config
+        return mod, param_manager, [None] * len(param_manager.param_names), config, lambda mod:mod
 
     raise ValueError(f"Unsupported model {model}")

--- a/mlc_llm/relax_model/gpt_bigcode.py
+++ b/mlc_llm/relax_model/gpt_bigcode.py
@@ -676,6 +676,6 @@ def get_model(args: argparse.Namespace, hf_config):
                 (torch_pname, torch_param.astype(dtype))
             ],
         )
-        return mod, param_manager, [None] * len(param_manager.param_names), config
+        return mod, param_manager, [None] * len(param_manager.param_names), config, lambda mod:mod
 
     raise ValueError(f"Unsupported model {model}")

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -733,4 +733,4 @@ def get_model(
     param_manager.set_param_loading_func(
         args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
-    return mod, param_manager, [None] * len(param_manager.param_names), config
+    return mod, param_manager, [None] * len(param_manager.param_names), config, lambda mod:mod

--- a/mlc_llm/relax_model/gptj.py
+++ b/mlc_llm/relax_model/gptj.py
@@ -708,4 +708,4 @@ def get_model(args, hf_config):
     param_manager.set_param_loading_func(
         args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
-    return mod, param_manager, [None] * len(param_manager.param_names), config
+    return mod, param_manager, [None] * len(param_manager.param_names), config, lambda mod:mod

--- a/mlc_llm/relax_model/minigpt.py
+++ b/mlc_llm/relax_model/minigpt.py
@@ -577,7 +577,7 @@ def get_model(args):
                 tvm.nd.array(llama_state_dict[key].numpy().astype(config.dtype), device)
             )
 
-        return mod, param_manager, param_list, config
+        return mod, param_manager, param_list, config, lambda mod:mod
 
     raise ValueError(f"Unsupported model: {model_name}")
 

--- a/mlc_llm/relax_model/param_manager.py
+++ b/mlc_llm/relax_model/param_manager.py
@@ -747,7 +747,7 @@ class ParamReplacer(PyExprMutator):
             ret_struct_info=func.ret_struct_info,
             is_pure=func.is_pure,
             attrs=func.attrs,
-        ).without_attr("num_input")
+        )
 
     def visit_var_(self, var: Var) -> Expr:
         if var not in self.param_set:

--- a/mlc_llm/relax_model/rwkv.py
+++ b/mlc_llm/relax_model/rwkv.py
@@ -637,4 +637,4 @@ def get_model(args, hf_config):
     param_manager.set_param_loading_func(
         args.model_path, args.use_safetensors, f_convert_pname_fwd, f_convert_param_bkwd
     )
-    return mod, param_manager, [None] * len(param_manager.param_names), config
+    return mod, param_manager, [None] * len(param_manager.param_names), config, lambda mod:mod

--- a/mlc_llm/transform/reorder_transform_func.py
+++ b/mlc_llm/transform/reorder_transform_func.py
@@ -221,8 +221,7 @@ class ReorderTransformFunc:
         self, mod: IRModule, ctx: tvm.transform.PassContext
     ) -> IRModule:
         for gv, func in list(mod.functions.items()):
-            if isinstance(func, relax.Function):
-                assert gv.name_hint.endswith("transform_params")
+            if isinstance(func, relax.Function) and gv.name_hint.endswith("transform_params"):
                 func_updated = reorder_func(func, self.pidx2binname)
                 mod[gv] = func_updated
         return mod

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -329,13 +329,14 @@ def save_lifted_params(
                 transform_args_list = [world_size, rank]
             sharded_params = convert_weights(
                 mod_transform,
+                param_mgr,
                 params,
                 args,
                 transform_args=[tvm.runtime.ShapeTuple(transform_args_list)],
             )
             save_params(sharded_params, args.artifact_path, rank, world_size)
     else:
-        params = convert_weights(mod_transform, params, args)
+        params = convert_weights(mod_transform, param_mgr, params, args)
         save_params(params, args.artifact_path)
 
 


### PR DESCRIPTION
This PR is the first set of PRs that will bring multi-gpu support to mlc-llm. 

The main changes here are:

- Update `save_params` and `load_params` to save params in subdir when running in a multi-GPU setup.
- It is still useful to transform params after quantization using LiftTransformParams, and so this utility function should also be
retained.
- Save sharded weights with --multigpu, --num-gpu flags
- The parameters produced by `LiftTransformParams` may depend on an external parameter (e.g. the `rank` and `world_size` within a multi-GPU setup).  If such a parameter is needed, allow it to be passed in.


co-authored-by: Eric Lunderberg <elunderberg@octoml.ai> and  Chris Sullivan <csullivan@octoml.ai>