### PR TITLE
[REST] OpenAI compatible Rest API

### DIFF
--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -234,8 +234,16 @@ class GenerationConfig:
         The approximated average number of generated tokens in each round. Used
         to determine whether the maximum window size would be exceeded.
     max_gen_len : Optional[int]
-        The maximum number of tokens to be generated in each round. Would simply
-        stop generating after this number is exceeded.
+        This parameter determines the maximum length of the generated text. If it is
+        not set, the model will generate text until it encounters a stop token.
+    n : Optional[int]
+        This parameter determines the number of text samples to generate. The default
+        value is ``1``.
+    stop : Optional[Union[str, List[str]]]
+        When ``stop`` is encountered, the model will stop generating output.
+        It can be a string or a list of strings. If it is a list of strings, the model
+        will stop generating output when any of the strings in the list is encountered.
+        Note that this parameter does not override the default stop string of the model.
     """
 
     temperature: Optional[float] = None
@@ -245,6 +253,8 @@ class GenerationConfig:
     max_gen_len: Optional[int] = None
     presence_penalty: Optional[float] = 0.0
     frequency_penalty: Optional[float] = 0.0
+    n: Optional[int] = None
+    stop: Optional[Union[str, List[str]]] = None
 
     @classmethod
     def _from_chat_config(generation_config_cls, chat_config_obj: ChatConfig):
@@ -820,25 +830,36 @@ class ChatModule:
           )
           print(output)
         """
-        self._prefill(prompt, generation_config=generation_config)
+        new_msgs = []
+        num_return_sequences = 1
+        return_str = True
+        if generation_config.n:
+            num_return_sequences = generation_config.n
+            return_str = False
+        else:
+            num_return_sequences = 1
 
-        if not progress_callback:
-            while not self._stopped():
-                self._decode(generation_config=generation_config)
-            new_msg = self._get_message()
-            return new_msg
+        for _ in range(num_return_sequences):
+            self.reset_chat()
+            self._prefill(prompt, generation_config=generation_config)
 
-        # apply callback with a rate of callback_interval
-        i, new_msg = 0, ""
-        while not self._stopped():
-            self._decode(generation_config=generation_config)
-            if i % progress_callback.callback_interval == 0 or self._stopped():
+            if not progress_callback:
+                while not self._stopped():
+                    self._decode(generation_config=generation_config)
                 new_msg = self._get_message()
-                progress_callback(new_msg)
-            i += 1
-        progress_callback(stopped=True)
-
-        return new_msg
+                new_msgs.append(new_msg)
+            else:
+                # apply callback with a rate of callback_interval
+                i, new_msg = 0, ""
+                while not self._stopped():
+                    self._decode(generation_config=generation_config)
+                    if i % progress_callback.callback_interval == 0 or self._stopped():
+                        new_msg = self._get_message()
+                        progress_callback(new_msg)
+                    i += 1
+                progress_callback(stopped=True)
+                new_msgs.append(new_msg)
+        return new_msgs[0] if return_str else new_msgs
 
     def reset_chat(self, chat_config: Optional[ChatConfig] = None):
         r"""Reset the chat session, clear all chat history, and potentially
@@ -1014,16 +1035,21 @@ class ChatModule:
                         messages.append([role1, content])
                     else:
                         raise ValueError("Only user and assistant roles are supported.")
-                    
+
                 conv_config["messages"] = messages
-                conv_config["offset"] = 0 # Otherwise, the offset will be set to the length of the conversation, which means history will be retained even after calling reset_chat
-                self._load_json_override(json.dumps({"conv_config": conv_config}), partial_update=True)
+                conv_config[
+                    "offset"
+                ] = 0  # Otherwise, the offset will be set to the length of the conversation, which means history will be retained even after calling reset_chat
+                self._load_json_override(
+                    json.dumps({"conv_config": conv_config}), partial_update=True
+                )
             input_str = input[-1].content
         else:
             input_str = input
-        
 
-        self._prefill_func(input_str, decode_next_token, place_in_prompt.value, generation_config_str)
+        self._prefill_func(
+            input_str, decode_next_token, place_in_prompt.value, generation_config_str
+        )
 
     def _embed(
         self,
@@ -1087,7 +1113,6 @@ class ChatModule:
         """
         generation_config = _get_generation_config(self.chat_config, generation_config)
         generation_config_str = _convert_generation_config_to_json_str(generation_config)
