### PR TITLE
[Serving] Basic data structure set up

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -1,0 +1,121 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/config.cc
+ */
+#define PICOJSON_USE_INT64
+
+#include "config.h"
+
+#include <picojson.h>
+
+#include "data.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/****************** GenerationConfig ******************/
+
+TVM_REGISTER_OBJECT_TYPE(GenerationConfigNode);
+
+GenerationConfig::GenerationConfig(String config_json_str) {
+  picojson::value config_json;
+  std::string err = picojson::parse(config_json, config_json_str);
+  if (!err.empty()) {
+    LOG(FATAL) << err;
+    return;
+  }
+
+  ObjectPtr<GenerationConfigNode> n = make_object<GenerationConfigNode>();
+
+  picojson::object config = config_json.get<picojson::object>();
+  if (config.count("temperature")) {
+    CHECK(config["temperature"].is<double>());
+    n->temperature = config["temperature"].get<double>();
+  }
+  if (config.count("top_p")) {
+    CHECK(config["top_p"].is<double>());
+    n->top_p = config["top_p"].get<double>();
+  }
+  if (config.count("repetition_penalty")) {
+    CHECK(config["repetition_penalty"].is<double>());
+    n->repetition_penalty = config["repetition_penalty"].get<double>();
+    CHECK(n->repetition_penalty > 0) << "Repetition penalty must be a positive number!";
+  }
+  if (config.count("max_new_tokens")) {
+    CHECK(config["max_new_tokens"].is<int64_t>());
+    n->max_new_tokens = config["max_new_tokens"].get<int64_t>();
+  }
+  if (config.count("stop_strs")) {
+    CHECK(config["stop_strs"].is<picojson::array>())
+        << "Invalid stop_strs. Stop strs should be an array of strings";
+    picojson::array stop_strs_arr = config["stop_strs"].get<picojson::array>();
+    Array<String> stop_strs;
+    stop_strs.reserve(stop_strs_arr.size());
+    for (const picojson::value& v : stop_strs_arr) {
+      CHECK(v.is<std::string>()) << "Invalid stop string in stop_strs";
+      stop_strs.push_back(v.get<std::string>());
+    }
+    n->stop_strs = std::move(stop_strs);
+  }
+
+  data_ = std::move(n);
+}
+
+/****************** KVCacheConfig ******************/
+
+TVM_REGISTER_OBJECT_TYPE(KVCacheConfigNode);
+
+KVCacheConfig::KVCacheConfig(int page_size, int max_num_sequence, int max_total_sequence_length) {
+  ObjectPtr<KVCacheConfigNode> n = make_object<KVCacheConfigNode>();
+  n->page_size = page_size;
+  n->max_num_sequence = max_num_sequence;
+  n->max_total_sequence_length = max_total_sequence_length;
+  data_ = std::move(n);
+}
+
+KVCacheConfig::KVCacheConfig(const std::string& config_str, int max_single_sequence_length) {
+  int page_size;
+  int max_total_sequence_length;
+  int max_num_sequence = -1;
+
+  picojson::value config_json;
+  std::string err = picojson::parse(config_json, config_str);
+  if (!err.empty()) {
+    LOG(FATAL) << err;
+  }
+
+  // Get json fields.
+  picojson::object config = config_json.get<picojson::object>();
+  if (config.count("page_size")) {
+    CHECK(config["page_size"].is<int64_t>());
+    page_size = config["page_size"].get<int64_t>();
+    CHECK_GE(page_size, 16) << "KV cache page size smaller than 16 is not supported.";
+  } else {
+    LOG(FATAL) << "Key \"page_size\" not found.";
+  }
+  if (config.count("max_total_sequence_length")) {
+    CHECK(config["max_total_sequence_length"].is<int64_t>());
+    max_total_sequence_length = config["max_total_sequence_length"].get<int64_t>();
+  } else {
+    LOG(FATAL) << "Key \"max_total_sequence_length\" not found.";
+  }
+  if (config.count("max_num_sequence")) {
+    CHECK(config["max_num_sequence"].is<int64_t>());
+    max_num_sequence = config["max_num_sequence"].get<int64_t>();
+  }
+
+  if (max_num_sequence == -1) {
+    max_num_sequence = max_total_sequence_length / max_single_sequence_length;
+  }
+
+  ObjectPtr<KVCacheConfigNode> n = make_object<KVCacheConfigNode>();
+  n->page_size = page_size;
+  n->max_num_sequence = max_num_sequence;
+  n->max_total_sequence_length = max_total_sequence_length;
+  data_ = std::move(n);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -1,0 +1,71 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/config.h
+ */
+#ifndef MLC_LLM_SERVE_CONFIG_H_
+#define MLC_LLM_SERVE_CONFIG_H_
+
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/object.h>
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/****************** GenerationConfig ******************/
+
+/*! \brief The sampling configuration of a request. */
+class GenerationConfigNode : public Object {
+ public:
+  double temperature = 0.8;
+  double top_p = 0.95;
+  double repetition_penalty = 1.0;
+
+  int max_new_tokens = 128;
+  Array<String> stop_strs;
+
+  static constexpr const char* _type_key = "mlc.serve.GenerationConfig";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(GenerationConfigNode, Object);
+};
+
+class GenerationConfig : public ObjectRef {
+ public:
+  explicit GenerationConfig(String config_json_str);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(GenerationConfig, ObjectRef, GenerationConfigNode);
+};
+
+/****************** KV Cache config ******************/
+
+/*! \brief The sampling configuration of a request. */
+class KVCacheConfigNode : public Object {
+ public:
+  int page_size;
+  int max_num_sequence;
+  int max_total_sequence_length;
+
+  static constexpr const char* _type_key = "mlc.serve.KVCacheConfig";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(KVCacheConfigNode, Object);
+};
+
+class KVCacheConfig : public ObjectRef {
+ public:
+  explicit KVCacheConfig(int page_size, int max_num_sequence, int max_total_sequence_length);
+
+  explicit KVCacheConfig(const std::string& config_str, int max_single_sequence_length);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(KVCacheConfig, ObjectRef, KVCacheConfigNode);
+};
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_CONFIG_H_

--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -1,0 +1,37 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/data.cc
+ */
+#include "data.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+TVM_REGISTER_OBJECT_TYPE(DataNode);
+
+TVM_REGISTER_OBJECT_TYPE(TextDataNode);
+
+TextData::TextData(String text) {
+  ObjectPtr<TextDataNode> n = make_object<TextDataNode>();
+  n->text = std::move(text);
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_OBJECT_TYPE(TokenDataNode);
+
+TokenData::TokenData(ShapeTuple token_ids) {
+  ObjectPtr<TokenDataNode> n = make_object<TokenDataNode>();
+  n->token_ids = std::move(token_ids);
+  data_ = std::move(n);
+}
+
+TokenData::TokenData(std::vector<int32_t> token_ids) {
+  ObjectPtr<TokenDataNode> n = make_object<TokenDataNode>();
+  n->token_ids = ShapeTuple(token_ids.begin(), token_ids.end());
+  data_ = std::move(n);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/data.h
+++ b/cpp/serve/data.h
@@ -1,0 +1,78 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/data.h
+ */
+#ifndef MLC_LLM_SERVE_DATA_H_
+#define MLC_LLM_SERVE_DATA_H_
+
+#include <tvm/runtime/container/shape_tuple.h>
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/object.h>
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/****************** DataNode ******************/
+
+/*! \brief The base class of multi-modality data (text, tokens, embedding, etc). */
+class DataNode : public Object {
+ public:
+  static constexpr const char* _type_key = "mlc.serve.Data";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(DataNode, Object);
+};
+
+class Data : public ObjectRef {
+ public:
+  TVM_DEFINE_OBJECT_REF_METHODS(Data, ObjectRef, DataNode);
+};
+
+/****************** TextDataNode ******************/
+
+/*! \brief The class of text data, containing a text string. */
+class TextDataNode : public DataNode {
+ public:
+  /*! \brief The text string. */
+  String text;
+
+  static constexpr const char* _type_key = "mlc.serve.TextData";
+  TVM_DECLARE_BASE_OBJECT_INFO(TextDataNode, DataNode);
+};
+
+class TextData : public Data {
+ public:
+  explicit TextData(String text);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(TextData, Data, TextDataNode);
+};
+
+/****************** TokenDataNode ******************/
+
+/*! \brief The class of token data, containing a list of token ids. */
+class TokenDataNode : public DataNode {
+ public:
+  /*! \brief The token ids. */
+  ShapeTuple token_ids;
+
+  static constexpr const char* _type_key = "mlc.serve.TokenData";
+  TVM_DECLARE_BASE_OBJECT_INFO(TokenDataNode, DataNode);
+};
+
+class TokenData : public Data {
+ public:
+  explicit TokenData(ShapeTuple token_ids);
+
+  explicit TokenData(std::vector<int32_t> token_ids);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(TokenData, Data, TokenDataNode);
+};
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_DATA_H_

--- a/cpp/serve/request.cc
+++ b/cpp/serve/request.cc
@@ -1,0 +1,30 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/request.cc
+ */
+
+#include "request.h"
+
+#include <tvm/runtime/packed_func.h>
+
+#include "data.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/****************** Request ******************/
+
+TVM_REGISTER_OBJECT_TYPE(RequestNode);
+
+Request::Request(Array<Data> inputs, String generation_cfg_json, PackedFunc fcallback) {
+  ObjectPtr<RequestNode> n = make_object<RequestNode>();
+  n->inputs = std::move(inputs);
+  n->generation_cfg = GenerationConfig(generation_cfg_json);
+  n->fcallback = std::move(fcallback);
+  data_ = std::move(n);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/request.h
+++ b/cpp/serve/request.h
@@ -1,0 +1,68 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/request.h
+ * \brief Implementation of llm chat.
+ */
+#ifndef MLC_LLM_SERVE_REQUEST_H_
+#define MLC_LLM_SERVE_REQUEST_H_
+
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/object.h>
+#include <tvm/runtime/packed_func.h>
+
+#include "config.h"
+#include "data.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/****************** Request ******************/
+
+/*!
+ * \brief The user submitted text-generation request, which contains
+ * a list of multi-modal inputs and a set of sampling configuration
+ * parameters.
+ * \note Request is immutable and can be re-dispatched to another
+ * node and restart the request handling on the new one.
+ */
+class RequestNode : public Object {
+ public:
+  /*!
+   * \brief The user inputs of a request. Input may have multi-modality.
+   * \sa data.h
+   */
+  Array<Data> inputs;
+  /*!
+   * \brief The sampling configuration which may contain temperature,
+   * top_p, repetition_penalty, max_gen_len, etc.
+   */
+  GenerationConfig generation_cfg;
+  /*!
+   * \brief The provided callback function to handle the generation
+   * output. It has the signature of `(Request, Data) -> None`,
+   * which takes the request and the generation output as parameters.
+   */
+  PackedFunc fcallback;
+
+  static constexpr const char* _type_key = "mlc.serve.Request";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(RequestNode, Object);
+};
+
+class Request : public ObjectRef {
+ public:
+  explicit Request(Array<Data> inputs, String generation_cfg_json, PackedFunc fcallback);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(Request, ObjectRef, RequestNode);
+};
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_REQUEST_H_

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -1,0 +1,28 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/request_state.cc
+ */
+
+#include "request_state.h"
+
+#include "data.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/****************** RequestModelState ******************/
+
+TVM_REGISTER_OBJECT_TYPE(RequestModelStateNode);
+
+RequestModelState::RequestModelState(int model_id, Array<Data> inputs) {
+  ObjectPtr<RequestModelStateNode> n = make_object<RequestModelStateNode>();
+  n->model_id = model_id;
+  n->request_id = -1;
+  n->inputs = std::move(inputs);
+  data_ = std::move(n);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -1,0 +1,113 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/request_state.h
+ * \brief The data structure maintaining the generation states of user requests.
+ */
+#ifndef MLC_LLM_SERVE_REQUEST_STATE_H_
+#define MLC_LLM_SERVE_REQUEST_STATE_H_
+
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/object.h>
+
+#include "config.h"
+#include "data.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/*!
+ * \brief The state of a request with regard to some single model.
+ * \details In MLC LLM, the serving engine may leverage multiple models
+ * to fulfill a user generation request (e.g., use speculation decoding).
+ * For each request, we isolate its states (e.g. the generated tokens)
+ * on each model. This is to say, we use RequestModelState to store
+ * the state of a user request on a single model (rather than all models).
+ */
+class RequestModelStateNode : public Object {
+ public:
+  /*!
+   * \brief The corresponding request id of this state.
+   * It is the **physical index** of the request in the running request queue.
+   * If the request is on hold (not in the running queue), the request id
+   * should be -1.
+   */
+  int request_id = -1;
+  /*! \brief The corresponding model id of this state. */
+  int model_id = -1;
+  /*!
+   * \brief The committed generated token ids. A token is "committed"
+   * means it will no longer be updated (or changed).
+   */
+  std::vector<int32_t> committed_tokens;
+  /*! \brief The list of input data yet for the model to prefill. */
+  Array<Data> inputs;
+
+  // NOTE: The following fields are reserved for future speculative inference
+  // settings, and are produced by the speculative small models.
+  /*!
+   * \brief The draft generated token ids, which are usually generated
+   * by "small" speculative models. These tokens will be fed to a "large"
+   * model to determine the final result of speculation.
+   */
+  std::vector<int32_t> draft_output_tokens;
+  /*!
+   * \brief The probability distribution on each position in the
+   * draft. We keep the distributions for stochastic sampling when merging
+   * speculations from multiple models.
+   * \note We only need this value when we have multiple parallel small models
+   * and draft outputs in speculative inference settings.
+   */
+  std::vector<NDArray> draft_output_prob_dist;
+  /*!
+   * \brief The probability of the sampled token on each position in the
+   * draft. We keep the probabilities for stochastic sampling when merging
+   * speculations from multiple models.
+   *
+   * \note `draft_token_prob` can be inferred from `draft_tokens` and
+   * `draft_prob_dist`, but we still keep it so that we can have option
+   * choosing only to use one between them.
+   */
+  std::vector<float> draft_output_token_prob;
+
+  static constexpr const char* _type_key = "mlc.serve.RequestModelState";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(RequestModelStateNode, Object);
+};
+
+class RequestModelState : public ObjectRef {
+ public:
+  explicit RequestModelState(int model_id, Array<Data> inputs);
+
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(RequestModelState, ObjectRef, RequestModelStateNode);
+};
+
+struct RequestState {
+  /*!
+   * \brief The state with regard to each model.
+   * \sa RequestModelState
+   */
+  Array<RequestModelState> mstates;
+
+  /*! \brief The decoded text string output. */
+  std::string output = "";
+  /*! \brief The boolean flag indicating if the process of this request is finished. */
+  bool finished = false;
+
+  explicit RequestState(int num_models, Array<Data> inputs) {
+    mstates.reserve(num_models);
+    for (int i = 0; i < num_models; ++i) {
+      mstates.push_back(RequestModelState(i, inputs));
+    }
+  }
+};
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_REQUEST_STATE_H_


### PR DESCRIPTION
This PR sets up the basic data structures (multi-modality data, requests, etc.) for the continuous batching serving support.

Specifically, this PR contains
* multi-modality `Data` class,
  * supports text and token ids as data for now, embedding data will be introduced in the future
* `Request` class for user-submitted requests,
* `RequestState`/`RequestModelState` class for the engine to maintain the generation status of requests.
* Configuration data classes for generation and KV cache.