### PR TITLE
PoC implementation of SmoothQuant

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -378,6 +378,13 @@ class BuildArgs:
             "action": "store_true",
         },
     )
+    dataset: str = field(
+        default="dummy",
+        metadata={
+            "help": "Name of dataset for calibration.",
+            "choices": dataset_list,
+        },
+    )
 
     @property
     def convert_weight_only(self):

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -625,7 +625,7 @@ def mod_transform_before_build(
 
         has_cublas = tvm.get_global_func("relax.ext.cublas", True)
 
-        if has_cublas and args.quantization.name in ("q0f16", "q0f32") and not args.no_cublas:
+        if has_cublas and (args.quantization.name in ("q0f16", "q0f32") or args.quantization.name.startswith("smq_q8i8f16")) and not args.no_cublas:
             patterns += get_patterns_with_prefix("cublas")
 
         if len(patterns) > 0:

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -859,6 +859,13 @@ def build_model_from_args(args: argparse.Namespace):
                     repetition_penalty=0.996,
                     rwkv_world=True,
                 )
+            elif args.model_category == "chatglm":
+                dump_mlc_chat_config(
+                    args,
+                    vocab_size=config["padded_vocab_size"],
+                    max_window_size=model_config.max_sequence_length,
+                    max_gen_len=model_config.max_sequence_length,
+                )
             else:
                 dump_mlc_chat_config(
                     args,
@@ -915,38 +922,6 @@ def build_model_from_args(args: argparse.Namespace):
                 params, args.artifact_path, args.num_shards if args.use_presharded_weights else 1
             )
 
-<<<<<<< HEAD
-            if args.model_category != "minigpt":
-                utils.copy_tokenizer(args)
-            if args.model_category == "rwkv" or args.model_category == "rwkv_world":
-                # TODO: refactor config into model definition
-                dump_mlc_chat_config(
-                    args,
-                    vocab_size=config["vocab_size"],
-                    max_window_size=model_config.max_sequence_length,
-                    max_gen_len=model_config.max_sequence_length,
-                    top_p=0.6,
-                    temperature=1.2,
-                    repetition_penalty=0.996,
-                    rwkv_world=True,
-                )
-            elif args.model_category == "chatglm":
-                dump_mlc_chat_config(
-                    args,
-                    vocab_size=config["padded_vocab_size"],
-                    max_window_size=model_config.max_sequence_length,
-                    max_gen_len=model_config.max_sequence_length,
-                )
-            else:
-                dump_mlc_chat_config(
-                    args,
-                    vocab_size=config["vocab_size"],
-                    max_window_size=model_config.max_sequence_length,
-                    max_gen_len=model_config.max_sequence_length,
-                )
-
-=======
->>>>>>> efd4243 ([SmoothQuant] Merge smoothing and params transform into one step)
         if args.convert_weights_only:
             exit(0)
 

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -38,7 +38,6 @@ from tvm import relax
 from tvm.contrib.nvcc import parse_compute_version
 from tvm.relax.backend import get_patterns_with_prefix
 from tvm.relax.backend.contrib.cutlass import annotate_workspace
-from mlc_llm.quantization.smoothquant_utils import smoothquant, smoothquant_transform_params
 
 
 @dataclass
