### PR TITLE
[Serving] Engine "`generate`" function and latency benchmark

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -480,7 +480,7 @@ class Engine {
     for (Request request : requests) {
       total_input_length += GetRequestPrefillInputLength(request);
     }
-    return current_total_seq_len_ + total_input_length + max_single_sequence_length_ <
+    return current_total_seq_len_ + max_single_sequence_length_ <
            kv_cache_config_->max_total_sequence_length;
   }
 

--- a/python/mlc_chat/serve/data.py
+++ b/python/mlc_chat/serve/data.py
@@ -5,7 +5,6 @@ import tvm._ffi
 from tvm.runtime import Object
 from tvm.runtime.container import getitem_helper
 
-from .. import base
 from . import _ffi_api
 
 

--- a/tests/debug/benchmark_latency.py
+++ b/tests/debug/benchmark_latency.py
@@ -1,0 +1,62 @@
+import argparse
+import time
+from typing import Any, Callable, List
+
+from mlc_chat.serve import GenerationConfig, KVCacheConfig
+from mlc_chat.serve.engine import Engine, ModelInfo
+
+
+def _parse_args():
+    args = argparse.ArgumentParser()
+    args.add_argument("--model-id", type=str, default="Llama-2-7b-chat-hf-q4f16_1")
+    args.add_argument("--device", type=str, default="auto")
+    args.add_argument("--input-length", type=int, default=32)
+    args.add_argument("--output-length", type=int, default=256)
+    args.add_argument("--batch-size", type=int, default=16)
+    parsed = args.parse_args()
+    return parsed
+
+
+def time_evaluator(func: Callable, args: List[Any] = [], num_runs: int = 3, num_warmups: int = 1):
+    # warmup run
+    for _ in range(num_warmups):
+        func(*args)
+
+    total_time = 0.0
+    for run in range(num_runs):
+        print(f"start round {run}")
+        start = time.perf_counter()
+        func(*args)
+        end = time.perf_counter()
+        total_time += end - start
+        print(f"finish round {run}")
+
+    return total_time / num_runs
+
+
+def benchmark(args: argparse.Namespace):
+    # Initialize model loading info and KV cache config
+    model = ModelInfo(args.model_id, args.device)
+    kv_cache_config = KVCacheConfig(
+        page_size=16,
+        max_num_sequence=args.batch_size,
+        max_total_sequence_length=args.output_length * args.batch_size * 2,
+    )
+    generation_config = GenerationConfig(
+        temperature=1.0, top_p=1.0, max_new_tokens=args.output_length
+    )
+    prompts = [[0] * args.input_length] * args.batch_size
+    # Create engine
+    engine = Engine(model, kv_cache_config)
+
+    def engine_generate():
+        engine.generate(prompts, generation_config)
+
+    avg_latency = time_evaluator(engine_generate, num_runs=3)
+    print(args)
+    print(f"Average latency: {avg_latency} seconds for the entire batch")
+
+
+if __name__ == "__main__":
+    ARGS = _parse_args()
+    benchmark(ARGS)

--- a/tests/debug/test_serve_engine.py
+++ b/tests/debug/test_serve_engine.py
@@ -4,6 +4,19 @@ import numpy as np
 from mlc_chat.serve import GenerationConfig, KVCacheConfig, Request, data
 from mlc_chat.serve.engine import Engine, ModelInfo
 
+prompts = [
+    "What is the meaning of life?",
+    "Introduce the history of Pittsburgh to me. Please elaborate in detail.",
+    "Write a three-day Seattle travel plan. Please elaborate in detail.",
+    "What is Alaska famous of? Please elaborate in detail.",
+    "What is the difference between Lambda calculus and Turing machine? Please elaborate in detail.",
+    "What are the necessary components to assemble a desktop computer? Please elaborate in detail.",
+    "Why is Vitamin D important to human beings? Please elaborate in detail.",
+    "Where is milk tea originated from? Please elaborate in detail.",
+    "Where is the southernmost place in United States? Please elaborate in detail.",
+    "Do you know AlphaGo? What capabilities does it have, and what achievements has it got? Please elaborate in detail.",
+]
+
 
 def create_requests(
     num_requests: int,
@@ -14,19 +27,6 @@ def create_requests(
     max_new_tokens_low: int = 256,
     max_new_tokens_high: int = 257,
 ) -> List[Request]:
-    prompts = [
-        "What is the meaning of life?",
-        "Introduce the history of Pittsburgh to me. Please elaborate in detail.",
-        "Write a three-day Seattle travel plan. Please elaborate in detail.",
-        "What is Alaska famous of? Please elaborate in detail.",
-        "What is the difference between Lambda calculus and Turing machine? Please elaborate in detail.",
-        "What are the necessary components to assemble a desktop computer? Please elaborate in detail.",
-        "Why is Vitamin D important to human beings? Please elaborate in detail.",
-        "Where is milk tea originated from? Please elaborate in detail.",
-        "Where is the southernmost place in United States? Please elaborate in detail.",
-        "Do you know AlphaGo? What capabilities does it have, and what achievements has it got? Please elaborate in detail.",
-    ]
-
     assert num_requests >= 0 and num_requests <= len(prompts)
 
     stop_tokens = [stop_token] if stop_token is not None else []
@@ -340,8 +340,28 @@ def test_engine_continuous_batching_3():
         assert isinstance(output, data.TextData)
 
 
+def test_engine_generate():
+    # Initialize model loading info and KV cache config
+    model = ModelInfo("Llama-2-7b-chat-hf-q4f16_1")
+    kv_cache_config = KVCacheConfig(page_size=16)
+    # Create engine
+    engine = Engine(model, kv_cache_config)
+
+    num_requests = 10
+    max_new_tokens = 256
+
+    # Generate output.
+    outputs = engine.generate(
+        prompts[:num_requests], GenerationConfig(max_new_tokens=max_new_tokens)
+    )
+    for req_id, output in enumerate(outputs):
+        print(f"Prompt {req_id}: {prompts[req_id]}")
+        print(f"Output {req_id}:{output}\n")
+
+
 if __name__ == "__main__":
     test_engine_basic()
     test_engine_continuous_batching_1()
     test_engine_continuous_batching_2()
     test_engine_continuous_batching_3()
+    test_engine_generate()


### PR DESCRIPTION
This PR introduces the high-level `generate` function to do text generation for a batch of input prompts. This PR also adds the initial latency benchmark scripts.

Depending on #1075