-
         self._decode_func(generation_config_str)
 
     def _stopped(self) -> bool:

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -14,7 +14,6 @@ import tvm
 from tvm.runtime import disco
 
 from . import callback
-
 from .interface.openai_api import ChatMessage
 
 # pylint: disable=line-too-long
@@ -241,7 +240,7 @@ class GenerationConfig:
         not set, the model will generate text until it encounters a stop token.
     n : Optional[int]
         This parameter determines the number of text samples to generate. The default
-        value is ``1``. Note that this parameter is only used when ``stream`` is set to 
+        value is ``1``. Note that this parameter is only used when ``stream`` is set to
         ``False``.
     stop : Optional[Union[str, List[str]]]
         When ``stop`` is encountered, the model will stop generating output.

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -202,26 +202,27 @@ class GenerationConfig:
         The temperature applied to logits before sampling. The default value is
         ``0.7``. A higher temperature encourages more diverse outputs, while a
         lower temperature produces more deterministic outputs.
+    presence_penalty : Optional[float]
+        Number between -2.0 and 2.0. Positive values penalize new tokens based on
+        whether they appear in the text so far, increasing the model's likelihood
+        to talk about new topics. Negative values can increase the likelihood of
+        repetition.
+    frequency_penalty : Optional[float]
+        Number between -2.0 and 2.0. Positive values penalize new tokens based on their
+        existing frequency in the text so far, decreasing the model's likelihood to
+        repeat the same line verbatim. Negative values can increase the likelihood of
+        repetition.
     repetition_penalty : Optional[float]
         The repetition penalty controls the likelihood of the model generating
         repeated texts. The default value is set to ``1.0``, indicating that no
         repetition penalty is applied. Increasing the value reduces the
         likelihood of repeat text generation. However, setting a high
         ``repetition_penalty`` may result in the model generating meaningless
