### PR TITLE
Fix two bugs in kv-cache backtrack loop

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -807,10 +807,9 @@ class LLMChat {
           // back tracking, find the first set of token that is smaller
           // than the length
           size_t backoff = 0;
-          for (; backoff < output_ids_.size(); ++backoff) {
+          for (; (output_ids_.size() > 0) && (output_message_.length() > stop_pos); ++backoff) {
             output_ids_.pop_back();
             output_message_ = tokenizer_->Decode(output_ids_);
-            if (output_message_.length() <= stop_pos) break;
           }
           // resize kv to remove the context
           fkvcache_array_popn_(kv_cache_, backoff);


### PR DESCRIPTION
I am using openchat v3.2 which uses <|end_of_turn|> as the stop string, and when the bot replied with short messages, e.g. "Hi, are you ok?<|end_of_turn|>", i got something like "Hi, are you ok?<|" returned to me. I narrowed it down to the backtracking loop and fixed the bug, which was that backoff was compared to `output_ids_.size()` while output_ids_.size() was decreasing due to `pop()`. Along the way I noted and fixed another bug (backoff was too small by 1 as it wasn't incremented if we used `break` to leave the loop.

Bug 1: old code would stop early because output_ids was shortened in-place during the loop

Bug 2: off-by-one in backoff size due to break