### PR TITLE
Add doc for ChatConfig, ConvConfig, GenerationConfig, BuildArgs

### DIFF
--- a/docs/community/guideline.rst
+++ b/docs/community/guideline.rst
@@ -55,7 +55,7 @@ Contribute New Models to MLC-LLM
 
 * If you have compiled a model using our :doc:`/compilation/compile_models` tutorial for an existing model architecture, please upload your models to the internet (e.g., Hugging Face) by following :ref:`distribute-compiled-models` tutorial. Once you have done that, you can create a pull request to add an entry in the :doc:`/prebuilt_models` page. Additionally, you have the option to `create a speed report issue <https://github.com/mlc-ai/mlc-llm/issues/new?assignees=&labels=Work+Item&projects=&template=speed-report.md&title=>`__ to track the speed and memory consumption of your model. You don't need to test it on all devices; let the community collaborate on building it together!
 
-* If you add a new model variant to MLC-LLM by following our :doc:`/tutorials/bring-your-own-models` tutorial.
+* If you add a new model variant to MLC-LLM by following our :doc:`/tutorials/customize/define_new_models` tutorial.
   Please create a pull request to add your model architecture (currently model architectures are placed under
   `relax_models <https://github.com/mlc-ai/mlc-llm/tree/main/mlc_llm/relax_model>`__ folder).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,8 @@ import tlcpack_sphinx_addon
 # -- General configuration ------------------------------------------------
 
 sys.path.insert(0, os.path.abspath("../python"))
+sys.path.insert(0, os.path.abspath("../"))
+autodoc_mock_imports = ["torch"]
 # do not load mlc-llm.so in docs
 os.environ["SKIP_LOADING_MLCLLM_SO"] = "1"
 
@@ -29,9 +31,7 @@ extensions = [
     "sphinx_reredirects",
 ]
 
-redirects = {
-     "get_started/try_out": "../index.html#getting-started"
-}
+redirects = {"get_started/try_out": "../index.html#getting-started"}
 
 source_suffix = [".rst"]
 

--- a/docs/deploy/python.rst
+++ b/docs/deploy/python.rst
@@ -314,6 +314,15 @@ The :class:`mlc_chat.ChatModule` class provides the following methods:
 
    .. automethod:: __init__
 
+.. autoclass:: ChatConfig
+   :members:
+
+.. autoclass:: ConvConfig
+   :members:
+
+.. autoclass:: GenerationConfig
+   :members:
+
 Gradio Frontend
 ---------------
 


### PR DESCRIPTION
For `ChatModule` python API, linked in-code comments to documentation for `ChatConfig`, `ConvConfig`, and `GenerationConfig` at https://llm.mlc.ai/docs/compilation/python.html#api-reference.

For model compilation python API, fixed previous issue where sphinx cannot import `mlc-llm`. Now `BuildArgs` and `build_model()` documentation should show up on https://llm.mlc.ai/docs/compilation/python.html#api-reference.