### PR TITLE
Fix windows build

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -206,16 +206,16 @@ struct FunctionTable {
   ObjectRef LoadParams(const std::string& model_path, Device device) {
     if (this->use_disco) {
       std::filesystem::path fs_model_path = model_path;
-      std::filesystem::path shard_info_path = fs_model_path / "shard_info.json";
-      std::filesystem::path metadata_path = fs_model_path / "ndarray-cache.json";
+      std::string shard_info_path = (fs_model_path / "shard_info.json").operator std::string();
+      std::string metadata_path = (fs_model_path / "ndarray-cache.json").operator std::string();
       std::string ndarray_cache_metadata = LoadBytesFromFile(metadata_path);
       std::string shard_info = LoadBytesFromFile(shard_info_path);
       PackedFunc loader_create = this->get_global_func("runtime.disco.ShardLoader");
       PackedFunc loader_load_all = this->get_global_func("runtime.disco.ShardLoaderLoadAll");
       CHECK(loader_create != nullptr);
       CHECK(loader_load_all != nullptr);
-      DRef loader = loader_create(metadata_path.operator std::string(), ndarray_cache_metadata,
-                                  shard_info, this->disco_mod);
+      DRef loader =
+          loader_create(metadata_path, ndarray_cache_metadata, shard_info, this->disco_mod);
       DRef params = loader_load_all(loader);
       return params;
     } else {


### PR DESCRIPTION
MSVC we are using in nightly wheels doesn't seem to support implicit conversion from `std::filesystem::path` to `std::string` according to the error messages below:

```
llm_chat.cc(211,44): error C2664: 'std::string mlc::llm::LoadBytesFromFile(const std::string &)': cannot convert argument 1 from 'std::filesystem::path' to 'const std::string &' [D:\a\package\package\mlc-llm\build\mlc_llm_objs.vcxproj]
llm_chat.cc(212,32): error C2664: 'std::string mlc::llm::LoadBytesFromFile(const std::string &)': cannot convert argument 1 from 'std::filesystem::path' to 'const std::string &' [D:\a\package\package\mlc-llm\build\mlc_llm_objs.vcxproj]
llm_chat.cc(217,1): error C2738: 'operator std::basic_string<char,std::char_traits<char>,std::allocator<char>>': is ambiguous or is not a member of 'std::filesystem::path' [D:\a\package\package\mlc-llm\build\mlc_llm_objs.vcxproj]
```

This PR introduces a fix that explicitly convert
`std::filesystem::path` to string.