### PR TITLE
Parameter Loading for New `nn.Module` API

### DIFF
--- a/mlc_llm/models/__init__.py
+++ b/mlc_llm/models/__init__.py
@@ -1,0 +1,3 @@
+"""Model definition using PyTorch-like nn.Module API"""
+from . import llama, llama_param_map
+from .model_config_base import ModelConfig

--- a/mlc_llm/models/llama.py
+++ b/mlc_llm/models/llama.py
@@ -1,123 +1,104 @@
 """Implementation for Llama2 architecture"""
 import dataclasses
 import math
-from typing import Optional
+from typing import Any, Dict, Optional
 
-import numpy as np
 from tvm import te, tir
-from tvm.relax.frontend.nn import (
-    Embedding,
-    KVCache,
-    Linear,
-    Module,
-    ModuleList,
-    RMSNorm,
-    Tensor,
-    full,
-    matmul,
-    reshape,
-    silu,
-    softmax,
-    squeeze,
-    tensor_expr_op,
-)
+from tvm.relax.frontend import nn
+from tvm.relax.frontend.nn import Tensor, op
+
+from .model_config_base import ModelConfig
 
 # pylint: disable=invalid-name,missing-docstring
 
 
 @dataclasses.dataclass
-class LlamaConfig:  # pylint: disable=too-many-instance-attributes
+class LlamaConfig(ModelConfig):  # pylint: disable=too-many-instance-attributes
     hidden_act: str
     hidden_size: int
     intermediate_size: int
-    max_sequence_length: int
     num_attention_heads: int
     num_hidden_layers: int
     rms_norm_eps: float
     vocab_size: int
-    position_embedding_base: int
-
-    bos_token_id: int
-    eos_token_id: int
-    pad_token_id: int
-
-    initializer_range: float
-    model_type: str
-    torch_dtype: str
+    max_sequence_length: int = 2048
+    position_embedding_base: int = 10000
     num_key_value_heads: int = 0
+    kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    head_dim: int = 0
 
     def __post_init__(self):
         if self.num_key_value_heads == 0:
             self.num_key_value_heads = self.num_attention_heads
-        assert self.hidden_size % self.num_attention_heads == 0
+        if self.head_dim == 0:
+            self.head_dim = self.hidden_size // self.num_attention_heads
         assert self.num_attention_heads % self.num_key_value_heads == 0
-
-    @classmethod
-    def from_dict(cls, d: dict) -> "LlamaConfig":
-        field_names = (field.name for field in dataclasses.fields(cls))
-        return cls(**{k: v for k, v in d.items() if k in field_names})
+        assert self.head_dim * self.num_attention_heads == self.hidden_size
 
 
-class RotaryEmbedding(Module):
-    def __init__(self, position_embedding_base: int, max_seq_len: int, rotary_dim: int):
+class RotaryEmbedding(nn.Module):
+    def __init__(self, config: LlamaConfig):
         super().__init__()
-        self.position_embedding_base = position_embedding_base
-        self.max_seq_len = max_seq_len
-        self.rotary_dim = rotary_dim
+        self.head_dim = config.head_dim
+        self.position_embedding_base = config.position_embedding_base
 
     def forward(self, q: Tensor, k: Tensor, offset: tir.Var):
-        def te_op(x: te.Tensor, cos: te.Tensor, sin: te.Tensor, offset: tir.Var):
+        def te_op(x: te.Tensor, offset: tir.Var):
             def compute(b: tir.Var, s: tir.Var, h: tir.Var, d: tir.Var):
