### PR TITLE
[Core][Llama] Argument `max_vocab_size` and `max_batch_size`

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -147,6 +147,10 @@ class BuildArgs:
         default=-1,
         metadata={"help": "The maximum allowed sequence length for the model."},
     )
+    max_vocab_size: int = field(
+        default=40000,
+        metadata={"help": "The maximum allowed vocabulary size for the model."},
+    )
     target: str = field(
         default="auto",
         metadata={"help": "The target platform to compile the model for."},
@@ -235,6 +239,14 @@ class BuildArgs:
                 "in the future and remove this flag then."
             ),
             "action": "store_true",
+        },
+    )
+    max_batch_size: int = field(
+        default=80,
+        metadata={
+            "help": (
+                "The maximum batch size for build. It has effect only when batching is enabled."
+            ),
         },
     )
     no_cutlass_attn: bool = field(


### PR DESCRIPTION
This PR introduces the `max_vocab_size` and `max_batch_size` as two new compile arguments. The purpose is for better memory planning.

The default value for `max_vocab_size` is set to 40000, which I think is larger than the values of most models. The default value for `max_batch_size` is currently set as 256. It is possible that we update this value in the future to have a good default number.