### PR TITLE
[Serving] Python-side data structure abstractions

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -62,6 +62,22 @@ GenerationConfig::GenerationConfig(String config_json_str) {
   data_ = std::move(n);
 }
 
+String GenerationConfigNode::AsJSONString() const {
+  picojson::object config;
+  config["temperature"] = picojson::value(this->temperature);
+  config["top_p"] = picojson::value(this->top_p);
+  config["repetition_penalty"] = picojson::value(this->repetition_penalty);
+  config["max_new_tokens"] = picojson::value(static_cast<int64_t>(this->max_new_tokens));
+
+  picojson::array stop_strs_arr;
+  for (String stop_str : this->stop_strs) {
+    stop_strs_arr.push_back(picojson::value(stop_str));
+  }
+  config["stop_strs"] = picojson::value(stop_strs_arr);
+
+  return picojson::value(config).serialize(true);
+}
+
 /****************** KVCacheConfig ******************/
 
 TVM_REGISTER_OBJECT_TYPE(KVCacheConfigNode);
@@ -114,6 +130,15 @@ KVCacheConfig::KVCacheConfig(const std::string& config_str, int max_single_seque
   n->max_num_sequence = max_num_sequence;
   n->max_total_sequence_length = max_total_sequence_length;
   data_ = std::move(n);
+}
+
+String KVCacheConfigNode::AsJSONString() const {
+  picojson::object config;
+  config["page_size"] = picojson::value(static_cast<int64_t>(this->page_size));
+  config["max_num_sequence"] = picojson::value(static_cast<int64_t>(this->max_num_sequence));
+  config["max_total_sequence_length"] =
+      picojson::value(static_cast<int64_t>(this->max_total_sequence_length));
+  return picojson::value(config).serialize(true);
 }
 
 }  // namespace serve

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -17,7 +17,7 @@ using namespace tvm::runtime;
 
 /****************** GenerationConfig ******************/
 