-        texts. The ideal choice of repetition penalty may vary among models.
+        texts. The ideal choice of repetition penalty may vary among models. Only
+        Active when presence_penalty and frequency_penalty are both 0.0.
 
         For more details on how repetition penalty controls text generation, please
         check out the CTRL paper (https://arxiv.org/pdf/1909.05858.pdf).
-    presence_penalty : Optional[float]
-        Number between -2.0 and 2.0. Positive values penalize new tokens based on
-        whether they appear in the text so far, increasing the model's likelihood
-        to talk about new topics. Negative values can increase the likelihood of
-        repetition. Only active if ``repetition_penalty`` is ``1.0``.
-    frequency_penalty : Optional[float]
-        Number between -2.0 and 2.0. Positive values penalize new tokens based on their
-        existing frequency in the text so far, decreasing the model's likelihood to
-        repeat the same line verbatim. Negative values can increase the likelihood of
-        repetition. Only active if ``repetition_penalty`` is ``1.0``.
     top_p : Optional[float]
         This parameter determines the set of tokens from which we sample during
         decoding. The default value is set to ``0.95``. At each step, we select
@@ -255,6 +256,8 @@ class GenerationConfig:
     frequency_penalty: Optional[float] = 0.0
     n: Optional[int] = None
     stop: Optional[Union[str, List[str]]] = None
+    presence_penalty: Optional[float] = 0.0
+    frequency_penalty: Optional[float] = 0.0
 
     @classmethod
     def _from_chat_config(generation_config_cls, chat_config_obj: ChatConfig):

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -212,6 +212,16 @@ class GenerationConfig:
 
         For more details on how repetition penalty controls text generation, please
         check out the CTRL paper (https://arxiv.org/pdf/1909.05858.pdf).
+    presence_penalty : Optional[float]
+        Number between -2.0 and 2.0. Positive values penalize new tokens based on
+        whether they appear in the text so far, increasing the model's likelihood
+        to talk about new topics. Negative values can increase the likelihood of
+        repetition. Only active if ``repetition_penalty`` is ``1.0``.
+    frequency_penalty : Optional[float]
+        Number between -2.0 and 2.0. Positive values penalize new tokens based on their
+        existing frequency in the text so far, decreasing the model's likelihood to
+        repeat the same line verbatim. Negative values can increase the likelihood of
+        repetition. Only active if ``repetition_penalty`` is ``1.0``.
     top_p : Optional[float]
         This parameter determines the set of tokens from which we sample during
         decoding. The default value is set to ``0.95``. At each step, we select
@@ -233,6 +243,8 @@ class GenerationConfig:
     top_p: Optional[float] = None
     mean_gen_len: Optional[int] = None
     max_gen_len: Optional[int] = None
+    presence_penalty: Optional[float] = 0.0
+    frequency_penalty: Optional[float] = 0.0
 
     @classmethod
     def _from_chat_config(generation_config_cls, chat_config_obj: ChatConfig):

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -30,6 +30,8 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: float = None
     n: int = None
     stop: Union[str, List[str]] = None
+    presence_penalty: float = None
+    frequency_penalty: float = None
     # TODO: Implement support for the OpenAI API parameters
     # function []
     # function_call

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -28,10 +28,11 @@ class ChatCompletionRequest(BaseModel):
     max_gen_len: int = None
     presence_penalty: float = None
     frequency_penalty: float = None
+    n: int = None
+    stop: Union[str, List[str]] = None
     # TODO: Implement support for the OpenAI API parameters
     # function []
     # function_call
-    # n: Optional[int] = 1
     # stop: Optional[Union[str, List[str]]] = None
     # max_tokens: Optional[int]
     # logit_bias

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -30,8 +30,6 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: float = None
     n: int = None
     stop: Union[str, List[str]] = None
-    presence_penalty: float = None
-    frequency_penalty: float = None
     # TODO: Implement support for the OpenAI API parameters
     # function []
     # function_call

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -26,14 +26,14 @@ class ChatCompletionRequest(BaseModel):
     mean_gen_len: int = None
     # TODO: replace by max_tokens
     max_gen_len: int = None
+    presence_penalty: float = None
+    frequency_penalty: float = None
     # TODO: Implement support for the OpenAI API parameters
     # function []
     # function_call
     # n: Optional[int] = 1
     # stop: Optional[Union[str, List[str]]] = None
     # max_tokens: Optional[int]
-    # presence_penalty: Optional[float] = 0.0
-    # frequency_penalty: Optional[float] = 0.0
     # logit_bias
     # user: Optional[str] = None
 
@@ -87,6 +87,8 @@ class CompletionRequest(BaseModel):
     mean_gen_len: int = None
     # TODO: replace by max_tokens
     max_gen_len: int = None
+    presence_penalty: float = None
+    frequency_penalty: float = None
     # TODO: Implement support for the OpenAI API parameters
     # suffix
     # max_tokens: Optional[int]
@@ -94,8 +96,6 @@ class CompletionRequest(BaseModel):
     # logprobs
     # echo
     # stop: Optional[Union[str, List[str]]] = None
-    # presence_penalty: Optional[float] = 0.0
-    # frequency_penalty: Optional[float] = 0.0
     # best_of
     # logit_bias
     # user: Optional[str] = None

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -180,12 +180,10 @@ async def request_completion(request: ChatCompletionRequest):
         stop=request.stop,
     )
 
-    session["chat_mod"].reset_chat() # Reset previous history, KV cache, etc.
+    session["chat_mod"].reset_chat()  # Reset previous history, KV cache, etc.
 
     if request.stream:
-        session["chat_mod"]._prefill(
-            input=request.messages, generation_config=generation_config
-        )
+        session["chat_mod"]._prefill(input=request.messages, generation_config=generation_config)
 
         async def iter_response():
             prev_txt = ""
@@ -218,7 +216,8 @@ async def request_completion(request: ChatCompletionRequest):
                     index=index,
                     message=ChatMessage(role="assistant", content=msg[index]),
                     finish_reason="stop",
-                ) for index in range(len(msg))
+                )
+                for index in range(len(msg))
             ],
             # TODO: Fill in correct usage info
             usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -167,6 +167,15 @@ class AsyncCompletionStream:
 async def request_completion(request: ChatCompletionRequest):
     """
     Creates model response for the given chat conversation.
+    The messages field contains a list of messages (describing the conversation history). eg:
+    ```"messages": [{"role": "user", "content": "What's my name?"}, 
+                    {"role": "assistant", "content": "Your name is Llama."}, 
+                    {"role": "user", "content": "No, that's your name. My name is X."},
+                    {"role": "assistant", "content": "Ah, my apologies! Your name is X! "},
+                    {"role": "user", "content": "What is the meaning of life?"},
+                ]
+    ```
+    ]
     """
     generation_config = GenerationConfig(
         temperature=request.temperature,

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -176,6 +176,8 @@ async def request_completion(request: ChatCompletionRequest):
         top_p=request.top_p,
         mean_gen_len=request.mean_gen_len,
         max_gen_len=request.max_gen_len,
+        n=request.n,
+        stop=request.stop,
     )
 
     session["chat_mod"].reset_chat() # Reset previous history, KV cache, etc.
