### PR TITLE
[Multi-GPU] Use Process-based Workers

### DIFF
--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -5,14 +5,14 @@ import json
 import logging
 import os
 import sys
-from dataclasses import dataclass, fields, asdict
+from dataclasses import asdict, dataclass, fields
 from enum import Enum
 from typing import List, Optional
 
 import tvm
+from tvm.runtime import disco
 
 from . import callback
-
 
 # pylint: disable=line-too-long
 _PYTHON_GET_STARTED_TUTORIAL_URL = "https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_chat_module_getting_started.ipynb"


### PR DESCRIPTION
To run multi-GPU inference, one could do the following:

```python
from mlc_chat import ChatModule
from mlc_chat.callback import StreamToStdout

# Create a ChatModule instance
cm = ChatModule(model="llama-2-7b-chat-hf-q4f16_1")

# Generate a response for a given prompt
output = cm.generate(
    prompt="Hi",
    progress_callback=StreamToStdout(callback_interval=2),
)

# Print prefill and decode performance statistics
print(f"Statistics: {cm.stats()}\n")

# Reset the chat module by
# cm.reset_chat(
```