### PR TITLE
Add pypi wheels for ROCm 5.7 and CUDA 12.2

### DIFF
--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -39,13 +39,6 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
               conda activate your-environment
               python3 -m pip install --pre --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly
 
-         .. tab:: CUDA 11.6
-
-            .. code-block:: bash
-
-              conda activate your-environment
-              python3 -m pip install --pre --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-cu116
-
          .. tab:: CUDA 11.7
 
             .. code-block:: bash
@@ -67,12 +60,26 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
               conda activate your-environment
               python3 -m pip install --pre --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-cu121
 
+         .. tab:: CUDA 12.2
+
+            .. code-block:: bash
+
+              conda activate your-environment
+              python3 -m pip install --pre --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-cu122
+
          .. tab:: ROCm 5.6
 
             .. code-block:: bash
 
               conda activate your-environment
-              python3 -m pip install --pre --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-rocm
+              python3 -m pip install --pre --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-rocm56
+
+         .. tab:: ROCm 5.7
+
+            .. code-block:: bash
+
+              conda activate your-environment
+              python3 -m pip install --pre --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-rocm57
 
          .. tab:: Vulkan
 


### PR DESCRIPTION
A few changes:
* CUDA 11.6 is deprecated
* Support for CUDA 12.2
* Support for ROCm 5.7; Existing ROCm 5.6 wheel is renamed from rocm to rocm56
* Support for Python 3.12