### PR TITLE
[Bugfix] Always use int32 in quantization

### DIFF
--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -220,6 +220,7 @@ def convert_weights(
     # so that the LazyTransformParams pass can be applied.
     mod_transform = relax.transform.ToNonDataflow()(mod_transform)
     mod_transform = relax.transform.LazyTransformParams()(mod_transform)
+    mod_transform = tvm.tir.transform.ForceNarrowIndexToInt32()(mod_transform)
 
     debug_dump_script(mod_transform, "mod_convert_weights.py", args)
 
@@ -458,6 +459,7 @@ def parse_target(args: argparse.Namespace) -> None:
         from tvm.contrib.cc import (  # pylint: disable=import-outside-toplevel
             cross_compiler,
         )
+
         args.export_kwargs = {
             "fcompile": cross_compiler(
                 args.cc_path,


### PR DESCRIPTION
Before this change, int64 is used as index/loop variables in quantization as the default dtype for integers in TVM. However, int64 is not always available on certain GPU architectures. This PR fixes this behavior by force-converting the index/loop variables back to int32.