@@ -655,9 +654,7 @@ def mod_transform_before_build(
     mod = relax.transform.DeadCodeElimination(model_names)(mod)
     mod = mlc_llm.transform.CleanUpTIRAttrs()(mod)
     if args.quantization.name == "smq_a8q8f16":
-        mod = relax.transform.LiftTransformParams()(mod)
-        mod_transform, mod_deploy = utils.split_transform_deploy_mod(mod, model_names)
-        new_params = smoothquant_transform_params(args, mod_transform)
+        mod_deploy, new_params = smoothquant_quantize_params(mod, model_names, args)
         utils.save_params(new_params, args.artifact_path)
     else:
         mod_deploy = mod

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -566,7 +566,7 @@ def mod_transform_before_build(
         if args.model.lower().startswith("rwkv-"):
             model_names += ["reset_kv_cache"]
 
-    if args.quantization.name == "smq_a8q8f16":
+    if args.quantization.name.startswith("smq_q8i8f16"):
         mod = smoothquant(args, mod, model_names)
         utils.debug_dump_script(mod, "mod_smoothquant.py", args)
     else:
@@ -660,7 +660,7 @@ def mod_transform_before_build(
     mod = mlc_llm.transform.FuseDecodeTake()(mod)
     mod = relax.transform.DeadCodeElimination(model_names)(mod)
     mod = mlc_llm.transform.CleanUpTIRAttrs()(mod)
-    if args.quantization.name == "smq_a8q8f16":
+    if args.quantization.name.startswith("smq_q8i8f16"):
         mod_deploy, new_params = smoothquant_quantize_params(mod, model_names, args)
         utils.save_params(new_params, args.artifact_path)
     else:

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -662,6 +662,7 @@ def mod_transform_before_build(
     mod = mlc_llm.transform.CleanUpTIRAttrs()(mod)
     if args.quantization.name.startswith("smq_q8i8f16"):
         mod_deploy, new_params = smoothquant_quantize_params(mod, model_names, args)
+        smoothquant_prepare_dir(os.path.join(args.artifact_path, "params"))
         utils.save_params(new_params, args.artifact_path)
     else:
         mod_deploy = mod

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -231,4 +231,5 @@ quantization_schemes = {
     ),
     "smq_q8i8f16_0": QuantizationScheme("smq_q8i8f16_0", NoQuantizationSpec("float16")),
     "smq_q8i8f16_1": QuantizationScheme("smq_q8i8f16_1", NoQuantizationSpec("float16")),
+    "smq_q8i8f16_2": QuantizationScheme("smq_q8i8f16_2", NoQuantizationSpec("float16")),
 }

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -229,5 +229,6 @@ quantization_schemes = {
         embedding_table="same_as_linear_weight",
         final_fc_weight="same_as_linear_weight",
     ),
-    "smq_a8q8f16": QuantizationScheme("smq_a8q8f16", NoQuantizationSpec("float16")),
+    "smq_q8i8f16_0": QuantizationScheme("smq_q8i8f16_0", NoQuantizationSpec("float16")),
+    "smq_q8i8f16_1": QuantizationScheme("smq_q8i8f16_1", NoQuantizationSpec("float16")),
 }

--- a/mlc_llm/quantization/__init__.py
+++ b/mlc_llm/quantization/__init__.py
@@ -229,4 +229,5 @@ quantization_schemes = {
         embedding_table="same_as_linear_weight",
         final_fc_weight="same_as_linear_weight",
     ),
+    "smq_a8q8f16": QuantizationScheme("smq_a8q8f16", NoQuantizationSpec("float16")),
 }

--- a/mlc_llm/quantization/smoothquant_utils.py
+++ b/mlc_llm/quantization/smoothquant_utils.py
@@ -162,8 +162,6 @@ def _smooth(
     for fname in funcs:
         scale_params = _calculate_scale_params(fname, stat, config, tvm.cpu(0))
         mod = relax.transform.BindParams(fname, scale_params)(mod)
-
-    mod = mlc_llm.transform.SmoothQuantOpConverter("multiply")(mod)
     return mod
 
 

--- a/mlc_llm/quantization/smoothquant_utils.py
+++ b/mlc_llm/quantization/smoothquant_utils.py
@@ -28,7 +28,7 @@ def _try_convert_to_scalar_const(expr: tvm.relax.Expr) -> Union[tvm.relax.Expr, 
         elif expr.struct_info.ndim == 1:
             dim_size = expr.struct_info.shape[0].value
             if dim_size == 1:
-                return expr.data.numpy()[0]
+                return expr.data.numpy()[0].item()
     return expr
 
 

--- a/mlc_llm/quantization/smoothquant_utils.py
+++ b/mlc_llm/quantization/smoothquant_utils.py
@@ -18,7 +18,7 @@ from ..transform.smoothquant import SCALE_PREFIX_NAME, ZP_PREFIX_NAME
 
 
 # List of supported calibration datasets.
-dataset_list = ["dummy", "piqa"]
+dataset_list = ["dummy", "piqa", "gsm8k"]
 
 
 def get_runtime_func(funcs: List[str], mod: tvm.IRModule):
@@ -431,15 +431,22 @@ def _get_dataset(name: str, artifact_path: str, device: tvm.runtime.Device):
 
     if name not in dataset_list:
         raise ValueError(f"Dataset {name} is not supported")
+    config_name = None
+    split = "train"
     if name == "piqa":
         data_files = None
         text_name = "goal"
+    elif name == "gsm8k":
+        data_files = None
+        text_name = "question"
+        config_name = "main"
+        split = "test[:10%]"
     else:
         # Dummy dataset consisting of 4 simple questions.
         name = text_name = "text"
         data_files = _prepare_dummy_dataset(artifact_path)
-
-    dataset = load_dataset(name, data_files=data_files, split="validation")
+        config_name = None
+    dataset = load_dataset(name, name=config_name, data_files=data_files, split=split)
     calibration_dataset = []
     for record in dataset:
         data = tokenizer(record[text_name], return_tensors="np")

--- a/mlc_llm/quantization/smoothquant_utils.py
+++ b/mlc_llm/quantization/smoothquant_utils.py
@@ -305,20 +305,9 @@ def _get_dummy_dataset(artifact_path, device, num=3):
     prompts_dataset = [
         "The capital of Canada is",
         "2+2=?",
-        "What is the capital of Russia?",
+        "What is the capital of France?",
         "Who is the president of the USA?",
     ]
-
-    """
-    qqq = [
-        [1, 450, 7483, 310, 7400, 338],
-        [1, 29871, 29906, 29974, 29906, 29922, 29973],
-        [1, 1724, 338, 278, 7483, 310, 12710, 29973],
-        [1, 11644, 338, 278, 6673, 310, 278, 8278, 29973],
-    ]
-    qidx = 0
-    """
-
     dataset = []
     print("[SmoothQuant] Starting to initialize tokenizer...")
     tokenizer_path = os.path.join(artifact_path, "params")
@@ -326,11 +315,8 @@ def _get_dummy_dataset(artifact_path, device, num=3):
     print("[SmoothQuant] Initialization of tokenizer was completed...")
     for prompt in prompts_dataset:
         prompt_tokens = tokenizer.encode(prompt)
-        #prompt_tokens = qqq[qidx]
-        #qidx += 1
         data = tvm.nd.array(np.array([prompt_tokens]).astype("int32"), device=device)
         dataset.append(data)
     stop_tokens = ([tokenizer.eos_token_id])
-    #stop_tokens = ([2])
 
     return dataset, stop_tokens

--- a/mlc_llm/quantization/smoothquant_utils.py
+++ b/mlc_llm/quantization/smoothquant_utils.py
@@ -1,0 +1,320 @@
+import numpy as np
+import os
+from tqdm import tqdm
+import argparse
+from transformers import AutoTokenizer
+from typing import List, Dict, Any
+
+import tvm
+from tvm import relax
+
+from mlc_llm.utils import load_params
+from mlc_llm.transform import FuseTransposeMatmul
+
+
+def get_runtime_func(funcs: List[str], mod: tvm.IRModule):
+    lowered_mod = relax.transform.LegalizeOps()(mod)
+    target = tvm.target.Target.current(allow_none=False)
+    target_kind = target.kind.default_keys[0]
+    vm_device = tvm.device(target_kind)
+    if target_kind != "cpu":
+        with target:
+            lowered_mod = tvm.tir.transform.DefaultGPUSchedule()(lowered_mod)
+    exe = relax.build(lowered_mod, target)
+    vm = relax.VirtualMachine(exe, vm_device)
+    runtime_funcs = [vm[fname] for fname in funcs]
+    return runtime_funcs[0] if len(funcs) == 1 else runtime_funcs
+
+
+def _accumulate_outlier_stat(stat, data):
+    if stat is None:
+        stat = [[] for i in range(len(data))]
+    for idx, out in enumerate(data):
+        stat[idx].append(out.numpy())
+    return stat
+
+
+def _accumulate_act_outlier_stat(stat, data):
+    a_data = data[::2]
+    return _accumulate_outlier_stat(stat, a_data)
+
+
+def _accumulate_weight_outlier_stat(stat, data):
+    # Optimization step: no need to accumulate weights for each new element in dataset since
+    # weights are the same.
+    if stat is not None:
+        return stat
+    w_data = data[1::2]
+    return _accumulate_outlier_stat(stat, w_data)
+
+
+def _calculate_scale_params(
+    func_name: str,
+    stats,
+    config: Dict[str, Any],
+    dev: tvm.runtime.Device,
+):
+    if stats[func_name] is None:
+        return {}
+
+    # scales = act_scales.pow(alpha) / weight_scales.pow(1-alpha)
+    alpha = config["alpha"]
+    a_stat, w_stat = stats[func_name]
+    assert len(a_stat) == len(w_stat)
+    idx = 0
+    scale_params = {}
+    for a_element, w_elemet in zip(a_stat, w_stat):
+        assert a_element.shape == w_elemet.shape
+        assert len(a_element.shape) == 1
+        scales = np.power(a_element, alpha) / np.power(w_elemet, 1 - alpha)
+        if scales.size - np.count_nonzero(scales) > 0:
+            print("Warning: Smoothing: scales have zero value")
+            scales = np.ones_like(scales)
+            assert False, "Not supported case: please, add more elements in dataset. Otherwise, NaNs in output are possible."
+        scale_params[f"sq_scale_{idx}"] = tvm.nd.array(scales, dev)
+        scale_params[f"sq_scale_{idx+1}"] = tvm.nd.array(scales, dev)
+        idx += 2
+
+    return scale_params
+
+
+def _calculate_quant_scale_params(
+        func_name: str,
+        stats,
+        config: Dict[str, Any],
+        dev: tvm.runtime.Device,
+):
+    if stats[func_name] is None:
+        return {}
+
+    a_dtype = config["adtype"]
+    w_dtype = config["wdtype"]
+
+    idx = 0
+    scale_params = {}
+    for a_element, w_element in zip(*stats[func_name]):
+        a_scale = np.max(a_element) / a_element.dtype.type(np.iinfo(a_dtype).max)
+        w_scale = np.max(w_element) / w_element.dtype.type(np.iinfo(w_dtype).max)
+        scale_params[f"sq_scale_{idx}"] = tvm.nd.array(np.array([a_scale]), dev)
+        scale_params[f"sq_scale_{idx+1}"] = tvm.nd.array(np.array([w_scale]), dev)
+        idx += 2
+
+    return scale_params
+
+
+def _smooth(
+    mod: tvm.IRModule,
+    params: List[tvm.nd.NDArray],
+    funcs: List[str],
+    dataset: List[tvm.nd.NDArray],
+    config: Dict[str, Any],
+):
+    mod = relax.transform.Annotate(funcs)(mod)
+    mod = relax.transform.DeadCodeElimination(funcs)(mod)
+    stat_mod = relax.transform.CollectStat()(mod)
+    stat_mod = FuseTransposeMatmul()(stat_mod)
+
+    prefill, decode, kvc, _, _ = get_runtime_func(funcs, stat_mod)
+
+    # Calculate max statistics
+    # Number of dimension in a_stat/w_stat is equal to 3, where:
+    #  * 1st dimension - number of outputs in compute graph / 2
+    #  * 2nd dimension - number of elements in dataset
+    #  * 3rd dimension - scale(multiplier) dimension.
+    a_stat = None
+    w_stat = None
+
+    target = tvm.target.Target.current(allow_none=False)
+    for data in tqdm(dataset, desc="Smoothing"):
+        # Create KV-cache
+        kv_caches = kvc()
+        num_tokens = data.shape[1]
+        seq_len_shape = tvm.runtime.ShapeTuple([num_tokens])
+
+        # Run Encoder and update statistics for activations/weights
+        (logits, kv_caches), outputs = prefill(data, seq_len_shape, kv_caches, *params)
+        a_stat = _accumulate_act_outlier_stat(a_stat, outputs)
+        w_stat = _accumulate_weight_outlier_stat(w_stat, outputs)
+
+        # Run Decoder and update statistics for activations/weights
+        for _ in range(config["decoder_invoke_num"]):
+            # TODO: support softmax with temperature.
+            logits_max = np.argmax(logits.numpy(), axis=-1).astype("int32")
+            if logits_max[0] in config["stop_tokens"]:
+                break
+            next_token = tvm.nd.array(logits_max, device=tvm.device(target.kind.default_keys[0]))
+            num_tokens += logits_max.shape[1]
+            seq_len_shape = tvm.runtime.ShapeTuple([num_tokens])
+            (logits, kv_caches), outputs = decode(next_token, seq_len_shape, kv_caches, *params)
+            a_stat = _accumulate_act_outlier_stat(a_stat, outputs)
+            w_stat = _accumulate_weight_outlier_stat(w_stat, outputs)
+
+    a_stat = [np.max(s, axis=0) for s in a_stat]
+    w_stat = [np.max(s, axis=0) for s in w_stat]
+    # Use the same statistics for "prefill"/"decode"
+    stat = dict.fromkeys(funcs)
+    stat["prefill"] = (a_stat, w_stat)
+    stat["decode"] = (a_stat, w_stat)
+    for fname in funcs:
+        scale_params = _calculate_scale_params(fname, stat, config, tvm.cpu(0))
+        mod = relax.transform.BindParams(fname, scale_params)(mod)
+
+    mod = relax.transform.SmoothQuantLegalize("multiply")(mod)
+    return mod
+
+
+def _calibrate(
+    mod: tvm.IRModule,
+    params: List[tvm.nd.NDArray],
+    funcs: List[str],
+    dataset: List[tvm.nd.NDArray],
+    config: Dict[str, Any],
+):
+    mod = relax.transform.Annotate(funcs, "quantize")(mod)
+    mod = relax.transform.DeadCodeElimination(funcs)(mod)
+    stat_mod = relax.transform.CollectStat()(mod)
+    stat_mod = FuseTransposeMatmul()(stat_mod)
+
+    prefill, decode, kvc, _, _ = get_runtime_func(funcs, stat_mod)
+
+    # Calculate max statistics
+    # Number of dimension in a_stat/w_stat is equal to 3, where:
+    #  * 1st dimension - number of outputs in compute graph / 2
+    #  * 2nd dimension - number of elements in dataset
+    #  * 3rd dimension - scale(multiplier) dimension.
+    a_stat = None
+    w_stat = None
+
+    target = tvm.target.Target.current(allow_none=False)
+    for data in tqdm(dataset, desc="Calibration"):
+        # Create KV-cache
+        kv_caches = kvc()
+        num_tokens = data.shape[1]
+        seq_len_shape = tvm.runtime.ShapeTuple([num_tokens])
+
+        # Run Encoder and update statistics for activations/weights
+        (logits, kv_caches), outputs = prefill(data, seq_len_shape, kv_caches, *params)
+        a_stat = _accumulate_act_outlier_stat(a_stat, outputs)
+        w_stat = _accumulate_weight_outlier_stat(w_stat, outputs)
+
+        # Run Decoder and update statistics for activations/weights
+        for _ in range(config["decoder_invoke_num"]):
+            # TODO: support softmax with temperature.
+            logits_max = np.argmax(logits.numpy(), axis=-1).astype("int32")
+            if logits_max[0] in config["stop_tokens"]:
+                break
+            next_token = tvm.nd.array(logits_max, device=tvm.device(target.kind.default_keys[0]))
+            num_tokens += logits_max.shape[1]
+            seq_len_shape = tvm.runtime.ShapeTuple([num_tokens])
+            (logits, kv_caches), outputs = decode(next_token, seq_len_shape, kv_caches, *params)
+            a_stat = _accumulate_act_outlier_stat(a_stat, outputs)
+            w_stat = _accumulate_weight_outlier_stat(w_stat, outputs)
+
+    a_stat = [np.max(s, axis=0) for s in a_stat]
+    w_stat = [np.max(s, axis=0) for s in w_stat]
+    # Use the same statistics for "prefill"/"decode"
+    stat = dict.fromkeys(funcs)
+    stat["prefill"] = (a_stat, w_stat)
+    stat["decode"] = (a_stat, w_stat)
+    for fname in funcs:
+        scale_params = _calculate_quant_scale_params(fname, stat, config, tvm.cpu(0))
+        mod = relax.transform.BindParams(fname, scale_params)(mod)
+
+    legalized_mod = relax.transform.SmoothQuantLegalize("quantize")(mod)
+    mod = relax.transform.SmoothQuantRealize()(legalized_mod)
+    mod = relax.transform.DeadCodeElimination(funcs)(mod)
+    return mod
+
+
+def smoothquant(args, mod, model_names):
+    target = args.target
+    smq_device = tvm.device(target.kind.default_keys[0])
+    assert args.build_model_only is False, "build_model_only in True is not supported in SMQ"
+    params = load_params(args.artifact_path, device=smq_device)
+
+    dataset, stop_tokens = _get_dummy_dataset(args.artifact_path, device=smq_device)
+    smq_config: Dict[str, Any] = {}
+    smq_config["decoder_invoke_num"] = 5
+    smq_config["alpha"] = 0.5
+    smq_config["stop_tokens"] = stop_tokens
+    smq_config["adtype"] = "int8"
+    smq_config["wdtype"] = "int8"
+    with target:
+        print("[SmoothQuant] Run smoothing...")
+        mod = _smooth(mod, params, model_names, dataset, smq_config)
+        print("[SmoothQuant] Run calibration and quantization...")
+        mod = _calibrate(mod, params, model_names, dataset, smq_config)
+    # Free memory:
+    params.clear()
+    return mod
+
+
+def smoothquant_transform_params(
+    args: argparse.Namespace,
+    mod_transform: tvm.IRModule
+) -> List[tvm.nd.NDArray]:
+    mod_transform = relax.transform.ToNonDataflow()(mod_transform)
+    mod_transform = relax.transform.LazyTransformParams()(mod_transform)
+
+    target = args.target
+    smq_device=tvm.device(target.kind.default_keys[0])
+
+    new_params: List[tvm.nd.NDArray] = []
+    assert args.build_model_only is False, "build_model_only in True is not supported in SMQ"
+    params = load_params(args.artifact_path, device=smq_device)
+
+    @tvm.register_func("get_item", override=True)
+    def get_item(i):
+        assert params[i] is not None
+        return tvm.nd.array(params[i], device=smq_device)
+
+    @tvm.register_func("set_item", override=True)
+    def set_item(i, value):
+        if len(new_params) <= i:
+            new_params.extend([None for _ in range(i - len(new_params) + 1)])
+        new_params[i] = tvm.nd.array(value, device=tvm.cpu())
+
+    if target.kind.name != "llvm":
+        with tvm.target.Target(target):
+            mod_transform = tvm.tir.transform.DefaultGPUSchedule()(mod_transform)
+
+    assert "decode_transform_params" in [gv.name_hint for gv in mod_transform.get_global_vars()]
+    ex = relax.build(mod_transform, target=target)
+    vm = relax.vm.VirtualMachine(ex, smq_device)
+    vm["decode_transform_params"]()
+    return new_params
+
+
+def _get_dummy_dataset(artifact_path, device, num=3):
+    prompts_dataset = [
+        "The capital of Canada is",
+        "2+2=?",
+        "What is the capital of Russia?",
+        "Who is the president of the USA?",
+    ]
+
+    """
+    qqq = [
+        [1, 450, 7483, 310, 7400, 338],
+        [1, 29871, 29906, 29974, 29906, 29922, 29973],
+        [1, 1724, 338, 278, 7483, 310, 12710, 29973],
+        [1, 11644, 338, 278, 6673, 310, 278, 8278, 29973],
+    ]
+    qidx = 0
+    """
+
+    dataset = []
+    print("[SmoothQuant] Starting to initialize tokenizer...")
+    tokenizer_path = os.path.join(artifact_path, "params")
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+    print("[SmoothQuant] Initialization of tokenizer was completed...")
+    for prompt in prompts_dataset:
+        prompt_tokens = tokenizer.encode(prompt)
+        #prompt_tokens = qqq[qidx]
+        #qidx += 1
+        data = tvm.nd.array(np.array([prompt_tokens]).astype("int32"), device=device)
+        dataset.append(data)
+    stop_tokens = ([tokenizer.eos_token_id])
+    #stop_tokens = ([2])
+
+    return dataset, stop_tokens

--- a/mlc_llm/transform/__init__.py
+++ b/mlc_llm/transform/__init__.py
@@ -7,9 +7,4 @@ from .lift_tir_global_buffer_alloc import LiftTIRGlobalBufferAlloc
 from .reorder_transform_func import ReorderTransformFunc
 from .rewrite_attention import rewrite_attention
 from .transpose_matmul import FuseTransposeMatmul
-from .smoothquant import (
-    SmoothQuantLegalizer,
-    SmoothQuantOpConverter,
-    SmoothQuantAnnotator,
-    SmoothQuantStatCollector,
-)
+from .smoothquant import SmoothQuantLegalizer, SmoothQuantAnnotator, SmoothQuantStatCollector

--- a/mlc_llm/transform/__init__.py
+++ b/mlc_llm/transform/__init__.py
@@ -7,4 +7,9 @@ from .lift_tir_global_buffer_alloc import LiftTIRGlobalBufferAlloc
 from .reorder_transform_func import ReorderTransformFunc
 from .rewrite_attention import rewrite_attention
 from .transpose_matmul import FuseTransposeMatmul
-from .smoothquant import SmoothQuantLegalizer, SmoothQuantAnnotator, SmoothQuantStatCollector
+from .smoothquant import (
+    SmoothQuantLegalizer,
+    SmoothQuantAnnotator,
+    SmoothQuantStatCollector,
+    SmoothQuantStopLiftParamsOptimizer,
+)

--- a/mlc_llm/transform/__init__.py
+++ b/mlc_llm/transform/__init__.py
@@ -7,3 +7,9 @@ from .lift_tir_global_buffer_alloc import LiftTIRGlobalBufferAlloc
 from .reorder_transform_func import ReorderTransformFunc
 from .rewrite_attention import rewrite_attention
 from .transpose_matmul import FuseTransposeMatmul
+from .smoothquant import (
+    SmoothQuantLegalizer,
+    SmoothQuantOpConverter,
+    SmoothQuantAnnotator,
+    SmoothQuantStatCollector,
+)

--- a/mlc_llm/transform/smoothquant.py
+++ b/mlc_llm/transform/smoothquant.py
@@ -6,11 +6,21 @@ from tvm.relax.dpl import rewrite_call, is_op, wildcard
 from tvm.relax.expr_functor import PyExprMutator, mutator
 from tvm.script import relax as R
 
-from typing import Dict
+from ..quantization.smoothquant_utils import (
+    SCALE_PREFIX_NAME, ZP_PREFIX_NAME, _try_convert_to_scalar_const
+)
+
+from typing import Dict, List, Union
+from enum import Enum
 
 
-QSCHEMES = ("smq_q8i8f16_0", "smq_q8i8f16_1")
+QSCHEMES = ("smq_q8i8f16_0", "smq_q8i8f16_1", "smq_q8i8f16_2")
 OPMODES = ("smoothing", *QSCHEMES)
+
+class QKind(Enum):
+    KIND_ACT = 1,
+    KIND_WEIGHTS = 2,
+
 
 @mutator
 class Annotator(PyExprMutator):
@@ -54,7 +64,7 @@ class Annotator(PyExprMutator):
         if act.struct_info.ndim != 2 and act.struct_info.ndim != 3:
             return call
 
-        def make_scale_param(shape: relax.ShapeExpr, dtype: str, kind: int) -> tvm.relax.Var:
+        def make_scale_param(shape: relax.ShapeExpr, dtype: str, kind: QKind) -> tvm.relax.Var:
             """
             Create scale parameter.
 
@@ -68,20 +78,31 @@ class Annotator(PyExprMutator):
             """
             if self.op_mode == "smq_q8i8f16_0":
                 n = 1 # per-tensor quantization for activations and weights
-            elif self.op_mode == "smq_q8i8f16_1":
-                n = 1 if kind == 1 else shape[-2]  # per-channel quantization for weights
+            elif self.op_mode == "smq_q8i8f16_1" or self.op_mode == "smq_q8i8f16_2":
+                # per-channel quantization for weights and per-tensor for activations
+                n = 1 if kind == QKind.KIND_ACT else shape[-2]
             else:
                 n = shape[-1]  # smoothing scale
-            scale = relax.Var(f"sq_scale_{self.sm_counter}", relax.TensorStructInfo([n], dtype))
+            var_name = f"{SCALE_PREFIX_NAME}{self.sm_counter}"
+            scale = relax.Var(var_name, relax.TensorStructInfo([n], dtype))
             self.sm_counter += 1
             self.new_params.append(scale)
             return scale
 
-        a_scale = make_scale_param(act.struct_info.shape, act.struct_info.dtype, kind=1)
-        w_scale = make_scale_param(weights.struct_info.shape, weights.struct_info.dtype, kind=2)
+        def make_zero_point_param(shape: relax.ShapeExpr, dtype: str) -> tvm.relax.Var:
+            var_name = f"{ZP_PREFIX_NAME}{self.sm_counter}"
+            zero_point = relax.Var(var_name, relax.TensorStructInfo(shape, dtype))
+            self.sm_counter += 1
+            self.new_params.append(zero_point)
+            return zero_point
+
+        a_scale = make_scale_param(act.struct_info.shape, act.struct_info.dtype, kind=QKind.KIND_ACT)
+        w_scale = make_scale_param(weights.struct_info.shape, weights.struct_info.dtype, kind=QKind.KIND_WEIGHTS)
         if self.op_mode.startswith("smq_q8i8f16"):
-            lhs = R.smooth(act, a_scale, kind=1, mode="identity")
-            rhs = R.smooth(weights, w_scale, kind=2, mode="identity")
+            a_zp = make_zero_point_param(a_scale.struct_info.shape, dtype="int8")
+            w_zp = make_zero_point_param(w_scale.struct_info.shape, dtype="int8")
+            lhs = R.smooth(act, a_scale, a_zp, kind=1, mode="identity")
+            rhs = R.smooth(weights, w_scale, w_zp, kind=2, mode="identity")
         else:
             lhs = R.divide(act, a_scale)
             rhs = R.multiply(weights, w_scale)
@@ -120,9 +141,9 @@ class SmoothQuantStatCollector:
        (R.annotate.smooth/R.divide/R.multiply). This is done for memory footprint optimization only.
        Since we do not want to dump the whole tensor and dump already preprocessed information
        (abs -> max -> squeeze).
-    2) Substitute scale param in R.annotate.smooth (or second arguemnt in R.divide/R.multiply) with
-       dummy ones and remove these params from relax.Function. Dummy param is np.ones array in this
-       case.
+    2) Substitute scale and zero_point params in R.annotate.smooth (or second arguemnt in
+       R.divide/R.multiply) with dummy ones and remove these params from relax.Function. Dummy param
+       is np.ones or np.empty arrays in this case.
     3) Add new outputs in relax.Function that correspond to the last op from 1).
     """
     def __init__(self, op_mode: str = "smoothing") -> None:
@@ -145,11 +166,11 @@ class SmoothQuantStatCollector:
 
                 attrs = {"mode": "identity"}
                 self.lhs_sm = (
-                    is_op("relax.annotate.smooth")(wildcard(), wildcard()).has_attr(attrs) |
+                    is_op("relax.annotate.smooth")(wildcard(), wildcard(), wildcard()).has_attr(attrs) |
                     is_op("relax.divide")(wildcard(), wildcard())
                 )
                 self.rhs_sm = (
-                    is_op("relax.annotate.smooth")(wildcard(), wildcard()).has_attr(attrs) |
+                    is_op("relax.annotate.smooth")(wildcard(), wildcard(), wildcard()).has_attr(attrs) |
                     is_op("relax.multiply")(wildcard(), wildcard())
                 )
                 self.permute = is_op("relax.permute_dims")(self.rhs_sm)
@@ -193,12 +214,20 @@ class SmoothQuantStatCollector:
                 if matchings:
                     m_smq1 = matchings[self.lhs_sm]
                     a_smq = self._emit_annotate_op(m_smq1, kind=1)
-                    a_out = self._emit_abs_max_ops_chain(a_smq, kind=1)
                     m_smq2 = matchings[self.rhs_sm]
                     w_smq = self._emit_annotate_op(m_smq2, kind=2)
-                    w_out = self._emit_abs_max_ops_chain(w_smq, kind=2)
-                    self.profile_points.extend([a_out, w_out])
-                    self.params_to_remove.extend([m_smq1.args[1], m_smq2.args[1]])
+                    if self.op_mode == "smoothing":
+                        a_out = self._emit_abs_max_ops_chain(a_smq)
+                        w_out = self._emit_abs_max_ops_chain(w_smq)
+                        self.profile_points.extend([a_out, w_out])
+                        self.params_to_remove.extend([m_smq1.args[1], m_smq2.args[1]])
+                    else:
+                        a_max_out, a_min_out = self._emit_max_min_ops_chain(a_smq, axis=-2)
+                        w_max_out, w_min_out = self._emit_max_min_ops_chain(w_smq, axis=-1)
+                        self.profile_points.extend([a_max_out, a_min_out, w_max_out, w_min_out])
+                        self.params_to_remove.extend(
+                            [m_smq1.args[1], m_smq2.args[1], m_smq1.args[2], m_smq2.args[2]]
+                        )
                     return self.builder_.emit(R.linear(a_smq, w_smq))
 
                 return call
@@ -212,28 +241,41 @@ class SmoothQuantStatCollector:
                 elif call.op == tvm.ir.Op.get("relax.divide"):
                     smq = self.builder_.emit(R.divide(call.args[0], relax.Constant(scale)))
                 else:
+                    zero_point = tvm.runtime.ndarray.empty(
+                        call.args[2].struct_info.shape, device=tvm.cpu()
+                    )
                     smq = self.builder_.emit(
-                        R.smooth(call.args[0], relax.Constant(scale), kind=kind, mode="identity")
+                        R.smooth(
+                            call.args[0],
+                            relax.Constant(scale),
+                            relax.Constant(zero_point),
+                            kind=kind,
+                            mode="identity",
+                        )
                     )
                 return smq
 
-            def _emit_abs_max_ops_chain(self, expr: relax.Var, kind: str) -> relax.Var:
+            def _emit_abs_max_ops_chain(self, expr: relax.Var) -> relax.Var:
                 assert expr.struct_info.ndim >= 2, "Tensor dim num should be >= 2"
                 abs_expr = self.builder_.emit(R.abs(expr))
-                if self.op_mode == "smq_q8i8f16_1":
-                    if kind == 1:
-                        max_expr = self.builder_.emit(R.max(abs_expr, axis=-2))
-                    else:
-                        max_expr = self.builder_.emit(R.max(abs_expr, axis=-1))
-                else:
-                    max_expr = self.builder_.emit(R.max(abs_expr, axis=-2))
+                max_expr = self.builder_.emit(R.max(abs_expr, axis=-2))
                 if expr.struct_info.ndim > 2:
                     max_expr = self.builder_.emit(R.squeeze(max_expr))
                 return max_expr
 
+            def _emit_max_min_ops_chain(self, expr: relax.Var, axis: int) -> List[relax.Var]:
+                assert expr.struct_info.ndim >= 2, "Tensor dim num should be >= 2"
+                max_expr = self.builder_.emit(R.max(expr, axis=axis))
+                min_expr = self.builder_.emit(R.min(expr, axis=axis))
+                if expr.struct_info.ndim > 2:
+                    max_expr = self.builder_.emit(R.squeeze(max_expr))
+                    min_expr = self.builder_.emit(R.squeeze(min_expr))
+                return max_expr, min_expr
+
         return ParamsAndOutputsMutator(mod, self.op_mode).transform()
 
 
+"""
 @tvm.transform.module_pass(opt_level=0, name="SmoothQuantOpConverter")
 class SmoothQuantOpConverter:
     def __init__(self, op_mode: str) -> None:
