### PR TITLE
Minor typo fix

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -605,7 +605,7 @@ def build_model_from_args(args: argparse.Namespace):
     if args.sep_embed and args.model_category != "llama":
         raise ValueError(f"separate embedding not supported on {args.model}")
 
-    if args.model_cateogry == "minigpt":
+    if args.model_category == "minigpt":
         # Special case for minigpt, which neither provides nor requires a configuration.
         config = {}
     else:


### PR DESCRIPTION
Fixed a minor typo that was breaking building models.

```
🚀 python build.py --model ~/LLM_models/stablelm-3b-4e1t --quantization q4f16_1 --target metal --use-safetensors --use-cache=0
Using path "/Users/jeethu/LLM_models/stablelm-3b-4e1t" for model "stablelm-3b-4e1t"
Host CPU dection:
  Target triple: arm64-apple-darwin23.0.0
  Process triple: arm64-apple-darwin23.0.0
  Host CPU: apple-m1
Target configured: metal -keys=metal,gpu -max_function_args=31 -max_num_threads=256 -max_shared_memory_per_block=32768 -max_threads_per_block=1024 -thread_warp_size=32
Traceback (most recent call last):
  File "/Users/jeethu/Developer/mlc-llm/build.py", line 4, in <module>
    main()
  File "/Users/jeethu/Developer/mlc-llm/mlc_llm/build.py", line 42, in main
    core.build_model_from_args(parsed_args)
  File "/Users/jeethu/Developer/mlc-llm/mlc_llm/core.py", line 608, in build_model_from_args
    if args.model_cateogry == "minigpt":
       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'model_cateogry'. Did you mean: 'model_category'?
```