### PR TITLE
[Serving] Model/Sampler/Tokenizer runtime modules

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -58,6 +58,18 @@ GenerationConfig::GenerationConfig(String config_json_str) {
     }
     n->stop_strs = std::move(stop_strs);
   }
+  if (config.count("stop_tokens")) {
+    CHECK(config["stop_tokens"].is<picojson::array>())
+        << "Invalid stop_tokens. Stop tokens should be an array of integers";
+    picojson::array stop_tokens_arr = config["stop_tokens"].get<picojson::array>();
+    std::vector<int> stop_tokens;
+    stop_tokens.reserve(stop_tokens_arr.size());
+    for (const picojson::value& v : stop_tokens_arr) {
+      CHECK(v.is<int64_t>()) << "Invalid stop token in stop_tokens";
+      stop_tokens.push_back(v.get<int64_t>());
+    }
+    n->stop_tokens = std::move(stop_tokens);
+  }
 
   data_ = std::move(n);
 }
@@ -74,6 +86,12 @@ String GenerationConfigNode::AsJSONString() const {
     stop_strs_arr.push_back(picojson::value(stop_str));
   }
   config["stop_strs"] = picojson::value(stop_strs_arr);
+
+  picojson::array stop_tokens_arr;
+  for (int stop_token : this->stop_tokens) {
+    stop_tokens_arr.push_back(picojson::value(static_cast<int64_t>(stop_token)));
+  }
+  config["stop_tokens"] = picojson::value(stop_tokens_arr);
 
   return picojson::value(config).serialize(true);
 }

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -26,6 +26,7 @@ class GenerationConfigNode : public Object {
 
   int max_new_tokens = 128;
   Array<String> stop_strs;
+  std::vector<int> stop_tokens;
 
   String AsJSONString() const;
 

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -1,0 +1,199 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/function_table.cc
+ * \brief The implementation of function table in serving for distributed inference.
+ */
+
+#include "function_table.h"
+
+#include <tvm/runtime/disco/session.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/runtime/relax_vm/memory_manager.h>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "../support.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+PackedFunc FunctionTable::SessionFuncAsPackedFunc(Session sess, DRef sess_func, String name) {
+  return PackedFunc([sess, func = std::move(sess_func), name = std::move(name)](
+                        TVMArgs args, TVMRetValue* rv) -> void {
+    std::vector<TVMValue> tvm_values(args.num_args + 3);
+    std::vector<int> tvm_type_codes(args.num_args + 3);
+    TVMArgsSetter setter(tvm_values.data(), tvm_type_codes.data());
+    setter(0, static_cast<int>(DiscoAction::kCallPacked));
+    setter(1, 0);
+    setter(2, func);
+    for (int i = 0; i < args.num_args; ++i) {
+      tvm_values[i + 3] = args.values[i];
+      tvm_type_codes[i + 3] = args.type_codes[i];
+    }
+    *rv =
+        sess->CallWithPacked(TVMArgs(tvm_values.data(), tvm_type_codes.data(), args.num_args + 3));
+  });
+}
+
+void FunctionTable::Init(TVMArgValue reload_lib, Device device, int num_shards) {
+  Device null_device{DLDeviceType(0), 0};
+  if (num_shards > 1) {
+    String lib_path{nullptr};
+    try {
+      lib_path = reload_lib.operator String();
+    } catch (...) {
+      LOG(FATAL)
+          << "ValueError: In multi-GPU inference, we expect the first argument to Reload to be a "
+             "string path to the model library (.so on Linux or .dll on Windows), but got: "
+          << ArgTypeCode2Str(reload_lib.type_code());
+    }
+    constexpr const char* f_create_process_pool = "runtime.disco.create_process_pool";
+    if (Registry::Get(f_create_process_pool) == nullptr) {
+      LOG(FATAL) << "Cannot find process launcher `" << f_create_process_pool << "`. "
+                 << "Multi-GPU inference depends on MLC LLM Python API to launch process.";
+    }
+    std::string ccl;
+    if (device.device_type == kDLCUDA) {
+      ccl = "nccl";
+    } else if (device.device_type == kDLROCM) {
+      ccl = "rccl";
+    } else {
+      LOG(FATAL) << "ValueError: Multi-GPU on device " << DLDeviceType2Str(device.device_type)
+                 << " is not supported. Currently, only NCCL and RCCL are integrated.";
+    }
+    std::vector<int64_t> device_ids(num_shards);
+    for (int i = 0; i < num_shards; ++i) {
+      device_ids[i] = i;
+    }
+    this->use_disco = true;
+    this->sess = Session::ProcessSession(num_shards, f_create_process_pool);
+    this->sess->InitCCL(ccl, ShapeTuple(device_ids));
+    this->disco_mod = sess->CallPacked(sess->GetGlobalFunc("runtime.disco.load_vm_module"),
+                                       lib_path, null_device);
+    this->mod_get_func = [this,
+                          fmodule_get_function = sess->GetGlobalFunc("runtime.ModuleGetFunction")](
+                             const std::string& name) -> PackedFunc {
+      DRef func = sess->CallPacked(fmodule_get_function, this->disco_mod, name, false);
+      bool exists = (func->DebugGetFromRemote(0).operator PackedFunc()) != nullptr;
+      if (!exists) {
+        return PackedFunc(nullptr);
+      }
+      return SessionFuncAsPackedFunc(sess, func, name);
+    };
+    this->get_global_func = [this](const std::string& name) -> PackedFunc {
+      return SessionFuncAsPackedFunc(sess, sess->GetGlobalFunc(name), name);
+    };
+    this->_InitFunctions();
+    {
+      Module mod = this->disco_mod->DebugGetFromRemote(0);
+      this->softmax_func_ = mod->GetFunction("softmax_with_temperature");
+    }
+  } else {
+    Module executable{nullptr};
+    if (reload_lib.type_code() == kTVMModuleHandle) {
+      executable = reload_lib.operator Module();
+    } else {
+      String lib_path = reload_lib.operator String();
+      executable = tvm::runtime::Module::LoadFromFile(lib_path);
+    }
+    this->use_disco = false;
+    auto fload_exec = executable->GetFunction("vm_load_executable");
+    ICHECK(fload_exec.defined()) << "TVM runtime cannot find vm_load_executable";
+    this->local_vm = fload_exec();
+    this->local_vm->GetFunction("vm_initialization")(
+        static_cast<int>(device.device_type), device.device_id,
+        static_cast<int>(relax_vm::AllocatorType::kPooled), static_cast<int>(kDLCPU), 0,
+        static_cast<int>(relax_vm::AllocatorType::kPooled));
+    this->mod_get_func = [this](const std::string& name) -> PackedFunc {
+      return this->local_vm->GetFunction(name, false);
+    };
+    this->get_global_func = [](const std::string& name) -> PackedFunc {
+      const auto* f = tvm::runtime::Registry::Get(name);
+      CHECK(f != nullptr) << "ValueError: Cannot find function " << name;
+      return *f;
+    };
+    this->_InitFunctions();
+  }
+}
+
+ObjectRef FunctionTable::LoadParams(const std::string& model_path, Device device) {
+  if (this->use_disco) {
+    std::filesystem::path fs_model_path = model_path;
+    std::string metadata_path = (fs_model_path / "ndarray-cache.json").string();
+    std::string ndarray_cache_metadata = LoadBytesFromFile(metadata_path);
+    PackedFunc loader_create = this->get_global_func("runtime.disco.ShardLoader");
+    PackedFunc loader_load_all = this->get_global_func("runtime.disco.ShardLoaderLoadAll");
+    CHECK(loader_create != nullptr);
+    CHECK(loader_load_all != nullptr);
+    DRef loader = loader_create(metadata_path, ndarray_cache_metadata, "", this->disco_mod);
+    DRef params = loader_load_all(loader);
+    return params;
+  } else {
+    const PackedFunc* fload_cache = tvm::runtime::Registry::Get("vm.builtin.ndarray_cache.load");
+    ICHECK(fload_cache) << "TVM runtime cannot find vm.builtin.ndarray_cache.load";
+    (*fload_cache)(model_path, static_cast<int32_t>(device.device_type), device.device_id);
+    const PackedFunc* fload_params =
+        tvm::runtime::Registry::Get("vm.builtin.param_array_from_cache");
+    ICHECK(fload_params) << "Cannot find env function vm.builtin.param_array_from_cache";
+    Array<NDArray> params = (*fload_params)("param", -1);
+    // after we get params, it is safe to simply clear the cached version
+    // as these params are referenced by params_
+    const PackedFunc* fclear_ndarray_cache =
+        tvm::runtime::Registry::Get("vm.builtin.ndarray_cache.clear");
+    ICHECK(fclear_ndarray_cache) << "Cannot find env function vm.builtin.ndarray_cache.clear";
+    (*fclear_ndarray_cache)();
+    return params;
+  }
+}
+
+void FunctionTable::_InitFunctions() {
+  this->embed_func_ = mod_get_func("embed");
+  this->prefill_func_ = mod_get_func("prefill_with_embed");
+  this->decode_func_ = mod_get_func("decode_with_embed");
+  this->softmax_func_ = mod_get_func("softmax_with_temperature");
+  this->create_kv_cache_func_ = mod_get_func("create_kv_cache");
+  this->reset_kv_cache_func_ = get_global_func("vm.builtin.paged_attention_kv_cache_clear");
+  this->add_sequence_to_kv_cache_func_ =
+      get_global_func("vm.builtin.paged_attention_kv_cache_add_sequence");
+  this->reserve_length_in_kv_cache_func_ =
+      get_global_func("vm.builtin.paged_attention_kv_cache_reserve_extra_length_for_append");
+  this->reset_append_length_kv_cache_func_ =
+      get_global_func("vm.builtin.paged_attention_kv_cache_reset_append_lengths");
+  this->sync_device_kv_cache_func_ =
+      get_global_func("vm.builtin.paged_attention_kv_cache_sync_aux_array_to_device");
+  this->remove_from_kv_cache_func_ = get_global_func("vm.builtin.paged_attention_kv_cache_remove");
+  this->popn_from_kv_cache_func_ = get_global_func("vm.builtin.paged_attention_kv_cache_popn");
+  support_backtracking_kv_ = true;
+}
+
+ObjectRef FunctionTable::Empty(ShapeTuple shape, DataType dtype, Device device) const {
+  Device null_device{DLDeviceType(0), 0};
+  if (this->use_disco) {
+    DRef empty_func = sess->GetGlobalFunc("runtime.disco.empty");
+    return sess->CallPacked(empty_func, shape, dtype, null_device);
+  } else {
+    return NDArray::Empty(shape, dtype, device);
+  }
+}
+
+ObjectRef FunctionTable::CopyToWorker0(const NDArray& host_array) {
+  Device null_device{DLDeviceType(0), 0};
+  if (this->use_disco) {
+    DRef array =
+        Downcast<DRef>(this->Empty(host_array.Shape(), host_array.DataType(), null_device));
+    sess->CopyToWorker0(host_array, array);
+    return array;
+  } else {
+    return host_array;
+  }
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -1,0 +1,78 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/function_table.h
+ * \brief The header for function table in serving for distributed inference.
+ */
+
+#ifndef MLC_LLM_SERVE_FUNCTION_TABLE_H_
+#define MLC_LLM_SERVE_FUNCTION_TABLE_H_
+
+#include <tvm/runtime/disco/session.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+
+#include <string>
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using tvm::Device;
+using namespace tvm::runtime;
+
+//--------------------------------------------------------
+// The function table under batching settings.
+// The implementation is mostly the same as the one for
+// single-sequence distributed inference in llm_chat.cc.
+// The only difference is that the function table for
+// batching uses a different set of packed functions.
+//
+// Here we choose to have the duplicate code instead of
+// reusing the existing function table. This is mainly
+// for the independent development of batching/serving
+// and make the codebase manageable.
+// We will eventually merge two implementation into one
+// after the batching development becomes stable.
+//--------------------------------------------------------
+struct FunctionTable {
+  static PackedFunc SessionFuncAsPackedFunc(Session sess, DRef sess_func, String name);
+
+  void Init(TVMArgValue reload_lib, Device device, int num_shards);
+
+  ObjectRef LoadParams(const std::string& model_path, Device device);
+
+  void _InitFunctions();
+
+  ObjectRef Empty(ShapeTuple shape, DataType dtype, Device device) const;
+
+  ObjectRef CopyToWorker0(const NDArray& host_array);
+
+  bool use_disco = false;
+  Session sess{nullptr};
+  DRef disco_mod{nullptr};
+  tvm::runtime::Module local_vm{nullptr};
+
+  TypedPackedFunc<PackedFunc(const std::string&)> mod_get_func;
+  TypedPackedFunc<PackedFunc(const std::string&)> get_global_func;
+
+  PackedFunc embed_func_;
+  PackedFunc prefill_func_;
+  PackedFunc decode_func_;
+  PackedFunc softmax_func_;
+  PackedFunc create_kv_cache_func_;
+  PackedFunc reset_kv_cache_func_;
+  bool support_backtracking_kv_;
+  PackedFunc add_sequence_to_kv_cache_func_;
+  PackedFunc reserve_length_in_kv_cache_func_;
+  PackedFunc reset_append_length_kv_cache_func_;
+  PackedFunc sync_device_kv_cache_func_;
+  PackedFunc remove_from_kv_cache_func_;
+  PackedFunc popn_from_kv_cache_func_;
+};
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_FUNCTION_TABLE_H_

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -1,0 +1,413 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/model.cc
+ * \brief The implementation of runtime module of LLM functions (prefill/decode/etc.)
+ */
+#define PICOJSON_USE_INT64
+#define __STDC_FORMAT_MACROS
+
+#include "model.h"
+
+#include <picojson.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+
+#include <fstream>
+
+#include "config.h"
+#include "function_table.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*!
+ * \brief The runtime module for LLM functions.
+ * It runs an LLM, and has an internal KV cache that maintains
+ * the history KV values of all processed tokens.
+ *
+ * It contains the following functions:
+ *
+ * Model related:
+ * - "token_embed": take token ids as input and return the embeddings,
+ * - "single_seq_prefill": take embedding of a single sequence
+ * as input, forward the embedding through LLM and return the logits,
+ * - "decode": take the embeddings of the last-committed token of an
+ * entire batch as input, forward through LLM and return the logits
+ * for all sequences in the batch,
+ * - "softmax_with_temperature": take logits and temperatures, return
+ * probabilities.
+ *
+ * KV cache related:
+ * - "create_kv_cache": create the KV cache for this module,
+ * - "add_new_sequence": add (declare) a new sequence in the KV cache,
+ * - "remove_sequence": remove a sequence from KV cache.
+ *
+ * ... and more other auxiliary functions.
+ */
+class ModelModule : public ModuleNode {
+ public:
+  explicit ModelModule(TVMArgValue reload_lib, String model_path, DLDevice device)
+      : device_(device) {
+    // Step 1. Process model config json string.
+    {
+      std::ifstream config_istream((model_path + "/mlc-chat-config.json").c_str());
+      std::ostringstream config_ostream;
+      ICHECK(config_istream);
+      config_ostream << config_istream.rdbuf();
+      std::string config_str = config_ostream.str();
+      LoadModelConfigJSON(config_str);
+    }
+    // Step 2. Initialize vm, we use the packed function mechanism
+    // so there is no explicit abi dependency on these extra
+    // classes other than basic tvm runtime.
+    this->ft_.Init(reload_lib, device_, num_shards_);
+    // Step 3. Load params in nd-array cache.
+    this->params_ = ft_.LoadParams(model_path, device_);
+    // Step 4. Reset
+    this->Reset();
+  }
+
+  // overrides
+  PackedFunc GetFunction(const String& name, const ObjectPtr<Object>& sptr_to_self) final {
+    if (name == "token_embed") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 1);
+        *rv = TokenEmbed(args[0]);
+      });
+    } else if (name == "single_seq_prefill") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 2);
+        *rv = SingleSequencePrefill(args[0], args[1]);
+      });
+    } else if (name == "decode") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 1);
+        *rv = Decode(args[0]);
+      });
+    } else if (name == "softmax_with_temperature") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 2);
+        *rv = SoftmaxWithTemperature(args[0], args[1]);
+      });
+    } else if (name == "create_kv_cache") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        ICHECK_EQ(args.size(), 1);
+        KVCacheConfig kv_cache_config = args[0];
+        kv_cache_ = ft_.create_kv_cache_func_(
+            ShapeTuple({kv_cache_config->max_num_sequence,
+                        kv_cache_config->max_total_sequence_length, kv_cache_config->page_size}));
+      });
+    } else if (name == "add_new_sequence") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        ICHECK_EQ(args.size(), 0);
+        *rv = ft_.add_sequence_to_kv_cache_func_(kv_cache_);
+      });
+    } else if (name == "remove_sequence") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        ICHECK_EQ(args.size(), 1);
+        ft_.remove_from_kv_cache_func_(kv_cache_, args[0]);
+      });
+    } else if (name == "reset") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        ICHECK_EQ(args.size(), 0);
+        Reset();
+      });
+    } else if (name == "get_max_window_size") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        ICHECK_EQ(args.size(), 0);
+        CHECK_NE(max_window_size_, -1) << "The model has not been initialized";
+        *rv = max_window_size_;
+      });
+    } else if (name == "runtime_stats_text") {
+      // Todo: JSON style
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) { *rv = GetStats(); });
+    } else {
+      return PackedFunc(nullptr);
+    }
+  }
+
+  const char* type_key() const final { return "mlc.serve.Model"; }
+
+ private:
+  /*!
+   * \brief Compute embeddings for the input token ids.
+   * \param batch_token_ids The batch of token ids to compute embedding for.
+   * \return The computed embeddings.
+   * \note This function will **flatten** the input batch token ids,
+   * and return the NDArray flattened on the batch/sequence dimension.
+   * The caller side can decide whether to reshape the returned
+   * NDArray into some other shape or not.
+   * This brings the convenience for batched prefill and speculation
+   * verification where input sequences / draft outputs might can
+   * have different lengths, and we forward the flattened embeddings
+   * to prefill/verification.
+   */
+  NDArray TokenEmbed(Array<ShapeTuple> batch_token_ids) {
+    // Flatten input tokens.
+    int total_length = 0;
+    std::vector<int32_t> flattened_token_ids;
+    for (ShapeTuple token_ids : batch_token_ids) {
+      flattened_token_ids.insert(flattened_token_ids.end(), token_ids->data,
+                                 token_ids->data + token_ids.size());
+      total_length += token_ids.size();
+    }
+    // Copy input token ids to device.
+    DLDataType dtype(DataType::Int(32));
+    NDArray token_ids_nd = CopyArrayToDevice(flattened_token_ids, &input_token_ids_, dtype, 2048);
+    ICHECK_EQ(token_ids_nd->ndim, 1);
+    ICHECK_EQ(token_ids_nd->shape[0], total_length);
+    token_ids_nd = token_ids_nd.CreateView({1, total_length}, dtype);
+
+    CHECK(ft_.embed_func_.defined())
+        << "`embed` function is not found in the model. Please make sure the model is compiled "
+           "with flag `--sep-embed` and `--enable-batching`";
+
+    auto tstart = std::chrono::high_resolution_clock::now();
+    NDArray embeddings = ft_.embed_func_(ft_.CopyToWorker0(token_ids_nd), params_);
+    auto tend = std::chrono::high_resolution_clock::now();
+
+    this->embed_total_time += static_cast<double>((tend - tstart).count()) / 1e9;
+    this->embed_total_tokens += total_length;
+
+    // embeddings: (1, total_length, hidden_size)
+    ICHECK_EQ(embeddings->ndim, 3);
+    ICHECK_EQ(embeddings->shape[0], 1);
+    ICHECK_EQ(embeddings->shape[1], total_length);
+    return embeddings;
+  }
+
+  /*!
+   * \brief Single-sequence prefill function. Embedding in, logits out.
+   * \param embeddings The embedding of the input to be prefilled.
+   * \param seq_id The id of the sequence in the KV cache.
+   * \return The logits for the next token.
+   */
+  NDArray SingleSequencePrefill(NDArray embeddings, int seq_id) {
+    // embeddings: (1, n, h)
+    CHECK_EQ(embeddings->ndim, 3);
+    CHECK_EQ(embeddings->shape[0], 1);
+    CHECK_EQ(embeddings->device.device_type, device_.device_type);
+    CHECK_EQ(embeddings->device.device_id, device_.device_id);
+
+    CHECK(ft_.prefill_func_.defined())
+        << "`prefill_with_embed` function is not found in the model. Please make sure the model is "
+           "compiled with flag `--sep-embed` and `--enable-batching`";
+    ICHECK(ft_.reset_append_length_kv_cache_func_.defined());
+    ICHECK(ft_.reserve_length_in_kv_cache_func_.defined());
+    ICHECK(ft_.sync_device_kv_cache_func_.defined());
+    ICHECK(kv_cache_.defined()) << "KV cache has not been initialized.";
+
+    // Reserve in KV cache for the length of the input.
+    ft_.reset_append_length_kv_cache_func_(kv_cache_);
+    ft_.reserve_length_in_kv_cache_func_(kv_cache_, seq_id, /*length=*/embeddings->shape[1]);
+    ft_.sync_device_kv_cache_func_(kv_cache_);
+
+    auto tstart = std::chrono::high_resolution_clock::now();
+    // args: embeddings, kv_cache, params
+    Array<ObjectRef> ret = ft_.prefill_func_(ft_.CopyToWorker0(embeddings), kv_cache_, params_);
+    auto tend = std::chrono::high_resolution_clock::now();
+
+    this->prefill_total_time += static_cast<double>((tend - tstart).count()) / 1e9;
+    this->prefill_total_tokens += embeddings->shape[1];
+
+    // logits: (1, 1, v)
+    NDArray logits = Downcast<NDArray>(ret[0]);
+    ICHECK_EQ(logits->ndim, 3);
+    ICHECK_EQ(logits->shape[0], 1);
+    ICHECK_EQ(logits->shape[1], 1);
+    return logits;
+  }
+
+  /*!
+   * \brief Batch decode function. Embedding in, logits out.
+   * \param embeddings The embedding of last generated token in the entire batch.
+   * \return The logits for the next token for each sequence in the batch.
+   * \note The function runs for **every** sequence in the batch.
+   * That is to say, it does not accept "running a decode step for a subset
+   * of the full batch".
+   */
+  NDArray Decode(NDArray embeddings) {
+    // embeddings: (b, 1, h)
+    CHECK_EQ(embeddings->ndim, 3);
+    CHECK_EQ(embeddings->shape[1], 1);
+    CHECK_EQ(embeddings->device.device_type, device_.device_type);
+    CHECK_EQ(embeddings->device.device_id, device_.device_id);
+
+    CHECK(ft_.decode_func_.defined())
+        << "`decode_with_embed` function is not found in the model. Please make sure the model is "
+           "compiled with flag `--sep-embed` and `--enable-batching`";
+    ICHECK(ft_.reset_append_length_kv_cache_func_.defined());
+    ICHECK(ft_.reserve_length_in_kv_cache_func_.defined());
+    ICHECK(ft_.sync_device_kv_cache_func_.defined());
+    ICHECK(kv_cache_.defined()) << "KV cache has not been initialized.";
+
+    // Reserve in KV cache for the lengths of the input.
+    ft_.reset_append_length_kv_cache_func_(kv_cache_);
+    for (int64_t seq_id = 0; seq_id < embeddings->shape[0]; ++seq_id) {
+      ft_.reserve_length_in_kv_cache_func_(kv_cache_, seq_id, /*length=*/1);
+    }
+    ft_.sync_device_kv_cache_func_(kv_cache_);
+
+    auto tstart = std::chrono::high_resolution_clock::now();
+    // args: embeddings, kv_cache, params
+    Array<ObjectRef> ret = ft_.decode_func_(ft_.CopyToWorker0(embeddings), kv_cache_, params_);
+    auto tend = std::chrono::high_resolution_clock::now();
+
+    this->decode_total_time += static_cast<double>((tend - tstart).count()) / 1e9;
+    this->decode_total_tokens += embeddings->shape[0];
+
+    // logits: (b, 1, v)
+    NDArray logits = Downcast<NDArray>(ret[0]);
+    ICHECK_EQ(logits->ndim, 3);
+    ICHECK_EQ(logits->shape[0], embeddings->shape[0]);
+    ICHECK_EQ(logits->shape[1], 1);
+    return logits;
+  }
+
+  /*!
+   * \brief Computing probabilities from logits with softmax and temperatures.
+   * \param logits The logits to compute from.
+   * \param generation_cfg The generation config which contains the temperatures.
+   * \return The computed probabilities distribution.
+   */
+  NDArray SoftmaxWithTemperature(NDArray logits, Array<GenerationConfig> generation_cfg) {
+    // logits: (b, n, v)
+    CHECK_EQ(logits->ndim, 3);
+    CHECK_EQ(logits->shape[0], generation_cfg.size());
+    CHECK_EQ(logits->device.device_type, device_.device_type);
+    CHECK_EQ(logits->device.device_id, device_.device_id);
+
+    int batch_size = logits->shape[0];
+    std::vector<float> temperatures;
+    temperatures.reserve(batch_size);
+    for (GenerationConfig cfg : generation_cfg) {
+      temperatures.push_back(cfg->temperature);
+    }
+    NDArray temperatures_nd = CopyArrayToDevice(temperatures, &temperature_arr_, logits->dtype, 16);
+    ICHECK_EQ(temperatures_nd->ndim, 1);
+    ICHECK_EQ(temperatures_nd->shape[0], batch_size);
+
+    NDArray probs = ft_.softmax_func_(logits, temperatures_nd);
+    ICHECK_EQ(probs->ndim, 3);
+    ICHECK_EQ(probs->shape[0], logits->shape[0]);
+    ICHECK_EQ(probs->shape[1], logits->shape[1]);
+    ICHECK_EQ(probs->shape[2], logits->shape[2]);
+    return probs;
+  }
+
+  /*! \brief Copy input array to the device. */
+  template <typename T>
+  NDArray CopyArrayToDevice(const std::vector<T>& array, NDArray* dst, DLDataType dtype,
+                            int default_init_size) {
+    ICHECK(!array.empty());
+    ICHECK(dst != nullptr);
+    ICHECK(!dst->defined() || (*dst)->ndim == 1);
+    int64_t init_size = dst->defined() ? (*dst)->shape[0] : default_init_size;
+    while (init_size < static_cast<int64_t>(array.size())) {
+      init_size *= 2;
+    }
+    if (!dst->defined() || init_size != (*dst)->shape[0]) {
+      (*dst) = NDArray::Empty({init_size}, dtype, device_);
+    }
+    ICHECK_LE(static_cast<int64_t>(array.size()), (*dst)->shape[0]);
+    NDArray view = dst->CreateView(ShapeTuple({static_cast<int64_t>(array.size())}), dtype);
+    view.CopyFromBytes(array.data(), array.size() * sizeof(T));
+    return view;
+  }
+
+  /*! \brief Load model configuration from JSON. */
+  void LoadModelConfigJSON(const std::string& config_str) {
+    picojson::value config_json;
+    std::string err = picojson::parse(config_json, config_str);
+    if (!err.empty()) {
+      LOG(FATAL) << err;
+    }
+
+    // Get json fields.
+    picojson::object config = config_json.get<picojson::object>();
+    if (config.count("num_shards")) {
+      CHECK(config["num_shards"].is<int64_t>());
+      this->num_shards_ = config["num_shards"].get<int64_t>();
+    } else {
+      this->num_shards_ = 1;
+    }
+    if (config.count("model_name")) {
+      CHECK(config["model_name"].is<std::string>());
+      this->model_name_ = config["model_name"].get<std::string>();
+    } else {
+      LOG(FATAL) << "Key \"model_name\" not found.";
+    }
+    if (config.count("max_window_size")) {
+      CHECK(config["max_window_size"].is<int64_t>());
+      this->max_window_size_ = config["max_window_size"].get<int64_t>();
+    } else {
+      LOG(FATAL) << "Key \"max_window_size\" not found.";
+    }
+  }
+
+  /*! \brief reset the runtime states. */
+  void Reset() {
+    // Reset the statistics.
+    this->embed_total_tokens = 0;
+    this->prefill_total_tokens = 0;
+    this->decode_total_tokens = 0;
+    this->embed_total_time = 0;
+    this->prefill_total_time = 0;
+    this->decode_total_time = 0;
+    // Reset the KV cache.
+    if (kv_cache_.defined()) {
+      ft_.reset_kv_cache_func_(kv_cache_);
+    }
+  }
+
+  /*! \brief Return statistics in JSON format. */
+  String GetStats() {
+    picojson::object stats;
+    stats["prefill_speed"] = picojson::value(prefill_total_tokens / prefill_total_time);
+    stats["decode_speed"] = picojson::value(decode_total_tokens / decode_total_time);
+    stats["embed_speed"] = picojson::value(embed_total_tokens / embed_total_time);
+    return picojson::value(stats).serialize(true);
+  }
+
+  //----------------------------
+  // Statistics
+  //----------------------------
+  double embed_total_time = 0;
+  double decode_total_time = 0;
+  double prefill_total_time = 0;
+  int64_t embed_total_tokens = 0;
+  int64_t decode_total_tokens = 0;
+  int64_t prefill_total_tokens = 0;
+  //----------------------------
+  // Model configurations
+  //----------------------------
+  std::string model_name_;
+  int num_shards_ = -1;
+  int max_window_size_ = -1;
+  //----------------------------
+  // TVM related states
+  //----------------------------
+  // Packed function table
+  FunctionTable ft_;
+  // Paged KV cache
+  ObjectRef kv_cache_{nullptr};
+  // runtime device
+  Device device_;
+  // model params
+  ObjectRef params_;
+  // Shared NDArray
+  NDArray input_token_ids_{nullptr};
+  NDArray temperature_arr_{nullptr};
+};
+
+tvm::runtime::Module CreateModelModule(TVMArgValue reload_lib, String model_path, DLDevice device) {
+  ObjectPtr<ModelModule> n = make_object<ModelModule>(reload_lib, std::move(model_path), device);
+  return Module(n);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -1,0 +1,37 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/model.h
+ * \brief The header for runtime module of LLM functions (prefill/decode/etc.)
+ */
+
+#ifndef MLC_LLM_SERVE_MODEL_H_
+#define MLC_LLM_SERVE_MODEL_H_
+
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/module.h>
+
+#include "../base.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using tvm::Device;
+using namespace tvm::runtime;
+
+/*!
+ * \brief Create the runtime module for LLM functions.
+ * \param reload_lib The model library. It might be a path to the binary
+ * file or an executable module that is pre-loaded.
+ * \param model_path The path to the model weight parameters.
+ * \param device The device to run the model on.
+ * \return The created runtime module.
+ */
+MLC_LLM_DLL tvm::runtime::Module CreateModelModule(TVMArgValue reload_lib, String model_path,
+                                                   DLDevice device);
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_MODEL_H_

--- a/cpp/serve/sampler.cc
+++ b/cpp/serve/sampler.cc
@@ -1,0 +1,306 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/sampler.cc
+ * \brief The implementation for runtime module of sampler functions.
+ */
+#define __STDC_FORMAT_MACROS
+
+#include "sampler.h"
+
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+
+#include <cmath>
+
+#include "../random.h"
+#include "request_state.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*!
+ * \brief The sampler runtime module.
+ * It contains functions to
+ * - compute probability distribution out from logits,
+ * - sample token from probability distribution.
+ */
+class SamplerModule : public ModuleNode {
+ public:
+  explicit SamplerModule(DLDevice device) : device_(device) {
+    // Set sampling function.
+    auto fsample_topp_from_prob_ptr =
+        tvm::runtime::Registry::Get("vm.builtin.sample_top_p_from_prob");
+    ICHECK(fsample_topp_from_prob_ptr)
+        << "Cannot find env function vm.builtin.sample_top_p_from_prob";
+    fsample_topp_from_prob_ = *fsample_topp_from_prob_ptr;
+  }
+
+  // overrides
+  PackedFunc GetFunction(const String& name, const ObjectPtr<Object>& sptr_to_self) final {
+    if (name == "compute_probs_from_logits") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 4);
+        *rv = ComputeProbsFromLogits(args[0], args[1], args[2], args[3]);
+      });
+    } else if (name == "sample_token_from_probs") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 3);
+        *rv = SampleTokenFromProbs(args[0], args[1], args[2]);
+      });
+    } else if (name == "require_gpu_softmax") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 1);
+        *rv = RequireGPUSoftmax(args[0]);
+      });
+    } else {
+      return PackedFunc(nullptr);
+    }
+  }
+
+  void Init(DLDevice device) { device_ = device; }
+
+  const char* type_key() const final { return "mlc.serve.Sampler"; }
+
+ private:
+  /*!
+   * \brief Given the generation config of a batch, check if the
+   * probability distributions needs to be computed on device via softmax.
+   * \param generation_cfg The input generation config.
+   * \return A boolean flag indicating if the check result.
+   */
+  bool RequireGPUSoftmax(Array<GenerationConfig> generation_cfg) {
+    // - Return false if there is customized probability compute function.
+    const PackedFunc* f_logits_to_probs = Registry::Get("mlc.llm.f_logits_to_probs");
+    if (f_logits_to_probs != nullptr) {
+      return false;
+    }
+    // - Return false if any sampling param has repetition penalty other than 1.0.
+    // - Return false if any sampling param has zero temperature.
+    for (GenerationConfig cfg : generation_cfg) {
+      if (cfg->repetition_penalty != 1.0 || cfg->temperature < 1e-6) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /*!
+   * \brief Compute the probability distribution from logits for
+   * a **single token**.
+   * The input logits may be batched. We use an input "token offset"
+   * to determine the start logit offset of the token to compute.
+   * \param logits The input logits.
+   * \param token_offset The input token offset to determine where the
+   * logits of the target token start.
+   * \param state The request state, which contains the history generated tokens.
+   * \param generation_cfg The generation config.
+   * \return The computed probability distribution for the specified token.
+   */
+  NDArray ComputeProbsFromLogits(NDArray logits, int token_offset, RequestModelState state,
+                                 GenerationConfig generation_cfg) {
+    // logits: (b, n, v)
+    CHECK_EQ(logits->ndim, 3);
+
+    // - Copy logits to host.
+    //   We only copy a slice of size `vocab_size` and do not copy the entire array.
+    NDArray logits_on_cpu = UpdateLogitsOrProbsOnCPUSync(logits, token_offset, nullptr);
+    ICHECK(logits_on_cpu.defined());
+    ICHECK_EQ(logits_on_cpu->ndim, 1);
+    ICHECK_EQ(logits_on_cpu->shape[0], logits->shape[2]);
+
+    // - Invoke environment compute function if exists.
+    const PackedFunc* f_logits_to_probs = Registry::Get("mlc.llm.compute_probs_from_logits");
+    if (f_logits_to_probs != nullptr) {
+      return (*f_logits_to_probs)(logits_on_cpu, state, generation_cfg);
+    }
+
+    // - Apply repetition penalty (inplace).
+    if (generation_cfg->repetition_penalty != 1.0) {
+      ApplyRepetitionPenaltyOnCPU(logits_on_cpu, state, generation_cfg->repetition_penalty);
+    }
+    // - Compute probability (inplace) from logits.
+    //   Using softmax if temperature is non-zero.
+    //   Or set probability of the max-logit position to 1.
+    if (generation_cfg->temperature >= 1e-6) {
+      ApplySoftmaxWithTemperatureOnCPU(logits_on_cpu, generation_cfg->temperature);
+    } else {
+      SetProbWithArgmaxOnCPU(logits_on_cpu);
+    }
+
+    return logits_on_cpu;
+  }
+
+  /*!
+   * \brief Sample a token from the input probability distribution.
+   * The input logits may be batched. We use an input "token offset"
+   * to determine the start probability offset of the token to compute.
+   * \param probs The input probability distribution.
+   * \param token_offset The input token offset to determine where the
+   * probability distribution of the target token start.
+   * \param generation_cfg The generation config.
+   * \return The sampled token.
+   */
+  int32_t SampleTokenFromProbs(NDArray probs, int token_offset, GenerationConfig generation_cfg) {
+    // probs: (b, n, v) or (v,)
+    CHECK(probs->ndim == 3 || probs->ndim == 1);
+
+    NDArray probs_on_cpu{nullptr};
+    if (probs->ndim == 3) {
+      // - Copy probs to host.
+      //   We only copy a slice of size `vocab_size` and do not copy the entire array.
+      if (probs->device.device_type == kDLCPU && probs->shape[0] == 1 && probs->shape[1] == 1) {
+        // No need to copy.
+        probs_on_cpu = probs_on_cpu.CreateView({probs->shape[2]}, probs->dtype);
+      } else {
+        probs_on_cpu = UpdateLogitsOrProbsOnCPUSync(probs, token_offset, &probs_on_cpu_);
+      }
+      ICHECK(probs_on_cpu.defined());
+      ICHECK_EQ(probs_on_cpu->shape[0], probs->shape[2]);
+    } else {
+      probs_on_cpu = probs;
+    }
+    ICHECK_EQ(probs_on_cpu->ndim, 1);
+
+    // - Invoke environment compute function if exists.
+    const PackedFunc* f_sample_from_probs = Registry::Get("mlc.llm.sample_from_probs");
+    if (f_sample_from_probs != nullptr) {
+      return (*f_sample_from_probs)(probs_on_cpu, generation_cfg);
+    }
+
+    // Sample top p from probability.
+    return fsample_topp_from_prob_(probs_on_cpu, generation_cfg->top_p, GetRandomNumber());
+  }
+
+  /*! \brief Copy logits or probabilities to CPU memory. */
+  NDArray UpdateLogitsOrProbsOnCPUSync(NDArray arr_on_device, int token_offset,
+                                       NDArray* p_arr_on_cpu) {
+    // arr_on_device: (b, n, v)
+    ICHECK_EQ(arr_on_device->ndim, 3);
+    int vocab_size = arr_on_device->shape[2];
+    DLDataType dtype = arr_on_device->dtype;
+
+    // - Reuse the NDArray object if `p_arr_on_cpu` is not null.
+    // - Otherwise, allocate a new NDArray.
+    NDArray arr_on_cpu;
+    if (p_arr_on_cpu != nullptr) {
+      if (p_arr_on_cpu->defined()) {
+        ICHECK_EQ((*p_arr_on_cpu)->ndim, 1);
+        ICHECK_EQ((*p_arr_on_cpu)->shape[0], vocab_size)
+            << "Expect vocabulary size remain unchanged";
+        ICHECK((*p_arr_on_cpu).DataType() == arr_on_device.DataType());
+      } else {
+        *p_arr_on_cpu = NDArray::Empty({vocab_size}, dtype, DLDevice{kDLCPU, 0});
+      }
+      arr_on_cpu = *p_arr_on_cpu;
+    } else {
+      arr_on_cpu = NDArray::Empty({vocab_size}, dtype, DLDevice{kDLCPU, 0});
+    }
+
+    DLTensor copy_dst = *(arr_on_cpu.operator->());
+    DLTensor copy_src = *(arr_on_device.operator->());
+    copy_src.byte_offset = token_offset * vocab_size * ((dtype.bits * dtype.lanes + 7) / 8);
+    copy_src.shape = arr_on_cpu->shape;
+    copy_src.ndim = 1;
+    NDArray::CopyFromTo(&copy_src, &copy_dst);
+    TVMSynchronize(device_.device_type, device_.device_id, nullptr);
+    return arr_on_cpu;
+  }
+
+  /*! \brief Apply repetition penalty to logits based on history tokens. */
+  void ApplyRepetitionPenaltyOnCPU(NDArray logits_on_cpu, RequestModelState state,
+                                   double repetition_penalty) {
+    // logits: (v,)
+    CHECK(logits_on_cpu.DataType() == DataType::Float(32)) << "Logits data type is not float32!";
+    CHECK_EQ(logits_on_cpu->ndim, 1);
+    CHECK_EQ(logits_on_cpu->device.device_type, DLDeviceType::kDLCPU);
+    int vocab_size = logits_on_cpu->shape[0];
+
+    // Collect appeared tokens.
+    std::unordered_set<int32_t> appeared_token_ids;
+    appeared_token_ids.insert(state->committed_tokens.begin(), state->committed_tokens.end());
+    appeared_token_ids.insert(state->draft_output_tokens.begin(), state->draft_output_tokens.end());
+
+    float* logits_raw_data = static_cast<float*>(logits_on_cpu->data);
+    for (int32_t token_id : appeared_token_ids) {
+      ICHECK_GE(token_id, 0);
+      ICHECK_LT(token_id, vocab_size);
+      if (logits_raw_data[token_id] <= 0) {
+        logits_raw_data[token_id] *= repetition_penalty;
+      } else {
+        logits_raw_data[token_id] /= repetition_penalty;
+      }
+    }
+  }
+
+  /*! \brief Compute softmax with temperature on CPU. */
+  void ApplySoftmaxWithTemperatureOnCPU(NDArray logits_on_cpu, double temperature) {
+    // logits: (v,)
+    CHECK(logits_on_cpu.DataType() == DataType::Float(32)) << "Logits data type is not float32!";
+    CHECK_EQ(logits_on_cpu->ndim, 1);
+    CHECK_EQ(logits_on_cpu->device.device_type, DLDeviceType::kDLCPU);
+    int vocab_size = logits_on_cpu->shape[0];
+
+    float* logits_raw_data = static_cast<float*>(logits_on_cpu->data);
+    float m = std::numeric_limits<float>::min();
+    float inv_temp = 1.0f / temperature;
+    double d = 0.0f;
+    for (int i = 0; i < vocab_size; ++i) {
+      float x = logits_raw_data[i] * inv_temp;
+      float m_prev = m;
+      m = std::max(m, x);
+      d = d * std::exp(m_prev - m) + std::exp(x - m);
+    }
+    for (int i = 0; i < vocab_size; ++i) {
+      float x = logits_raw_data[i] * inv_temp;
+      logits_raw_data[i] = std::exp(x - m) / d;
+    }
+  }
+
+  /*!
+   * \brief Inplace set probability via argmax.
+   * This is used for zero-temperature sampling cases
+   */
+  void SetProbWithArgmaxOnCPU(NDArray logits_on_cpu) {
+    // logits: (v,)
+    CHECK(logits_on_cpu.DataType() == DataType::Float(32)) << "Logits data type is not float32!";
+    CHECK_EQ(logits_on_cpu->ndim, 1);
+    CHECK_EQ(logits_on_cpu->device.device_type, kDLCPU);
+    int vocab_size = logits_on_cpu->shape[0];
+
+    float* logits_raw_data = static_cast<float*>(logits_on_cpu->data);
+    int argmax_pos = -1;
+    float max_logits = std::numeric_limits<float>::min();
+    for (int i = 0; i < vocab_size; ++i) {
+      if (logits_raw_data[i] > max_logits) {
+        max_logits = logits_raw_data[i];
+        argmax_pos = i;
+      }
+    }
+    ICHECK_NE(argmax_pos, -1);
+
+    std::vector<float> probs(/*count=*/vocab_size, /*value=*/0.0);
+    probs[argmax_pos] = 1.0;
+    logits_on_cpu.CopyFromBytes(probs.data(), vocab_size * sizeof(float));
+  }
+
+  static double GetRandomNumber() { return RandomGenerator::GetInstance().GetRandomNumber(); }
+
+  /*! \brief The runtime device where the input logits is. */
+  DLDevice device_;
+  /*! \brief Function which samples a token from prob distribution with top_p value. */
+  PackedFunc fsample_topp_from_prob_;
+  /*! \brief Shared array for probability distribution on cpu */
+  NDArray probs_on_cpu_{nullptr};
+};
+
+tvm::runtime::Module CreateSamplerModule(DLDevice device) {
+  ObjectPtr<SamplerModule> n = make_object<SamplerModule>(device);
+  return Module(n);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/sampler.h
+++ b/cpp/serve/sampler.h
@@ -1,0 +1,33 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/sampler.h
+ * \brief The header for runtime module of sampler functions.
+ */
+
+#ifndef MLC_LLM_SERVE_SAMPLER_H_
+#define MLC_LLM_SERVE_SAMPLER_H_
+
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/module.h>
+
+#include "../base.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using tvm::Device;
+using namespace tvm::runtime;
+
+/*!
+ * \brief Create the runtime module for sampler functions.
+ * \param device The device to run the sampling-related functions on.
+ * \return The created runtime module.
+ */
+MLC_LLM_DLL tvm::runtime::Module CreateSamplerModule(DLDevice device);
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_SAMPLER_H_

--- a/cpp/serve/tokenizer.cc
+++ b/cpp/serve/tokenizer.cc
@@ -1,0 +1,82 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/tokenizer.cc
+ * \brief The implementation of runtime module of tokenizer encode/decode functions.
+ */
+#define __STDC_FORMAT_MACROS
+
+#include "tokenizer.h"
+
+#include <tokenizers_cpp.h>
+#include <tvm/runtime/c_runtime_api.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+
+#include "../tokenizers.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*!
+ * \brief The tokenizer runtime module.
+ * It contains the encode and decode functions of the tokenizer.
+ */
+class TokenizerModule : public ModuleNode {
+ public:
+  explicit TokenizerModule(String model_path) { tokenizer_ = TokenizerFromPath(model_path); }
+
+  // overrides
+  PackedFunc GetFunction(const String& name, const ObjectPtr<Object>& sptr_to_self) final {
+    if (name == "tokenize") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 1);
+        *rv = Tokenize(args[0]);
+      });
+    } else if (name == "decode") {
+      return PackedFunc([this, sptr_to_self](TVMArgs args, TVMRetValue* rv) {
+        CHECK_EQ(args.size(), 1);
+        *rv = Decode(args[0]);
+      });
+    } else {
+      return PackedFunc(nullptr);
+    }
+  }
+
+  const char* type_key() const final { return "mlc.serve.Tokenizer"; }
+
+ private:
+  /*!
+   * \brief Encode the input text to token ids.
+   * \param text The input to be tokenized
+   * \return The tokenization result.
+   */
+  ShapeTuple Tokenize(std::string text) {
+    CHECK(tokenizer_ != nullptr) << "Tokenizer is not initialized.";
+    std::vector<int32_t> token_ids = this->tokenizer_->Encode(text);
+    return ShapeTuple(token_ids.begin(), token_ids.end());
+  }
+
+  /*!
+   * \brief Decode the input token ids to text.
+   * \param token_ids The input token ids to decode.
+   * \return The decode result.
+   */
+  std::string Decode(ShapeTuple token_ids) {
+    CHECK(tokenizer_ != nullptr) << "Tokenizer is not initialized.";
+    return this->tokenizer_->Decode(std::vector<int32_t>(token_ids.begin(), token_ids.end()));
+  }
+
+  /*! \brief The tokenizer pointer. */
+  std::unique_ptr<Tokenizer> tokenizer_;
+};
+
+tvm::runtime::Module CreateTokenizerModule(String model_path) {
+  ObjectPtr<TokenizerModule> n = make_object<TokenizerModule>(model_path);
+  return Module(n);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/tokenizer.h
+++ b/cpp/serve/tokenizer.h
@@ -1,0 +1,33 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/tokenizer.h
+ * \brief The header for runtime module of tokenizer encode/decode functions.
+ */
+
+#ifndef MLC_LLM_SERVE_TOKENIZER_H_
+#define MLC_LLM_SERVE_TOKENIZER_H_
+
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/module.h>
+
+#include "../base.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using tvm::Device;
+using namespace tvm::runtime;
+
+/*!
+ * \brief Create the runtime module for tokenizer encode/decode functions.
+ * \param model_path The path to the model weights which also contains the tokenizer.
+ * \return The created runtime module.
+ */
+MLC_LLM_DLL tvm::runtime::Module CreateTokenizerModule(String model_path);
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_TOKENIZER_H_

--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -25,6 +25,9 @@ class GenerationConfig:
 
     stop_strs : List[str]
         The list of strings that mark the end of generation.
+
+    stop_tokens : List[int]
+        The list of tokens that mark the end of generation.
     """
 
     temperature: float = 0.8
@@ -33,6 +36,7 @@ class GenerationConfig:
 
     max_new_tokens: int = 128
     stop_strs: List[str] = field(default_factory=list)
+    stop_tokens: List[int] = field(default_factory=list)
 
     def asjson(self) -> str:
         return json.dumps(asdict(self))


### PR DESCRIPTION
This PR introduces the backbone runtime modules
* `ModelModule`, which runs LLM with an internally maintained KV cache,
* `TokenizerModule`, which encodes text to tokens and decodes tokens to text,
* `SamplerModule`, which helps compute prob distribution from logits and sample tokens from prob distributions.

Meanwhile this PR adds `stop_tokens` to GenerationConfig.