### PR TITLE
[Fix] Use CMake `copy` to speed up building for Android

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -33,7 +33,7 @@ add_jar(tvm4j_core ${javasources} GENERATE_NATIVE_HEADERS tvm4jheaders DESTINATI
 
 add_custom_command(
   TARGET tvm4j_core POST_BUILD 
-  COMMAND ${CMAKE_COMMAND} -E rename ${JNI_HEADER}/org_apache_tvm_LibInfo.h ${JNI_HEADER}/org_apache_tvm_native_c_api.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${JNI_HEADER}/org_apache_tvm_LibInfo.h ${JNI_HEADER}/org_apache_tvm_native_c_api.h
 )
 
 add_library(model_android STATIC IMPORTED)
@@ -65,5 +65,4 @@ target_link_libraries(tvm4j_runtime_packed
 target_compile_definitions(tvm4j_runtime_packed PUBLIC TVM4J_ANDROID)
 add_dependencies(tvm4j_runtime_packed tvm4j_core)
 
-install_jar(tvm4j_core output)
 install(TARGETS tvm4j_runtime_packed LIBRARY DESTINATION output/${ANDROID_ABI})

--- a/android/prepare_libs.sh
+++ b/android/prepare_libs.sh
@@ -3,7 +3,6 @@ set -euxo pipefail
 
 rustup target add aarch64-linux-android
 
-rm -rf build
 mkdir -p build/model_lib
 
 python prepare_model_lib.py


### PR DESCRIPTION
This PR updates CMake command to `copy` instead of `rename` before. So we do not need to remove `build` directory each time, to make it easy to build when debugging.

cc: @spectrometerHBH 