### PR TITLE
[MultiGPU] Support pre-sharded model weights

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring, redefined-outer-name, not-callable
 import argparse
+import functools
 import json
 import os
 import pickle
@@ -29,7 +30,8 @@ from mlc_llm.relax_model import (
     rwkv,
     stablelm_3b,
 )
-from mlc_llm.relax_model.commons import create_shard_info_func
+from mlc_llm.relax_model.commons import create_shard_info_func, create_shard_transformation_func
+from mlc_llm.relax_model.param_manager import transform_params_for_each_rank, chain_parameter_transforms
 from mlc_llm.transform import fuse_split_rotary_embedding, rewrite_attention
 
 
@@ -279,6 +281,13 @@ class BuildArgs:
             ),
         },
     )
+    use_presharded_weights: bool = field(
+        default=False,
+        metadata={
+            "action": "store_true",
+            "help": "Produce separate weight sets for each shard.",
+        },
+    )
     use_flash_attn_mqa: bool = field(
         default=False,
         metadata={
@@ -366,9 +375,14 @@ def _parse_args(parsed) -> argparse.Namespace:
             "tvm.contrib.vllm.single_query_cached_kv_attention", True
         ), "TVM needs to be built with -DUSE_VLLM=ON."
 
-    parsed.artifact_path = os.path.join(
-        parsed.artifact_path, f"{parsed.model}-{parsed.quantization.name}"
-    )
+    model_name = [
+        parsed.model,
+        parsed.quantization.name,
+    ]
+    if parsed.use_presharded_weights:
+        model_name.append(f'presharded-{parsed.num_shards}gpu')
+
+    parsed.artifact_path = os.path.join(parsed.artifact_path, '-'.join(model_name))
 
     return parsed
 
@@ -602,6 +616,7 @@ def dump_mlc_chat_config(
     config["mean_gen_len"] = mean_gen_len
     config["max_gen_len"] = max_gen_len
     config["num_shards"] = args.num_shards
+    config["use_presharded_weights"] = args.use_presharded_weights
     config["shift_fill_factor"] = shift_fill_factor
     if rwkv_world:
         config["tokenizer_files"] = ["tokenizer_model"]
@@ -741,14 +756,45 @@ def build_model_from_args(args: argparse.Namespace):
             qspec_updater.visit_module(mod)
 
         if not args.build_model_only:
+            parameter_transforms = []
+
             # Run pre-quantization if provided.
             args.model_path = param_manager.run_pre_quantize(args.model_path)
             param_manager.init_torch_pname_to_bin_name(args.use_safetensors)
+            parameter_transforms.append(param_manager.create_parameter_transformation())
 
-            mod_transform = param_manager.create_parameter_transformation()
+            # Run pre-sharding if required
+            if args.num_shards > 1 and args.use_presharded_weights:
+                mod_shard = create_shard_transformation_func(param_manager, args, model_config)
+                mod_shard = transform_params_for_each_rank(mod_shard, num_shards=args.num_shards)
+                parameter_transforms.append(mod_shard)
+
+            # Chain all parameter transforms together.  This allows
+            # ReorderTransformFunc to be applied to the single
+            # resulting parameter transformation function.
+            mod_transform = functools.reduce(chain_parameter_transforms, parameter_transforms)
+
+            seq = tvm.ir.transform.Sequential(
+                [
+                    relax.transform.CanonicalizeBindings(),
+                    relax.transform.EliminateCommonSubexpr(),
+                    relax.transform.DeadCodeElimination(),
+                    # TODO(Lunderberg): Implement
+                    # relax.transform.Simplify() that applies
+                    # canonicalization, CSE, and DCE until
+                    # convergence.
+                    relax.transform.CanonicalizeBindings(),
+                    relax.transform.EliminateCommonSubexpr(),
+                    relax.transform.DeadCodeElimination(),
+                    param_manager.optimize_transform_param_order(),
+                ],
+                name="SimplifyModTransform",
+            )
+
+            mod_transform = seq(mod_transform)
+
             params = utils.convert_weights(mod_transform, param_manager, params, args)
-            utils.save_params(params, args.artifact_path)
-
+            utils.save_params(params, args.artifact_path, args.num_shards if args.use_presharded_weights else 1)
 
             if args.model_category != "minigpt":
                 utils.copy_tokenizer(args)

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -745,8 +745,11 @@ def build_model_from_args(args: argparse.Namespace):
             args.model_path = param_manager.run_pre_quantize(args.model_path)
             param_manager.init_torch_pname_to_bin_name(args.use_safetensors)
 
-            new_params = utils.convert_weights(param_manager, params, args)
-            utils.save_params(new_params, args.artifact_path)
+            mod_transform = param_manager.create_parameter_transformation()
+            params = utils.convert_weights(mod_transform, param_manager, params, args)
+            utils.save_params(params, args.artifact_path)
+
+
             if args.model_category != "minigpt":
                 utils.copy_tokenizer(args)
             if args.model_category == "rwkv" or args.model_category == "rwkv_world":

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -380,9 +380,9 @@ def _parse_args(parsed) -> argparse.Namespace:
         parsed.quantization.name,
     ]
     if parsed.use_presharded_weights:
-        model_name.append(f'presharded-{parsed.num_shards}gpu')
+        model_name.append(f"presharded-{parsed.num_shards}gpu")
 
-    parsed.artifact_path = os.path.join(parsed.artifact_path, '-'.join(model_name))
+    parsed.artifact_path = os.path.join(parsed.artifact_path, "-".join(model_name))
 
     return parsed
 
@@ -827,7 +827,6 @@ def build_model_from_args(args: argparse.Namespace):
             # initialization-time transforms to apply is empty.
             sharding_module = create_shard_info_func(param_manager, args, model_config)
             mod.update(sharding_module)
-
 
         with open(cache_path, "wb") as outfile:
             pickle.dump(mod, outfile)

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -821,7 +821,7 @@ def build_model_from_args(args: argparse.Namespace):
 
         mod = mod_transform_before_build(mod, param_manager, args, model_config)
         if args.num_shards > 1:
-            # We requires a "create_sharding_info" function for all
+            # We require a "create_sharding_info" function for all
             # multi-GPU models, even if they are using pre-sharded
             # weights.  When using pre-sharded weights, the list of
             # initialization-time transforms to apply is empty.

--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -1,8 +1,10 @@
 import json
-from typing import List
+from typing import List, Optional, Dict
 
 import tvm
-from tvm import relax, te, topi
+from tvm import relax, tir, te, topi
+
+import mlc_llm
 
 
 def create_metadata_func(
@@ -28,10 +30,9 @@ def create_metadata_func(
         bb.emit_func_output(relax.StringImm(metadata))
 
 
-def create_shard_info_func(param_manager, args, model_config) -> tvm.IRModule:
-    num_shards = args.num_shards
-    param_shape_is_already_sharded = args.build_model_only
-
+def _get_shard_strategies(
+    model_config, num_shards: int, param_shape_is_already_sharded: bool
+) -> Dict[str, tvm.tir.PrimFunc]:
     head_dim = model_config.hidden_size // model_config.num_attention_heads
     q_heads = model_config.num_attention_heads
     kv_heads = model_config.get_num_key_value_heads()
@@ -83,22 +84,34 @@ def create_shard_info_func(param_manager, args, model_config) -> tvm.IRModule:
 
     # pylint: enable=invalid-name
 
-    shard_strategy_to_func = {
+    return {
         "shard_qkv": shard_qkv_weight_scale,
         "shard_mlp_k": shard_k_weight_scale,
         "shard_o_proj_k": shard_k_weight_scale,
         "shard_gate_up": shard_gate_up_weight_scale,
     }
 
+
+def create_shard_info_func(param_manager, args, model_config) -> tvm.IRModule:
+    shard_strategy_to_func = _get_shard_strategies(
+        model_config,
+        num_shards=args.num_shards,
+        param_shape_is_already_sharded=args.build_model_only,
+    )
+
     shard_info_dict = {}
     shard_funcs = {}
 
-    def add_to_shard_info(param_name: str, func_name: str):
-        func = shard_funcs[func_name]
-        buffer = func.buffer_map[func.params[-1]]
-        shape = [int(i) for i in buffer.shape]
-        dtype = str(buffer.dtype)
-        shard_info_dict[param_name] = [(func_name, [shape, dtype])]
+    def add_to_shard_info(param_name: str, func_name: Optional[str]):
+        shard_info = []
+        if func_name is not None:
+            func = shard_funcs[func_name]
+            buffer = func.buffer_map[func.params[-1]]
+            shape = [int(i) for i in buffer.shape]
+            dtype = str(buffer.dtype)
+            shard_info.append((func_name, [shape, dtype]))
+
+        shard_info_dict[param_name] = shard_info
 
     q_params = param_manager.get_quantized_param_info("prefill").fields
     for _, param in param_manager.params.items():
@@ -106,12 +119,15 @@ def create_shard_info_func(param_manager, args, model_config) -> tvm.IRModule:
             pass
         elif param.shard_strategy in shard_strategy_to_func:
             for i, weight in enumerate(param_manager.param2qrange[param]):
-                name = f"{param.shard_strategy}_{i}"
-                if name not in shard_funcs:
-                    shard_funcs[name] = shard_strategy_to_func[param.shard_strategy](
-                        q_params[weight]
-                    )
-                add_to_shard_info(f"param_{weight}", name)
+                if args.use_presharded_weights:
+                    sharding_func_name = None
+                else:
+                    sharding_func_name = f"{param.shard_strategy}_{i}"
+                    if sharding_func_name not in shard_funcs:
+                        shard_funcs[sharding_func_name] = shard_strategy_to_func[
+                            param.shard_strategy
+                        ](q_params[weight])
+                add_to_shard_info(f"param_{weight}", sharding_func_name)
         else:
             raise NotImplementedError(f"Shard strategy not implemented: {param.shard_strategy}")
 
@@ -123,5 +139,102 @@ def create_shard_info_func(param_manager, args, model_config) -> tvm.IRModule:
 
     with bb.function("get_shard_info", params=[]):
         bb.emit_func_output(relax.StringImm(json.dumps(shard_info_dict)))
+
+    return bb.get()
+
+
+def create_shard_transformation_func(param_manager, args, model_config) -> tvm.IRModule:
+    shard_strategy_to_func = _get_shard_strategies(
+        model_config,
+        num_shards=args.num_shards,
+        param_shape_is_already_sharded=args.build_model_only,
+    )
+
+    q_params = param_manager.get_quantized_param_info("prefill").fields
+
+    # The order of the quantized parameters must be preserved.
+    # Therefore, we need to loop over q_params and look up information
+    # as needed, rather than looping over original parameters and
+    # looking up the quantized parameters as needed.
+    orig_param_lookup = {}
+    for param in param_manager.params_in_func["prefill"]:
+        qrange = param_manager.param2qrange[param]
+        for i_orig_part, i_qparam in enumerate(qrange):
+            orig_param_lookup[i_qparam] = (
+                param,
+                i_orig_part,
+                len(qrange),
+            )
+
+    bb = relax.BlockBuilder()  # pylint: disable=invalid-name
+    with bb.function("transform_params"):
+        rank = tir.Var("rank", "int64")
+        # TODO(Lunderberg): Support primitive inputs to relax
+        # functions.  Currently, using a PrimStructInfo as the
+        # argument results in an error thrown during
+        # `vm_shape_lower.cc`, due to BindParams failing to replace
+        # the symbolic variable "rank" when defined in a R.PrimValue.
+        #
+        # rank_arg = relax.Var("rank", relax.PrimStructInfo(value=rank))
+        rank_arg = relax.Var("rank_arg", relax.ShapeStructInfo([rank]))
+
+        args = [rank_arg]
+        output = []
+
+        for i_qparam, qparam_sinfo in enumerate(q_params):
+            param, i_orig_part, num_orig_parts = orig_param_lookup[i_qparam]
+
+            if isinstance(param.quant_spec, mlc_llm.quantization.NoQuantizationSpec):
+                arg_name = param.name
+            elif num_orig_parts == 1:
+                arg_name = f"{param.name}.quantized"
+            else:
+                arg_name = f"{param.name}.quantized_{i_orig_part}"
+
+            arg = relax.Var(arg_name, qparam_sinfo)
+
+            if param.shard_strategy is None:
+                sharded = arg
+            else:
+                strategy_func = shard_strategy_to_func[param.shard_strategy](
+                    qparam_sinfo
+                ).without_attr("global_symbol")
+                strategy_gvar = bb.add_func(
+                    strategy_func,
+                    func_name=f"{arg_name}.sharding_func",
+                )
+
+                # TODO(Lunderberg): Write the strategies as relax
+                # functions, so the sharded shapes can be inferred.
+                reordered_buffer = strategy_func.buffer_map[strategy_func.params[-1]]
+                reordered_sinfo = relax.TensorStructInfo(
+                    reordered_buffer.shape, reordered_buffer.dtype
+                )
+                reordered = relax.op.call_tir(
+                    strategy_gvar, relax.Tuple([arg]), out_sinfo=reordered_sinfo
+                )
+
+                # TODO(Lunderberg): Allow relax.PrimValue as the index
+                # in a TupleGetItem.  This would allow all of the
+                # splits to be generated at once in the merged
+                # function, and could be optimized to an in-place view.
+                #
+                # split = relax.op.split(reordered, indices_or_sections=num_shards, axis=0)[rank]
+                split = relax.op.strided_slice(
+                    reordered,
+                    axes=[0],
+                    begin=[rank],
+                    end=[rank + 1],
+                    assume_inbound=True,
+                )
+
+                sharded = relax.op.squeeze(split, axis=0)
+
+            args.append(arg)
+            output.append(sharded)
+
+        with bb.dataflow():
+            gv = bb.emit_output(output)
+        bb.emit_func_output(output=gv, params=args)
 
     return bb.get()

--- a/mlc_llm/relax_model/param_manager.py
+++ b/mlc_llm/relax_model/param_manager.py
@@ -1015,3 +1015,132 @@ def _create_quantize_func(param_manager: ParamManager) -> tvm.IRModule:
     param_manager.param2qrange = param2qrange
     # Return the created IRModule.
     return bb.get()
+
+
+def transform_params_for_each_rank(
+    mod: tvm.IRModule, num_shards: int, rank_argument_name: str = "rank_arg"
+) -> tvm.IRModule:
+    """Update a parameter transform to apply across all ranks
+
+    For use in generating a pre-sharded set of weights.  Given a
+    parameter transformation that generates sharded model weights for
+    a single shard, produce a parameter transformation that generates
+    sharded model weights for each shard.
+
+    Parameters
+    ----------
+    mod: tvm.IRModule
+
+        A module containing the parameter transformation function,
+        named "transform_params", along with any subroutines called by
+        the parameter transformation.
+
+    num_shards: int
+
+        The number of shards to generate.
+
+    rank_argument_name: str
+
+        The name of the argument that specifies the rank.  Should be a
+        R.ShapeTuple with a single R.PrimStructInfo('int64').
+
+    Returns
+    -------
+    tvm.IRModule
+
+        The modified parameter transformation
+    """
+    generic_transform = mod["transform_params"]
+    tensor_params = generic_transform.params[1:]
+
+    bb = relax.BlockBuilder()
+
+    with bb.function("transform_params", params=tensor_params):
+        output = []
+        for rank in range(num_shards):
+            # TODO(Lunderberg): Implement this in terms of a
+            # generic utility that inlines local functions.
+            func = generic_transform
+            func = func.bind_params({rank_argument_name: relax.ShapeExpr([rank])})
+            func = relax.utils.copy_with_new_vars(func)
+            func = func.bind_params(
+                {var: tensor_param for (var, tensor_param) in zip(func.params, tensor_params)}
+            )
+            shard_tuple = func.body
+            output.extend([shard_tuple[i] for i in range(len(tensor_params))])
+
+        with bb.dataflow():
+            gv = bb.emit_output(relax.Tuple(output))
+        bb.emit_func_output(gv)
+
+    mod["transform_params"] = bb.get()["transform_params"]
+    return mod
+
+
+def chain_parameter_transforms(mod_a: tvm.IRModule, mod_b: tvm.IRModule) -> tvm.IRModule:
+    """Chain two sequential parameter transformations
+
+    For use in manipulating sets of model weights.  Given two
+    parameter transformations that could be applied sequentially,
+    produce a single parameter transformation whose output is the same
+    as applying the parameter transformations sequentially.
+
+
+    .. code-block:: python
+
+        # Before
+        params_after_a = mod_a['transform_params'](orig_params)
+        params_after_b = mod_b['transform_params'](params_after_a)
+
+        # After
+        mod_ab = chain_parameter_transforms(mod_a, mod_b)
+        params_after_b = mod_ab['transform_params'](orig_params)
+
+    Parameters
+    ----------
+    mod_a: tvm.IRModule
+
+        The module containing the first parameter transformation.
+
+    mod_b: tvm.IRModule
+
+        The module containing the second parameter transformation.
+
+    Returns
+    -------
+    tvm.IRModule
+
+        The module containing the output
+
+    """
+    func_a = mod_a["transform_params"]
+    func_b = mod_b["transform_params"]
+
+    bb = relax.BlockBuilder()
+
+    with bb.function("transform_params", params=func_a.params):
+        with bb.dataflow():
+            # TODO(Lunderberg): Implement this in terms of a
+            # generic utility that inlines local functions.
+            func_a_output = bb.emit(func_a.body)
+            func_b_param_map = {param: expr for (param, expr) in zip(func_b.params, func_a_output)}
+            func_b_output = func_b.bind_params(func_b_param_map).body
+            gv = bb.emit_output(func_b_output)
+        bb.emit_func_output(gv)
+
+    merged_transform_func = bb.get()["transform_params"]
+
+    new_mod = {
+        **{
+            gvar: func
+            for gvar, func in mod_a.functions.items()
+            if gvar.name_hint != "transform_params"
+        },
+        **{
+            gvar: func
+            for gvar, func in mod_b.functions.items()
+            if gvar.name_hint != "transform_params"
+        },
+        "transform_params": merged_transform_func,
+    }
+    return tvm.IRModule(new_mod)

--- a/mlc_llm/relax_model/param_manager.py
+++ b/mlc_llm/relax_model/param_manager.py
@@ -763,13 +763,22 @@ class ParamManager:
         """
         mod = _create_quantize_func(self)
         if optimize_parameter_order:
-            reorder_pass = ReorderTransformFunc(
-                self.pidx2pname,
-                self.torch_pname2binname,
-                self.f_convert_pname_fwd,
-            )
-            mod = reorder_pass(mod)
+            mod = self.optimize_transform_param_order()(mod)
         return mod
+
+    def optimize_transform_param_order(self) -> tvm.transform.Pass:
+        """Produce an transformation that optimizes for minimal memory footprint
+
+        Returns
+        -------
+        tvm.transform.Pass
+            The transformation
+        """
+        return ReorderTransformFunc(
+            self.pidx2pname,
+            self.torch_pname2binname,
+            self.f_convert_pname_fwd,
+        )
 
 
 @mutator

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -231,6 +231,7 @@ def convert_weights(
     mod_transform = relax.transform.ToNonDataflow()(mod_transform)
     mod_transform = relax.transform.LazyTransformParams()(mod_transform)
     mod_transform = tvm.tir.transform.ForceNarrowIndexToInt32()(mod_transform)
+    mod_transform = relax.transform.LegalizeOps()(mod_transform)
 
     debug_dump_script(mod_transform, "mod_convert_weights.py", args)
 

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -210,16 +210,11 @@ def debug_dump_shader(ex: tvm.relax.Executable, name: str, args: argparse.Namesp
 
 
 def convert_weights(
+    mod_transform: tvm.IRModule,
     param_mgr: param_manager.ParamManager,
     model_params: List[Optional[tvm.nd.NDArray]],
     args: argparse.Namespace,
 ):
-    # Create the quantization function.
-    # We first create an initial one, then reorder it according to each
-    # weight's location in the binary files, in the purpose of reducing
-    # memory usage when loading torch weights as well as acceleration.
-    mod_transform = param_mgr.create_parameter_transformation()
-
     # Save the number of parameters before we lower mod_transform, so
     # we can use them in the progress bar.
     transform_func = mod_transform["transform_params"]

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -280,11 +280,9 @@ def save_params(params: List[tvm.nd.NDArray], artifact_path: str, num_presharded
     assert len(params) % num_presharded == 0
     num_weights = len(params) // num_presharded
 
-
     meta_data = {}
     param_dict = {}
     meta_data["ParamSize"] = len(params)
-    total_size = 0.0
     for i, nd in enumerate(params):
         if num_presharded == 1:
             param_name = f"param_{i}"

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -153,6 +153,8 @@ class ChatConfig:  # pylint: disable=too-many-instance-attributes
         Name of the model (e.g. ``Llama-2-7b-chat-hf``).
     num_shards: Optional[str]
         Tensor parallel degree.
+    use_presharded_weights: Optional[bool]
+        If True, the weights were saved with sharding already applied.
     max_window_size: Optional[str]
         Maximum kv cache window size.
     """
@@ -171,6 +173,7 @@ class ChatConfig:  # pylint: disable=too-many-instance-attributes
     model_category: Optional[str] = None
     model_name: Optional[str] = None
     num_shards: Optional[int] = None
+    use_presharded_weights: Optional[bool] = None
     max_window_size: Optional[int] = None
 
     @classmethod


### PR DESCRIPTION
Prior to this PR, sharding of model weights was done as the model is being initialized.  This allows a single set of model weights to be used regardless of the number of GPUs available, but may have slow model start-up time, due to the processing performed during start-up.  This processing is done by GPU-0, which then scatters the resulting model weights to all other GPUs.

This PR allows generation and use of pre-sharded model weights.  Here, the sharding of weight tensors is performed at model-build time, removing the run-time computations.  In addition, because each sharded weight tensor is only required by a specific worker, each worker can directly load their subset of the model weights.

The improvement in startup time when compared to initialization-time sharding depends on the number of GPUs being used.  This is due both to the decreased initialization time with pre-sharded weights (smaller sharded size per GPU), and the increased initialization time with un-sharded weights (GPU-0 must scatter data to more GPUs).