-/*! \brief The sampling configuration of a request. */
+/*! \brief The generation configuration of a request. */
 class GenerationConfigNode : public Object {
  public:
   double temperature = 0.8;
@@ -26,6 +26,8 @@ class GenerationConfigNode : public Object {
 
   int max_new_tokens = 128;
   Array<String> stop_strs;
+
+  String AsJSONString() const;
 
   static constexpr const char* _type_key = "mlc.serve.GenerationConfig";
   static constexpr const bool _type_has_method_sequal_reduce = false;
@@ -42,12 +44,14 @@ class GenerationConfig : public ObjectRef {
 
 /****************** KV Cache config ******************/
 
-/*! \brief The sampling configuration of a request. */
+/*! \brief The configuration of paged KV cache. */
 class KVCacheConfigNode : public Object {
  public:
   int page_size;
   int max_num_sequence;
   int max_total_sequence_length;
+
+  String AsJSONString() const;
 
   static constexpr const char* _type_key = "mlc.serve.KVCacheConfig";
   static constexpr const bool _type_has_method_sequal_reduce = false;

--- a/cpp/serve/request.cc
+++ b/cpp/serve/request.cc
@@ -6,6 +6,7 @@
 #include "request.h"
 
 #include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
 
 #include "data.h"
 
@@ -17,13 +18,27 @@ namespace serve {
 
 TVM_REGISTER_OBJECT_TYPE(RequestNode);
 
-Request::Request(Array<Data> inputs, String generation_cfg_json, PackedFunc fcallback) {
+Request::Request(Array<Data> inputs, GenerationConfig generation_cfg, PackedFunc fcallback) {
   ObjectPtr<RequestNode> n = make_object<RequestNode>();
   n->inputs = std::move(inputs);
-  n->generation_cfg = GenerationConfig(generation_cfg_json);
+  n->generation_cfg = std::move(generation_cfg);
   n->fcallback = std::move(fcallback);
   data_ = std::move(n);
 }
+
+TVM_REGISTER_GLOBAL("mlc.serve.Request")
+    .set_body_typed([](Array<Data> inputs, String generation_cfg_json, PackedFunc fcallback) {
+      return Request(std::move(inputs), GenerationConfig(std::move(generation_cfg_json)),
+                     std::move(fcallback));
+    });
+
+TVM_REGISTER_GLOBAL("mlc.serve.RequestGetInputs").set_body_typed([](Request request) {
+  return request->inputs;
+});
+
+TVM_REGISTER_GLOBAL("mlc.serve.RequestGetGenerationConfigJSON").set_body_typed([](Request request) {
+  return request->generation_cfg->AsJSONString();
+});
 
 }  // namespace serve
 }  // namespace llm

--- a/cpp/serve/request.h
+++ b/cpp/serve/request.h
@@ -24,8 +24,8 @@ using namespace tvm::runtime;
 
 /*!
  * \brief The user submitted text-generation request, which contains
- * a list of multi-modal inputs and a set of sampling configuration
- * parameters.
+ * a list of multi-modal inputs, a set of generation configuration
+ * parameters and a callback function for request finish handling.
  * \note Request is immutable and can be re-dispatched to another
  * node and restart the request handling on the new one.
  */
@@ -56,7 +56,7 @@ class RequestNode : public Object {
 
 class Request : public ObjectRef {
  public:
-  explicit Request(Array<Data> inputs, String generation_cfg_json, PackedFunc fcallback);
+  explicit Request(Array<Data> inputs, GenerationConfig generation_cfg, PackedFunc fcallback);
 
   TVM_DEFINE_OBJECT_REF_METHODS(Request, ObjectRef, RequestNode);
 };

--- a/python/mlc_chat/__init__.py
+++ b/python/mlc_chat/__init__.py
@@ -2,8 +2,6 @@
 
 MLC Chat is the app runtime of MLC LLM.
 """
+from . import serve
+from .chat_module import ChatConfig, ChatModule, ConvConfig, GenerationConfig
 from .libinfo import __version__
-from .chat_module import ChatModule
-from .chat_module import ConvConfig
-from .chat_module import ChatConfig
-from .chat_module import GenerationConfig

--- a/python/mlc_chat/serve/__init__.py
+++ b/python/mlc_chat/serve/__init__.py
@@ -1,0 +1,5 @@
+# Load MLC LLM library by importing base
+from .. import base
+from .config import GenerationConfig, KVCacheConfig
+from .data import Data, TextData, TokenData
+from .request import Request

--- a/python/mlc_chat/serve/_ffi_api.py
+++ b/python/mlc_chat/serve/_ffi_api.py
@@ -1,0 +1,6 @@
+"""FFI APIs for mlc_chat.serve"""
+import tvm._ffi
+
+# Exports functions registered via TVM_REGISTER_GLOBAL with the "mlc.serve" prefix.
+# e.g. TVM_REGISTER_GLOBAL("mlc.serve.TextData")
+tvm._ffi._init_api("mlc.serve", __name__)

--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -1,0 +1,72 @@
+"""Configuration dataclasses used in MLC LLM serving"""
+import json
+from dataclasses import asdict, dataclass, field
+from typing import List
+
+
+@dataclass
+class GenerationConfig:
+    """The generation configuration dataclass.
+
+    Parameters
+    ----------
+    temperature : float
+        The value that applies to logits and modulates the next token probabilities.
+
+    top_p : float
+        In sampling, only the most probable tokens with probabilities summed up to
+        `top_k` are kept for sampling.
+
+    repetition_penalty : float
+        The penalty term that applies to logits to control token repetition in generation.
+
+    max_new_tokens : int
+        The maximum number of generated tokens.
+
+    stop_strs : List[str]
+        The list of strings that mark the end of generation.
+    """
+
+    temperature: float = 0.8
+    top_p: float = 0.95
+    repetition_penalty: float = 1.0
+
+    max_new_tokens: int = 128
+    stop_strs: List[str] = field(default_factory=list)
+
+    def asjson(self) -> str:
+        return json.dumps(asdict(self))
+
+    @staticmethod
+    def from_json(json_str: str) -> "GenerationConfig":
+        return GenerationConfig(**json.loads(json_str))
+
+
+@dataclass
+class KVCacheConfig:
+    """The KV cache initialization configuration.
+
+    Parameters
+    ----------
+    page_size : int
+        The number of consecutive tokens handled in each page in paged KV cache.
+
+    max_num_sequence : int
+        The maximum number of sequences that are allowed to processed by the KV
+        cache at any time.
+
+    max_total_sequence_length : int
+        The maximum total number of tokens whose KV data are allowed to exist
+        in the KV cache at any time.
+    """
+
+    page_size: int = 16
+    max_num_sequence: int = 32
+    max_total_sequence_length: int = 16384
+
+    def asjson(self) -> str:
+        return json.dumps(asdict(self))
+
+    @staticmethod
+    def from_json(json_str: str) -> "KVCacheConfig":
+        return KVCacheConfig(**json.loads(json_str))

--- a/python/mlc_chat/serve/data.py
+++ b/python/mlc_chat/serve/data.py
@@ -1,0 +1,58 @@
+"""Classes denoting multi-modality data used in MLC LLM serving"""
+from typing import List
+
+import tvm._ffi
+from tvm.runtime import Object
+from tvm.runtime.container import getitem_helper
+
+from .. import base
+from . import _ffi_api
+
+
+@tvm._ffi.register_object("mlc.serve.Data")
+class Data(Object):
+    """The base class of multi-modality data (text, tokens, embedding, etc)."""
+
+    def __init__(self):
+        pass
+
+
+@tvm._ffi.register_object("mlc.serve.TextData")
+class TextData(Data):
+    """The class of text data, containing a text string.
+
+    Parameters
+    ----------
+    text : str
+        The text string.
+    """
+
+    def __init__(self, text: str):
+        self.__init_handle_by_constructor__(_ffi_api.TextData, text)
+
+    @property
+    def text(self) -> str:
+        return str(_ffi_api.TextDataGetTextString(self))
+
+    def __str__(self) -> str:
+        return self.text
+
+
+@tvm._ffi.register_object("mlc.serve.TokenData")
+class TokenData(Data):
+    """The class of token data, containing a list of token ids.
+
+    Parameters
+    ----------
+    token_ids : List[int]
+        The list of token ids.
+    """
+
+    def __init__(self, token_ids: List[int]):
+        self.__init_handle_by_constructor__(_ffi_api.TokenData, *token_ids)
+
+    def __len__(self) -> int:
+        return _ffi_api.TokenDataGetLength(self)
+
+    def __getitem__(self, idx) -> int:
+        return getitem_helper(self, _ffi_api.TokenDataGetElem, len(self), idx)

--- a/python/mlc_chat/serve/request.py
+++ b/python/mlc_chat/serve/request.py
@@ -1,0 +1,51 @@
+"""The request class in MLC LLM serving"""
+from typing import Callable, List, Union
+
+import tvm._ffi
+from tvm.runtime import Object
+
+from . import _ffi_api
+from .config import GenerationConfig
+from .data import Data
+
+
+@tvm._ffi.register_object("mlc.serve.Request")
+class Request(Object):
+    """The user submitted text-generation request, which contains
+    a list of multi-modal inputs, a set of generation configuration
+    parameters and a callback function for request finish handling.
+
+    Parameters
+    ----------
+    inputs : List[Data]
+        The user inputs of a request. Input may have multi-modality.
+
+    generation_config : GenerationConfig
+        The sampling configuration which may contain temperature,
+        top_p, repetition_penalty, max_gen_len, etc.
+
+    fcallback : Callable[[Request, Data], None]
+        The provided callback function to handle the generation
+        output. It has the signature of `(Request, Data) -> None`,
+        which takes the request and the generation output as parameters.
+    """
+
+    def __init__(
+        self,
+        inputs: Union[Data, List[Data]],
+        generation_config: GenerationConfig,
+        fcallback: Callable[["Request", Data], None],
+    ):
+        if not isinstance(inputs, list):
+            inputs = [inputs]
+        self.__init_handle_by_constructor__(
+            _ffi_api.Request, inputs, generation_config.asjson(), fcallback
+        )
+
+    @property
+    def inputs(self) -> List[Data]:
+        return _ffi_api.RequestGetInputs(self)
+
+    @property
+    def generation_config(self) -> GenerationConfig:
+        return GenerationConfig.from_json(_ffi_api.RequestGetGenerationConfigJSON(self))


### PR DESCRIPTION
This PR introduces the Python-side abstraction for the basic data structures introduced in #1046. These abstraction in Python leverages the object system and FFI in TVM.