### PR TITLE
[Docs] Model prebuilts tracking page revamp

### DIFF
--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -7,18 +7,52 @@ Model Prebuilts
     :depth: 3
     :local:
 
+.. _model-prebuilts-overview:
+
+Overview
+--------
+
 MLC-LLM is a universal solution for deploying different language models. Any language models that can be described in `TVM Relax <https://mlc.ai/chapter_graph_optimization/index.html>`__ (a general representation for Neural Networks and can be imported from models written in PyTorch) can be recognized by MLC-LLM and thus deployed to different backends with the help of :doc:`TVM Unity </install/tvm>`.
 
 The community has already supported several LLM architectures (LLaMA, GPT-NeoX, etc.) and have prebuilt some models (Vicuna, RedPajama, etc.) which you can use off the shelf.
 With the goal of democratizing the deployment of LLMs, we eagerly anticipate further contributions from the community to expand the range of supported model architectures.
 
-This page contains the list of prebuilt models for our CLI (command line interface) app, iOS and Android apps.
+This pages tracks the model architectures and variants that MLC-LLM currently supports.
+
+You can check `MLC-LLM pull requests <https://github.com/mlc-ai/mlc-llm/pulls?q=is%3Aopen+is%3Apr+label%3Anew-models>`__ to track the ongoing efforts of new models. We encourage users to upload their compiled models to Hugging Face and share with the community.
+
+Prerequisite: Model Libraries and Compiled Weights
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to run a specific model on MLC-LLM, you roughly need two parts:
+
+**1. A model library:** a binary file containing the end-to-end functionality to inference a model. This is a single file that ends in `.so` or other suffix depending on the platform. Such a file is model-architecture-specific (e.g. Llama vs. rwkv). See the full list of precompiled model libraries `here <https://github.com/mlc-ai/binary-mlc-llm-libs>`__. 
+
+**2. Compiled weights:** a folder containing multiple files that store the compiled and quantized weights of a model. Besides the weights, there are also config files required by MLC-LLM such as ``mlc-chat-config.json``. Such a folder is model-variant-specific (e.g. Code Llama vs. WizardCoder). See the list of precompiled weights `here <https://huggingface.co/mlc-ai>`__.
+
+
+How We Organize this Page 
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Accordingly, we organize our page with three levels of hierarchy here (from high to low):
+
+**1. Supported model architectures**: The **all-in-one** table demonstrating what model architectures we support and what variants belong to each architecture. Each entry hyperlinks to the corresponding model library table and model variant table. 
+
+**2. Model library tables**: For each table, we describe the **model libraries** we have pre-compiled for a specific model architecture (e.g. Llama). Specifically, it is categorized as the platform, parameters count, and quantization scheme. We link to the corresponding github link.
+
+**3. Model variant tables**: For each table, we describe the **weights** we have pre-compiled for a specific model variant (e.g. Code Llama). Specifically, it is categorized by model size and quantization scheme. We link to the corresponding hugging face link.
+
+
+Afterwards, we address how to use our prebuilt models in CLI (command line interface), iOS, and Android.
 The models have undergone extensive testing on various devices, and their performance has been optimized by developers with the help of TVM.
 
 .. _supported-model-architectures:
 
-Supported Model Architectures
------------------------------
+Level 1: Supported Model Architectures (All-In-One)
+---------------------------------------------------
+
+For each model architecture (e.g. Llama), there are multiple variants (e.g. Code Llama, WizardLM). The variants share the same code for inference and only differ in their weights. In other words, running Code Llama and WizardLM can use the same model library file (specified in Level 2 tables), but different precompiled weights (specified in Level 3 tables). Note that we have not provided prebuilt weights for all model variants.
+
+Each entry below hyperlinks to the corresponding level 2 and level 3 tables.
 
 MLC-LLM supports the following model architectures:
 
@@ -104,14 +138,30 @@ MLC-LLM supports the following model architectures:
       * `CodeGeeX2 <https://huggingface.co/THUDM/codegeex2-6b>`__
 
 
-For models structured in these model architectures, you can check the :doc:`model compilation page </compilation/compile_models>` on how to compile models.
-Please `create a new issue <https://github.com/mlc-ai/mlc-llm/issues/new/choose>`_ if you want to request a new model architecture.
-Our tutorial :doc:`Define New Models </tutorials/customize/define_new_models>` introduces how to bring a new model architecture to MLC-LLM.
+For models structured in these model architectures, you can check the :doc:`model compilation page </compilation/compile_models>` on how to compile your own models.
+
+For models structed in a different architecture, you could:
+
+- Either `create a new issue <https://github.com/mlc-ai/mlc-llm/issues/new/choose>`_ to request a new model architecture.
+
+- Or follow our tutorial :doc:`Define New Models </tutorials/customize/define_new_models>`, which introduces how to bring a new model architecture to MLC-LLM.
 
 
 
-Model Library Tables
---------------------
+Level 2: Model Library Tables (Precompiled Binary Files)
+--------------------------------------------------------
+
+As mentioned earlier, each model architecture corresponds to a different model library file. That is, you cannot use the same model library file to run ``RedPajam`` and ``Llama-2``.
+
+Each table below demonstrates the pre-compiled model library files for each model architecture. This is catageroized by:
+
+- **Size**: each size of model has its own distinct model library file (e.g. 7B or 13B number of parameters)
+
+- **Platform**: the backend that the model library is intended to be run on (e.g. CUDA, ROCm, iphone, etc.)
+
+- **Quantization scheme**: the model library file also differs due to the quantization scheme used. For more on this, please see the :doc:`model compilation page </compilation/compile_models>` (e.g. ``q3f16_1`` vs. ``q4f16_1``)
+
+Each entry links to the specific model library file found in `this github repo <https://github.com/mlc-ai/binary-mlc-llm-libs>`__.
 
 .. _llama_library_table:
 
