### PR TITLE
[Slim-LM] Smart path finding for config and weight

### DIFF
--- a/python/mlc_chat/support/auto_config.py
+++ b/python/mlc_chat/support/auto_config.py
@@ -1,0 +1,34 @@
+"""Help function for detecting the model configuration file `config.json`"""
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def detect_config(config_path: Path) -> Path:
+    """Detect and return the path that points to config.json. If config_path is a directory,
+    it looks for config.json below it.
+
+    Parameters
+    ---------
+    config_path : pathlib.Path
+        The path to config.json or the directory containing config.json.
+
+    Returns
+    -------
+    config_json_path : pathlib.Path
+        The path points to config.json.
+    """
+    if not config_path.exists():
+        raise ValueError(f"{config_path} does not exist.")
+
+    if config_path.is_dir():
+        # search config.json under config_path
+        config_json_path = config_path / "config.json"
+        if not config_json_path.exists():
+            raise ValueError(f"Fail to find config.json under {config_path}.")
+    else:
+        config_json_path = config_path
+
+    logger.info("Found config.json: %s", config_json_path)
+    return config_json_path

--- a/python/mlc_chat/support/auto_weight.py
+++ b/python/mlc_chat/support/auto_weight.py
@@ -1,0 +1,125 @@
+"""Help functions for detecting weight paths and weight formats."""
+import json
+import logging
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def detect_weight(
+    weight_path: Path, config_json_path: Path, weight_format: str = "auto"
+) -> Tuple[Path, str]:
+    """Detect the weight directory, and detect the weight format.
+
+    Parameters
+    ---------
+    weight_path : pathlib.Path
+        The path to weight files. If `weight_path` is not None, check if it exists. Otherwise, find
+        `weight_path` in `config.json` or use the same directory as `config.json`.
+
+    config_json_path: pathlib.Path
+        The path to `config.json`.
+
+    weight_format : str
+        The hint for the weight format. If it is "auto", guess the weight format.
+        Otherwise, check the weights are in that format.
+        Available weight formats:
+            - auto (guess the weight format)
+            - PyTorch (validate via checking pytorch_model.bin.index.json)
+            - SafeTensor (validate via checking model.safetensors.index.json)
+            - AWQ
+            - GGML/GGUF
+
+    Returns
+    -------
+    weight_path : pathlib.Path
+        The path that points to the weights.
+
+    weight_format : str
+        The valid weight format.
+    """
+    if weight_path is None:
+        assert (
+            config_json_path is not None and config_json_path.exists()
+        ), "Please provide config.json path."
+
+        # 1. Find the weight_path in config.json
+        with open(config_json_path, encoding="utf-8") as i_f:
+            config = json.load(i_f)
+        if "weight_path" in config:
+            weight_path = Path(config["weight_path"])
+            logger.info('Found "weight_path" in config.json: %s', weight_path)
+            if not weight_path.exists():
+                raise ValueError(f"weight_path doesn't exist: {weight_path}")
+        else:
+            # 2. Find the weights file in the same directory as config.json
+            weight_path = config_json_path.parent
+    else:
+        if not weight_path.exists():
+            raise ValueError(f"weight_path doesn't exist: {weight_path}")
+
+    logger.info("Loading weights from directory: %s", weight_path)
+
+    # check weight format
+    # weight_format = "auto", guess the weight format.
+    # otherwise, check the weight format is valid.
+    if weight_format == "auto":
+        weight_format = _guess_weight_format(weight_path)
+
+    if weight_format not in AVAILABLE_WEIGHT_FORMAT:
+        raise ValueError(
+            f"Available weight format list: {AVAILABLE_WEIGHT_FORMAT}, but got {weight_format}"
+        )
+    if weight_format in CHECK_FORMAT_METHODS:
+        check_func = CHECK_FORMAT_METHODS[weight_format]
+        if not check_func(weight_path):
+            raise ValueError(f"The weight is not in {weight_format} format.")
+    return weight_path, weight_format
+
+
+def _guess_weight_format(weight_path: Path):
+    possible_formats = []
+    for weight_format, check_func in CHECK_FORMAT_METHODS.items():
+        if check_func(weight_path):
+            possible_formats.append(weight_format)
+
+    if len(possible_formats) == 0:
+        raise ValueError(
+            "Fail to detect weight format. Use `--weight-format` to manually specify the format."
+        )
+
+    selected_format = possible_formats[0]
+    logging.info(
+        "Using %s format now. Use `--weight-format` to manually specify the format.",
+        selected_format,
+    )
+    return selected_format
+
+
+def _check_pytorch(weight_path: Path):
+    pytorch_json_path = weight_path / "pytorch_model.bin.index.json"
+    result = pytorch_json_path.exists()
+    if result:
+        logger.info("[Y] Found Huggingface PyTorch: %s", pytorch_json_path)
+    else:
+        logger.info("[X] Not found: Huggingface PyTorch")
+    return result
+
+
+def _check_safetensor(weight_path: Path):
+    safetensor_json_path = weight_path / "model.safetensors.index.json"
+    result = safetensor_json_path.exists()
+    if result:
+        logger.info("[Y] Found SafeTensor: %s", safetensor_json_path)
+    else:
+        logger.info("[X] Not found: SafeTensor")
+    return result
+
+
+CHECK_FORMAT_METHODS = {
+    "PyTorch": _check_pytorch,
+    "SafeTensor": _check_safetensor,
+}
+
+AVAILABLE_WEIGHT_FORMAT = ["PyTorch", "SafeTensor", "GGML", "GGUF", "AWQ"]

