### PR TITLE
Support for `chatml` format conversation (for TinyLlama-1.1B-Chat-v0.2)

### DIFF
--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -581,6 +581,7 @@ using ConvFactory = Conversation (*)();
 
 Conversation Conversation::FromTemplate(const std::string& name) {
   static std::unordered_map<std::string, ConvFactory> factory = {
+      {"chatml", ChatML},
       {"llama_default", LlamaDefault},
       {"llama-2", Llama2},
       {"mistral_default", MistralDefault},

--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -7,6 +7,27 @@ namespace mlc {
 namespace llm {
 namespace {
 
+Conversation ChatML() {
+  Conversation conv;
+  conv.name = "chatml";
+  conv.roles = {"<|im_start|>user", "<|im_start|>assistant"};
+  conv.system =
+      ("<|im_start|>system A conversation between a user and an LLM-based AI assistant. The "
+       "assistant gives helpful and honest answers.<|im_end|> ");
+  conv.messages = {};
+  conv.offset = 0;
+  conv.separator_style = SeparatorStyle::kSepRoleMsg;
+  conv.seps = {"<|im_end|>", "<|im_end|>"};
+  conv.role_msg_sep = "\n";
+  conv.role_empty_sep = "\n";
+  // TODO(mlc-team): add eos to mlc-chat-config
+  // and remove eos from stop token setting.
+  conv.stop_tokens = {2};
+  conv.stop_str = "<|im_end|>";
+  conv.add_bos = true;
+  return conv;
+}
+
 Conversation LlamaDefault() {
   Conversation conv;
   conv.name = "llama_default";


### PR DESCRIPTION
I added `chatml` support because of TinyLlama-1.1b. TinyLlama-1.1B is a 1.1B llama model that's being trained on 3 trillion tokens. Since it's a very small model it will run on almost any device which make it very suitable for MLC-LLM.
https://github.com/jzhang38/TinyLlama

They published a checkpoint version with 500B parameters trained and fine-tuned to chat (chatml format), which I converted to MLC-LLM format:
https://huggingface.co/acalatrava/mlc-chat-TinyLlama-1.1B-Chat-v0.2-q4f16_1

I also created a fine-tuned version and converted to MLC-LLM using the orca dataset.
https://huggingface.co/acalatrava/mlc-chat-TinyLlama-1.1B-orca-gpt4-q4f16_1

https://github.com/mlc-ai/binary-mlc-llm-libs/pull/32