@@ -349,8 +399,14 @@ However, any GPTBigCode model variants should be able to reuse these (e.g. StarC
     - 
   
 
-Model Variant Tables
---------------------
+Level 3: Model Variant Tables (Precompiled Weights)
+---------------------------------------------------
+
+Finally, for each model variant, we provide the precompiled weights we uploaded to huggingface.
+
+Each precompiled weight is categorized by its model size (e.g. 7B vs. 13B) and the quantization scheme (e.g. ``q3f16_1`` vs. ``q4f16_1``). We note that the weights are platfrom-agnostic.
+
+Some of these files are uploaded by our community contributors--thank you!
 
 .. _llama2_variant_table:
 
@@ -560,96 +616,10 @@ Model Variant Tables
   * - 15B
     - `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-WizardCoder-15B-V1.0-q4f16_1>`__
 
-.. _prebuilt-models-cli:
+z.. _using-prebuilt-models-cli:
 
-Prebuilt Models for CLI
------------------------
-
-.. list-table::
-  :widths: 15 15 15 15
-  :header-rows: 1
-
-  * - Model code
-    - Original Model
-    - Quantization Mode
-    - Hugging Face repo
-  * - `Llama-2-{7, 13, 70}b-chat-hf-q4f16_1`
-    - `Llama-2 <https://ai.meta.com/llama/>`__
-    - * Weight storage data type: int4
-      * Running data type: float16
-      * Symmetric quantization
-    - * `7B link <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1>`__
-      * `13B link <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f16_1>`__
-      * `70B link <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q4f16_1>`__
-  * - `vicuna-v1-7b-q3f16_0`
-    - `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
-    - * Weight storage data type: int3
-      * Running data type: float16
-      * Symmetric quantization
-    - `link <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
-  * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
-    - `RedPajama <https://www.together.xyz/blog/redpajama>`__
-    - * Weight storage data type: int4
-      * Running data type: float16
-      * Symmetric quantization
-    - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
-  * - `rwkv-raven-{1b5, 3b, 7b}-q8f16_0`
-    - `RWKV <https://github.com/BlinkDL/RWKV-LM>`__
-    - * Weight storage data type: uint8
-      * Running data type: float16
-      * Symmetric quantization
-    - * `1b5 link <https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-1b5-q8f16_0>`__
-      * `3b link <https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-3b-q8f16_0>`__
-      * `7b link <https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-7b-q8f16_0>`__
-  * - `WizardLM-13B-V1.2-{q4f16_1, q4f32_1}`
-    - `WizardLM <https://github.com/nlpxucan/WizardLM>`__
-    - * Weight storage data type: int4
-      * Running data type: float{16, 32}
-      * Symmetric quantization
-    - * `q4f16_1 link <https://huggingface.co/mlc-ai/mlc-chat-WizardLM-13B-V1.2-q4f16_1>`__
-      * `q4f32_1 link <https://huggingface.co/mlc-ai/mlc-chat-WizardLM-13B-V1.2-q4f32_1>`__
-  * - `WizardCoder-15B-V1.0-{q4f16_1, q4f32_1}`
-    - `WizardCoder <https://github.com/nlpxucan/WizardLM>`__
-    - * Weight storage data type: int4
-      * Running data type: float{16, 32}
-      * Symmetric quantization
-    - * `q4f16_1 link <https://huggingface.co/mlc-ai/mlc-chat-WizardCoder-15B-V1.0-q4f16_1>`__
-      * `q4f32_1 link <https://huggingface.co/mlc-ai/mlc-chat-WizardCoder-15B-V1.0-q4f32_1>`__
-  * - `WizardMath-{7, 13, 70}B-V1.0-q4f16_1`
-    - `WizardMath <https://github.com/nlpxucan/WizardLM>`__
-    - * Weight storage data type: int4
-      * Running data type: float16
-      * Symmetric quantization
-    - * `7B link <https://huggingface.co/mlc-ai/mlc-chat-WizardMath-7B-V1.0-q4f16_1>`__
-      * `13B link <https://huggingface.co/mlc-ai/mlc-chat-WizardMath-13B-V1.0-q4f16_1>`__
-      * `70B link <https://huggingface.co/mlc-ai/mlc-chat-WizardMath-70B-V1.0-q4f16_1>`__
-  * - `llama2-7b-chat-uncensored-{q4f16_1, q4f32_1}`
-    - `georgesung <https://huggingface.co/georgesung/llama2_7b_chat_uncensored>`__
-    - * Weight storage data type: int4
-      * Running data type: float{16, 32}
-      * Symmetric quantization
-    - * `q4f16_1 link <https://huggingface.co/mlc-ai/mlc-chat-georgesung-llama2-7b-chat-uncensored-q4f16_1>`__
-      * `q4f32_1 link <https://huggingface.co/mlc-ai/mlc-chat-georgesung-llama2-7b-chat-uncensored-q4f32_1>`__
-  * - `Llama2-Chinese-7b-Chat-{q4f16_1, q4f32_1}`
-    - `FlagAlpha <https://github.com/FlagAlpha/Llama2-Chinese>`__
-    - * Weight storage data type: int4
-      * Running data type: float{16, 32}
-      * Symmetric quantization
-    - * `q4f16_1 link <https://huggingface.co/mlc-ai/mlc-chat-FlagAlpha-Llama2-Chinese-7b-Chat-q4f16_1>`__
-      * `q4f32_1 link <https://huggingface.co/mlc-ai/mlc-chat-FlagAlpha-Llama2-Chinese-7b-Chat-q4f32_1>`__
-  * - `GOAT-7B-Community-{q4f16_1, q4f32_1}`
-    - `GOAT-AI <https://huggingface.co/GOAT-AI/GOAT-7B-Community>`__
-    - * Weight storage data type: int4
-      * Running data type: float{16, 32}
-      * Symmetric quantization
-    - * `q4f16_1 link <https://huggingface.co/mlc-ai/mlc-chat-GOAT-7B-Community-q4f16_1>`__
-      * `q4f32_1 link <https://huggingface.co/mlc-ai/mlc-chat-GOAT-7B-Community-q4f32_1>`__
-  * - `OpenOrca-Platypus2-13B-q4f16_1`
-    - `Llama-2 <https://ai.meta.com/llama/>`__
-    - * Weight storage data type: int4
-      * Running data type: float16
-      * Symmetric quantization
-    - `link <https://huggingface.co/DavidSharma/mlc-chat-OpenOrca-Platypus2-13B-q4f16_1>`__
+Using Prebuilt Models for CLI
+-----------------------------
 
 To download and run one model with CLI, follow the instructions below:
 
@@ -678,10 +648,12 @@ To download and run one model with CLI, follow the instructions below:
   # mlc_chat_cli --model rwkv-raven-7b-q8f16_0
 
 
-.. _prebuilt-models-ios:
+.. _using-prebuilt-models-ios:
 
-Prebuilt Models for iOS
------------------------
+Using Prebuilt Models for iOS
+-----------------------------
+
+For more, please see :doc:`the iOS page </deploy/ios>`.
 
 .. list-table:: Prebuilt models for iOS
   :widths: 15 15 15 15
@@ -784,8 +756,10 @@ For example, if you compile `OpenLLaMA-7B <https://github.com/openlm-research/op
 
 .. _prebuilt-models-android:
 
-Prebuilt Models for Android
----------------------------
+Using Prebuilt Models for Android
+---------------------------------
+
+For more, please see :doc:`the Android page </deploy/android>`.
 
 .. list-table:: Prebuilt models for Android
   :widths: 15 15 15 15
@@ -809,8 +783,6 @@ Prebuilt Models for Android
     - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
 
 ------------------
-
-You can check `MLC-LLM pull requests <https://github.com/mlc-ai/mlc-llm/pulls?q=is%3Aopen+is%3Apr+label%3Anew-models>`__ to track the ongoing efforts of new models. We encourage users to upload their compiled models to Hugging Face and share with the community.
 
 
 .. _contribute-models-to-mlc-llm:

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -15,6 +15,79 @@ With the goal of democratizing the deployment of LLMs, we eagerly anticipate fur
 This page contains the list of prebuilt models for our CLI (command line interface) app, iOS and Android apps.
 The models have undergone extensive testing on various devices, and their performance has been optimized by developers with the help of TVM.
 
+.. _supported-model-architectures:
+
+Supported Model Architectures
+-----------------------------
+
+MLC-LLM supports the following model architectures:
+
+.. list-table:: Supported Model Architectures
+  :widths: 10 10 10 15 15
+  :header-rows: 1
+
+  * - Category Code
+    - Series
+    - Model Definition
+    - Variants w/ MLC prebuilts
+    - Variants w/o MLC prebuilts
+  * - ``llama``
+    - `LLaMa <https://github.com/facebookresearch/llama>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/llama.py>`__
+    - * `Llama-2 <https://ai.meta.com/llama/>`__
+      * CodeLlama
+      * `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
+      * `WizardLM <https://github.com/nlpxucan/WizardLM>`__
+      * `WizardMath <https://github.com/nlpxucan/WizardLM/tree/main/WizardMath>`__
+      * `FlagAlpha Llama-2 Chinese <https://github.com/FlagAlpha/Llama2-Chinese>`__
+      * Llama2 uncensored (georgesung)
+    - * `Alpaca <https://github.com/tatsu-lab/stanford_alpaca>`__
+      * `Guanaco <https://github.com/artidoro/qlora>`__
+      * `OpenLLaMA <https://github.com/openlm-research/open_llama>`__
+      * `Gorilla <https://huggingface.co/gorilla-llm/gorilla-7b-hf-delta-v0>`__
+      * `YuLan-Chat <https://github.com/RUC-GSAI/YuLan-Chat>`__
+      * WizardCoder (new version)
+  * - ``gpt-neox``
+    - `GPT-NeoX <https://github.com/EleutherAI/gpt-neox>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_neox.py>`__
+    - * `RedPajama <https://www.together.xyz/blog/redpajama>`__
+    - * `Dolly <https://github.com/databrickslabs/dolly>`__
+      * `Pythia <https://huggingface.co/EleutherAI/pythia-1.4b>`__
+      * `StableCode <https://huggingface.co/stabilityai/stablecode-instruct-alpha-3b>`__
+  * - ``gptj``
+    - `GPT-J <https://huggingface.co/EleutherAI/gpt-j-6b>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gptj.py>`__
+    - 
+    - * `MOSS <https://github.com/OpenLMLab/MOSS>`__
+  * - ``rwkv``
+    - `RWKV <https://github.com/BlinkDL/RWKV-LM>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/rwkv.py>`__
+    - * `RWKV-raven <https://github.com/BlinkDL/RWKV-LM>`__
+    - 
+  * - ``minigpt``
+    - `MiniGPT <https://huggingface.co/Vision-CAIR/MiniGPT-4>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/minigpt.py>`__
+    - 
+    - 
+  * - ``gpt_bigcode``
+    - `GPTBigCode <https://huggingface.co/docs/transformers/model_doc/gpt_bigcode>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_bigcode.py>`__
+    - * WizardCoder (old version)
+    - * `StarCoder <https://huggingface.co/bigcode/starcoder>`__
+      * `SantaCoder <https://huggingface.co/bigcode/gpt_bigcode-santacoder>`__
+  * - ``chatglm``
+    - `ChatGLM <https://github.com/THUDM/ChatGLM-6B/blob/main/README_en.md>`__
+    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/chatglm.py>`__
+    - 
+    - * `ChatGLM2 <https://huggingface.co/THUDM/chatglm2-6b>`__
+      * `CodeGeeX2 <https://huggingface.co/THUDM/codegeex2-6b>`__
+
+
+For models structured in these model architectures, you can check the :doc:`model compilation page </compilation/compile_models>` on how to compile models.
+Please `create a new issue <https://github.com/mlc-ai/mlc-llm/issues/new/choose>`_ if you want to request a new model architecture.
+Our tutorial :doc:`Define New Models </tutorials/customize/define_new_models>` introduces how to bring a new model architecture to MLC-LLM.
+
+
 .. _prebuilt-models-cli:
 
 Prebuilt Models for CLI
@@ -267,69 +340,6 @@ Prebuilt Models for Android
 
 You can check `MLC-LLM pull requests <https://github.com/mlc-ai/mlc-llm/pulls?q=is%3Aopen+is%3Apr+label%3Anew-models>`__ to track the ongoing efforts of new models. We encourage users to upload their compiled models to Hugging Face and share with the community.
 
-.. _supported-model-architectures:
-
-Supported Model Architectures
------------------------------
-
-MLC-LLM supports the following model architectures:
-
-.. list-table:: Supported Model Architectures
-  :widths: 15 15 15 15
-  :header-rows: 1
-
-  * - Category Code
-    - Series
-    - Model Definition
-    - Variants
-  * - ``llama``
-    - `LLaMa <https://github.com/facebookresearch/llama>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/llama.py>`__
-    - * `Llama-2 <https://ai.meta.com/llama/>`__
-      * `Alpaca <https://github.com/tatsu-lab/stanford_alpaca>`__
-      * `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
-      * `Guanaco <https://github.com/artidoro/qlora>`__
-      * `OpenLLaMA <https://github.com/openlm-research/open_llama>`__
-      * `Gorilla <https://huggingface.co/gorilla-llm/gorilla-7b-hf-delta-v0>`__
-      * `WizardLM <https://github.com/nlpxucan/WizardLM>`__
-      * `YuLan-Chat <https://github.com/RUC-GSAI/YuLan-Chat>`__
-      * `WizardMath <https://github.com/nlpxucan/WizardLM/tree/main/WizardMath>`__
-      * `FlagAlpha Llama-2 Chinese <https://github.com/FlagAlpha/Llama2-Chinese>`__
-  * - ``gpt-neox``
-    - `GPT-NeoX <https://github.com/EleutherAI/gpt-neox>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_neox.py>`__
-    - * `RedPajama <https://www.together.xyz/blog/redpajama>`__
-      * `Dolly <https://github.com/databrickslabs/dolly>`__
-      * `Pythia <https://huggingface.co/EleutherAI/pythia-1.4b>`__
-      * `StableCode <https://huggingface.co/stabilityai/stablecode-instruct-alpha-3b>`__
-  * - ``gptj``
-    - `GPT-J <https://huggingface.co/EleutherAI/gpt-j-6b>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gptj.py>`__
-    - * `MOSS <https://github.com/OpenLMLab/MOSS>`__
-  * - ``rwkv``
-    - `RWKV <https://github.com/BlinkDL/RWKV-LM>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/rwkv.py>`__
-    - * `RWKV-raven <https://github.com/BlinkDL/RWKV-LM>`__
-  * - ``minigpt``
-    - `MiniGPT <https://huggingface.co/Vision-CAIR/MiniGPT-4>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/minigpt.py>`__
-    -
-  * - ``gpt_bigcode``
-    - `GPTBigCode <https://huggingface.co/docs/transformers/model_doc/gpt_bigcode>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_bigcode.py>`__
-    - * `StarCoder <https://huggingface.co/bigcode/starcoder>`__
-      * `WizardCoder <https://huggingface.co/WizardLM/WizardCoder-15B-V1.0>`__
-      * `SantaCoder <https://huggingface.co/bigcode/gpt_bigcode-santacoder>`__
-  * - ``chatglm``
-    - `ChatGLM <https://github.com/THUDM/ChatGLM-6B/blob/main/README_en.md>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/chatglm.py>`__
-    - * `ChatGLM2 <https://huggingface.co/THUDM/chatglm2-6b>`__
-      * `CodeGeeX2 <https://huggingface.co/THUDM/codegeex2-6b>`__
-
-
-For models structured in these model architectures, you can check the :doc:`model compilation page </compilation/compile_models>` on how to compile models.
-Please `create a new issue <https://github.com/mlc-ai/mlc-llm/issues/new/choose>`_ if you want to request a new model architecture.
-Our tutorial :doc:`Define New Models </tutorials/customize/define_new_models>` introduces how to bring a new model architecture to MLC-LLM.
 
 .. _contribute-models-to-mlc-llm:
 

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -365,26 +365,86 @@ Model Variant Tables
     - Hugging Face Repo Link
   * - 7B
     - * `q3f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1>`__
-
       * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1>`__
-
       * `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f32_1>`__
 
   * - 13B
     - * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f16_1>`__
-
       * `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f32_1>`__
 
   * - 70B
-    - * `q3f16 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q3f16_1>`__
-
+    - * `q3f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q3f16_1>`__
       * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q4f16_1>`__
+
+.. _code_llama_variant_table:
+
+`Code Llama <https://about.fb.com/news/2023/08/code-llama-ai-for-coding/>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: Code Llama
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 7B
+    - * `q4f16_1 (Base) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-7b-hf-q4f16_1>`__
+      * `q4f16_1 (Instruct) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-7b-Instruct-hf-q4f16_1>`__
+      * `q4f16_1 (Python) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-7b-Python-hf-q4f16_1>`__
+
+  * - 13B
+    - * `q4f16_1 (Base) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-13b-hf-q4f16_1>`__
+      * `q4f16_1 (Instruct) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-13b-Instruct-hf-q4f16_1>`__
+      * `q4f16_1 (Python) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-13b-Python-hf-q4f16_1>`__
+
+  * - 34B
+    - * `q4f16_1 (Base) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-34b-hf-q4f16_1>`__
+      * `q4f16_1 (Instruct) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-34b-Instruct-hf-q4f16_1>`__
+      * `q4f16_1 (Python) <https://huggingface.co/mlc-ai/mlc-chat-CodeLlama-34b-Python-hf-q4f16_1>`__
+
+
+.. _vicuna_variant_table:
+
+`Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: Vicuna
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 7B
+    - * `q3f16_0 <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
+      * `q4f32_0 <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q4f32_0>`__
+      * `int3 (demo) <https://huggingface.co/mlc-ai/demo-vicuna-v1-7b-int3>`__
+      * `int4 (demo) <https://huggingface.co/mlc-ai/demo-vicuna-v1-7b-int4>`__
+
+
+.. _WizardLM_variant_table:
+
+`WizardLM <https://github.com/nlpxucan/WizardLM>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: WizardLM
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 13B
+    - * `q4f16_1 (V1.2) <https://huggingface.co/mlc-ai/mlc-chat-WizardLM-13B-V1.2-q4f16_1>`__
+      * `q4f32_1 (V1.2) <https://huggingface.co/mlc-ai/mlc-chat-WizardLM-13B-V1.2-q4f32_1>`__
+
+  * - 70B
+    - * `q3f16_1 (V1.0) <https://huggingface.co/mlc-ai/mlc-chat-WizardLM-70B-V1.0-q3f16_1>`__
+      * `q4f16_1 (V1.0) <https://huggingface.co/mlc-ai/mlc-chat-WizardLM-70B-V1.0-q4f16_1>`__
 
 
 .. _wizard_math_variant_table:
 
 `WizardMath <https://github.com/nlpxucan/WizardLM/tree/main/WizardMath>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: WizardMath
   :widths: 30 30
@@ -404,7 +464,7 @@ Model Variant Tables
 .. _open_orca_variant_table:
 
 `OpenOrca Platypus2 <https://huggingface.co/Open-Orca/OpenOrca-Platypus2-13B>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: OpenOrca Platypus2
   :widths: 30 30
@@ -419,7 +479,7 @@ Model Variant Tables
 .. _flag_alpha_llama2_variant_table:
 
 `FlagAlpha Llama-2 Chinese <https://github.com/FlagAlpha/Llama2-Chinese>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: FlagAlpha Llama-2 Chinese
   :widths: 30 30
@@ -435,7 +495,7 @@ Model Variant Tables
 .. _llama2_uncensored_variant_table:
 
 `Llama2 uncensored (georgesung) <https://huggingface.co/georgesung/llama2_7b_chat_uncensored>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: Llama2 uncensored
   :widths: 30 30
@@ -450,7 +510,7 @@ Model Variant Tables
 .. _red_pajama_variant_table:
 
 `RedPajama <https://www.together.xyz/blog/redpajama>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table:: RWKV-raven
   :widths: 30 30
@@ -459,10 +519,10 @@ Model Variant Tables
   * - Size
     - Hugging Face Repo Link
   * - 3B
-    - * `Instruct q4f16_0 <https://huggingface.co/mlc-ai/RedPajama-INCITE-Instruct-3B-v1-q4f16_0>`__
-      * `Chat q4f16_0 <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
-      * `Chat q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
-      * `Chat q4f32_0 <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_0>`__
+    - * `q4f16_0 (Instruct) <https://huggingface.co/mlc-ai/RedPajama-INCITE-Instruct-3B-v1-q4f16_0>`__
+      * `q4f16_0 (Chat) <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
+      * `q4f16_1 (Chat) <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
+      * `q4f32_0 (Chat) <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_0>`__
 
 
 .. _rwkv_raven_variant_table:
@@ -499,8 +559,6 @@ Model Variant Tables
     - Hugging Face Repo Link
   * - 15B
     - `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-WizardCoder-15B-V1.0-q4f16_1>`__
-
-
 
 .. _prebuilt-models-cli:
 

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -23,17 +23,19 @@ Supported Model Architectures
 MLC-LLM supports the following model architectures:
 
 .. list-table:: Supported Model Architectures
-  :widths: 10 10 10 15 15
+  :widths: 10 10 15 15
   :header-rows: 1
 
-  * - Category Code
-    - Series
-    - Model Definition
+  * - Code
+    - Architecture
     - Variants w/ MLC prebuilts
     - Variants w/o MLC prebuilts
   * - ``llama``
-    - `LLaMa <https://github.com/facebookresearch/llama>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/llama.py>`__
+    - LLaMa
+
+      * :ref:`Prebuilt library table <llama_library_table>`
+      * `Official link <https://github.com/facebookresearch/llama>`__
+      * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/llama.py>`__
     - * `Llama-2 <https://ai.meta.com/llama/>`__
       * CodeLlama
       * `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
@@ -48,36 +50,54 @@ MLC-LLM supports the following model architectures:
       * `YuLan-Chat <https://github.com/RUC-GSAI/YuLan-Chat>`__
       * WizardCoder (new version)
   * - ``gpt-neox``
-    - `GPT-NeoX <https://github.com/EleutherAI/gpt-neox>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_neox.py>`__
+    - GPT-NeoX 
+
+      * :ref:`Prebuilt library table <gpt_neox_library_table>`
+      * `Official link <https://github.com/EleutherAI/gpt-neox>`__
+      * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_neox.py>`__
     - * `RedPajama <https://www.together.xyz/blog/redpajama>`__
     - * `Dolly <https://github.com/databrickslabs/dolly>`__
       * `Pythia <https://huggingface.co/EleutherAI/pythia-1.4b>`__
       * `StableCode <https://huggingface.co/stabilityai/stablecode-instruct-alpha-3b>`__
   * - ``gptj``
-    - `GPT-J <https://huggingface.co/EleutherAI/gpt-j-6b>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gptj.py>`__
+    - GPT-J
+
+      * Prebuilt not compiled yet
+      * `Official link <https://huggingface.co/EleutherAI/gpt-j-6b>`__
+      * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gptj.py>`__
     - 
     - * `MOSS <https://github.com/OpenLMLab/MOSS>`__
   * - ``rwkv``
-    - `RWKV <https://github.com/BlinkDL/RWKV-LM>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/rwkv.py>`__
+    - RWKV 
+
+      * :ref:`Prebuilt library table <rwkv_library_table>`
+      * `Official link <https://github.com/BlinkDL/RWKV-LM>`__
+      * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/rwkv.py>`__
     - * `RWKV-raven <https://github.com/BlinkDL/RWKV-LM>`__
     - 
   * - ``minigpt``
-    - `MiniGPT <https://huggingface.co/Vision-CAIR/MiniGPT-4>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/minigpt.py>`__
+    - MiniGPT
+
+      * Prebuilt not compiled yet
+      * `Official link <https://huggingface.co/Vision-CAIR/MiniGPT-4>`__
+      * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/minigpt.py>`__
     - 
     - 
   * - ``gpt_bigcode``
-    - `GPTBigCode <https://huggingface.co/docs/transformers/model_doc/gpt_bigcode>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_bigcode.py>`__
+    - GPTBigCode
+
+      * :ref:`Prebuilt library table <gpt_big_code_library_table>`
+      * `Official link <https://huggingface.co/docs/transformers/model_doc/gpt_bigcode>`__
+      * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_bigcode.py>`__
     - * WizardCoder (old version)
     - * `StarCoder <https://huggingface.co/bigcode/starcoder>`__
       * `SantaCoder <https://huggingface.co/bigcode/gpt_bigcode-santacoder>`__
   * - ``chatglm``
-    - `ChatGLM <https://github.com/THUDM/ChatGLM-6B/blob/main/README_en.md>`__
-    - `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/chatglm.py>`__
+    - ChatGLM
+
+      * Prebuilt not compiled yet
+      * `Official link <https://github.com/THUDM/ChatGLM-6B/blob/main/README_en.md>`__
+      * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/chatglm.py>`__
     - 
     - * `ChatGLM2 <https://huggingface.co/THUDM/chatglm2-6b>`__
       * `CodeGeeX2 <https://huggingface.co/THUDM/codegeex2-6b>`__
@@ -91,6 +111,8 @@ Our tutorial :doc:`Define New Models </tutorials/customize/define_new_models>` i
 
 Model Library Tables
 --------------------
+
+.. _llama_library_table:
 
 Llama
 ^^^^^
@@ -164,6 +186,7 @@ Llama
     - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm>`__
     - 
 
+.. _gpt_neox_library_table:
   
 GPT-NeoX (RedPajama-INCITE)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,6 +240,7 @@ GPT-NeoX (RedPajama-INCITE)
       `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f32_1-webgpu.wasm>`__
     - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-mali.so>`__
 
+.. _rwkv_library_table:
 
 RWKV
 ^^^^
@@ -273,6 +297,8 @@ RWKV
     -
     -
     -
+
+.. _gpt_big_code_library_table:
 
 GPTBigCode
 ^^^^^^^^^^

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -364,22 +364,141 @@ Model Variant Tables
   * - Size
     - Hugging Face Repo Link
   * - 7B
-    - `q3f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1>`__
+    - * `q3f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1>`__
 
-      `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1>`__
+      * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1>`__
 
-      `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f32_1>`__
+      * `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f32_1>`__
 
   * - 13B
-    - `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f16_1>`__
+    - * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f16_1>`__
 
-      `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f32_1>`__
-
+      * `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f32_1>`__
 
   * - 70B
-    - `q3f16 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q3f16_1>`__
+    - * `q3f16 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q3f16_1>`__
 
-      `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q4f16_1>`__
+      * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q4f16_1>`__
+
+
+.. _wizard_math_variant_table:
+
+`WizardMath <https://github.com/nlpxucan/WizardLM/tree/main/WizardMath>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: WizardMath
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 7B
+    - * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-WizardMath-7B-V1.0-q4f16_1>`__
+      * `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-WizardMath-7B-V1.0-q4f32_1>`__
+  * - 13B
+    - `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-WizardMath-13B-V1.0-q4f16_1>`__
+  * - 70B
+    - `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-WizardMath-70B-V1.0-q4f16_1>`__
+
+
+.. _open_orca_variant_table:
+
+`OpenOrca Platypus2 <https://huggingface.co/Open-Orca/OpenOrca-Platypus2-13B>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: OpenOrca Platypus2
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 13B
+    - `q4f16_1 <https://huggingface.co/DavidSharma/mlc-chat-OpenOrca-Platypus2-13B-q4f16_1>`__
+
+
+.. _flag_alpha_llama2_variant_table:
+
+`FlagAlpha Llama-2 Chinese <https://github.com/FlagAlpha/Llama2-Chinese>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: FlagAlpha Llama-2 Chinese
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 7B
+    - * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-FlagAlpha-Llama2-Chinese-7b-Chat-q4f16_1>`__
+      * `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-FlagAlpha-Llama2-Chinese-7b-Chat-q4f32_1>`__
+
+
+.. _llama2_uncensored_variant_table:
+
+`Llama2 uncensored (georgesung) <https://huggingface.co/georgesung/llama2_7b_chat_uncensored>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: Llama2 uncensored
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 7B
+    - * `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-georgesung-llama2-7b-chat-uncensored-q4f16_1>`__
+      * `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-georgesung-llama2-7b-chat-uncensored-q4f32_1>`__
+
+.. _red_pajama_variant_table:
+
+`RedPajama <https://www.together.xyz/blog/redpajama>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: RWKV-raven
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 3B
+    - * `Instruct q4f16_0 <https://huggingface.co/mlc-ai/RedPajama-INCITE-Instruct-3B-v1-q4f16_0>`__
+      * `Chat q4f16_0 <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0>`__
+      * `Chat q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
+      * `Chat q4f32_0 <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_0>`__
+
+
+.. _rwkv_raven_variant_table:
+
+`RWKV-raven <https://github.com/BlinkDL/RWKV-LM>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: RWKV-raven
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 1B5
+    - `q8f16_0 <https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-1b5-q8f16_0>`__
+
+  * - 3B
+    - `q8f16_0 <https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-3b-q8f16_0>`__
+
+  * - 7B
+    - `q8f16_0 <https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-7b-q8f16_0>`__
+
+
+.. _wizard_coder_variant_table:
+
+`WizardCoder <https://github.com/nlpxucan/WizardLM>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: WizardCoder
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 15B
+    - `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-WizardCoder-15B-V1.0-q4f16_1>`__
 
 
 

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -41,6 +41,7 @@ MLC-LLM supports the following model architectures:
       * `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
       * `WizardLM <https://github.com/nlpxucan/WizardLM>`__
       * `WizardMath <https://github.com/nlpxucan/WizardLM/tree/main/WizardMath>`__
+      * OpenOrca Platypus2
       * `FlagAlpha Llama-2 Chinese <https://github.com/FlagAlpha/Llama2-Chinese>`__
       * Llama2 uncensored (georgesung)
     - * `Alpaca <https://github.com/tatsu-lab/stanford_alpaca>`__
@@ -347,6 +348,40 @@ However, any GPTBigCode model variants should be able to reuse these (e.g. StarC
       `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f32_1-webgpu.wasm>`__
     - 
   
+
+Model Variant Tables
+--------------------
+
+.. _llama2_variant_table:
+
+`Llama-2 <https://ai.meta.com/llama/>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table:: Llama-2
+  :widths: 30 30
+  :header-rows: 1
+
+  * - Size
+    - Hugging Face Repo Link
+  * - 7B
+    - `q3f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1>`__
+
+      `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1>`__
+
+      `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f32_1>`__
+
+  * - 13B
+    - `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f16_1>`__
+
+      `q4f32_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-13b-chat-hf-q4f32_1>`__
+
+
+  * - 70B
+    - `q3f16 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q3f16_1>`__
+
+      `q4f16_1 <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-70b-chat-hf-q4f16_1>`__
+
+
 
 .. _prebuilt-models-cli:
 

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -274,7 +274,53 @@ RWKV
     -
     -
 
+GPTBigCode
+^^^^^^^^^^
+Note that these all links to model libraries for WizardCoder (the older version released in Jun. 2023). 
+However, any GPTBigCode model variants should be able to reuse these (e.g. StarCoder, SantaCoder).
 
+.. list-table:: GPTBigCode
+  :widths: 8 8 8 8 8 8 8 8 8 8
+  :header-rows: 1
+  :stub-columns: 1
+
+  * -
+    - CUDA
+    - ROCm
+    - Vulkan
+
+      (Linux)
+    - Vulkan
+
+      (Windows)
+    - Metal
+
+      (M1/M2)
+    - Metal
+
+      (Intel)
+    - iOS
+    - webgpu
+    - mali
+  * - 15B
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f16_1-cuda.so>`__
+
+      `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f32_1-cuda.so>`__
+    - 
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f16_1-vulkan.so>`__
+      
+      `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f32_1-vulkan.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f16_1-vulkan.dll>`__
+    
+      `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f32_1-vulkan.dll>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f16_1-metal.so>`__
+    - 
+    - 
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f16_1-webgpu.wasm>`__
+
+      `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/WizardCoder-15B-V1.0-q4f32_1-webgpu.wasm>`__
+    - 
+  
 
 .. _prebuilt-models-cli:
 

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -118,45 +118,51 @@ Llama
     - webgpu
     - mali
   * - 7B
-    - a
-    - A
-    - a
-    - a
-    - a
-    - A
-    - A
-    - a
-    - a
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-cuda.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-rocm.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-vulkan.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-vulkan.dll>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-metal.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-metal_x86_64.dylib>`__
+    - `q3f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q3f16_1-iphone.tar>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-webgpu.wasm>`__
+
+      `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-7b-chat-hf-q4f16_1-mali.so>`__
   * - 13B
-    - a
-    - A
-    - a
-    - a
-    - a
-    - A
-    - A
-    - a
-    - a
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-cuda.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-rocm.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-vulkan.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-vulkan.dll>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-metal.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-metal_x86_64.dylib>`__
+    - 
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-webgpu.wasm>`__
+    
+      `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f32_1-webgpu.wasm>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-13b-chat-hf-q4f16_1-mali.so>`__
   * - 34B
-    - a
-    - A
-    - a
-    - a
-    - a
-    - A
-    - A
-    - a
-    - a
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/CodeLlama-34b-hf-q4f16_1-cuda.so>`__
+    - 
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/CodeLlama-34b-hf-q4f16_1-vulkan.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/CodeLlama-34b-hf-q4f16_1-vulkan.dll>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/CodeLlama-34b-hf-q4f16_1-metal.so>`__
+    - 
+    - 
+    - 
+    - 
   * - 70B
-    - a
-    - A
-    - a
-    - a
-    - a
-    - A
-    - A
-    - a
-    - a
+    - 
+    - 
+    - 
+    - 
+    - `q3f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-70b-chat-hf-q3f16_1-metal.so>`__
+
+      `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-70b-chat-hf-q4f16_1-metal.so>`__
+    - 
+    - 
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm>`__
+    - 
 
   
 GPT-NeoX (RedPajama-INCITE)

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -114,7 +114,7 @@ Llama
     - Metal
 
       (Intel)
-    - iphone
+    - iOS
     - webgpu
     - mali
   * - 7B
@@ -157,6 +157,59 @@ Llama
     - A
     - a
     - a
+
+  
+GPT-NeoX (RedPajama-INCITE)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. list-table:: GPT-NeoX (RedPajama-INCITE)
+  :widths: 8 8 8 8 8 8 8 8 8 8
+  :header-rows: 1
+  :stub-columns: 1
+
+  * -
+    - CUDA
+    - ROCm
+    - Vulkan
+
+      (Linux)
+    - Vulkan
+
+      (Windows)
+    - Metal
+
+      (M1/M2)
+    - Metal
+
+      (Intel)
+    - iOS
+    - webgpu
+    - mali
+  * - 3B
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-cuda.so>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-rocm.so>`__
+    - `q4f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-vulkan.so>`__
+
+      `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-vulkan.so>`__
+    - `q4f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-vulkan.dll>`__
+
+      `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-vulkan.dll>`__
+    - `q4f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-metal.so>`__
+
+      `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-metal.so>`__
+    - `q4f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-metal_x86_64.dylib>`__
+
+      `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-metal_x86_64.dylib>`__
+    - `q4f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-iphone.tar>`__
+
+      `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-iphone.tar>`__
+    - `q4f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-webgpu-v1.wasm>`__
+
+      `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-webgpu.wasm>`__
+
+      `q4f32_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f32_0-webgpu-v1.wasm>`__
+
+      `q4f32_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f32_1-webgpu.wasm>`__
+    - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-mali.so>`__
 
 
 

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -88,6 +88,78 @@ Please `create a new issue <https://github.com/mlc-ai/mlc-llm/issues/new/choose>
 Our tutorial :doc:`Define New Models </tutorials/customize/define_new_models>` introduces how to bring a new model architecture to MLC-LLM.
 
 
+
+Model Library Tables
+--------------------
+
+Llama
+^^^^^
+.. list-table:: Llama
+  :widths: 8 8 8 8 8 8 8 8 8 8
+  :header-rows: 1
+  :stub-columns: 1
+
+  * -
+    - CUDA
+    - ROCm
+    - Vulkan
+
+      (Linux)
+    - Vulkan
+
+      (Windows)
+    - Metal
+
+      (M1/M2)
+    - Metal
+
+      (Intel)
+    - iphone
+    - webgpu
+    - mali
+  * - 7B
+    - a
+    - A
+    - a
+    - a
+    - a
+    - A
+    - A
+    - a
+    - a
+  * - 13B
+    - a
+    - A
+    - a
+    - a
+    - a
+    - A
+    - A
+    - a
+    - a
+  * - 34B
+    - a
+    - A
+    - a
+    - a
+    - a
+    - A
+    - A
+    - a
+    - a
+  * - 70B
+    - a
+    - A
+    - a
+    - a
+    - a
+    - A
+    - A
+    - a
+    - a
+
+
+
 .. _prebuilt-models-cli:
 
 Prebuilt Models for CLI

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -36,27 +36,27 @@ MLC-LLM supports the following model architectures:
       * :ref:`Prebuilt library table <llama_library_table>`
       * `Official link <https://github.com/facebookresearch/llama>`__
       * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/llama.py>`__
-    - * `Llama-2 <https://ai.meta.com/llama/>`__
-      * CodeLlama
-      * `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
-      * `WizardLM <https://github.com/nlpxucan/WizardLM>`__
-      * `WizardMath <https://github.com/nlpxucan/WizardLM/tree/main/WizardMath>`__
-      * OpenOrca Platypus2
-      * `FlagAlpha Llama-2 Chinese <https://github.com/FlagAlpha/Llama2-Chinese>`__
-      * Llama2 uncensored (georgesung)
+    - * :ref:`Llama-2 <llama2_variant_table>`
+      * :ref:`Code Llama <code_llama_variant_table>`
+      * :ref:`Vicuna <vicuna_variant_table>`
+      * :ref:`WizardLM <WizardLM_variant_table>` 
+      * :ref:`WizardMath <wizard_math_variant_table>`
+      * :ref:`OpenOrca Platypus2 <open_orca_variant_table>`
+      * :ref:`FlagAlpha Llama-2 Chinese <flag_alpha_llama2_variant_table>` 
+      * :ref:`georgesung Llama-2 Uncensored <llama2_uncensored_variant_table>`
     - * `Alpaca <https://github.com/tatsu-lab/stanford_alpaca>`__
       * `Guanaco <https://github.com/artidoro/qlora>`__
       * `OpenLLaMA <https://github.com/openlm-research/open_llama>`__
       * `Gorilla <https://huggingface.co/gorilla-llm/gorilla-7b-hf-delta-v0>`__
       * `YuLan-Chat <https://github.com/RUC-GSAI/YuLan-Chat>`__
-      * WizardCoder (new version)
+      * `WizardCoder (new) <https://github.com/nlpxucan/WizardLM/tree/main/WizardCoder>`__
   * - ``gpt-neox``
     - GPT-NeoX 
 
       * :ref:`Prebuilt library table <gpt_neox_library_table>`
       * `Official link <https://github.com/EleutherAI/gpt-neox>`__
       * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_neox.py>`__
-    - * `RedPajama <https://www.together.xyz/blog/redpajama>`__
+    - * :ref:`RedPajama <red_pajama_variant_table>` 
     - * `Dolly <https://github.com/databrickslabs/dolly>`__
       * `Pythia <https://huggingface.co/EleutherAI/pythia-1.4b>`__
       * `StableCode <https://huggingface.co/stabilityai/stablecode-instruct-alpha-3b>`__
@@ -74,7 +74,7 @@ MLC-LLM supports the following model architectures:
       * :ref:`Prebuilt library table <rwkv_library_table>`
       * `Official link <https://github.com/BlinkDL/RWKV-LM>`__
       * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/rwkv.py>`__
-    - * `RWKV-raven <https://github.com/BlinkDL/RWKV-LM>`__
+    - * :ref:`RWKV-raven <rwkv_raven_variant_table>` 
     - 
   * - ``minigpt``
     - MiniGPT
@@ -83,14 +83,14 @@ MLC-LLM supports the following model architectures:
       * `Official link <https://huggingface.co/Vision-CAIR/MiniGPT-4>`__
       * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/minigpt.py>`__
     - 
-    - 
+    - * `MiniGPT-4 <https://huggingface.co/Vision-CAIR/MiniGPT-4>`__
   * - ``gpt_bigcode``
     - GPTBigCode
 
       * :ref:`Prebuilt library table <gpt_big_code_library_table>`
       * `Official link <https://huggingface.co/docs/transformers/model_doc/gpt_bigcode>`__
       * `Relax Code <https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/gpt_bigcode.py>`__
-    - * WizardCoder (old version)
+    - * :ref:`WizardCoder (old) <wizard_coder_variant_table>` 
     - * `StarCoder <https://huggingface.co/bigcode/starcoder>`__
       * `SantaCoder <https://huggingface.co/bigcode/gpt_bigcode-santacoder>`__
   * - ``chatglm``
@@ -512,7 +512,7 @@ Model Variant Tables
 `RedPajama <https://www.together.xyz/blog/redpajama>`__
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. list-table:: RWKV-raven
+.. list-table:: Red Pajama
   :widths: 30 30
   :header-rows: 1
 

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -218,6 +218,63 @@ GPT-NeoX (RedPajama-INCITE)
     - `q4f16_1 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-mali.so>`__
 
 
+RWKV
+^^^^
+.. list-table:: RWKV
+  :widths: 8 8 8 8 8 8 8 8 8 8
+  :header-rows: 1
+  :stub-columns: 1
+
+  * -
+    - CUDA
+    - ROCm
+    - Vulkan
+
+      (Linux)
+    - Vulkan
+
+      (Windows)
+    - Metal
+
+      (M1/M2)
+    - Metal
+
+      (Intel)
+    - iOS
+    - webgpu
+    - mali
+  * - 1B5
+    -
+    -
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-1b5-q8f16_0-vulkan.so>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-1b5-q8f16_0-vulkan.dll>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-1b5-q8f16_0-metal.so>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-1b5-q8f16_0-metal_x86_64.dylib>`__
+    -
+    -
+    -
+  * - 3B
+    -
+    -
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-3b-q8f16_0-vulkan.so>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-3b-q8f16_0-vulkan.dll>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-3b-q8f16_0-metal.so>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-3b-q8f16_0-metal_x86_64.dylib>`__
+    -
+    -
+    -
+  * - 7B
+    -
+    -
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-7b-q8f16_0-vulkan.so>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-7b-q8f16_0-vulkan.dll>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-7b-q8f16_0-metal.so>`__
+    - `q8f16_0 <https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/rwkv-raven-7b-q8f16_0-metal_x86_64.dylib>`__
+    -
+    -
+    -
+
+
 
 .. _prebuilt-models-cli:
 


### PR DESCRIPTION
The current documentation for the prebuilt models is not the most intuitive to follow for new users, nor the easiest to update whenever there is a new model architecture or model variant.

As part of the effort to streamline the process of adding new models, we made the page for tracking prebuilt model libraries and weights more structured.

Co-author: @rickzx