@@ -208,13 +210,15 @@ async def request_completion(request: ChatCompletionRequest):
         msg = session["chat_mod"].generate(
             prompt=request.messages, generation_config=generation_config
         )
+        if isinstance(msg, str):
+            msg = [msg]
         return ChatCompletionResponse(
             choices=[
                 ChatCompletionResponseChoice(
-                    index=0,
-                    message=ChatMessage(role="assistant", content=msg),
+                    index=index,
+                    message=ChatMessage(role="assistant", content=msg[index]),
                     finish_reason="stop",
-                )
+                ) for index in range(len(msg))
             ],
             # TODO: Fill in correct usage info
             usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -32,7 +32,7 @@ class RestAPIArgs:
             )
         }
     )
-    lib_path: str = field(
+    model_lib_path: str = field(
         default=None,
         metadata={
             "help": (
@@ -168,8 +168,8 @@ async def request_completion(request: ChatCompletionRequest):
     """
     Creates model response for the given chat conversation.
     The messages field contains a list of messages (describing the conversation history). eg:
-    ```"messages": [{"role": "user", "content": "What's my name?"}, 
-                    {"role": "assistant", "content": "Your name is Llama."}, 
+    ```"messages": [{"role": "user", "content": "What's my name?"},
+                    {"role": "assistant", "content": "Your name is Llama."},
                     {"role": "user", "content": "No, that's your name. My name is X."},
                     {"role": "assistant", "content": "Ah, my apologies! Your name is X! "},
                     {"role": "user", "content": "What is the meaning of life?"},

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -168,10 +168,11 @@ async def request_completion(request: ChatCompletionRequest):
     """
     Creates model response for the given chat conversation.
     """
-
     generation_config = GenerationConfig(
         temperature=request.temperature,
         repetition_penalty=request.repetition_penalty,
+        presence_penalty=request.presence_penalty,
+        frequency_penalty=request.frequency_penalty,
         top_p=request.top_p,
         mean_gen_len=request.mean_gen_len,
         max_gen_len=request.max_gen_len,
@@ -235,6 +236,8 @@ async def request_completion(request: CompletionRequest):
     generation_config = GenerationConfig(
         temperature=request.temperature,
         repetition_penalty=request.repetition_penalty,
+        presence_penalty=request.presence_penalty,
+        frequency_penalty=request.frequency_penalty,
         top_p=request.top_p,
         mean_gen_len=request.mean_gen_len,
         max_gen_len=request.max_gen_len,

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -32,7 +32,7 @@ class RestAPIArgs:
             )
         }
     )
-    model_lib_path: str = field(
+    lib_path: str = field(
         default=None,
         metadata={
             "help": (


### PR DESCRIPTION
**Add support for additional parameters in REST API**

This PR extends support for the following rest API parameters in accordance with [OpenAI API reference](https://platform.openai.com/docs/api-reference/chat/create) :

- temperature
- top_p
- n
- stop
- max_gen_len
- presence_penalty
- frequency_penalty 

The PR also adds support for passing conversation history in the chat completion endpoint.