### PR TITLE
Fix windows build again

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -206,8 +206,8 @@ struct FunctionTable {
   ObjectRef LoadParams(const std::string& model_path, Device device) {
     if (this->use_disco) {
       std::filesystem::path fs_model_path = model_path;
-      std::string shard_info_path = (fs_model_path / "shard_info.json").operator std::string();
-      std::string metadata_path = (fs_model_path / "ndarray-cache.json").operator std::string();
+      std::string shard_info_path = (fs_model_path / "shard_info.json").string();
+      std::string metadata_path = (fs_model_path / "ndarray-cache.json").string();
       std::string ndarray_cache_metadata = LoadBytesFromFile(metadata_path);
       std::string shard_info = LoadBytesFromFile(shard_info_path);
       PackedFunc loader_create = this->get_global_func("runtime.disco.ShardLoader");


### PR DESCRIPTION
Following up with the previous commit, MSVC is still unhappy saying:

```
D:\a\package\package\mlc-llm\cpp\llm_chat.cc(209,1): error C2738: 'operator std::basic_string<char,std::char_traits<char>,std::allocator<char>>': is ambiguous or is not a member of 'std::filesystem::path' [D:\a\package\package\mlc-llm\build\mlc_llm_objs.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\fstream(29,23): message : see declaration of 'std::filesystem::path' [D:\a\package\package\mlc-llm\build\mlc_llm_objs.vcxproj]
D:\a\package\package\mlc-llm\cpp\llm_chat.cc(210,1): error C2738: 'operator std::basic_string<char,std::char_traits<char>,std::allocator<char>>': is ambiguous or is not a member of 'std::filesystem::path' [D:\a\package\package\mlc-llm\build\mlc_llm_objs.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\fstream(29,23): message : see declaration of 'std::filesystem::path' [D:\a\package\package\mlc-llm\build\mlc_llm_objs.vcxproj]
```

Given that `operator std::string()` does not seem properly supported in MSVC, I am changing to the `string()` method as documented in [cppreference](https://en.cppreference.com/w/cpp/filesystem/path/string).