@@ -243,11 +285,14 @@ class SmoothQuantOpConverter:
         attrs = {"mode": "identity"}
         data = wildcard()
         scale = wildcard()
-        pattern = is_op("relax.annotate.smooth")(data, scale).has_attr(attrs)
+        zp = wildcard()
+        pattern = is_op("relax.annotate.smooth")(data, scale, zp).has_attr(attrs)
 
         def rewriter(_, matchings):
             kind = matchings[pattern].attrs.kind
-            return R.smooth(matchings[data], matchings[scale], kind=kind, mode=self.op_name)
+            return R.smooth(
+                matchings[data], matchings[scale], matchings[zp], kind=kind, mode=self.op_name
+            )
 
         new_mod = tvm.IRModule()
         for gv, func in mod.functions.items():
@@ -256,6 +301,7 @@ class SmoothQuantOpConverter:
             else:
                 new_mod[gv] = func
         return new_mod
+"""
 
 
 @tvm.transform.module_pass(opt_level=0, name="SmoothQuantLegalizer")
@@ -263,31 +309,42 @@ class SmoothQuantLegalizer:
     """
     Pass that converts matmul(fp16, fp16) -> quantize + matmul(int8, int8) + dequantize.
     """
-    def __init__(self, op_mode: str, adtype: str = "int8", wdtype: str = "int8"):
+    def __init__(self, adtype: str = "int8", wdtype: str = "int8"):
         self.dtype_act = adtype
         self.dtype_weight = wdtype
-        # Operation mode of the legalizer: "smoothing" or "quantization"
-        assert op_mode in OPMODES, f"unsupported operation mode: '{op_mode}'"
-        self.op_mode = op_mode
 
     def transform_module(self, mod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
-        attrs = {"mode": "quantize"}
+        attrs = {"mode": "identity"}
         act_scale = wildcard()
+        act_zp = wildcard()
         w_scale = wildcard()
-        lhs_sm = is_op("relax.annotate.smooth")(wildcard(), act_scale).has_attr(attrs)
-        rhs_sm = is_op("relax.annotate.smooth")(wildcard(), w_scale).has_attr(attrs)
+        w_zp = wildcard()
+        lhs_sm = is_op("relax.annotate.smooth")(wildcard(), act_scale, act_zp).has_attr(attrs)
+        rhs_sm = is_op("relax.annotate.smooth")(wildcard(), w_scale, w_zp).has_attr(attrs)
         permute = is_op("relax.permute_dims")(rhs_sm)
         pattern = is_op("relax.matmul")(lhs_sm, permute)
 
         def rewriter(_, matchings):
+
+            def _try_expand_param_dim(param: tvm.relax.Constant) -> Union[tvm.relax.Constant, tvm.relax.Call]:
+                assert param.struct_info.ndim == 1
+                if param.struct_info.shape[0].value != 1:
+                    return R.expand_dims(param, axis=[1])
+                return param
+
             def _make_quantize(call: tvm.relax.Call, out_dtype: str):
                 in_dtype = call.args[0].struct_info.dtype
                 min_value = tvm.tir.min_value(out_dtype).astype(in_dtype)
                 max_value = tvm.tir.max_value(out_dtype).astype(in_dtype)
                 scale = call.args[1]
-                if self.op_mode == "smq_q8i8f16_1":
-                    scale = R.expand_dims(scale, axis=[1])
+                zero_point = call.args[2]
+                zp_const = _try_convert_to_scalar_const(zero_point)
+                is_zp_zero = isinstance(zp_const, (int, np.integer)) and zp_const == 0
+                scale = _try_expand_param_dim(scale)
+                zero_point = _try_expand_param_dim(zero_point)
                 data = R.round(R.divide(call.args[0], scale))
+                if not is_zp_zero:
+                    data = R.add(data, R.astype(zero_point, dtype=in_dtype))
                 return R.astype(R.clip(data, min_value, max_value), dtype=out_dtype)
             
             def _make_dequantize(
@@ -306,9 +363,44 @@ class SmoothQuantLegalizer:
                     out = R.multiply(R.astype(call, dtype="float32"), dq_scale)
                     return R.astype(R.clip(out, min_value, max_value), dtype=out_dtype)
 
+            def _make_linear(
+                lhs: tvm.relax.Call,
+                rhs: tvm.relax.Call,
+                lhs_zp: tvm.relax.Constant,
+                rhs_zp: tvm.relax.Constant,
+                reduction_dim_size: int
+            ):
+                #return R.linear(lhs, rhs, out_dtype="int32")
+                lhs_zp_const = _try_convert_to_scalar_const(lhs_zp)
+                rhs_zp_const = _try_convert_to_scalar_const(rhs_zp)
+                is_lhs_zp_zero = isinstance(lhs_zp_const, (int, np.integer)) and lhs_zp_const == 0
+                is_rhs_zp_zero = isinstance(rhs_zp_const, (int, np.integer)) and rhs_zp_const == 0
+                # Make term1:
+                term1 = R.linear(lhs, rhs, out_dtype="int32")
+                # Make term2:
+                lhs_reduced = R.sum(R.astype(lhs, dtype="int32"), axis=-1, keepdims=True)
+                rhs_zp = R.astype(rhs_zp, dtype="int32")
+                term2 = R.multiply(lhs_reduced, rhs_zp)
+                # Make term3:
+                rhs_reduced = R.sum(R.astype(rhs, dtype="int32"), axis=-1, keepdims=False)
+                lhs_zp = R.astype(lhs_zp, dtype="int32")
+                term3 = R.multiply(rhs_reduced, lhs_zp)
+                # Make term4:
+                term4 = R.multiply(R.multiply(lhs_zp, rhs_zp), R.const(reduction_dim_size, "int32"))
+                # Combine result:
+                if is_lhs_zp_zero and is_rhs_zp_zero:
+                    return term1
+                elif is_lhs_zp_zero and not is_rhs_zp_zero:
+                    return R.subtract(term1, term2)
+                elif not is_lhs_zp_zero and is_rhs_zp_zero:
+                    return R.subtract(term1, term3)
+                else:
+                    return R.add(R.subtract(R.subtract(term1, term2), term3), term4)
+
+            reduction_axis_size: int = matchings[lhs_sm].struct_info.shape[-1].value
             lhs = _make_quantize(matchings[lhs_sm], self.dtype_act)
             rhs = _make_quantize(matchings[rhs_sm], self.dtype_weight)
-            mm = R.linear(lhs, rhs, out_dtype="int32")
+            mm = _make_linear(lhs, rhs, matchings[act_zp], matchings[w_zp], reduction_axis_size)
             dtype = matchings[pattern].struct_info.dtype
             return _make_dequantize(mm, matchings[act_scale], matchings[w_scale], dtype)
 

--- a/mlc_llm/transform/smoothquant.py
+++ b/mlc_llm/transform/smoothquant.py
@@ -1,0 +1,245 @@
+import tvm
+from tvm import relax
+from tvm.relax.analysis import remove_all_unused
+from tvm.relax.dpl import rewrite_call, is_op, wildcard
+from tvm.relax.expr_functor import PyExprMutator, mutator
+from tvm.script import relax as R
+
+from typing import Dict
+
+
+@mutator
+class Annotator(PyExprMutator):
+    def __init__(self, irmod: tvm.IRModule, mode: str) -> None:
+        super().__init__(irmod)
+        self.mod = irmod
+        self.sm_counter = 0
+        self.new_params = []
+        self.mode = mode
+
+    def transform(self) -> tvm.IRModule:
+        for gv, func in self.mod.functions.items():
+            if not isinstance(func, relax.Function):
+                continue
+            self.sm_counter = 0
+            self.new_params = []
+            updated_func = self.visit_expr(func)
+            updated_func = remove_all_unused(updated_func)
+            self.builder_.update_func(gv, updated_func)
+
+        return self.builder_.get()
+    
+    def visit_function_(self, f):
+        body = super().visit_expr(f.body)
+        params = list(f.params) + list(self.new_params)
+        return tvm.relax.Function(params, body, f.ret_struct_info, f.is_pure, f.attrs, f.span)
+
+    def visit_call_(self, call: relax.Call) -> relax.Expr:
+        call = super().visit_call_(call)
+        if call.op != tvm.ir.Op.get("relax.matmul"):
+            return call
+        permute = self.lookup_binding(call.args[1])
+        if permute is None or permute.op != tvm.ir.Op.get("relax.permute_dims"):
+            return call
+        act = call.args[0]
+        weights = permute.args[0]
+        if weights.struct_info.ndim != 2:
+            return call
+        if act.struct_info.ndim != 2 and act.struct_info.ndim != 3:
+            return call
+
+        def make_scale_param(shape: relax.ShapeExpr, dtype: str) -> tvm.relax.Var:
+            n = 1 if self.mode == "quantize" else shape[-1]
+            scale = relax.Var(f"sq_scale_{self.sm_counter}", relax.TensorStructInfo([n], dtype))
+            self.sm_counter += 1
+            self.new_params.append(scale)
+            return scale
+
+        a_scale = make_scale_param(act.struct_info.shape, act.struct_info.dtype)
+        w_scale = make_scale_param(weights.struct_info.shape, weights.struct_info.dtype)
+        lhs = R.smooth(act, a_scale, kind=1, mode="identity")
+        rhs = R.smooth(weights, w_scale, kind=2, mode="identity")
+        return R.linear(lhs, rhs)
+
+
+@tvm.transform.module_pass(opt_level=0, name="SmoothQuantAnnotator")
+class SmoothQuantAnnotator:
+    """
+    Insert R.smooth ops with "identity" attribute before R.linear. Add scales (second argument of 
+    R.smooth) to the list of relax.Function parameters. Example:
+    R.linear(lhs, rhs)  -->  op1 = R.smooth(lhs, scale1, kind=1, mode="identity")
+                             op2 = R.smooth(rhs, scale2, kind=2, mode="identity")
+                             R.linear(op1, op2)
+    """
+    def __init__(self, mode: str = "") -> None:
+        self.mode = mode
+        pass
+
+    def transform_module(self, irmod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
+        return Annotator(irmod, self.mode).transform()
+
+
+@tvm.transform.module_pass(opt_level=0, name="SmoothQuantStatCollector")
+class SmoothQuantStatCollector:
+    """
+    This pass modifies IRModule to enable statistics collection. It does several modifications:
+    1) Inserts R.annotate.absmax just after R.annotate.smooth.
+    2) Substitute scale params in R.annotate.smooth with dummy ones and remove these params
+       from relax.Function.
+    3) Add new outputs in relax.Function that correspond to R.annotate.absmax ops.
+    """
+    def transform_module(self, mod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
+        @mutator
+        class ParamsAndOutputsMutator(PyExprMutator):
+            def __init__(self, mod: tvm.IRModule) -> None:
+                super().__init__(mod)
+                self.mod = mod
+                self.var2val: Dict[relax.Var, relax.Expr] = {}
+                self.profile_points = []
+                self.params_to_remove = []
+
+                attrs = {"mode": "identity"}
+                self.a_scale = wildcard()
+                self.w_scale = wildcard()
+                self.lhs_sm = is_op("relax.annotate.smooth")(wildcard(), self.a_scale).has_attr(attrs)
+                self.rhs_sm = is_op("relax.annotate.smooth")(wildcard(), self.w_scale).has_attr(attrs)
+                self.permute = is_op("relax.permute_dims")(self.rhs_sm)
+                self.pattern = is_op("relax.matmul")(self.lhs_sm, self.permute)
+            
+            def transform(self) -> tvm.IRModule:
+                for gv, func in self.mod.functions.items():
+                    if not isinstance(func, relax.Function):
+                        continue
+                    self.var2val = tvm.relax.analysis.get_var2val(func)
+                    self.profile_points = []
+                    self.params_to_remove = []
+                    updated_func = self.visit_expr(func)
+                    updated_func = remove_all_unused(updated_func)
+                    self.builder_.update_func(gv, updated_func)
+                return self.builder_.get()
+            
+            def visit_function_(self, f):
+                body = super().visit_expr(f.body)
+                new_params = [param for param in f.params if param not in self.params_to_remove]
+                return relax.Function(new_params, body, None, f.is_pure, f.attrs, f.span)
+            
+            def visit_seq_expr_(self, op: relax.SeqExpr) -> relax.Expr:
+                op = super().visit_seq_expr_(op)
+                if len(self.profile_points) != 0:
+                    new_body = relax.Tuple([op.body, relax.Tuple(self.profile_points)])
+                    return relax.SeqExpr(op.blocks, new_body, op.span)
+                return op
+
+            def visit_dataflow_block_(self, block: relax.DataflowBlock) -> relax.DataflowBlock:
+                self.builder_._begin_dataflow_block()
+                for binding in block.bindings:
+                    self.visit_binding(binding)
+                if len(self.profile_points) != 0:
+                    self.builder_.emit_output(self.profile_points)
+                return self.builder_._end_block()
+
+            def visit_call_(self, call: relax.Call) -> relax.Expr:
+                call = super().visit_call_(call)
+                matchings = self.pattern.extract_matched_expr(call, self.var2val)
+                if matchings:
+                    m_smq1 = matchings[self.lhs_sm]
+                    m_smq2 = matchings[self.rhs_sm]
+                    a_info = matchings[self.a_scale].struct_info
+                    w_info = matchings[self.w_scale].struct_info
+                    a_scale = tvm.runtime.ndarray.empty(a_info.shape, a_info.dtype, tvm.cpu())
+                    w_scale = tvm.runtime.ndarray.empty(w_info.shape, w_info.dtype, tvm.cpu())
+                    a_smq = self.builder_.emit(
+                        R.smooth(m_smq1.args[0], relax.Constant(a_scale), kind=1, mode="identity")
+                    )
+                    w_smq = self.builder_.emit(
+                        R.smooth(m_smq2.args[0], relax.Constant(w_scale), kind=2, mode="identity")
+                    )
+                    a_out = self.builder_.emit(R.absmax(a_smq, kind=1), "a_out")
+                    w_out = self.builder_.emit(R.absmax(w_smq, kind=2), "w_out")
+                    self.profile_points.extend([a_out, w_out])
+                    self.params_to_remove.extend([m_smq1.args[1], m_smq2.args[1]])
+                    return self.builder_.emit(R.linear(a_smq, w_smq))
+
+                return call
+
+        return ParamsAndOutputsMutator(mod).transform()
+
+
+@tvm.transform.module_pass(opt_level=0, name="SmoothQuantOpConverter")
+class SmoothQuantOpConverter:
+    def __init__(self, op_name: str) -> None:
+        self.op_name = op_name
+
+    def transform_module(self, mod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
+        attrs = {"mode": "identity"}
+        data = wildcard()
+        scale = wildcard()
+        pattern = is_op("relax.annotate.smooth")(data, scale).has_attr(attrs)
+
+        def rewriter(_, matchings):
+            kind = matchings[pattern].attrs.kind
+            return R.smooth(matchings[data], matchings[scale], kind=kind, mode=self.op_name)
+
+        new_mod = tvm.IRModule()
+        for gv, func in mod.functions.items():
+            if isinstance(func, relax.Function):
+                new_mod[gv] = rewrite_call(pattern, rewriter, func)
+            else:
+                new_mod[gv] = func
+        return new_mod
+
+
+@tvm.transform.module_pass(opt_level=0, name="SmoothQuantLegalizer")
+class SmoothQuantLegalizer:
+    """
+    Pass that converts matmul(fp16, fp16) -> quantize + matmul(int8, int8) + dequantize.
+    """
+    def __init__(self):
+        self.dtype_act = "int8"
+        self.dtype_weight = "int8"
+
+    def transform_module(self, mod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
+        attrs = {"mode": "quantize"}
+        act_scale = wildcard()
+        w_scale = wildcard()
+        lhs_sm = is_op("relax.annotate.smooth")(wildcard(), act_scale).has_attr(attrs)
+        rhs_sm = is_op("relax.annotate.smooth")(wildcard(), w_scale).has_attr(attrs)
+        permute = is_op("relax.permute_dims")(rhs_sm)
+        pattern = is_op("relax.matmul")(lhs_sm, permute)
+
+        def rewriter(_, matchings):
+            def _make_quantize(call: tvm.relax.Call, out_dtype: str):
+                min_value = tvm.tir.min_value(out_dtype)
+                max_value = tvm.tir.max_value(out_dtype)
+                data = R.round(R.divide(call.args[0], call.args[1]))
+                return R.astype(R.clip(data, min_value, max_value), dtype=out_dtype)
+            
+            def _make_dequantize(
+                call: tvm.relax.Call,
+                scale1: tvm.relax.Constant,
+                scale2: tvm.relax.Constant,
+                out_dtype: str,
+            ):
+                if out_dtype == "float32":
+                    return R.multiply(R.astype(call, dtype=out_dtype), R.multiply(scale1, scale2))
+                else:
+                    assert out_dtype == "float16"
+                    min_value = tvm.tir.min_value(out_dtype)
+                    max_value = tvm.tir.max_value(out_dtype)
+                    dq_scale = R.multiply(R.astype(scale1, "float32"), R.astype(scale2, "float32"))
+                    out = R.multiply(R.astype(call, dtype="float32"), dq_scale)
+                    return R.astype(R.clip(out, min_value, max_value), dtype=out_dtype)
+
+            lhs = _make_quantize(matchings[lhs_sm], self.dtype_act)
+            rhs = _make_quantize(matchings[rhs_sm], self.dtype_weight)
+            mm = R.linear(lhs, rhs, out_dtype="int32")
+            dtype = matchings[pattern].struct_info.dtype
+            return _make_dequantize(mm, matchings[act_scale], matchings[w_scale], dtype)
+
+        new_mod = tvm.IRModule()
+        for gv, func in mod.functions.items():
+            if isinstance(func, relax.Function):
+                new_mod[gv] = rewrite_call(pattern, rewriter, func)
+            else:
+                new_mod[gv] = func
+        return new_mod

--- a/mlc_llm/transform/smoothquant.py
+++ b/mlc_llm/transform/smoothquant.py
@@ -81,45 +81,44 @@ class Annotator(PyExprMutator):
         if act.struct_info.ndim != 2 and act.struct_info.ndim != 3:
             return call
 
-        def make_scale_param(shape: relax.ShapeExpr, dtype: str, kind: QKind) -> tvm.relax.Var:
+        def _make_param(param_name: str, shape, dtype: str) -> tvm.relax.Var:
+            param = relax.Var(param_name, relax.TensorStructInfo(shape, dtype))
+            self.sm_counter += 1
+            self.new_params.append(param)
+            return param
+
+        def _make_scale_param(shape: relax.ShapeExpr, dtype: str, kind: QKind) -> tvm.relax.Var:
             """
             Create scale parameter.
 
