### PR TITLE
Clean up `num_key_value_heads` accessor

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -392,11 +392,7 @@ def mod_transform_before_build(
             max_seq_len = config.max_sequence_length
 
         if max_seq_len:
-            num_key_value_heads = (
-                config.num_key_value_heads is None
-                and config.num_attention_heads
-                or config.num_key_value_heads
-            )
+            num_key_value_heads = config.get_num_key_value_heads()
             mod = fuse_split_rotary_embedding(
                 mod,
                 config.num_attention_heads // args.num_shards,

--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -27,7 +27,7 @@ def create_shard_info_func(mod, param_manager, args, model_config):
     num_shards = args.num_shards
     head_dim = model_config.hidden_size // model_config.num_attention_heads
     q_heads = model_config.num_attention_heads
-    kv_heads = model_config.num_key_value_heads
+    kv_heads = model_config.get_num_key_value_heads()
 
     # pylint: disable=invalid-name
     def shard_qkv_weight_scale(weight: relax.TensorStructInfo):


### PR DESCRIPTION
I found myself repeatedly copy-pasting the cryptic code

```
num_key_value_heads = (
    config.num_key_value_heads is None
    and config.num_attention_heads
    or config.num_key_value_heads
) 
```

to get the kv head size correctly. Also hit a bug where `config.num_key_value_heads` is accessed directly but found to be None (vicuna). 

I added a helper function to `LlamaConfig` to avoid these troubles.

@junrushao @LeshengJin 