### PR TITLE
Enable offloading multi-query attention by Flash Attention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ target_link_libraries(mlc_llm PRIVATE tokenizers_cpp)
 find_library(FLASH_ATTN_LIBRARY flash_attn)
 
 if (FLASH_ATTN_LIBRARY STREQUAL "FLASH_ATTN_LIBRARY-NOTFOUND")
-  message(WARNING "Cannot find libflash_attn.")
+  message(WARNING "Cannot find libflash_attn. The model must not have been built with --use-flash-attn-mqa option.")
 else ()
   target_link_libraries(mlc_llm PUBLIC -Wl,--no-as-needed ${FLASH_ATTN_LIBRARY})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(mlc_llm C CXX)
 
-link_directories(/home/masahi/projects/dev/tvm/build/3rdparty/libflash_attn/src)
-
 include(CheckCXXCompilerFlag)
 if(NOT MSVC)
   check_cxx_compiler_flag("-std=c++17" SUPPORT_CXX17)
@@ -96,8 +94,16 @@ add_library(mlc_llm_static STATIC $<TARGET_OBJECTS:mlc_llm_objs>)
 add_dependencies(mlc_llm_static tokenizers_cpp sentencepiece-static tokenizers_c tvm_runtime)
 set_target_properties(mlc_llm_static PROPERTIES OUTPUT_NAME mlc_llm)
 
-target_link_libraries(mlc_llm PUBLIC tvm_runtime -Wl,--no-as-needed flash_attn)
+target_link_libraries(mlc_llm PUBLIC tvm_runtime)
 target_link_libraries(mlc_llm PRIVATE tokenizers_cpp)
+
+find_library(FLASH_ATTN_LIBRARY flash_attn)
+
+if (FLASH_ATTN_LIBRARY STREQUAL "FLASH_ATTN_LIBRARY-NOTFOUND")
+  message(WARNING "Cannot find libflash_attn.")
+else ()
+  target_link_libraries(mlc_llm PUBLIC -Wl,--no-as-needed ${FLASH_ATTN_LIBRARY})
+endif()
 
 if (BUILD_CPP_TEST)
   message(STATUS "Building cpp unittests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.18)
 project(mlc_llm C CXX)
 
+link_directories(/home/masahi/projects/dev/tvm/build/3rdparty/libflash_attn/src)
+
 include(CheckCXXCompilerFlag)
 if(NOT MSVC)
   check_cxx_compiler_flag("-std=c++17" SUPPORT_CXX17)
@@ -94,7 +96,7 @@ add_library(mlc_llm_static STATIC $<TARGET_OBJECTS:mlc_llm_objs>)
 add_dependencies(mlc_llm_static tokenizers_cpp sentencepiece-static tokenizers_c tvm_runtime)
 set_target_properties(mlc_llm_static PROPERTIES OUTPUT_NAME mlc_llm)
 
-target_link_libraries(mlc_llm PUBLIC tvm_runtime)
+target_link_libraries(mlc_llm PUBLIC tvm_runtime -Wl,--no-as-needed flash_attn)
 target_link_libraries(mlc_llm PRIVATE tokenizers_cpp)
 
 if (BUILD_CPP_TEST)

--- a/cpp/cli_main.cc
+++ b/cpp/cli_main.cc
@@ -426,10 +426,6 @@ void Chat(ChatModule* chat, const std::string& device_name, std::string local_id
   PrintSpecialCommands();
   chat->Reload(model);
   chat->ProcessSystemPrompts();
-  auto input = "Who is Shohei Ohtani?";
-  Converse(chat, input, stream_interval, std::cout);
-  std::cout << chat->RuntimeStatsText() << std::endl << std::flush;
-  return;
   while (true) {
     std::string input;
     std::cout << chat->GetRole0() << ": " << std::flush;

--- a/cpp/cli_main.cc
+++ b/cpp/cli_main.cc
@@ -426,6 +426,10 @@ void Chat(ChatModule* chat, const std::string& device_name, std::string local_id
   PrintSpecialCommands();
   chat->Reload(model);
   chat->ProcessSystemPrompts();
+  auto input = "Who is Shohei Ohtani?";
+  Converse(chat, input, stream_interval, std::cout);
+  std::cout << chat->RuntimeStatsText() << std::endl << std::flush;
+  return;
   while (true) {
     std::string input;
     std::cout << chat->GetRole0() << ": " << std::flush;

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -182,8 +182,7 @@ class BuildArgs:
         default=False,
         metadata={
             "help": (
-                "Offload attention operations to CUTLASS when the target is CUDA"
-                "and TVM has been built with CUTLASS enabled."
+                "Disable offloading attention operations to CUTLASS."
             ),
             "action": "store_true",
         },
@@ -192,8 +191,7 @@ class BuildArgs:
         default=False,
         metadata={
             "help": (
-                "Offload layer and RMS norm operations to CUTLASS when the target is CUDA"
-                "and TVM has been built with CUTLASS enabled."
+                "Disable offloading layer and RMS norm operations to CUTLASS."
             ),
             "action": "store_true",
         },
@@ -226,6 +224,15 @@ class BuildArgs:
                 "Number of shards to split the model into in tensor parallelism multi-gpu "
                 "inference"
             ),
+        },
+    )
+    no_flash_attn_mqa: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Disable offloading multi-query attention workload to Flash Attention."
+            ),
+            "action": "store_true",
         },
     )
 
