### PR TITLE
Compatible with vicuna

### DIFF
--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -855,7 +855,6 @@ def get_model(args, hf_config):
     config = LlamaConfig(
         **hf_config,
         dtype=dtype,
-        max_sequence_length=max_position_embeddings,
         position_embedding_base=position_embedding_base,
         combine_matmul=True,
         num_shards=args.num_shards,


### PR DESCRIPTION
I found that latest MLCLLM project cannot compile vicuna. The error show "max_sequence_length" has multiple value. 

The config.json in Llama and Llama-2 is different:
Llama config has max_sequence_length value
Llama2 config dont has max_sequence_length value

After delete max_sequence_length param setting in LlamaConfig() will compatible vicuna and llama2