### PR TITLE
Fix Stable LM 3B build

### DIFF
--- a/mlc_llm/relax_model/stablelm_3b.py
+++ b/mlc_llm/relax_model/stablelm_3b.py
@@ -579,7 +579,7 @@ def create_embed_func(
     bsz = 1
     seq_len = tvm.tir.Var("n", "int64")
     with bb.function(func_name):
-        model = StableLM3bEmbedTokensWrapper(config, tvm.tir.Var("v", "int64"))
+        model = StableLM3bEmbedTokensWrapper(config, tvm.tir.Var("vocab_size", "int64"))
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, seq_len), dtype="int32", name="input_ids")
@@ -608,7 +608,7 @@ def create_encoding_func(
     all_seq_len = tvm.tir.Var("m", "int64")
     hidden_size = config.hidden_size
     with bb.function(func_name):
-        model = StableLM3bForCausalLM(config, tvm.tir.Var("v", "int64"), sep_embed)
+        model = StableLM3bForCausalLM(config, tvm.tir.Var("vocab_size", "int64"), sep_embed)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         inputs = (
@@ -652,7 +652,7 @@ def create_decoding_func(
     all_seq_len = tvm.tir.Var("n", "int64")
 
     with bb.function(func_name):
-        model = StableLM3bForCausalLM(config, tvm.tir.Var("v", "int64"))
+        model = StableLM3bForCausalLM(config, tvm.tir.Var("vocab_size", "int64"))
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, 1), dtype="int32", name="input_ids")
@@ -714,7 +714,9 @@ def create_kv_cache_func(bb: relax.BlockBuilder, config: StableLM3bConfig) -> No
 
 def create_softmax_func(bb: relax.BlockBuilder, config: StableLM3bConfig) -> None:
     with bb.function("softmax_with_temperature"):
-        logits = nn.Placeholder((1, 1, tvm.tir.Var("v", "int64")), dtype="float32", name="logits")
+        logits = nn.Placeholder(
+            (1, 1, tvm.tir.Var("vocab_size", "int64")), dtype="float32", name="logits"
+        )
         temperature = nn.Placeholder((), dtype="float32", name="temperature")
         with bb.dataflow():
             div = bb.emit(relax.op.divide(logits, temperature))

--- a/mlc_llm/relax_model/stablelm_3b.py
+++ b/mlc_llm/relax_model/stablelm_3b.py
@@ -66,6 +66,11 @@ class StableLM3bConfig:
             self.num_shards = 1
         self.kwargs = kwargs
 
+    def get_num_key_value_heads(self):
+        if self.num_key_value_heads is None:
+            return self.num_attention_heads
+        return self.num_key_value_heads
+
 
 class LayerNorm(nn.Module):
     def __init__(


### PR DESCRIPTION
Building StableLM 3B based models was throwing an exception due to an unrelated change introduced in #1027. Also, pulled in the Llama change to rename the vocab size variable from #1019.

```python
Traceback (most recent call last):
  File "/Users/jeethu/Developer/mlc-llm/build.py", line 4, in <module>
    main()
  File "/Users/jeethu/Developer/mlc-llm/mlc_llm/build.py", line 42, in main
    core.build_model_from_args(parsed_args)
  File "/Users/jeethu/Developer/mlc-llm/mlc_llm/core.py", line 644, in build_model_from_args
    mod = mod_transform_before_build(mod, param_manager, args, model_config)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jeethu/Developer/mlc-llm/mlc_llm/core.py", line 403, in mod_transform_before_build
    num_key_value_heads = config.get_num_key_value_heads()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'StableLM3bConfig' object has no attribute 'get_num_key_value_heads'. Did you mean: 'num_key_value_heads'?
```