### PR TITLE
[BugFix] Correct Order of Temperature and Top_P in Sample Function

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1091,7 +1091,7 @@ class LLMChat {
     ICHECK(logits_on_cpu_.defined()) << "logits_on_cpu_ is not defined";
     ICHECK_EQ(logits_on_cpu_->ndim, 3) << "logits_on_cpu_ should be 3D";
     ICHECK_EQ(logits_on_cpu_->shape[0], 1) << "logits_on_cpu_ should be 1 batch";
-    return fsample_topp_from_logits_(logits_on_cpu_, top_p_, temperature_, GetRandomNumber());
+    return fsample_topp_from_logits_(logits_on_cpu_, temperature_, top_p_, GetRandomNumber());
   }
 
   int32_t SampleFromProbOnCPU() {


### PR DESCRIPTION
This PR fixes a issue where the order of `temperature` and `top_p` is inconsistent between relax and mlc-llm.
In [relax function implementation](https://github.com/mlc-ai/relax/blob/afaeeb1381c91362f4821db7e5365fe30529b29d/src/runtime/relax_vm/lm_support.cc#L277) the function calls temperature first so moving the order in mlc-llm.
```c++
int SampleTopPFromLogits(NDArray logits, double temperature, double top_p, double uniform_sample) ...
```
And this function is later used via FFI
```c++
TVM_REGISTER_GLOBAL("vm.builtin.sample_top_p_from_logits").set_body_typed(SampleTopPFromLogits);
```
In MLC it's called via FFI
```c++
auto fsample_topp_from_logits_ptr =
    tvm::runtime::Registry::Get("vm.builtin.sample_top_p_from_logits");
ICHECK(fsample_topp_from_logits_ptr)
    << "Cannot find env function vm.builtin.sample_top_p_from_logits";
fsample_topp_from_logits_ = *fsample_topp_from_logits_ptr;
```
Thanks @nverke for identifying this issue!

Co-authored-by: Noah Verke <<nverke@users.noreply.github.com>>

CC @jinhongyii @MasterJH5574 