-            In case of quantization:
-              scale is a Tensor with the single element for per-tensor quantization scheme
-              (smq_q8i8f16_0) or 1D Tensor for weights in per-channel quantization scheme.
-
             In case of smoothing:
-              scale is a 1D Tensor with the size == dimension of reduction axis in matmul op
-              (shape[-1]).
+              scale is a 1D Tensor with the size of reduction axis for the given R.linear op
+              (size == shape[-1] of activations/weights).
+
+            In case of quantization:
+              scale is a 1D Tensor with the size == shape[-1] for activations and size == shape[-2]
+              for the weights. In case of per-tensor quantization scheme, single element is
+              broadcasted to the corresponding size.
             """
-            if self.op_mode == "smq_q8i8f16_0":
-                n = 1 # per-tensor quantization for activations and weights
-            elif self.op_mode == "smq_q8i8f16_1" or self.op_mode == "smq_q8i8f16_2":
-                # per-channel quantization for weights and per-tensor for activations
-                n = 1 if kind == QKind.KIND_ACT else shape[-2]
-            else:
-                n = shape[-1]  # smoothing scale
-            var_name = f"{SCALE_PREFIX_NAME}{self.sm_counter}"
-            scale = relax.Var(var_name, relax.TensorStructInfo([n], dtype))
-            self.sm_counter += 1
-            self.new_params.append(scale)
-            return scale
+            axis = -1
+            if kind == QKind.KIND_WEIGHTS and self.op_mode.startswith("smq_q8i8f16"):
+                axis = -2
+            n = shape[axis]
+            scale = _make_param(f"{SCALE_PREFIX_NAME}{self.sm_counter}", shape=[n], dtype=dtype)
+            return scale, axis
 
-        def make_zero_point_param(shape: relax.ShapeExpr, dtype: str) -> tvm.relax.Var:
-            var_name = f"{ZP_PREFIX_NAME}{self.sm_counter}"
-            zero_point = relax.Var(var_name, relax.TensorStructInfo(shape, dtype))
-            self.sm_counter += 1
-            self.new_params.append(zero_point)
-            return zero_point
+        def _make_zero_point_param(shape: relax.ShapeExpr, dtype: str) -> tvm.relax.Var:
+            return _make_param(f"{ZP_PREFIX_NAME}{self.sm_counter}", shape=shape, dtype=dtype)
 
-        a_scale = make_scale_param(act.struct_info.shape, act.struct_info.dtype, kind=QKind.KIND_ACT)
-        w_scale = make_scale_param(weights.struct_info.shape, weights.struct_info.dtype, kind=QKind.KIND_WEIGHTS)
+        a_scale, a_axis = _make_scale_param(act.struct_info.shape, act.struct_info.dtype, kind=QKind.KIND_ACT)
+        w_scale, w_axis = _make_scale_param(weights.struct_info.shape, weights.struct_info.dtype, kind=QKind.KIND_WEIGHTS)
         if self.op_mode.startswith("smq_q8i8f16"):
-            a_zp = make_zero_point_param(a_scale.struct_info.shape, dtype="int8")
-            w_zp = make_zero_point_param(w_scale.struct_info.shape, dtype="int8")
-            lhs = R.smooth(act, a_scale, a_zp, kind=1, mode="identity")
-            rhs = R.smooth(weights, w_scale, w_zp, kind=2, mode="identity")
+            a_zp = _make_zero_point_param(a_scale.struct_info.shape, dtype="int8")
+            w_zp = _make_zero_point_param(w_scale.struct_info.shape, dtype="int8")
+            qa = R.quantize(act, a_scale, a_zp, axis=a_axis, out_dtype="int8")
+            lhs = R.dequantize(qa, a_scale, a_zp, axis=a_axis, out_dtype=act.struct_info.dtype)
+            qw = R.quantize(weights, w_scale, w_zp, axis=w_axis, out_dtype="int8")
+            rhs = R.dequantize(qw, w_scale, w_zp, axis=w_axis, out_dtype=weights.struct_info.dtype)
         else:
             lhs = R.divide(act, a_scale)
             rhs = R.multiply(weights, w_scale)
@@ -129,13 +128,15 @@ class Annotator(PyExprMutator):
 @tvm.transform.module_pass(opt_level=0, name="SmoothQuantAnnotator")
 class SmoothQuantAnnotator:
     """