@@ -399,8 +406,15 @@ def mod_transform_before_build(
         has_cutlass = tvm.get_global_func("relax.ext.cutlass", True)
 
         if has_cutlass and not args.no_cutlass_attn:
-            mod["prefill"] = rewrite_attention(mod["prefill"])
-            mod["decode"] = rewrite_attention(mod["decode"])
+            use_flash_mqa = not args.no_flash_attn_mqa
+
+            if use_flash_mqa:
+                mod["prefill"] = rewrite_attention(mod["prefill"], use_flash_mqa=True)
+                mod["decode"] = rewrite_attention(mod["decode"], use_flash_mqa=True)
+
+            mod["prefill"] = rewrite_attention(mod["prefill"], use_flash_mqa=False)
+            mod["decode"] = rewrite_attention(mod["decode"], use_flash_mqa=False)
+
             patterns += get_patterns_with_prefix("cutlass.attention")
 
         if has_cutlass and not args.no_cutlass_norm:

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -226,11 +226,11 @@ class BuildArgs:
             ),
         },
     )
-    no_flash_attn_mqa: bool = field(
+    use_flash_attn_mqa: bool = field(
         default=False,
         metadata={
             "help": (
-                "Disable offloading multi-query attention workload to Flash Attention."
+                "Offload multi-query attention workload to Flash Attention."
             ),
             "action": "store_true",
         },
@@ -406,9 +406,7 @@ def mod_transform_before_build(
         has_cutlass = tvm.get_global_func("relax.ext.cutlass", True)
 
         if has_cutlass and not args.no_cutlass_attn:
-            use_flash_mqa = not args.no_flash_attn_mqa
-
-            if use_flash_mqa:
+            if args.use_flash_attn_mqa:
                 mod["prefill"] = rewrite_attention(mod["prefill"], use_flash_mqa=True)
                 mod["decode"] = rewrite_attention(mod["decode"], use_flash_mqa=True)
 

--- a/mlc_llm/transform/rewrite_attention.py
+++ b/mlc_llm/transform/rewrite_attention.py
@@ -8,8 +8,8 @@ def rewrite_attention(f):
     V = wildcard()
 
     Q_BNSH = is_op("relax.permute_dims")(Q)
-    K_BNSH = is_op("relax.permute_dims")(K)
-    V_BNSH = is_op("relax.permute_dims")(V)
+    K_BNSH = is_op("relax.permute_dims")(is_op("relax.repeat")(K))
+    V_BNSH = is_op("relax.permute_dims")(is_op("relax.repeat")(V))
 
     K_BNSH_T = is_op("relax.permute_dims")(K_BNSH)
 

--- a/mlc_llm/transform/rewrite_attention.py
+++ b/mlc_llm/transform/rewrite_attention.py
@@ -7,13 +7,14 @@ def rewrite_attention(f, use_flash_mqa=False):
     K = wildcard()
     V = wildcard()
 
-    if use_flash_mqa:
-        K = is_op("relax.repeat")(K)
-        V = is_op("relax.repeat")(V)
-
     Q_BNSH = is_op("relax.permute_dims")(Q)
-    K_BNSH = is_op("relax.permute_dims")(K)
-    V_BNSH = is_op("relax.permute_dims")(V)
+
+    if use_flash_mqa:
+        K_BNSH = is_op("relax.permute_dims")(is_op("relax.repeat")(K))
+        V_BNSH = is_op("relax.permute_dims")(is_op("relax.repeat")(V))
+    else:
+        K_BNSH = is_op("relax.permute_dims")(K)
+        V_BNSH = is_op("relax.permute_dims")(V)
 
     K_BNSH_T = is_op("relax.permute_dims")(K_BNSH)
 

--- a/mlc_llm/transform/rewrite_attention.py
+++ b/mlc_llm/transform/rewrite_attention.py
@@ -2,14 +2,18 @@ from tvm.relax.dpl import PatternContext, is_const, is_op, rewrite_call, wildcar
 from tvm.script import relax as R
 
 
-def rewrite_attention(f):
+def rewrite_attention(f, use_flash_mqa=False):
     Q = wildcard()
     K = wildcard()
     V = wildcard()
 
+    if use_flash_mqa:
+        K = is_op("relax.repeat")(K)
+        V = is_op("relax.repeat")(V)
+
     Q_BNSH = is_op("relax.permute_dims")(Q)
-    K_BNSH = is_op("relax.permute_dims")(is_op("relax.repeat")(K))
-    V_BNSH = is_op("relax.permute_dims")(is_op("relax.repeat")(V))
+    K_BNSH = is_op("relax.permute_dims")(K)
+    V_BNSH = is_op("relax.permute_dims")(V)
 
     K_BNSH_T = is_op("relax.permute_dims")(K_BNSH)
 


### PR DESCRIPTION
Following https://github.com/apache/tvm/pull/15831, this is the mlc-side change to enable MQA offload. 

To use the new option, `use_flash_attn_mqa`, `${TVM_HOME}` must point to a TVM build with that commit. In particular, since the TVM submodule pulled by mlc is [a custom one](https://github.com/mlc-ai/relax) that doesn't support flash attention at all, it cannot use this new feature. The option is set to False by default to avoid potential troubles.  