### PR TITLE
[Chat] Support deterministic runtime

### DIFF
--- a/python/mlc_chat/base.py
+++ b/python/mlc_chat/base.py
@@ -43,3 +43,16 @@ def get_delta_message(curr_message: str, new_message: str) -> str:
     """
     f_get_delta_message = tvm.get_global_func("mlc.get_delta_message")
     return f_get_delta_message(curr_message, new_message)
+
+
+def set_global_random_seed(seed):
+    if "numpy" in sys.modules:
+        sys.modules["numpy"].random.seed(seed)
+    if "torch" in sys.modules:
+        sys.modules["torch"].manual_seed(seed)
+    if "random" in sys.modules:
+        sys.modules["random"].seed(seed)
+    if "tvm" in sys.modules:
+        set_seed = sys.modules["tvm"].get_global_func("mlc.random.set_seed")
+        if set_seed:
+            set_seed(seed)

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from dataclasses import dataclass, field, fields
 from typing import Optional
 
+from .base import set_global_random_seed
 from .chat_module import ChatModule
 from .interface.openai_api import *
 
@@ -79,6 +80,18 @@ class RestAPIArgs:
             )
         }
     )
+    random_seed: int = field(
+        default=None,
+        metadata={
+            "help": {
+                """
+                The random seed to initialize all the RNG used in mlc-chat. By default,
+                no seed is set.
+                """
+            }
+        }
+    )
+
 
 def convert_args_to_argparser() -> argparse.ArgumentParser:
     """Convert from RestAPIArgs to an equivalent ArgumentParser."""
@@ -98,8 +111,11 @@ def convert_args_to_argparser() -> argparse.ArgumentParser:
 
 session = {}
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    if ARGS.random_seed is not None:
+        set_global_random_seed(ARGS.random_seed)
     chat_mod = ChatModule(
         model=ARGS.model,
         device=ARGS.device,


### PR DESCRIPTION
Set random seed uniformly for torch, numpy, random, and lm_chat. Expose arg control of the random seed to the mlc-chat rest server. Maintain use of `std::random_device{}` by default in lm_chat if seed is unset. 