-    Insert R.multiply and R.divide (or R.smooth in case of op_mode == "smq_q8i8f16_*") ops before
-    R.linear. Add scales (second argument of R.multiply or R.smooth) to the list of relax.Function
-    parameters.
+    Insert R.multiply + R.divide (or R.quantize + R.dequantize in case of op_mode == "smq_q8i8f16*")
+    ops before R.linear. Add scales (second argument of R.multiply or R.smooth) or scales and
+    zero_points (in case of quantization) to the list of relax.Function parameters.
     Example:
-      R.linear(lhs, rhs)  -->  op1 = R.smooth(lhs, scale1, kind=1, mode="identity")
-                               op2 = R.smooth(rhs, scale2, kind=2, mode="identity")
-                               R.linear(op1, op2)
+      R.linear(lhs, rhs)  -->  op1 = R.quantize(lhs, scale1, zero_point1)
+                               op2 = R.dequantize(op1, scale1, zero_point1)
+                               op3 = R.quantize(rhs, scale2, zero_point2)
+                               op4 = R.dequantize(op3, scale2, zero_point2)
+                               R.linear(op2, op4)
 
       for the self.op_mode == "smoothing" case:
       R.linear(lhs, rhs)  -->  op1 = R.divide(lhs, scale1)
@@ -154,41 +155,34 @@ class SmoothQuantAnnotator:
 class SmoothQuantStatCollector:
     """
     This pass modifies IRModule to enable statistics collection. It does several modifications:
-    1) Insert chain of simple ops (abs, max, squeeze) just after annotate operation
-       (R.annotate.smooth/R.divide/R.multiply). This is done for memory footprint optimization only.
-       Since we do not want to dump the whole tensor and dump already preprocessed information
-       (abs -> max -> squeeze).
-    2) Substitute scale and zero_point params in R.annotate.smooth (or second arguemnt in
-       R.divide/R.multiply) with dummy ones and remove these params from relax.Function. Dummy param
-       is np.ones or np.empty arrays in this case.
-    3) Add new outputs in relax.Function that correspond to the last op from 1).
+    1) Insert chain of simple ops (abs, max, squeeze) just before R.linear op and remove annotate
+       operation (R.quantize/R.dequantize/R.divide/R.multiply). This is done for memory footprint
+       optimization only. Since we do not want to dump the whole tensor and dump already
+       preprocessed information (abs -> max -> squeeze for smoothing, min/max for quantization).
+    2) Remove scale and zero_point params from relax.Function.
+    3) Add new outputs in relax.Function that correspond to the last op in the sequance from 1).
     """
