### PR TITLE
Fix prefill stats

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -761,7 +761,7 @@ class LLMChat {
         this->PrepareBeforeEmbedding(inp, append_conversation, place_in_prompt);
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
     if (token_len == 0) return;
-    if(ft_.use_disco){
+    if (ft_.use_disco) {
       // exclude load shard time from prefill
       this->ft_.sess->SyncWorker(0);
     }

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -761,7 +761,10 @@ class LLMChat {
         this->PrepareBeforeEmbedding(inp, append_conversation, place_in_prompt);
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
     if (token_len == 0) return;
-
+    if(ft_.use_disco){
+      // exclude load shard time from prefill
+      this->ft_.sess->SyncWorker(0);
+    }
     auto tstart = std::chrono::high_resolution_clock::now();
 
     int32_t new_seq_len = total_seq_len_ + token_len;


### PR DESCRIPTION
When using disco runtime, prefill time calculated does not reflect the actual prefill time because the runtime is async. We add a sync_worker before the time measuring