### PR TITLE
[Doc] Update URL to llm.mlc.ai

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Check the MLC-LLM Documentation
-    url: https://mlc.ai/mlc-llm/docs/
+    url: https://llm.mlc.ai/docs/
     about: Our documentation might provide answers to your questions.
   - name: Chat on Discord
     url: https://discord.gg/9Xpy2HGBuD

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F4DA Documentation"
-about: Report an issue related to https://mlc.ai/mlc-llm/docs
+about: Report an issue related to https://llm.mlc.ai/docs/
 title: '[Doc] '
 labels: ['documentation']
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/model-request.md
+++ b/.github/ISSUE_TEMPLATE/model-request.md
@@ -10,7 +10,7 @@ assignees: ''
 ## ⚙️  Request New Models
 
 - Link to an existing implementation (e.g. Hugging Face/Github): <!-- Link to the model -->
-- Is this model architecture supported by MLC-LLM? (the list of [supported models](https://mlc.ai/mlc-llm/docs/prebuilt_models.html)) <!-- Yes/No -->
+- Is this model architecture supported by MLC-LLM? (the list of [supported models](https://llm.mlc.ai/docs/prebuilt_models.html)) <!-- Yes/No -->
 
 ## Additional context
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # MLC LLM
 
-[Documentation](https://mlc.ai/mlc-llm/docs/) | [Blog](https://mlc.ai/blog/) | [WebLLM](https://webllm.mlc.ai/) | [WebStableDiffusion](https://websd.mlc.ai/) | [Discord][discord-url]
+[Documentation](https://llm.mlc.ai/docs) | [Blog](https://blog.mlc.ai/) | [WebLLM](https://webllm.mlc.ai/) | [WebStableDiffusion](https://websd.mlc.ai/) | [Discord][discord-url]
 
 Machine Learning Compilation for Large Language Models (MLC LLM) is a high-performance **universal deployment** solution that allows native deployment of any large language models with native APIs with compiler acceleration. The mission of this project is to enable everyone to develop, optimize and deploy AI models natively on everyone's devices with ML compilation techniques.
 
@@ -59,17 +59,17 @@ MLC LLM supports the following platforms and hardware:
 
 ## Getting Started
 
-<ins>**[Check out our instruction page to try out!](https://mlc.ai/mlc-llm/docs/get_started/try_out.html)**</ins>
+<ins>**[Check out our instruction page to try out!](https://llm.mlc.ai/docs/get_started/try_out.html)**</ins>
 
 ## Universal Deployment APIs
 
 MLC LLM provides multiple sets of APIs across platforms and environments. These include
-* [Python API](https://mlc.ai/mlc-llm/docs/deploy/python.html)
-* [OpenAI-compatible Rest-API](https://mlc.ai/mlc-llm/docs/deploy/rest.html)
-* [C++ API](https://mlc.ai/mlc-llm/docs/deploy/cli.html)
-* [JavaScript API](https://mlc.ai/mlc-llm/docs/deploy/javascript.html) and [Web LLM](https://github.com/mlc-ai/web-llm)
-* [Swift API for iOS App](https://mlc.ai/mlc-llm/docs/deploy/ios.html)
-* [Java API and Android App](https://mlc.ai/mlc-llm/docs/deploy/android.html)
+* [Python API](https://llm.mlc.ai/docs/deploy/python.html)
+* [OpenAI-compatible Rest-API](https://llm.mlc.ai/docs/deploy/rest.html)
+* [C++ API](https://llm.mlc.ai/docs/deploy/cli.html)
+* [JavaScript API](https://llm.mlc.ai/docs/deploy/javascript.html) and [Web LLM](https://github.com/mlc-ai/web-llm)
+* [Swift API for iOS App](https://llm.mlc.ai/docs/deploy/ios.html)
+* [Java API and Android App](https://llm.mlc.ai/docs/deploy/android.html)
 
 ## Citation
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,6 +1,3 @@
 # MLC-LLM Android
 
-We are excited to share that we have enabled the Android support for MLC-LLM. Checkout [the instruction page](https://mlc.ai/mlc-llm/#android) for instructions to download and install our Android app. Checkout the [announcing blog post](https://mlc.ai/blog/2023/05/08/bringing-hardware-accelerated-language-models-to-android-devices) for the technical details throughout our process of making MLC-LLM possible for Android.
-
-This folder contains the source code for building Android application of MLC-LLM. Please checkout our [documentation](https://mlc.ai/mlc-llm/docs/deploy/android.html) on how to build and use the MLC-LLM for Android.
-
+[Documentation page](https://llm.mlc.ai/docs/deploy/android.html)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,3 +1,3 @@
 # Use MLC-Compiled Models in C++
 
-This directory contains a C++ project that loads an MLC-compiled model, allowing other projects to interact with the model using C++ API or command line. Please check out the [instructions](https://mlc.ai/mlc-llm/docs/tutorials/runtime/cpp.html) for details.
+[Documentation page](https://llm.mlc.ai/docs/deploy/cli.html)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -154,3 +154,11 @@ If you are interested in using Machine Learning Compilation in practice, we high
 
    community/guideline.rst
    community/faq.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Privacy
+   :hidden:
+
+   privacy.rst

--- a/docs/privacy.rst
+++ b/docs/privacy.rst
@@ -1,10 +1,5 @@
----
-layout: default
-title: Home
-notitle: true
----
-
-# MLC Chat App Privacy
+MLC Chat App Privacy
+====================
 
 MLC Chat run all generation locally.
 All data stays in users' device and is not collected by the app.

--- a/ios/MLCSwift/README.md
+++ b/ios/MLCSwift/README.md
@@ -1,4 +1,4 @@
 # MLCSwift
 
 This is a simple swift package that exposes the chat module to swift.
-Checkout our [documentation](https://mlc.ai/mlc-llm/docs/) for more examples.
+Checkout our [documentation](https://llm.mlc.ai/docs/) for more examples.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,4 +1,3 @@
 # MLC-LLM IOS
 
-The folder contains the source code for building ios-application of MLC-LLM.
-Please checkout our [documentation](https://mlc.ai/mlc-llm/docs/deploy/ios.html) on how to build and use the MLC-LLM for IOS.
+[Documentation page](https://llm.mlc.ai/docs/deploy/ios.html)

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,5 @@
 # MLC-Chat Python Package
 
-This folder contains the source code of MLC-Chat python package, please refer to the [REST API](https://mlc.ai/mlc-llm/docs/deploy/rest.html) and [Python API](https://mlc.ai/mlc-llm/docs/deploy/python.html) documentation for usage.
+This folder contains the source code of MLC-Chat python package,
+please refer to the [REST API](https://llm.mlc.ai/docs/deploy/rest.html)
+and [Python API](https://llm.mlc.ai/docs/deploy/python.html) documentation for usage.

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,8 +1,7 @@
-
 name: "MLC LLM"
 short_name: "MLC LLM"
 
-url: https://mlc.ai/mlc-llm
+url: https://llm.mlc.ai/
 
 exclude: [README.md, serve_local.sh]
 
@@ -24,7 +23,7 @@ permalink: /blog/:year/:month/:day/:title.html
 front_page_news: 8
 
 # Base pathname for links.
-base: '/mlc-llm'
+base: '/'
 
 # make pages for the _projects folder
 collections:

--- a/site/index.md
+++ b/site/index.md
@@ -6,43 +6,36 @@ notitle: true
 
 # MLC LLM
 
-MLC LLM is a universal solution that allows any language model to be deployed natively on a diverse set of hardware backends and native applications, plus a productive framework for everyone to further optimize model performance for their own use cases.
-**Everything runs locally  with no server support and accelerated with local GPUs on your phone and laptop**.
-Check out our [GitHub repository](https://github.com/mlc-ai/mlc-llm) to see how we did it.
-Check out [documentation](https://mlc.ai/mlc-llm/docs/index.html) if you are interested in exploring more possibilities of MLC LLM.
+MLC LLM is a universal solution that allows any language model to be deployed natively on a diverse set of hardware backends and native applications.
+
+Please visit **[Getting Started](https://llm.mlc.ai/docs/get_started/try_out.html)** for detailed instructions.
+
+## Demos
+
+- [iOS](#ios)
+- [Android](#android)
+- [Windows Linux Mac](#windows-linux-mac)
+- [Web browser](#web-browser)
+
+### iOS
+
+Our iOS app, MLCChat, is available on [App Store](https://apps.apple.com/us/app/mlc-chat/id6448482937) for iPhone and iPad.
+This app is tested on iPhone 15 Pro Max, iPhone 14 Pro Max, iPhone 14 Pro and iPhone 12 Pro.
+Besides the **[Getting Started](https://llm.mlc.ai/docs/get_started/try_out.html)** page,
+[documentation](https://llm.mlc.ai/docs/deploy/ios.html) is available for building iOS apps with MLC LLM.
 
 <p align="center">
 <img src="gif/ios-demo.gif" height="700">
 </p>
 
-## Try it out
-
-**[Visit our instruction page to try out MLC LLM!](https://mlc.ai/mlc-llm/docs/get_started/try_out.html)**
-
-This section also contains some brief instructions to run large-language models and chatbot natively on your environment.
-For more information, please visit our [instruction page](https://mlc.ai/mlc-llm/docs/get_started/try_out.html).
-
-- [iPhone](#iphone)
-- [Android](#android)
-- [Windows Linux Mac](#windows-linux-mac)
-- [Web browser](#web-browser)
-
-### iPhone
-
-The MLC-Chat app is available on App Store, try it out [here](https://apps.apple.com/us/app/mlc-chat/id6448482937) to install and use it for iOS devices (iPhone/iPad).
-Vicuna-7B takes 4GB of RAM and RedPajama-3B takes 2.2GB to run. Considering the iOS and other running applications, we will need a recent iPhone with 6GB for Vicuna-7B or 4GB for RedPajama-3B to run the app. The application is only tested on iPhone 14 Pro Max, iPhone 14 Pro and iPhone 12 Pro.
-
-To build the iOS app from source, You can also check out our [GitHub repo](https://github.com/mlc-ai/mlc-llm).
-
-Note: The text generation speed on the iOS app can be unstable from time to time. It might run slow in the beginning and recover to a normal speed then.
+Note: Llama-7B takes 4GB of RAM and RedPajama-3B takes 2.2GB to run. We recommend a latest device with 6GB RAM for Llama-7B, or 4GB RAM for RedPajama-3B, to run the app. The text generation speed could vary from time to time, for example, slow in the beginning but recover to a normal speed then.
 
 ### Android
 
-Download the APK file [here](https://github.com/mlc-ai/binary-mlc-llm-libs/raw/main/mlc-chat.apk) and install on your phone. You can then start a chat with LLM. When you first open the app, parameters need to be downloaded and the loading process could be slow. In future run, the parameters will be loaded from cache (which is fast) and you can use the app offline. Our current demo relies on OpenCL support on the phone and takes about 6GB of RAM, if you have a phone with the latest Snapdragon chip, you can try out out demo.
-
-We tested our demo on Samsung Galaxy S23. It does not yet work on Google Pixel due to limited OpenCL support. We will continue to bring support and welcome contributions from the open source community. You can also check out our [GitHub repo](https://github.com/mlc-ai/mlc-llm/tree/main/android) to build the Android app from source.
-
-Check out our [blog post](https://mlc.ai/blog/2023/05/08/bringing-hardware-accelerated-language-models-to-android-devices) for the technical details throughout our process of making MLC-LLM possible for Android.
+The demo APK is available to [download](https://github.com/mlc-ai/binary-mlc-llm-libs/raw/main/mlc-chat.apk).
+The demo is tested on Samsung S23 with Snapdragon 8 Gen 2 chip, Redmi Note 12 Pro with Snapdragon 685 and Google Pixel phones.
+Besides the **[Getting Started](https://llm.mlc.ai/docs/get_started/try_out.html)** page,
+[documentation](https://llm.mlc.ai/docs/deploy/android.html) is available for building android apps with MLC LLM.
 
 <p align="center">
 <img src="gif/android-demo.gif" height="700">
@@ -50,50 +43,9 @@ Check out our [blog post](https://mlc.ai/blog/2023/05/08/bringing-hardware-accel
 
 ### Windows Linux Mac
 
-We provide a CLI (command-line interface) app to chat with the bot in your terminal. Before installing
-the CLI app, we should install some dependencies first.
-1. We use Conda to manage our app, so we need to install a version of conda. We can install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Miniforge](https://github.com/conda-forge/miniforge).
-2. On Windows and Linux, the chatbot application runs on GPU via the Vulkan platform. For Windows and Linux users,
-please install the latest [Vulkan driver](https://developer.nvidia.com/vulkan-driver). For NVIDIA GPU users, please make sure to install
-Vulkan driver, as the CUDA driver may not be good.
-
-After installing all the dependencies, just follow the instructions below the install the CLI app:
-
-```shell
-# Create a new conda environment, install CLI app, and activate the environment.
-conda create -n mlc-chat-venv -c mlc-ai -c conda-forge mlc-chat-cli-nightly
-conda activate mlc-chat-venv
-
-# Install Git and Git-LFS if you haven't already.
-# They are used for downloading the model weights from HuggingFace.
-conda install git git-lfs
-git lfs install
-
-# Create a directory, download the model weights from HuggingFace, and download the binary libraries
-# from GitHub.
-mkdir -p dist/prebuilt
-git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt/lib
-
-# Download prebuilt weights of Vicuna-7B
-cd dist/prebuilt
-git clone https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0
-cd ../..
-mlc_chat_cli --model vicuna-v1-7b-q3f16_0
-
-# Download prebuilt weights of RedPajama-3B
-cd dist/prebuilt
-git clone https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0
-cd ../..
-mlc_chat_cli --model RedPajama-INCITE-Chat-3B-v1-q4f16_0
-
-# Download prebuilt weights of RWKV-raven-1.5B/3B/7B
-cd dist/prebuilt
-git clone https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-1b5-q8f16_0
-# or git clone https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-3b-q8f16_0
-# or git clone https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-7b-q8f16_0
-cd ../..
-mlc_chat_cli --model rwkv-raven-1b5-q8f16_0  # Replace your local id if you use 3b or 7b model.
-```
+Our cpp interface runs on AMD, Intel, Apple and NVIDIA GPUs.
+Besides the **[Getting Started](https://llm.mlc.ai/docs/get_started/try_out.html)** page,
+[documentation](https://llm.mlc.ai/docs/deploy/cli.html) is available for building C++ apps with MLC LLM.
 
 <p align="center">
 <img src="gif/linux-demo.gif" width="80%">
@@ -101,16 +53,15 @@ mlc_chat_cli --model rwkv-raven-1b5-q8f16_0  # Replace your local id if you use 
 
 ### Web Browser
 
-Please check out [WebLLM](https://webllm.mlc.ai/), our companion project that deploys models natively to browsers. Everything here runs inside the browser with no server support and accelerated with WebGPU.
+[WebLLM](https://webllm.mlc.ai/) is our companion project that deploys MLC LLM natively to browsers using WebGPU and WebAssembly. Still everything runs inside the browser without server resources, and accelerated by local GPUs (e.g. AMD, Intel, Apple or NVIDIA).
 
 ## Links
 
-* Check out our [GitHub repo](https://github.com/mlc-ai/mlc-llm) to see how we build, optimize and deploy the bring large-language models to various devices and backends.
-* Check out our companion project [WebLLM](https://webllm.mlc.ai/) to run the chatbot purely in your browser.
-* You might also be interested in [Web Stable Diffusion](https://websd.mlc.ai/), which runs the stable-diffusion model purely in the browser.
-* You might want to check out our online public [Machine Learning Compilation course](https://mlc.ai) for a systematic
-walkthrough of our approaches.
+* Our official [GitHub repo](https://github.com/mlc-ai/mlc-llm);
+* Our companion project [WebLLM](https://webllm.mlc.ai/) that enables running LLMs purely in browser.
+* [Web Stable Diffusion](https://websd.mlc.ai/) is another MLC-series that runs the diffusion models purely in the browser.
+* [Machine Learning Compilation course](https://mlc.ai) is available for a systematic walkthrough of our approach to universal deployment.
 
 ## Disclaimer
 
-The pre-packaged demos are for research purposes only, subject to the model License.
+The pre-packaged demos are subject to the model License.


### PR DESCRIPTION
According to existing effort:
- https://github.com/mlc-ai/mlc-llm/pull/962
- https://github.com/mlc-ai/mlc-llm/pull/961

However, the remaining item is that we need to figure out a way to redirect `llm.mlc.ai/docs/*` to `llm.mlc.ai/*`