-    def __init__(self, op_mode: str = "smoothing") -> None:
-        # Operation mode of the collector: "smoothing" or "quantization"
-        assert op_mode in OPMODES, f"unsupported operation mode: '{op_mode}'"
-        self.op_mode = op_mode
-
     def transform_module(self, mod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
         @mutator
         class ParamsAndOutputsMutator(PyExprMutator):
-            def __init__(self, mod: tvm.IRModule, op_mode: str) -> None:
+            def __init__(self, mod: tvm.IRModule) -> None:
                 super().__init__(mod)
                 self.mod = mod
-                # Operation mode of the annotator: "smoothing" or "quantization"
-                assert op_mode in OPMODES, f"unsupported operation mode: '{op_mode}'"
-                self.op_mode = op_mode
                 self.var2val: Dict[relax.Var, relax.Expr] = {}
                 self.profile_points = []
                 self.params_to_remove = []
 
-                attrs = {"mode": "identity"}
+                self.input = wildcard()
+                self.weights = wildcard()
+                lhs_quantize = is_op("relax.quantize")(self.input, wildcard(), wildcard())
                 self.lhs_sm = (
-                    is_op("relax.annotate.smooth")(wildcard(), wildcard(), wildcard()).has_attr(attrs) |
-                    is_op("relax.divide")(wildcard(), wildcard())
+                    is_op("relax.dequantize")(lhs_quantize, wildcard(), wildcard()) |
+                    is_op("relax.divide")(self.input, wildcard())
                 )
+                rhs_quantize = is_op("relax.quantize")(self.weights, wildcard(), wildcard())
                 self.rhs_sm = (
-                    is_op("relax.annotate.smooth")(wildcard(), wildcard(), wildcard()).has_attr(attrs) |
-                    is_op("relax.multiply")(wildcard(), wildcard())
+                    is_op("relax.dequantize")(rhs_quantize, wildcard(), wildcard()) |
+                    is_op("relax.multiply")(self.weights, wildcard())
                 )
                 self.permute = is_op("relax.permute_dims")(self.rhs_sm)
                 self.pattern = is_op("relax.matmul")(self.lhs_sm, self.permute)
@@ -229,48 +223,27 @@ class SmoothQuantStatCollector:
                 call = super().visit_call_(call)
                 matchings = self.pattern.extract_matched_expr(call, self.var2val)
                 if matchings:
-                    m_smq1 = matchings[self.lhs_sm]
-                    a_smq = self._emit_annotate_op(m_smq1, kind=1)
-                    m_smq2 = matchings[self.rhs_sm]
-                    w_smq = self._emit_annotate_op(m_smq2, kind=2)
-                    if self.op_mode == "smoothing":
-                        a_out = self._emit_abs_max_ops_chain(a_smq)
-                        w_out = self._emit_abs_max_ops_chain(w_smq)
+                    data = matchings[self.input]
+                    weights = matchings[self.weights]
+                    lhs_op = matchings[self.lhs_sm]
+                    rhs_op = matchings[self.rhs_sm]
+                    if lhs_op.op == tvm.ir.Op.get("relax.divide") and rhs_op.op == tvm.ir.Op.get("relax.multiply"):
+                        a_out = self._emit_abs_max_ops_chain(data)
+                        w_out = self._emit_abs_max_ops_chain(weights)
                         self.profile_points.extend([a_out, w_out])
-                        self.params_to_remove.extend([m_smq1.args[1], m_smq2.args[1]])
+                        self.params_to_remove.extend([lhs_op.args[1], rhs_op.args[1]])
                     else:
-                        a_max_out, a_min_out = self._emit_max_min_ops_chain(a_smq, axis=-2)
-                        w_max_out, w_min_out = self._emit_max_min_ops_chain(w_smq, axis=-1)
+                        assert lhs_op.op == tvm.ir.Op.get("relax.dequantize")
+                        assert rhs_op.op == tvm.ir.Op.get("relax.dequantize")
+                        a_max_out, a_min_out = self._emit_max_min_ops_chain(data, axis=-2)
+                        w_max_out, w_min_out = self._emit_max_min_ops_chain(weights, axis=-1)
                         self.profile_points.extend([a_max_out, a_min_out, w_max_out, w_min_out])
                         self.params_to_remove.extend(
-                            [m_smq1.args[1], m_smq2.args[1], m_smq1.args[2], m_smq2.args[2]]
+                            [lhs_op.args[1], rhs_op.args[1], lhs_op.args[2], rhs_op.args[2]]
                         )
-                    return self.builder_.emit(R.linear(a_smq, w_smq))
+                    return self.builder_.emit(R.linear(data, weights))
 
                 return call
-
-            def _emit_annotate_op(self, call: relax.Call, kind: int) -> relax.Var:
-                tinfo = call.args[1].struct_info
-                data = np.ones([int(dim) for dim in tinfo.shape], tinfo.dtype)
-                scale = tvm.runtime.ndarray.array(data, device=tvm.cpu())
-                if call.op == tvm.ir.Op.get("relax.multiply"):
-                    smq = self.builder_.emit(R.multiply(call.args[0], relax.Constant(scale)))
-                elif call.op == tvm.ir.Op.get("relax.divide"):
-                    smq = self.builder_.emit(R.divide(call.args[0], relax.Constant(scale)))
-                else:
-                    zero_point = tvm.runtime.ndarray.empty(
-                        call.args[2].struct_info.shape, device=tvm.cpu()
-                    )
-                    smq = self.builder_.emit(
-                        R.smooth(
-                            call.args[0],
-                            relax.Constant(scale),
-                            relax.Constant(zero_point),
-                            kind=kind,
-                            mode="identity",
-                        )
-                    )
-                return smq
 
             def _emit_abs_max_ops_chain(self, expr: relax.Var) -> relax.Var:
                 assert expr.struct_info.ndim >= 2, "Tensor dim num should be >= 2"
@@ -289,7 +262,7 @@ class SmoothQuantStatCollector:
                     min_expr = self.builder_.emit(R.squeeze(min_expr))
                 return max_expr, min_expr
 
-        return ParamsAndOutputsMutator(mod, self.op_mode).transform()
+        return ParamsAndOutputsMutator(mod).transform()
 
 
 def is_zero(expr: Union[int, tvm.relax.Constant]) -> bool:
@@ -301,20 +274,22 @@ def is_zero(expr: Union[int, tvm.relax.Constant]) -> bool:
 @tvm.transform.module_pass(opt_level=0, name="SmoothQuantLegalizer")
 class SmoothQuantLegalizer:
     """
-    Pass that converts matmul(fp16, fp16) -> quantize + matmul(int8, int8) + dequantize.
+    Pass that performs the following transformation:
+    quantize + dequantize + matmul(fp16, fp16) -> quantize + matmul(int8, int8) + dequantize.
     """
     def __init__(self, adtype: str = "int8", wdtype: str = "int8"):
         self.dtype_act = adtype
         self.dtype_weight = wdtype
 
     def transform_module(self, mod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
-        attrs = {"mode": "identity"}
+        act = wildcard()
         act_scale = wildcard()
         act_zp = wildcard()
+        weights = wildcard()
         w_scale = wildcard()
         w_zp = wildcard()
-        lhs_sm = is_op("relax.annotate.smooth")(wildcard(), act_scale, act_zp).has_attr(attrs)
-        rhs_sm = is_op("relax.annotate.smooth")(wildcard(), w_scale, w_zp).has_attr(attrs)
+        lhs_sm = is_op("relax.dequantize")(act, act_scale, act_zp)
+        rhs_sm = is_op("relax.dequantize")(weights, w_scale, w_zp)
         permute = is_op("relax.permute_dims")(rhs_sm)
         pattern = is_op("relax.matmul")(lhs_sm, permute)
 
@@ -323,18 +298,17 @@ class SmoothQuantLegalizer:
             dtype = matchings[pattern].struct_info.dtype
             mm_shape = matchings[pattern].struct_info.shape
 
-            def _make_quantize(call: tvm.relax.Call, axis: int, out_dtype: str):
-                scale = call.args[1]
-                zero_point = call.args[2]
-                scalar_scale = _try_convert_to_scalar_const(scale)
-                scalar_zero_point = _try_convert_to_scalar_const(zero_point)
-                if isinstance(scalar_scale, float) and isinstance(scalar_zero_point, int):
-                    axis = -1
-                    size = call.struct_info.shape[axis].value
-                    scale = R.const([scalar_scale] * size, scale.struct_info.dtype)
-                    zero_point = R.const([scalar_zero_point] * size, zero_point.struct_info.dtype)
-                return R.quantize(call.args[0], scale, zero_point, axis=axis, out_dtype=out_dtype)
-            
+            def _simplify_constant(expr: tvm.relax.Constant) -> tvm.relax.Constant:
+                """
+                Simplify R.const([value, value ... value]) -> R.const([value])
+                """
+                if expr.struct_info.ndim == 1 and expr.struct_info.shape[0].value > 1:
+                    # check that all elements of array are the same.
+                    if np.all(np.isclose(expr.data.numpy(), expr.data.numpy()[0])):
+                        scalar = expr.data.numpy()[0].item()
+                        return R.const([scalar], expr.struct_info.dtype)
+                return expr
+
             def _make_dequantize(
                 call: tvm.relax.Call,
                 scale1: tvm.relax.Constant,
@@ -382,12 +356,15 @@ class SmoothQuantLegalizer:
                 else:
                     return R.add(R.subtract(R.subtract(term1, term2), term3), term4)
 
-            lhs = _make_quantize(matchings[lhs_sm], axis=-2, out_dtype=self.dtype_act)
-            rhs = _make_quantize(matchings[rhs_sm], axis=-2, out_dtype=self.dtype_weight)
-            mm = _make_linear(lhs, rhs, matchings[act_zp], matchings[w_zp], reduction_axis_size)
-            return _make_dequantize(
-                mm, matchings[act_scale], matchings[w_scale], axis=-1, out_dtype=dtype
-            )
+            lhs = matchings[act]
+            rhs = matchings[weights]
+            scale1 = _simplify_constant(matchings[act_scale])
+            scale2 = _simplify_constant(matchings[w_scale])
+            lhs_zp = _simplify_constant(matchings[act_zp])
+            rhs_zp = _simplify_constant(matchings[w_zp])
+            mm = _make_linear(lhs, rhs, lhs_zp, rhs_zp, reduction_axis_size)
+            return _make_dequantize(mm, scale1, scale2, axis=-1, out_dtype=dtype)
+
 
         new_mod = tvm.IRModule()
         for gv, func in mod.functions.items():

--- a/mlc_llm/transform/smoothquant.py
+++ b/mlc_llm/transform/smoothquant.py
@@ -15,6 +15,7 @@ class Annotator(PyExprMutator):
         self.mod = irmod
         self.sm_counter = 0
         self.new_params = []
+        # Mode of operation of the annotator: "smoothing" or "quantization"
         self.mode = mode
 
     def transform(self) -> tvm.IRModule:
@@ -49,6 +50,12 @@ class Annotator(PyExprMutator):
             return call
 
         def make_scale_param(shape: relax.ShapeExpr, dtype: str) -> tvm.relax.Var:
+            """
+            Create scale parameter.
+            In case of quantization: scale is a Tensor with the single element.
+            In case of smoothing: scale is a 1D Tensor with the size == dimension of reduction axis
+                                  in matmul op (shape[-1]).
+            """
             n = 1 if self.mode == "quantize" else shape[-1]
             scale = relax.Var(f"sq_scale_{self.sm_counter}", relax.TensorStructInfo([n], dtype))
             self.sm_counter += 1

--- a/mlc_llm/transform/smoothquant.py
+++ b/mlc_llm/transform/smoothquant.py
@@ -194,9 +194,9 @@ class SmoothQuantLegalizer:
     """
     Pass that converts matmul(fp16, fp16) -> quantize + matmul(int8, int8) + dequantize.
     """
-    def __init__(self):
-        self.dtype_act = "int8"
-        self.dtype_weight = "int8"
+    def __init__(self, adtype="int8", wdtype="int8"):
+        self.dtype_act = adtype
+        self.dtype_weight = wdtype
 
     def transform_module(self, mod: tvm.IRModule, ctx: tvm.transform.PassContext) -> tvm.IRModule:
         attrs = {"mode": "quantize"}

--- a/mlc_llm/transform/smoothquant.py
+++ b/mlc_llm/transform/smoothquant.py
@@ -207,7 +207,7 @@ class SmoothQuantStatCollector:
             def visit_seq_expr_(self, op: relax.SeqExpr) -> relax.Expr:
                 op = super().visit_seq_expr_(op)
                 if len(self.profile_points) != 0:
-                    new_body = relax.Tuple([op.body, relax.Tuple(self.profile_points)])
+                    new_body = relax.Tuple([op.body, *self.profile_points])
                     return relax.SeqExpr(op.blocks, new_body, op.span)
                 return op
 
@@ -215,8 +215,9 @@ class SmoothQuantStatCollector:
                 self.builder_._begin_dataflow_block()
                 for binding in block.bindings:
                     self.visit_binding(binding)
+                # Mark all profile points as new outputs in the block.
                 if len(self.profile_points) != 0:
-                    self.builder_.emit_output(self.profile_points)
+                    self.profile_points = [self.builder_.emit_output(self.profile_points)]
                 return self.builder_._end_block()
 
             def visit_call_(self, call: relax.Call) -> relax.Expr:

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -124,7 +124,7 @@ def argparse_postproc_common(args: argparse.Namespace) -> None:
     args.quantization = quantization_schemes[args.quantization]
 
 
-def debug_dump_script(mod, name, args: argparse.Namespace, show_meta=True):
+def debug_dump_script(mod, name, args: argparse.Namespace, show_meta=False):
     """Debug dump mode"""
     if not args.debug_dump:
         return
@@ -335,16 +335,13 @@ def split_transform_deploy_mod(
 
     mod_transform = relax.transform.DeadCodeElimination(transform_func_names)(mod_transform)
     mod_deploy = relax.transform.DeadCodeElimination(model_names)(mod_deploy)
-    mod_deploy = mod_deploy.with_attrs(
-        {
-            "external_mods": mod.get_attr("external_mods"),
-            "const_name_to_constant": mod.get_attr("const_name_to_constant"),
-        }
-    )
     return mod_transform, mod_deploy
 
 
 def copy_tokenizer(args: argparse.Namespace) -> None:
+    params_dir = os.path.join(args.artifact_path, "params")
+    if not os.path.exists(params_dir):
+        os.makedirs(params_dir)
     for filename in os.listdir(args.model_path):
         if filename in [
             "tokenizer.model",
@@ -354,10 +351,7 @@ def copy_tokenizer(args: argparse.Namespace) -> None:
             "added_tokens.json",
             "tokenizer_config.json",
         ]:
-            shutil.copy(
-                os.path.join(args.model_path, filename),
-                os.path.join(args.artifact_path, "params"),
-            )
+            shutil.copy(os.path.join(args.model_path, filename), params_dir)
 
 
 def get_tokenizer_files(path) -> List[str]:

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -335,7 +335,12 @@ def split_transform_deploy_mod(
 
     mod_transform = relax.transform.DeadCodeElimination(transform_func_names)(mod_transform)
     mod_deploy = relax.transform.DeadCodeElimination(model_names)(mod_deploy)
-
+    mod_deploy = mod_deploy.with_attrs(
+        {
+            "external_mods": mod.get_attr("external_mods"),
+            "const_name_to_constant": mod.get_attr("const_name_to_constant"),
+        }
+    )
     return mod_transform, mod_deploy
 
 


### PR DESCRIPTION
This is PoC implementation of SmoothQuant.

**Some important notes:**
- It quantizes not only weights, but also activations. This quantization was not integrated into ParamManager and lives as a separate pipeline. That's why `NoQuantizationSpec` was used in the `QuantizationScheme` description.
- 3 new quantization schemes were implemented in this PR:
    - `smq_q8i8f16_0` - int8, per-tensor, symmetric for activations and int8, per-tensor, symmetric for weights.
    - `smq_q8i8f16_1` - int8, per-tensor, symmetric for activations and int8, per-channel, symmetric for weights.
    - `smq_q8i8f16_2` - int8, per-tensor, asymmetric for activations and int8, per-channel, asymmetric for weights.
- It quantizes only R.linear ops (not matmul ops).

**How to run:**
`python build.py --model=models/Llama-2-7b-chat-hf --use-cache=0 --quantization=smq_q8i8f16_2 --max-seq-len=2048 --dataset=dummy`

**Performance:**

By default, this implementation tries to offload linear ops to cuBLAS codegen. That's why it was decided to compare with q8f16_ft and q0f16 (cuBLAS). It was tested with Llama-2-7b-chat-hf. Example of performance numbers obtained with `examples/python/benchmark.py` on A10g GPU.

In case of small number of input tokens q8f16_ft outperforms smq_q8i8f16_2:
Q scheme         |   Prefill, tok/s   | Decoder, tok/s |
-----------------|---------------|---------------|
smq_q8i8f16_2  |        414.5       |        56.5       |
q8f16_ft            |       466.2       |        58.6       |
q0f16            |         259.7       |          35.4       |

But in case of bigger number of input tokens the situation is opposite and smq_q8i8f16_2 outperforms q8f16_ft (1.5x for prefill). Example with ~300 input tokens:

Q scheme         |   Prefill, tok/s   | Decoder, tok/s |
-----------------|---------------|---------------|
smq_q8i8f16_2  |        6050.1       |        54.7       |
q8f16_ft            |       4259.2       |        56.6       |


FYI cc @masahi 
