### PR TITLE
Enable Python Linter

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,0 +1,37 @@
+name: Python Lint
+
+on: [push, pull_request]
+
+env:
+  IMAGE: 'mlcaidev/ci-cpu:8a87699'
+
+jobs:
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: Version
+      run: |
+        wget https://raw.githubusercontent.com/mlc-ai/package/main/docker/bash.sh -O ./ci/bash.sh
+        chmod u+x ./ci/bash.sh
+        ./ci/bash.sh $IMAGE "conda env export --name ci-lint"
+    - name: Lint
+      run: |
+        ./ci/bash.sh $IMAGE bash ./ci/task/isort.sh
+
+  black:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: Version
+      run: |
+        wget https://raw.githubusercontent.com/mlc-ai/package/main/docker/bash.sh -O ./ci/bash.sh
+        chmod u+x ./ci/bash.sh
+        ./ci/bash.sh $IMAGE "conda env export --name ci-lint"
+    - name: Lint
+      run: |
+        ./ci/bash.sh $IMAGE bash ./ci/task/black.sh

--- a/ci/task/black.sh
+++ b/ci/task/black.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eo pipefail
+
+source ~/.bashrc
+micromamba activate ci-lint
+NUM_THREADS=$(nproc)
+
+black --check --workers $NUM_THREADS ./python/
+black --check --workers $NUM_THREADS ./tests/python

--- a/ci/task/isort.sh
+++ b/ci/task/isort.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eo pipefail
+
+source ~/.bashrc
+micromamba activate ci-lint
+NUM_THREADS=$(nproc)
+
+isort --check-only -j $NUM_THREADS --profile black ./python/
+isort --check-only -j $NUM_THREADS --profile black ./tests/python/


### PR DESCRIPTION
This PR enables two Python formatters "black" and "isort" on the following directory:
- `./python/`
- `./tests/python/`

Enabling pylint and mypy is left for future work