### PR TITLE
[WIP][Bugfix][Disco] new shard function for 1D scale in q4f16_ft

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -597,6 +597,11 @@ def build_model_from_args(args: argparse.Namespace):
                 "`num_shards` should be used together with "
                 "`--build-model-only` and `--convert-weight-only`"
             )
+        use_ft_quant = args.quantization.name in ["q4f16_ft", "q8f16_ft"]
+        if use_ft_quant:
+            raise ValueError(
+                "Currently, Multi-GPU deployments are not available for ft quantization."
+            )
     os.makedirs(args.artifact_path, exist_ok=True)
     if args.debug_dump:
         os.makedirs(os.path.join(args.artifact_path, "debug"), exist_ok=True)


### PR DESCRIPTION
In the current implementation, we assume quantized weight and scale are 2D tensors, but the weight scales in the FT quantization are 1D. This inappropriate assumption causes an error when we compile the models in`q4f16_ft`. This pr adds a new shard_func named as `shard_qkv_scale_1D` to handle the 1D scales.

@masahi @junrushao 