### PR TITLE
[Docs] Fix App Store download badge

### DIFF
--- a/docs/deploy/ios.rst
+++ b/docs/deploy/ios.rst
@@ -15,7 +15,7 @@ Use Pre-built iOS App
 ---------------------
 The MLC Chat app is now available in App Store at no cost. You can download and explore it by simply clicking the button below:
 
-    .. image:: https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/appstore-lrg.svg
+    .. image:: https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg
       :width: 135
       :target: https://apps.apple.com/us/app/mlc-chat/id6448482937
 


### PR DESCRIPTION
The link of previous iOS App Store download badge is broken. Updated to a new one.