### PR TITLE
Add nvidia/jetson target for cross-compile model

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -147,6 +147,10 @@ class BuildArgs:
         default="",
         metadata={"help": "/path/to/llvm-mingw-root, use llvm-mingw to cross compile to windows."},
     )
+    cc_path: str = field(
+        default="",
+        metadata={"help": "/path/to/cross_compiler_path, Currently only used for cross-compile for nvidia/jetson device."},
+    )
     system_lib: bool = field(
         default=False,
         metadata={"help": "A parameter to `relax.build`.", "action": "store_true"},

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -449,6 +449,22 @@ def parse_target(args: argparse.Namespace) -> None:
         args.target_kind = args.target.kind.default_keys[0]
         if multiarch:
             args.target_kind += "-multiarch"
+    elif args.target.startswith("nvidia/jetson"):
+        try:
+            args.target = tvm.target.Target(args.target)
+        except ValueError:
+            raise ValueError("Cannot find configuration of given nvidia/jetson board target!")
+        if not hasattr(args, "cc_path") or args.cc_path == "":
+            args.cc_path = "/usr/bin/aarch64-linux-gnu-g++"
+        from tvm.contrib.cc import (  # pylint: disable=import-outside-toplevel
+            cross_compiler,
+        )
+        args.export_kwargs = {
+            "fcompile": cross_compiler(
+                args.cc_path,
+            ),
+        }
+        args.target_kind = args.target.kind.default_keys[0]
     elif args.target == "metal":
         target = _detect_local_metal()
         if target is None:


### PR DESCRIPTION
Add nvidia/jetson target for cross-compile model. #847 

Also add `cc_path` parameter at `mlc_llm.BuildArgs` for using custom cross compiler which currently only used for cross-compile for nvidia/jetson device.

Usage : just set target according to user's jetson board name (ex, nvidia/jetson-agx-xavier)

``` python
build_args = mlc_llm.BuildArgs(
    hf_path="togethercomputer/RedPajama-INCITE-Chat-3B-v1",
    quantization="q4f16_1",
    target="nvidia/jetson-agx-xavier")
```

If someone wants to use custom cross compiler (default : `""` but when target is nvidia/jetson, automatically converted `/usr/bin/aarch64-linux-gnu-g++`)
``` python
build_args = mlc_llm.BuildArgs(
    hf_path="togethercomputer/RedPajama-INCITE-Chat-3B-v1",
    quantization="q4f16_1",
    target="nvidia/jetson-agx-xavier",
    cc_path="/usr/bin/aarch64-linux-gnu-g++"
)
```