-                result = cos[offset + s, d] * x[b, s, h, d] + sin[offset + s, d] * tir.if_then_else(
-                    d < self.rotary_dim // 2,
-                    -x[b, s, h, d + self.rotary_dim // 2],
-                    x[b, s, h, d - self.rotary_dim // 2],
+                head_dim = tir.const(self.head_dim, "int32")
+                position_embedding_base = tir.const(self.position_embedding_base, "float32")
+                freq = tir.power(
+                    position_embedding_base,
+                    (d * 2 % head_dim).astype("float32") / head_dim,
                 )
-                return tir.if_then_else(d < self.rotary_dim, result, x[b, s, h, d])
+                freq = (offset + s) / freq
+                return tir.cos(freq) * x[b, s, h, d] + tir.sin(freq) * tir.if_then_else(
+                    d < self.head_dim // 2,
+                    -x[b, s, h, d + self.head_dim // 2],
+                    x[b, s, h, d - self.head_dim // 2],
+                )
 
             return te.compute(x.shape, compute, name="rotary")
 
-        r0 = np.arange(0, self.rotary_dim, 2, dtype="float32")
-        r1 = np.arange(0, self.max_seq_len, dtype="float32")
-        inv_freq = 1.0 / (self.position_embedding_base ** (r0 / self.rotary_dim))
-        freq = np.einsum("i,j->ij", r1, inv_freq)
-        emb = np.concatenate((freq, freq), axis=-1)
-        cos = Tensor.from_const(np.cos(emb).astype(q.dtype))
-        sin = Tensor.from_const(np.sin(emb).astype(q.dtype))
-        q_embed = tensor_expr_op(te_op, "rotary_embedding", args=[q, cos, sin, offset])
-        k_embed = tensor_expr_op(te_op, "rotary_embedding", args=[k, cos, sin, offset])
+        q_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[q, offset])
+        k_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[k, offset])
         return q_embed, k_embed
 
 
-class LlamaFFN(Module):
+class LlamaFFN(nn.Module):
     def __init__(self, config: LlamaConfig):
         super().__init__()
-        self.gate_proj = Linear(config.hidden_size, config.intermediate_size, bias=False)
-        self.up_proj = Linear(config.hidden_size, config.intermediate_size, bias=False)
-        self.down_proj = Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.gate_up_proj = nn.MultiLinear(
+            in_features=config.hidden_size,
+            out_features=[config.intermediate_size, config.intermediate_size],
+            bias=False,
+        )
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
 
     def forward(self, x: Tensor):
-        x1 = self.gate_proj(x)
-        x2 = self.up_proj(x)
-        return self.down_proj(silu(x1) * x2)
+        x1, x2 = self.gate_up_proj(x)
+        return self.down_proj(op.silu(x1) * x2)
 
 
-class LlamaAttention(Module):  # pylint: disable=too-many-instance-attributes
+class LlamaAttention(nn.Module):  # pylint: disable=too-many-instance-attributes
     def __init__(self, config: LlamaConfig, rotary_embedding: RotaryEmbedding):
-        head_dim = config.hidden_size // config.num_attention_heads
-
         self.rotary_embedding = rotary_embedding
         self.hidden_size = config.hidden_size
-        self.head_dim = head_dim
-
+        self.head_dim = config.head_dim
         self.num_q_heads = config.num_attention_heads
         self.num_kv_heads = config.num_key_value_heads
-        self.q_proj = Linear(config.hidden_size, self.num_q_heads * head_dim, bias=False)
-        self.k_proj = Linear(config.hidden_size, self.num_kv_heads * head_dim, bias=False)
-        self.v_proj = Linear(config.hidden_size, self.num_kv_heads * head_dim, bias=False)
-        self.o_proj = Linear(config.hidden_size, config.hidden_size, bias=False)
-        self.k_cache = KVCache(config.max_sequence_length, [self.num_kv_heads, head_dim])
-        self.v_cache = KVCache(config.max_sequence_length, [self.num_kv_heads, head_dim])
+        self.qkv_proj = nn.MultiLinear(
+            in_features=config.hidden_size,
+            out_features=[
+                self.num_q_heads * self.head_dim,
+                self.num_kv_heads * self.head_dim,
+                self.num_kv_heads * self.head_dim,
+            ],
+            bias=False,
+        )
+        self.o_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.k_cache = nn.KVCache(config.max_sequence_length, [self.num_kv_heads, self.head_dim])
+        self.v_cache = nn.KVCache(config.max_sequence_length, [self.num_kv_heads, self.head_dim])
 
     def forward(  # pylint: disable=too-many-locals
         self,
@@ -128,30 +109,31 @@ class LlamaAttention(Module):  # pylint: disable=too-many-instance-attributes
         d, h_q, h_kv, t = self.head_dim, self.num_q_heads, self.num_kv_heads, total_seq_len
         b, s, _ = hidden_states.shape
         assert b == 1, "Only support batch size 1 at this moment."
-        q = reshape(self.q_proj(hidden_states), (b, s, h_q, d))
-        k = reshape(self.k_proj(hidden_states), (b, s, h_kv, d))
-        v = reshape(self.v_proj(hidden_states), (b, s, h_kv, d))
+        q, k, v = self.qkv_proj(hidden_states)
+        q = op.reshape(q, (b, s, h_q, d))
+        k = op.reshape(k, (b, s, h_kv, d))
+        v = op.reshape(v, (b, s, h_kv, d))
         q, k = self.rotary_embedding(q, k, t - s)
 
-        self.k_cache.append(squeeze(k, axis=0))
-        self.v_cache.append(squeeze(v, axis=0))
-        k = reshape(self.k_cache.view(total_seq_len), (t, b, h_kv, d))
-        v = reshape(self.v_cache.view(total_seq_len), (t, b, h_kv, d))
+        self.k_cache.append(op.squeeze(k, axis=0))
+        self.v_cache.append(op.squeeze(v, axis=0))
+        k = op.reshape(self.k_cache.view(total_seq_len), (t, b, h_kv, d))
+        v = op.reshape(self.v_cache.view(total_seq_len), (t, b, h_kv, d))
         if h_kv != h_q:
             k = k.repeat(h_q // h_kv, axis=2)
             v = v.repeat(h_q // h_kv, axis=2)
-        attn_weights = matmul(  # [b, h, s, t]
+        attn_weights = op.matmul(  # [b, h, s, t]
             q.permute_dims([0, 2, 1, 3]),  # [b, h, s, d]
             k.permute_dims([1, 2, 3, 0]),  # [b, h, d, t]
         ) / math.sqrt(d)
         dtype = attn_weights.dtype
         attn_weights = attn_weights.maximum(tir.min_value(dtype)).minimum(attention_mask)
         if dtype == "float32":
-            attn_weights = softmax(attn_weights, axis=-1)
+            attn_weights = op.softmax(attn_weights, axis=-1)
         else:
-            attn_weights = softmax(attn_weights.astype("float32"), axis=-1).astype(dtype)
+            attn_weights = op.softmax(attn_weights.astype("float32"), axis=-1).astype(dtype)
         return self.o_proj(
-            matmul(  # [b, h, s, d]
+            op.matmul(  # [b, h, s, d]
                 attn_weights,  # [b, h, s, t]
                 v.permute_dims([1, 2, 0, 3]),  # [b, h, t, d]
             )
@@ -160,35 +142,32 @@ class LlamaAttention(Module):  # pylint: disable=too-many-instance-attributes
         )
 
 
-class LlamaDecoderLayer(Module):
+class LlamaDecoderLayer(nn.Module):
     def __init__(self, config: LlamaConfig, rotary_embedding: RotaryEmbedding):
-        self.attn = LlamaAttention(config, rotary_embedding)
-        self.ffn = LlamaFFN(config)
-        self.input_norm = RMSNorm(config.hidden_size, -1, config.rms_norm_eps, bias=False)
-        self.post_attention_norm = RMSNorm(config.hidden_size, -1, config.rms_norm_eps, bias=False)
+        rms_norm_eps = config.rms_norm_eps
+        self.self_attn = LlamaAttention(config, rotary_embedding)
+        self.mlp = LlamaFFN(config)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, -1, rms_norm_eps, bias=False)
+        self.post_attention_layernorm = nn.RMSNorm(config.hidden_size, -1, rms_norm_eps, bias=False)
 
     def forward(self, hidden_states: Tensor, attention_mask: Tensor, total_seq_len: tir.Var):
         hidden_states = (
-            self.attn(self.input_norm(hidden_states), attention_mask, total_seq_len) + hidden_states
+            self.self_attn(self.input_layernorm(hidden_states), attention_mask, total_seq_len)
+            + hidden_states
         )
-        hidden_states = self.ffn(self.post_attention_norm(hidden_states)) + hidden_states
+        hidden_states = self.mlp(self.post_attention_layernorm(hidden_states)) + hidden_states
         return hidden_states
 
 
-class LlamaModel(Module):
+class LlamaModel(nn.Module):
     def __init__(self, config: LlamaConfig):
         assert config.hidden_size % config.num_attention_heads == 0
-        head_dim = config.hidden_size // config.num_attention_heads
-        rotary_embedding = RotaryEmbedding(
-            position_embedding_base=config.position_embedding_base,
-            max_seq_len=config.max_sequence_length,
-            rotary_dim=head_dim,
-        )
-        self.embed_tokens = Embedding(config.vocab_size, config.hidden_size)
-        self.layers = ModuleList(
+        rotary_embedding = RotaryEmbedding(config)
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = nn.ModuleList(
             [LlamaDecoderLayer(config, rotary_embedding) for _ in range(config.num_hidden_layers)]
         )
-        self.norm = RMSNorm(config.hidden_size, -1, config.rms_norm_eps, bias=False)
+        self.norm = nn.RMSNorm(config.hidden_size, -1, config.rms_norm_eps, bias=False)
 
     def forward(self, inputs: Tensor, total_seq_len: tir.Var, attention_mask: Tensor):
         hidden_states = self.embed_tokens(inputs)
@@ -198,10 +177,10 @@ class LlamaModel(Module):
         return hidden_states
 
 
-class LlamaForCasualLM(Module):
+class LlamaForCasualLM(nn.Module):
     def __init__(self, config: LlamaConfig, dtype: str = "float32"):
         self.model = LlamaModel(config)
-        self.lm_head = Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.vocab_size = config.vocab_size
         self.dtype = dtype
 
@@ -216,7 +195,7 @@ class LlamaForCasualLM(Module):
             return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
 
         hidden_states = self.model(inputs, total_seq_len, attention_mask)
-        hidden_states = tensor_expr_op(_index, name_hint="index", args=[hidden_states])
+        hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
         logits = self.lm_head(hidden_states)
         if logits.dtype != "float32":
             logits = logits.astype("float32")
@@ -235,7 +214,7 @@ class LlamaForCasualLM(Module):
             )
 
         batch_size, seq_len = inputs.shape
-        attention_mask = tensor_expr_op(
+        attention_mask = op.tensor_expr_op(
             _attention_mask,
             name_hint="attention_mask_prefill",
             args=[batch_size, seq_len, total_seq_len],
@@ -244,7 +223,7 @@ class LlamaForCasualLM(Module):
 
     def decode(self, inputs: Tensor, total_seq_len: tir.Var):
         batch_size, seq_len = inputs.shape
-        attention_mask = full(
+        attention_mask = op.full(
             shape=[batch_size, 1, seq_len, total_seq_len],
             fill_value=tir.max_value(self.dtype),
             dtype=self.dtype,
@@ -252,4 +231,22 @@ class LlamaForCasualLM(Module):
         return self.forward(inputs, total_seq_len, attention_mask)
 
     def softmax_with_temperature(self, logits: Tensor, temperature: Tensor):
-        return softmax(logits / temperature, axis=-1)
+        return op.softmax(logits / temperature, axis=-1)
+
+    def get_default_spec(self):
+        batch_size = 1
+        mod_spec = {
+            "prefill": {
+                "inputs": nn.spec.Tensor([batch_size, "seq_len"], "int32"),
+                "total_seq_len": int,
+            },
+            "decode": {
+                "inputs": nn.spec.Tensor([batch_size, 1], "int32"),
+                "total_seq_len": int,
+            },
+            "softmax_with_temperature": {
+                "logits": nn.spec.Tensor([1, 1, "vocab_size"], "float32"),
+                "temperature": nn.spec.Tensor([], "float32"),
+            },
+        }
+        return nn.spec.ModuleSpec.from_raw(mod_spec, self)

--- a/mlc_llm/models/llama_param_map.py
+++ b/mlc_llm/models/llama_param_map.py
@@ -1,0 +1,60 @@
+"""
+This file specifies how MLC's Llama parameter maps from other formats, for example HuggingFace
+PyTorch, HuggingFace safetensors.
+"""
+import numpy as np
+
+from mlc_llm.param_loader import ParameterMapping
+
+from .llama import LlamaConfig, LlamaForCasualLM
+
+
+def hf_torch(model_config: LlamaConfig) -> ParameterMapping:
+    """
+    Returns a parameter mapping that maps from the names of MLC LLM parameters to
+    the names of HuggingFace PyTorch parameters.
+
+    Parameters
+    ----------
+    model_config : LlamaConfig
+        The configuration of the Llama model.
+
+    Returns
+    -------
+    param_map : ParameterMapping
+        The parameter mapping from MLC to HuggingFace PyTorch.
+    """
+    model = LlamaForCasualLM(model_config)
+    _, named_params = model.export_tvm(spec=model.get_default_spec())
+    parameter_names = {name for name, _ in named_params}
+
+    name_map = {}
+    map_func = {}
+    unused_params = set()
+
+    for i in range(model_config.num_hidden_layers):
+        # Add QKV in self attention
+        attn = f"model.layers.{i}.self_attn"
+        assert f"{attn}.qkv_proj.weight" in parameter_names
+        map_func[f"{attn}.qkv_proj.weight"] = lambda q, k, v: np.concatenate([q, k, v], axis=0)
+        name_map[f"{attn}.qkv_proj.weight"] = (
+            f"{attn}.q_proj.weight",
+            f"{attn}.k_proj.weight",
+            f"{attn}.v_proj.weight",
+        )
+        # Add gates in MLP
+        mlp = f"model.layers.{i}.mlp"
+        assert f"{mlp}.gate_up_proj.weight" in parameter_names
+        map_func[f"{mlp}.gate_up_proj.weight"] = lambda gate, up: np.concatenate([gate, up], axis=0)
+        name_map[f"{mlp}.gate_up_proj.weight"] = (
+            f"{mlp}.gate_proj.weight",
+            f"{mlp}.up_proj.weight",
+        )
+        # inv_freq is not used in the model
+        unused_params.add(f"{attn}.rotary_emb.inv_freq")
+
+    for name in parameter_names:
+        if name not in map_func:
+            map_func[name] = lambda x: x
+            name_map[name] = (name,)
+    return ParameterMapping(name_map, map_func, unused_params)

--- a/mlc_llm/models/model_config_base.py
+++ b/mlc_llm/models/model_config_base.py
@@ -1,0 +1,57 @@
+"""
+Utilities that handle model configuration. Model configuration is usually a JSON file in HuggingFace
+that contains the model's hyperparameters. For instance, Vicuna-13b-v1.5-16k contains the following
+config file: https://huggingface.co/lmsys/vicuna-13b-v1.5-16k/blob/main/config.json
+"""
+import dataclasses
+import json
+from pathlib import Path
+from typing import Any, Dict, Type, TypeVar
+
+ConfigClass = TypeVar("ConfigClass", bound="ModelConfig")
+
+
+class ModelConfig:
+    """Base class for model configurations, providing a common interface for loading configs from a
+    JSON file or a dict. It requires the subclasses to be dataclasses, and has an `kwargs` field
+    that stores the extra fields that are not defined in the dataclass.
+    """
+
+    @classmethod
+    def from_dict(cls: Type[ConfigClass], source: Dict[str, Any]) -> ConfigClass:
+        """Create a config object from a dictionary.
+
+        Parameters
+        ----------
+        source : Dict[str, Any]
+            Source to create config from, usually loaded from `config.json` in HuggingFace style.
+
+        Returns
+        -------
+        cfg : ConfigClass
+            An instance of the config object.
+        """
+        field_names = [field.name for field in dataclasses.fields(cls)]
+        fields = {k: v for k, v in source.items() if k in field_names}
+        kwargs = {k: v for k, v in source.items() if k not in field_names}
+        return cls(**fields, kwargs=kwargs)
+
+    @classmethod
+    def from_file(cls: Type[ConfigClass], source: Path) -> ConfigClass:
+        """Create a config object from a file.
+
+        Parameters
+        ----------
+        cfg_cls : Type[ConfigClass]
+            The config class to create, for example, LlamaConfig.
+
+        source : pathlib.Path
+            Path to the source file, usually `config.json` in HuggingFace repo.
+
+        Returns
+        -------
+        cfg : ConfigClass
+            An instance of the config object.
+        """
+        with source.open("r", encoding="utf-8") as in_file:
+            return cls.from_dict(json.load(in_file))

--- a/mlc_llm/param_loader/__init__.py
+++ b/mlc_llm/param_loader/__init__.py
@@ -1,0 +1,6 @@
+"""
+Utilities for loading parameters from specific formats, for example, HuggingFace PyTorch,
+HuggingFace SafeTensor, GGML, AutoGPTQ.
+"""
+from .hf_torch_loader import HFTorchLoader
+from .param_mapping import ParameterMapping

--- a/mlc_llm/param_loader/hf_torch_loader.py
+++ b/mlc_llm/param_loader/hf_torch_loader.py
@@ -1,0 +1,191 @@
+"""A weight loader for HuggingFace's PyTorch format"""
+import gc
+import json
+import logging
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+
+from .param_mapping import ParameterMapping
+
+logger = logging.getLogger(__name__)
+
+
+class HFTorchLoader:
+    """A loader loading HuggingFace's PyTorch format and converts them to MLC's parameters.
+
+    Attributes
+    ----------
+    param_map : ParameterMapping
+        The parameter mapping from MLC to HuggingFace PyTorch.
+
+    torch_to_path : Dict[str, Path]
+        A mapping from PyTorch parameter name to the path of the file containing it.
+
+    cached_files : Dict[Path, Dict[str, np.ndarray]]
+        A cache of the loaded files. The key is the path of the file, and the value is a mapping
+        from parameter name to the parameter value.
+
+    stats_load_time_sec : float
+        The time spent on loading the files in seconds.
+
+    stats_load_data_gb : float
+        The amount of data loaded in GB.
+    """
+
+    param_map: ParameterMapping
+    torch_to_path: Dict[str, Path]
+    cached_files: Dict[Path, Dict[str, np.ndarray]]
+    stats_load_time_sec: float
+    stats_load_data_gb: float
+
+    def __init__(self, config_path: Path, param_map: ParameterMapping) -> None:
+        """Create a parameter loader from HuggingFace PyTorch format.
+
+        Parameters
+        ----------
+        config_path : pathlib.Path
+            Path to the torch indexing file, usually `pytorch_model.bin.index.json` in the repo.
+        param_map : ParameterMapping
+            The parameter mapping from MLC to HuggingFace PyTorch.
+        """
+        with config_path.open("r", encoding="utf-8") as in_file:
+            torch_weight_map = json.load(in_file)["weight_map"]
+        self.param_map = param_map
+        self.torch_to_path = {}
+        for torch_name, path_str in torch_weight_map.items():
+            path = config_path.parent / path_str
+            self.torch_to_path[torch_name] = path
+        self.cached_files = {}
+        self.stats_load_time_sec = 0.0
+        self.stats_load_data_gb = 0.0
+
+        used_torch_names = sum(param_map.name_map.values(), ())
+        # Check 1. All PyTorch parameters in the weight files are used unless explicitly specified
+        unused_torch_names = set(torch_weight_map) - set(used_torch_names) - param_map.unused_params
+        if unused_torch_names:
+            logger.warning(
+                "Unused torch parameters: %s",
+                ", ".join(sorted(unused_torch_names)),
+            )
+        # Check 2. All PyTorch parameters required are stored in the weight files
+        nonexistent_torch_names = set(used_torch_names) - set(torch_weight_map)
+        if nonexistent_torch_names:
+            raise ValueError(
+                "The following torch parameters do not exist in the weight files:\n  "
+                + "\n  ".join(sorted(nonexistent_torch_names)),
+            )
+
+    def suggest_loading_order(self) -> List[str]:
+        """Suggest a loading order for MLC parameters.
+
+        Returns
+        -------
+        order : List[str]
+            A list of MLC parameters in the order that ensures file locality.
+        """
+        # Step 1. Build a map from path to torch parameters
+        path_to_torch: Dict[Path, List[str]] = defaultdict(list)
+        for torch_name, path in self.torch_to_path.items():
+            path_to_torch[path].append(torch_name)
+        # Step 2. Build a map from torch parameters to MLC parameters
+        torch_to_mlc = defaultdict(list)
+        for mlc_name, torch_names in self.param_map.name_map.items():
+            for torch_name in torch_names:
+                torch_to_mlc[torch_name].append(mlc_name)
+        # Step 3. Construct the ordering that ensures file locality
+        order = []
+        for _, torch_names in path_to_torch.items():
+            for torch_name in torch_names:
+                for mlc_name in torch_to_mlc[torch_name]:
+                    order.append(mlc_name)
+        return order
+
+    def load_param(self, name: str) -> np.ndarray:
+        """Load a MLC parameter according to its name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the MLC parameter.
+
+        Returns
+        -------
+        param : np.ndarray
+            The parameter value as a numpy array. Note that if the parameter is stored in bfloat16,
+            it will be converted to float32.
+        """
+        mlc_name = name
+        torch_names = self.param_map.name_map[mlc_name]
+        files_required = {self.torch_to_path[p] for p in torch_names}
+        files_existing = set(self.cached_files.keys())
+        files_to_load = files_required - files_existing
+        files_to_unload = files_existing - files_required
+
+        # Step 1. When there is some file to unloaded:
+        # - If no pending file load: unloading is deferred as there is no gain in peak memory usage;
+        # - Need to load files: unload immediately to save memory and make space for the new files.
+        if files_to_load:
+            for path in files_to_unload:
+                self._unload_file(path)
+        # Step 2. Load all the files needed
+        for path in files_to_load:
+            self._load_file(path)
+        # Step 3. Collect all torch parameters in order
+        torch_names = [self._retrieve_torch_param_from_cache(name) for name in torch_names]
+        # Step 4. Apply the mapping function
+        map_func = self.param_map.map_func[mlc_name]
+        return map_func(*torch_names)
+
+    def __enter__(self) -> "HFTorchLoader":
+        self.stats_load_time_sec = 0.0
+        self.stats_load_data_gb = 0.0
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        cached_files = list(self.cached_files.keys())
+        for path in cached_files:
+            self._unload_file(path)
+        logger.info(
+            "Time used in PyTorch loading: %.3f sec. Total %.3f GB loaded",
+            self.stats_load_time_sec,
+            self.stats_load_data_gb,
+        )
+
+    def _load_file(self, path: Path) -> None:
+        import torch  # pylint: disable=import-outside-toplevel
+
+        logging.info("Loading PyTorch parameters from: %s", path)
+
+        start_time = time.time()
+        result = {}
+        for name, param in torch.load(path, map_location=torch.device("cpu")).items():
+            param = param.detach().cpu()
+            dtype = str(param.dtype)
+            if dtype == "torch.bfloat16":
+                param = param.float()
+            param = param.numpy()
+            self.stats_load_data_gb += param.nbytes / (1024**3)
+            result[name] = param
+            logging.debug('    Parameter: "%s", shape: %s, dtype: %s', name, param.shape, dtype)
+        self.cached_files[path] = result
+        self.stats_load_time_sec += time.time() - start_time
+
+    def _unload_file(self, path: Path) -> None:
+        logging.debug("Unloading PyTorch weight file: %s", path)
+
+        start_time = time.time()
+        del self.cached_files[path]
+        gc.collect()
+        self.stats_load_time_sec += time.time() - start_time
+
+    def _retrieve_torch_param_from_cache(self, name: str) -> np.ndarray:
+        assert name in self.torch_to_path
+        path = self.torch_to_path[name]
+        assert path in self.cached_files
+        cache = self.cached_files[path]
+        assert name in cache
+        return cache[name]

--- a/mlc_llm/param_loader/param_mapping.py
+++ b/mlc_llm/param_loader/param_mapping.py
@@ -1,0 +1,36 @@
+"""Parameter mapping for converting different LLM implementations to MLC LLM."""
+import dataclasses
+from typing import Callable, Dict, Set, Tuple
+
+import numpy as np
+
+
+@dataclasses.dataclass
+class ParameterMapping:
+    """Mapping from a parameter name in MLC LLM's model definition to its potential source,
+    for example, from MLC parameter "model.layers.2.post_attention_layernorm.weight" to PyTorch's
+    parameter correspondingly.
+
+    Parameters
+    ----------
+    name_map : Dict[str, Tuple[str, ...]]
+        A dictionary that maps the name of a parameter to its source. For example,
+        in Llama2, the source of MLC parameter "model.layers.0.self_attn.qkv_proj.weight" from
+        huggingface torch are:
+
+        - "model.layers.0.self_attn.q_proj.weight"
+        - "model.layers.0.self_attn.k_proj.weight"
+        - "model.layers.0.self_attn.v_proj.weight"
+
+    map_func: Dict[str, Callable[[np.ndarray, ...], np.ndarray]]
+        A dictionary that maps the name of a parameter to a function that combines the source
+        parameters into the MLC parameter. For example, for the above example, the function
+        would be: `lambda q, k, v: np.concatenate([q, k, v], axis=0)`.
+
+    unused_params : Set[str]
+        Parameter names in the source weights that are not used in the MLC LLM model definition.
+    """
+
+    name_map: Dict[str, Tuple[str, ...]]
+    map_func: Dict[str, Callable[[np.ndarray, ...], np.ndarray]]
+    unused_params: Set[str] = dataclasses.field(default_factory=dict)

--- a/tests/python/test_model_llama.py
+++ b/tests/python/test_model_llama.py
@@ -16,12 +16,6 @@ def main():
         rms_norm_eps=1e-05,
         vocab_size=4096,
         position_embedding_base=10000,
-        bos_token_id=0,
-        eos_token_id=0,
-        pad_token_id=0,
-        initializer_range=0.02,
-        model_type="llama",
-        torch_dtype="float32",
     )
     batch_size, total_seq_len, dtype = 1, 32, "float32"
 

--- a/tests/python/test_param_loader_llama.py
+++ b/tests/python/test_param_loader_llama.py
@@ -1,0 +1,32 @@
+# pylint: disable=missing-docstring
+import logging
+from pathlib import Path
+
+from mlc_llm.models.llama import LlamaConfig
+from mlc_llm.models.llama_param_map import hf_torch
+from mlc_llm.param_loader import HFTorchLoader
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    style="{",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="{asctime} {levelname} {filename}:{lineno}: {message}",
+)
+
+
+def test_load_7b():
+    prefix = Path("./dist/models/llama-2-7b-chat-hf/")
+    path_config = prefix / "config.json"
+    path_params = prefix / "pytorch_model.bin.index.json"
+
+    model_config = LlamaConfig.from_file(path_config)
+    with HFTorchLoader(
+        config_path=path_params,
+        param_map=hf_torch(model_config),
+    ) as loader:
+        for name in loader.suggest_loading_order():
+            loader.load_param(name=name)
+
+
+if __name__ == "__main__":
+    test_load_7b()


### PR DESCRIPTION
## New Components

This PR introduces `mlc_llm.param_loader` as a new subpackge of MLC LLM compiler, with the following components:

**`ParameterMapping`** that describes how a MLC parameter maps to one or more PyTorch parameters by their names. For example, the MLC parameter `qkv_proj.weight` corresponds to three parameters in PyTorch, which are `q_proj.weight`, `k_proj.weight` and `v_proj.weight`, and to map PyTorch parameters to this MLC parameter, the mapping function is:

```python
lambda q, k, v: np.concatenate([q, k, v], axis=0)
```

**`HFTorchLoader`** that loads HuggingFace's PyTorch parameters in a certain ordering to save peak memory footprint. More specifically, HuggingFace shards the full parameter set into a few `.bin` files of more reasonable size (usually less than 10G each), and the loader fetches them on disk to recover the PyTorch parameters, while unloading some files once not needed.

We implemented `mlc_llm.models.llama_param_map.hf_torch` that returns a `ParameterMapping`, then used by `HFTorchLoader` to convert PyTorch parameters provided by HuggingFace repo to MLC parameters. See the logic in `tests/python/test_param_loader_llama.py` for more details.

## Improvements

Furthermore, we brought up a few improvements along the way:

**ModelConfig** is introduced as a base class to specific model configurations such as `LlamaConfig` to allow more convenient loading of HuggingFace's `config.json` into a dataclass. It provides two class methods `from_dict` and `from_file` that can be used to construct its subclasses. The unused information in `config.json`, e.g. `initializer_range` is not used during inference, will be stored in the `kwargs` field in its subclass.

A few enhancement to the new Llama implementation is also provided:

- Horizontal fusion is introduced as `nn.MultiLinear` (originally by @MasterJH5574);
- Rotary embedding is now "online" - no precomputed sin/cos are used any more, meaning the upper limit of sequence length is removed at least for computation. NOTE: for certain embedding types, it is still limited by model training (originally brought up by @MasterJH5574 and @yzh119).
- Dynamic vocabulary size is supported by symbolic shape (originally by @CharlieFRuan);
- Added a `LlamaForCasualLM.get_default_spec` that allows more in-lined view of the model definition;
- `head_dim` is explicitly added in `LlamaConfig`, which is calculated during `__post_init__` phase of dataclass construction, to avoid re-calculate it everywhere once used. This is particularly useful for building a sharded model when `num_heads` need to be divided across GPU workers (by @junrushao myself).

A few detailed messages are added:
- If a PyTorch parameter is not used during weight conversion, for example, `rotary_emb.inv_freq`, unless explicitly specified, MLC will warn that it is unused;
- If a MLC parameter corresponds to a PyTorch parameter that does not exist in HuggingFace repo, it errors out immediately.

## Coding Style

Coding style in new modules `mlc_llm.param_loader` and `mlc_llm.models`:

- All Python files are formatted with isort and black;
- All Python files are linted with pylint, but not mypy yet;
- `print` is strictly avoided and instead `logging` is used (proposed by @CharlieFRuan).
- All Python APIs are documented unless for those starting with "_";
- Usage of `nn.Module` is now formalized as `nn.ModuleName` for Modules, and `op.op_name` for atomic operators;
- Paths in the file system are explicitly represented using `pathlib.Path` instead of raw strings to avoid potential issues (according to a previous bugfix #671).
- The word `relax` is avoided as possible and replaced with `MLC` or `TVM`, as I would consider `relax` is an implementation detail inside TVM to avoid potential confusion.

## Examples

To show some sample logging messages of parameter loading for Llama:

```
2023-09-20 16:27:18 INFO hf_torch_loader.py:161: Loading PyTorch parameters from: dist/models/llama-2-7b-chat-hf/pytorch_model-00002-of-00002.bin
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.self_attn.q_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.self_attn.k_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.self_attn.v_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.self_attn.o_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.self_attn.rotary_emb.inv_freq", shape: (64,), dtype: torch.float32
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.mlp.gate_proj.weight", shape: (11008, 4096), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.mlp.up_proj.weight", shape: (11008, 4096), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.mlp.down_proj.weight", shape: (4096, 11008), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.input_layernorm.weight", shape: (4096,), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.24.post_attention_layernorm.weight", shape: (4096,), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "model.norm.weight", shape: (4096,), dtype: torch.float16
2023-09-20 16:27:20 DEBUG hf_torch_loader.py:173:     Parameter: "lm_head.weight", shape: (32000, 4096), dtype: torch.float16
...
2023-09-20 16:27:31 DEBUG hf_torch_loader.py:178: Unloading PyTorch weight file: dist/models/llama-2-7b-chat-hf/pytorch_model-00002-of-00002.bin
2023-09-20 16:27:32 INFO hf_torch_loader.py:161: Loading PyTorch parameters from: dist/models/llama-2-7b-chat-hf/pytorch_model-00001-of-00002.bin
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.embed_tokens.weight", shape: (32000, 4096), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.self_attn.q_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.self_attn.k_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.self_attn.v_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.self_attn.o_proj.weight", shape: (4096, 4096), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.self_attn.rotary_emb.inv_freq", shape: (64,), dtype: torch.float32
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.mlp.gate_proj.weight", shape: (11008, 4096), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.mlp.up_proj.weight", shape: (11008, 4096), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.mlp.down_proj.weight", shape: (4096, 11008), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.input_layernorm.weight", shape: (4096,), dtype: torch.float16
2023-09-20 16:27:38 DEBUG hf_torch_loader.py:173:     Parameter: "model.layers.0.post_attention_layernorm.weight", shape: (4096,), dtype: torch.float16
...
2023-09-20 16:28:07 DEBUG hf_torch_loader.py:178: Unloading PyTorch weight file: dist/models/llama-2-7b-chat-hf/pytorch_model-00001-of-00002.bin
2023-09-20 16:28:07 INFO hf_torch_loader.py:152: Time used in PyTorch loading: 8.867 sec. Total 12.551 GB loaded
```
