### PR TITLE
[Android] Use `AlertDialog` instead of `Toast`

### DIFF
--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/StartView.kt
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/StartView.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -94,9 +95,14 @@ fun StartView(
                 }
             }
             if (isAddingModel) {
-                Text(
-                    text = "Add Model Variant", modifier = Modifier.padding(top = 10.dp)
-                )
+                Text(text = "Supported Base Model Libs", modifier = Modifier.padding(top = 10.dp))
+                for (lib in appViewModel.supportedModelLibs()) {
+                    Text(
+                        text = lib,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                Text(text = "Add Model Variant", modifier = Modifier.padding(top = 10.dp))
                 LazyColumn() {
                     items(
                         items = appViewModel.modelSampleList
@@ -148,8 +154,34 @@ fun StartView(
                 }
             }
         }
-
+        if (appViewModel.isShowingAlert()) {
+            AlertDialog(
+                onDismissRequest = { appViewModel.dismissAlert() },
+                onConfirmation = { appViewModel.copyError() },
+                error = appViewModel.errorMessage()
+            )
+        }
     }
+}
+
+@ExperimentalMaterial3Api
+@Composable
+fun AlertDialog(
+    onDismissRequest: () -> Unit,
+    onConfirmation: () -> Unit,
+    error: String,
+) {
+    AlertDialog(
+        title = { Text(text = "Error") },
+        text = { Text(text = error) },
+        onDismissRequest = { onDismissRequest() },
+        confirmButton = {
+            TextButton(onClick = { onConfirmation() }) { Text("Copy") }
+        },
+        dismissButton = {
+            TextButton(onClick = { onDismissRequest() }) { Text("Dismiss") }
+        }
+    )
 }
 
 @Composable

--- a/android/prepare_libs.sh
+++ b/android/prepare_libs.sh
@@ -9,7 +9,10 @@ python prepare_model_lib.py
 
 cd build
 touch config.cmake
-echo "set(TVM_HOME ${TVM_HOME})" >> config.cmake
+if [ ${TVM_HOME-0} -ne 0 ]; then
+  echo "set(TVM_HOME ${TVM_HOME})" >> config.cmake
+fi
+
 cmake .. \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \


### PR DESCRIPTION
This PR changes the `Toast` to `AlertDialog` in Android error reporting, for better demonstration. In addition, in the dialog, we support `copy` button to copy the error message into clipboard directly.

cc: @spectrometerHBH @junrushao 