### PR TITLE
Use dynamic vocab_size for llama

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -20,7 +20,7 @@ class LlamaConfig:
         self,
         dtype="float32",
         max_sequence_length=2048,
-        vocab_size=32000,
+        vocab_size=32000,  # some models like WizardMath can have 32001
         hidden_size=4096,
         intermediate_size=11008,
         num_hidden_layers=32,
@@ -470,8 +470,8 @@ def _make_causal_mask(input_ids_shape, dtype, src_len):
 
 
 class LlamaEmbedTokens(nn.Module):
-    def __init__(self, config: LlamaConfig):
-        self.embed_tokens = Embedding(config.vocab_size, config.hidden_size, dtype=config.dtype)
+    def __init__(self, config: LlamaConfig, vocab_size_var: tvm.tir.Var):
+        self.embed_tokens = Embedding(vocab_size_var, config.hidden_size, dtype=config.dtype)
 
     def forward(self, input_ids: relax.Expr):
         inputs_embeds = self.embed_tokens(input_ids)
@@ -479,9 +479,9 @@ class LlamaEmbedTokens(nn.Module):
 
 
 class LlamaEmbedTokensWrapper(nn.Module):
-    def __init__(self, config: LlamaConfig):
+    def __init__(self, config: LlamaConfig, vocab_size_var: tvm.tir.Var):
         # build a wrapper to ensure that the naming of the embed_tokens parameter is consistent
-        self.model = LlamaEmbedTokens(config)
+        self.model = LlamaEmbedTokens(config, vocab_size_var)
 
     def forward(self, input_ids: relax.Expr):
         inputs_embeds = self.model(input_ids)
@@ -489,13 +489,12 @@ class LlamaEmbedTokensWrapper(nn.Module):
 
 
 class LlamaModel(nn.Module):
-    def __init__(self, config: LlamaConfig, sep_embed: bool = False):
+    def __init__(self, config: LlamaConfig, vocab_size_var: tvm.tir.Var, sep_embed: bool = False):
         self.padding_idx = config.pad_token_id
-        self.vocab_size = config.vocab_size
         self.embed_tokens = None
 
         if not sep_embed:
-            self.embed_tokens = Embedding(config.vocab_size, config.hidden_size, dtype=config.dtype)
+            self.embed_tokens = Embedding(vocab_size_var, config.hidden_size, dtype=config.dtype)
 
         self.layers = ModuleList(
             [LlamaDecoderLayer(config) for _ in range(config.num_hidden_layers)]
@@ -569,9 +568,9 @@ class LlamaModel(nn.Module):
 
 
 class LlamaForCausalLM(nn.Module):
-    def __init__(self, config: LlamaConfig, sep_embed: bool = False):
-        self.model = LlamaModel(config, sep_embed)
-        self.lm_head = Linear(config.hidden_size, config.vocab_size, dtype=config.dtype, bias=False)
+    def __init__(self, config: LlamaConfig, vocab_size_var: tvm.tir.Var, sep_embed: bool = False):
+        self.model = LlamaModel(config, vocab_size_var, sep_embed)
+        self.lm_head = Linear(config.hidden_size, vocab_size_var, dtype=config.dtype, bias=False)
 
         ############ Rotary embedding constants ############
         assert config.hidden_size % config.num_attention_heads == 0
@@ -637,7 +636,7 @@ def create_embed_func(
     bsz = 1
     seq_len = tvm.tir.Var("n", "int64")
     with bb.function(func_name):
-        model = LlamaEmbedTokensWrapper(config)
+        model = LlamaEmbedTokensWrapper(config, tvm.tir.Var("v", "int64"))
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, seq_len), dtype="int32", name="input_ids")
@@ -666,7 +665,7 @@ def create_encoding_func(
     all_seq_len = tvm.tir.Var("m", "int64")
     hidden_size = config.hidden_size
     with bb.function(func_name):
-        model = LlamaForCausalLM(config, sep_embed)
+        model = LlamaForCausalLM(config, tvm.tir.Var("v", "int64"), sep_embed)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         inputs = (
@@ -710,7 +709,7 @@ def create_decoding_func(
     all_seq_len = tvm.tir.Var("n", "int64")
 
     with bb.function(func_name):
-        model = LlamaForCausalLM(config)
+        model = LlamaForCausalLM(config, tvm.tir.Var("v", "int64"))
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, 1), dtype="int32", name="input_ids")
@@ -772,7 +771,7 @@ def create_kv_cache_func(bb: relax.BlockBuilder, config: LlamaConfig) -> None:
 
 def create_softmax_func(bb: relax.BlockBuilder, config: LlamaConfig) -> None:
     with bb.function("softmax_with_temperature"):
-        logits = nn.Placeholder((1, 1, config.vocab_size), dtype="float32", name="logits")
+        logits = nn.Placeholder((1, 1, tvm.tir.Var("v", "int64")), dtype="float32", name="logits")
         temperature = nn.Placeholder((), dtype="float32", name="temperature")
         with bb.dataflow():
             div = bb.emit(relax.op.divide(logits, temperature))
@@ -793,7 +792,7 @@ def get_model(args, hf_config):
         position_embedding_base = hf_config["rope_theta"]
     if "max_position_embeddings" in hf_config:
         max_position_embeddings = hf_config["max_position_embeddings"]
-    
+
     config = LlamaConfig(
         **hf_config,
         dtype=dtype,


### PR DESCRIPTION
This PR uses a `tvm.tir.Var` to represent the `vocab_size` when compiling Llama models. 

The goal is to reuse Llama-2's model library when running its model variants like WizardMath. The default `vocab_size` is `32000`, but some models can have `32001`. 

Previous behavior:
```python
from mlc_chat import ChatModule
cm = ChatModule(
    model="dist/mlc-chat-WizardMath-7B-V1.0-q4f16_1",
    lib_path="dist/Llama-2-7b-chat-hf-q4f16_1/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
)
output = cm.generate(prompt="hi")
```

```bash
Traceback (most recent call last):
...
RuntimeError: Check failed: input_shape[i] == reg (32001 vs. 32000) : ErrorContext(fn=prefill, loc=param[3], param=params, annotation=R.Tuple(R.Tensor((32000, 512), dtype="uint32"), ...)  match_cast error,  shape[0] mismatch to specified constant.
```

After this PR, the code above can run without an error.

Tested:
- Compiled Llama2 7B's model library and used it to run WizardMath's model
- Confirmed that there is no performance regression despite the dynamic size (on RTX 4090)

### Another issue below (Edit: now fixed by #896)

However, this PR only abstracts out the `vocab_size`. After #890, `max_position_embeddings` is actually read from `config.json`. Before #890, `LlamaConfig.max_sequence_length` is always `2048`. Now, since `config.json` of Llama2 is `4096`, running the code above runs into error:
```bash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/ssd1/cfruan/mlc-llm-pr-vocab-size/mlc-llm/python/mlc_chat/chat_module.py", line 635, in generate
    self._prefill(prompt)
  File "/ssd1/cfruan/mlc-llm-pr-vocab-size/mlc-llm/python/mlc_chat/chat_module.py", line 804, in _prefill
    self._prefill_func(input, decode_next_token, place_in_prompt.value)
  File "/ssd1/cfruan/packages/tvm-unity/python/tvm/_ffi/_ctypes/packed_func.py", line 238, in __call__
    raise get_last_ffi_error()
tvm._ffi.base.TVMError: Traceback (most recent call last):
  10: 0x0000564f9dff1420
  9: mlc::llm::LLMChatModule::GetFunction(tvm::runtime::String const&, tvm::runtime::ObjectPtr<tvm::runtime::Object> const&)::{lambda(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)#5}::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const
        at /ssd1/cfruan/mlc-llm-pr-vocab-size/mlc-llm/cpp/llm_chat.cc:1068
  8: mlc::llm::LLMChat::PrefillStep(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool, mlc::llm::PlaceInPrompt)
        at /ssd1/cfruan/mlc-llm-pr-vocab-size/mlc-llm/cpp/llm_chat.cc:581
  7: mlc::llm::LLMChat::EmbedStep(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, mlc::llm::PlaceInPrompt)
        at /ssd1/cfruan/mlc-llm-pr-vocab-size/mlc-llm/cpp/llm_chat.cc:526
  6: tvm::runtime::relax_vm::VirtualMachineImpl::InvokeClosurePacked(tvm::runtime::ObjectRef const&, tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)
        at /ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/vm.cc:631
  5: operator()
        at /ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/vm.cc:704
  4: tvm::runtime::relax_vm::VirtualMachineImpl::InvokeBytecode(long, std::vector<tvm::runtime::TVMRetValue, std::allocator<tvm::runtime::TVMRetValue> > const&)
        at /ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/vm.cc:761
  3: tvm::runtime::relax_vm::VirtualMachineImpl::RunLoop()
        at /ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/vm.cc:886
  2: tvm::runtime::relax_vm::VirtualMachineImpl::RunInstrCall(tvm::runtime::relax_vm::VMFrame*, tvm::runtime::relax_vm::Instruction)
        at /ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/vm.cc:839
  1: tvm::runtime::relax_vm::VirtualMachineImpl::InvokeClosurePacked(tvm::runtime::ObjectRef const&, tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)
        at /ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/vm.cc:615
  0: tvm::runtime::relax_vm::MatchShape(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)
        at /ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/builtin.cc:101
  File "/ssd1/cfruan/packages/tvm-unity/src/runtime/relax_vm/builtin.cc", line 101
RuntimeError: Check failed: input_shape[i] == reg (2048 vs. 4096) : ErrorContext(fn=embed, loc=param[1], param=params, annotation=R.Tuple(R.Tensor((v, 512), dtype="uint32"),
```