--- a/tests/python/test_auto_config.py
+++ b/tests/python/test_auto_config.py
@@ -1,0 +1,44 @@
+# pylint: disable=missing-docstring
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+from mlc_chat.support.auto_config import detect_config
+
+logging.basicConfig(
+    level=logging.INFO,
+    style="{",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="{asctime} {levelname} {filename}:{lineno}: {message}",
+)
+
+
+def _create_json_file(json_path, data):
+    with open(json_path, "w", encoding="utf-8") as i_f:
+        json.dump(data, i_f)
+
+
+def test_detect_config():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_path = Path(tmpdir)
+        config_json_path = base_path / "config.json"
+        _create_json_file(config_json_path, {})
+
+        assert detect_config(base_path) == config_json_path
+        assert detect_config(config_json_path) == config_json_path
+
+
+def test_detect_config_fail():
+    with pytest.raises(ValueError):
+        detect_config(Path("do/not/exist"))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_path = Path(tmpdir)
+        with pytest.raises(ValueError):
+            assert detect_config(base_path)
+
+
+if __name__ == "__main__":
+    pass

--- a/tests/python/test_auto_weight.py
+++ b/tests/python/test_auto_weight.py
@@ -1,0 +1,104 @@
+# pylint: disable=missing-docstring
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from mlc_chat.support.auto_weight import detect_weight
+
+logging.basicConfig(
+    level=logging.INFO,
+    style="{",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="{asctime} {levelname} {filename}:{lineno}: {message}",
+)
+
+
+def _create_json_file(json_path, data):
+    with open(json_path, "w", encoding="utf-8") as i_f:
+        json.dump(data, i_f)
+
+
+@pytest.mark.parametrize(
+    "weight_format, index_filename, result",
+    [
+        ("PyTorch", "pytorch_model.bin.index.json", "PyTorch"),
+        ("SafeTensor", "model.safetensors.index.json", "SafeTensor"),
+        ("GGML", None, "GGML"),
+        ("GGUF", None, "GGUF"),
+        ("AWQ", None, "AWQ"),
+        ("auto", "pytorch_model.bin.index.json", "PyTorch"),
+        ("auto", "model.safetensors.index.json", "SafeTensor"),
+    ],
+)
+def test_detect_weight(weight_format, index_filename, result):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_path = Path(tmpdir)
+        if index_filename is not None:
+            weight_index_file = base_path / index_filename
+            _create_json_file(weight_index_file, {})
+        assert detect_weight(base_path, None, weight_format) == (base_path, result)
+
+
+@pytest.mark.parametrize(
+    "weight_format, index_filename, result",
+    [
+        ("PyTorch", "pytorch_model.bin.index.json", "PyTorch"),
+        ("SafeTensor", "model.safetensors.index.json", "SafeTensor"),
+        ("GGML", None, "GGML"),
+        ("GGUF", None, "GGUF"),
+        ("AWQ", None, "AWQ"),
+        ("auto", "pytorch_model.bin.index.json", "PyTorch"),
+        ("auto", "model.safetensors.index.json", "SafeTensor"),
+    ],
+)
+def test_detect_weight_in_config_json(weight_format, index_filename, result):
+    with tempfile.TemporaryDirectory() as config_dir, tempfile.TemporaryDirectory() as weight_dir:
+        config_path = Path(config_dir)
+        weight_path = Path(weight_dir)
+        config_json_path = config_path / "config.json"
+        _create_json_file(config_json_path, {"weight_path": weight_dir})
+        if index_filename is not None:
+            weight_index_file = weight_path / index_filename
+            _create_json_file(weight_index_file, {})
+
+        assert detect_weight(None, config_json_path, weight_format) == (weight_path, result)
+
+
+@pytest.mark.parametrize(
+    "weight_format, index_filename, result",
+    [
+        ("PyTorch", "pytorch_model.bin.index.json", "PyTorch"),
+        ("SafeTensor", "model.safetensors.index.json", "SafeTensor"),
+        ("GGML", None, "GGML"),
+        ("GGUF", None, "GGUF"),
+        ("AWQ", None, "AWQ"),
+        ("auto", "pytorch_model.bin.index.json", "PyTorch"),
+        ("auto", "model.safetensors.index.json", "SafeTensor"),
+    ],
+)
+def test_detect_weight_same_dir_config_json(weight_format, index_filename, result):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_path = Path(tmpdir)
+        config_json_path = base_path / "config.json"
+        _create_json_file(config_json_path, {})
+        if index_filename is not None:
+            weight_index_file = os.path.join(tmpdir, index_filename)
+            _create_json_file(weight_index_file, {})
+        assert detect_weight(None, config_json_path, weight_format) == (base_path, result)
+
+
+def test_find_weight_fail():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_path = Path(tmpdir)
+        with pytest.raises(ValueError):
+            detect_weight(Path("do/not/exist"), base_path, "AWQ")
+
+    with pytest.raises(AssertionError):
+        detect_weight(None, Path("do/not/exist"), "AWQ")
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
P0. [LLM-H1-1]
Smart path finding functions:

```python
def find_config_json(config_path: str) -> str:
    """Find and return the path to config.json. If config_path is a directory,
    it looks for config.json within it.
    """

def find_weight(weight_path: str, config_json_path: str) -> str:
    """Find the weight directory.
    If user provides `weight_path`, check if it exists.
    If not,
    Step 1. Find the `weight_path` in config file
    Step 2. Find the weight files in the same directory as config.json
    """

def validate_weight_format(weight_path: str, weight_format: str):
    """Valide weight format. Available weight formats:
    - PyTorch (Validate via checking pytorch_model.bin.index.json)
    - SafeTensor (Validate via checking model.safetensors.index.json)
    - AWQ
    - GGML/GGUF
    """
```

cc: @junrushao @zxybazh 
