### PR TITLE
[Utility] Check for isinstance(exc, Exception) before entering pdb

### DIFF
--- a/mlc_llm/build.py
+++ b/mlc_llm/build.py
@@ -10,7 +10,8 @@ def debug_on_except():
     try:
         yield
     finally:
-        if sys.exc_info() == (None, None, None):
+        raised_exception = sys.exc_info()[1]
+        if not isinstance(raised_exception, Exception):
             return
 
         import traceback


### PR DESCRIPTION
This is a follow-up to #1017, which added a `--pdb` flag to enter a debugger on exit.  This commit checks the type of the raised exception, and only enters the debugger if it is a subclass of `Exception`.  This ensures that implementation-details, such as a thrown `SystemExit` or `KeyboardInterrupt`, do not cause an erroneous entry to pdb.