### PR TITLE
[Slim-LM] Add BaseLoader and SafeTensorLoader

### DIFF
--- a/python/mlc_chat/compiler/model/llama_parameter.py
+++ b/python/mlc_chat/compiler/model/llama_parameter.py
@@ -58,3 +58,6 @@ def hf_torch(model_config: LlamaConfig) -> ExternMapping:
             map_func[name] = lambda x: x
             param_map[name] = [name]
     return ExternMapping(param_map, map_func, unused_params)
+
+
+hf_safetensor = hf_torch

--- a/python/mlc_chat/compiler/parameter/__init__.py
+++ b/python/mlc_chat/compiler/parameter/__init__.py
@@ -4,3 +4,4 @@ parameters and parameters in MLC-defined models.
 """
 from .hf_torch_loader import HFTorchLoader
 from .mapping import ExternMapping, QuantizeMapping
+from .safetensor_loader import SafeTensorLoader

--- a/python/mlc_chat/compiler/parameter/base_loader.py
+++ b/python/mlc_chat/compiler/parameter/base_loader.py
@@ -1,0 +1,217 @@
+"""Base class for parameter loaders."""
+import dataclasses
+import gc
+import logging
+import time
+from collections import OrderedDict, defaultdict
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, List, Set, Tuple
+
+import numpy as np
+from tqdm import tqdm
+from tvm.runtime import NDArray
+from tvm.runtime.ndarray import array as as_ndarray
+
+from .mapping import ExternMapping
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class Stats:
+    """Statistics of the loading process of loaders.
+
+    Attributes
+    ----------
+    load_time_sec : float
+        Time used in loading the parameters.
+
+    map_time_sec : float
+        Time used in applying the mapping function, i.e. `ExternMapping.map_func`.
+
+    quant_time_sec : float
+        Time used in quantizing the parameters, i.e. `QuantizeMapping.quant_func`.
+
+    current_memory_gb : float
+        The current RAM usage in GB.
+
+    total_memory_gb : float
+        The total size data loaded from disk in GB.
+
+    max_memory_gb : float
+        The maximum RAM usage in GB.
+    """
+
+    load_time_sec: float = 0.0
+    map_time_sec: float = 0.0
+    quant_time_sec: float = 0.0
+
+    current_memory_gb: float = 0.0
+    total_memory_gb: float = 0.0
+    max_memory_gb: float = 0.0
+
+    def timer(self, attr):
+        """A context manager to time the scope and add the time to the attribute."""
+
+        @contextmanager
+        def timed_scope():
+            start_time = time.time()
+            yield
+            elapsed_time = time.time() - start_time
+            setattr(self, attr, getattr(self, attr) + elapsed_time)
+
+        return timed_scope()
+
+    def mem_add(self, nbytes: int):
+        """Add the memory usage by the given number of bytes."""
+        mem_gb = float(nbytes) / float(1024**3)
+        self.current_memory_gb += mem_gb
+        self.total_memory_gb += mem_gb
+        self.max_memory_gb = max(self.max_memory_gb, self.current_memory_gb)
+
+    def mem_rm(self, nbytes: int):
+        """Remove the memory usage by the given number of bytes."""
+        mem_gb = float(nbytes) / float(1024**3)
+        self.current_memory_gb -= mem_gb
+
+
+class BaseLoader:  # pylint: disable=too-few-public-methods
+    """A base loader loading parameters in other format and converts them to MLC's parameters.
+
+    Attributes
+    ----------
+    stats : Stats
+        Statistics of the loading process.
+
+    extern_param_map : ExternMapping
+        The parameter mapping from MLC to the specific source format.
+
+    param_to_path : Dict[str, Path]
+        A mapping from parameter name to the path of the file containing it, or the path
+        meaning all parameters are stored in a single file.
+
+    cached_files : Dict[Path, Dict[str, np.ndarray]]
+        A cache of the loaded files. The key is the path of the file, and the value is a mapping
+        from parameter name to the parameter value.
+
+    weight_format : str
+        The name of the weight format.
+    """
+
+    stats: Stats
+    extern_param_map: ExternMapping
+    cached_files: Dict[Path, Dict[str, np.ndarray]]
+    param_to_path: Dict[str, Path]
+    weight_format: str
+
+    def load(self) -> Iterator[Tuple[str, NDArray]]:
+        """Load the parameters and yield the MLC parameter and its value."""
+        mlc_names = self._loading_order()
+        for mlc_name in tqdm(mlc_names):
+            param = self._load_mlc_param(mlc_name)
+            yield mlc_name, param
+        cached_files = list(self.cached_files.keys())
+        for path in cached_files:
+            self._unload_file(path)
+
+        logger.info(
+            "Time used: "
+            "%s loading: %.3f sec; "
+            "Pre-quantization mapping: %.3f sec; "
+            "Quantization: %.3f sec",
+            self.weight_format,
+            self.stats.load_time_sec,
+            self.stats.map_time_sec,
+            self.stats.quant_time_sec,
+        )
+        logger.info(
+            "Memory usage: Total size loaded from disk: %.3f GB; Peak memory usage: %.3f GB",
+            self.stats.total_memory_gb,
+            self.stats.max_memory_gb,
+        )
+
+    def _load_mlc_param(self, mlc_name: str) -> np.ndarray:
+        param_names = self.extern_param_map.param_map[mlc_name]
+        files_required = {self.param_to_path[p] for p in param_names}
+        files_existing = set(self.cached_files.keys())
+        files_to_load = files_required - files_existing
+        files_to_unload = files_existing - files_required
+
+        # Step 1. When there is some file to unloaded:
+        # - If no pending file load: unloading is deferred as there is no gain in peak memory usage;
+        # - Need to load files: unload immediately to save memory and make space for the new files.
+        if files_to_load:
+            for path in files_to_unload:
+                self._unload_file(path)
+        # Step 2. Load all the files needed
+        for path in files_to_load:
+            self._load_file(path)
+        # Step 3. Collect all source parameters in order
+        source_params = [self.cached_files[self.param_to_path[i]][i] for i in param_names]
+        # Step 4. Apply the mapping function
+        with self.stats.timer("map_time_sec"):
+            param = self.extern_param_map.map_func[mlc_name](*source_params)
+        logger.info('  Parameter: "%s", shape: %s, dtype: %s', mlc_name, param.shape, param.dtype)
+        param = as_ndarray(param)
+        return param
+
+    def _load_file(self, path: Path) -> None:
+        logger.info("Loading %s parameters from: %s", self.weight_format, path)
+        with self.stats.timer("load_time_sec"):
+            result = {}
+            for name, param in self._load_shard(path):
+                result[name] = param
+                self.stats.mem_add(param.nbytes)
+            self.cached_files[path] = result
+
+    def _unload_file(self, path: Path) -> None:
+        logger.info("Unloading %s weight file: %s", self.weight_format, path)
+        with self.stats.timer("load_time_sec"):
+            for _, param in self.cached_files[path].items():
+                self.stats.mem_rm(param.nbytes)
+            del self.cached_files[path]
+            gc.collect()
+
+    def _loading_order(self) -> List[str]:
+        # Step 1. Build a map from path to a specific-format source parameters
+        path_to_param: Dict[Path, List[str]] = defaultdict(list)
+        for param_name, path in self.param_to_path.items():
+            path_to_param[path].append(param_name)
+        # Step 2. Build a map source parameters to MLC parameters
+        param_to_mlc = defaultdict(list)
+        for mlc_name, param_names in self.extern_param_map.param_map.items():
+            for param_name in param_names:
+                param_to_mlc[param_name].append(mlc_name)
+        # Step 3. Construct the ordering that ensures file locality
+        order = OrderedDict()
+        for _, param_names in path_to_param.items():
+            for param_name in param_names:
+                for mlc_name in param_to_mlc[param_name]:
+                    if mlc_name not in order:
+                        order[mlc_name] = 1
+        return list(order.keys())
+
+    def _check_parameter_usage(self, source_weights: Set[str]):
+        used_src_param_names = set(sum(self.extern_param_map.param_map.values(), []))
+        # Check 1. All parameters in the source weight files are used unless explicitly specified
+        unused_src_param_names = (
+            source_weights - used_src_param_names - self.extern_param_map.unused_params
+        )
+        if unused_src_param_names:
+            logger.warning(
+                "Unused %s parameters: %s",
+                self.weight_format,
+                ", ".join(sorted(unused_src_param_names)),
+            )
+        # Check 2. All source parameters required are stored in the weight files
+        nonexistent_src_param_names = used_src_param_names - source_weights
+        if nonexistent_src_param_names:
+            raise ValueError(
+                f"The following {self.weight_format} parameters do not exist in the weight files:"
+                + "\n  "
+                + "\n  ".join(sorted(nonexistent_src_param_names)),
+            )
+
+    def _load_shard(self, path: Path):
+        raise NotImplementedError

--- a/python/mlc_chat/compiler/parameter/safetensor_loader.py
+++ b/python/mlc_chat/compiler/parameter/safetensor_loader.py
@@ -1,4 +1,4 @@
-"""A weight loader for HuggingFace's PyTorch format"""
+"""A weight loader for HuggingFace's SafeTensor format"""
 import json
 import logging
 from pathlib import Path
@@ -8,13 +8,13 @@ import numpy as np
 
 from .base_loader import BaseLoader, Stats
 from .mapping import ExternMapping
-from .utils import load_torch
+from .utils import load_safetensor
 
 logger = logging.getLogger(__name__)
 
 
-class HFTorchLoader(BaseLoader):  # pylint: disable=too-few-public-methods
-    """A loader loading HuggingFace's PyTorch format and converts them to MLC's parameters.
+class SafeTensorLoader(BaseLoader):  # pylint: disable=too-few-public-methods
+    """A loader loading HuggingFace's SafeTensor format and converts them to MLC's parameters.
 
     Attributes
     ----------
@@ -22,10 +22,10 @@ class HFTorchLoader(BaseLoader):  # pylint: disable=too-few-public-methods
         Statistics of the loading process.
 
     extern_param_map : ExternMapping
-        The parameter mapping from MLC to HuggingFace PyTorch.
+        The parameter mapping from MLC to HuggingFace SafeTensor.
 
     param_to_path : Dict[str, Path]
-        A mapping from PyTorch parameter name to the path of the file containing it, or the path
+        A mapping from SafeTensor parameter name to the path of the file containing it, or the path
         meaning all parameters are stored in a single file.
 
     cached_files : Dict[Path, Dict[str, np.ndarray]]
@@ -40,47 +40,47 @@ class HFTorchLoader(BaseLoader):  # pylint: disable=too-few-public-methods
     extern_param_map: ExternMapping
     cached_files: Dict[Path, Dict[str, np.ndarray]]
     param_to_path: Dict[str, Path]
-    weight_format: str = "PyTorch"
+    weight_format: str = "SafeTensor"
 
     def __init__(
         self,
         path: Path,
         extern_param_map: ExternMapping,
     ) -> None:
-        """Create a parameter loader from HuggingFace PyTorch format.
+        """Create a parameter loader from HuggingFace SafeTensor format.
 
         Parameters
         ----------
         path : pathlib.Path
-            Path to either a JSON indexing file, or a PyTorch bin file.
-            1) For JSON indexing file, it is usually `pytorch_model.bin.index.json` in the repo,
-            which contains a `weight_map` that maps each PyTorch parameter to the file containing
-            the weight. 2) For PyTorch bin file, it is usually `pytorch_model.bin` in the repo,
-            which contains all the parameters.
+            Path to either a JSON indexing file, or a SafeTensor bin file.
+            1) For JSON indexing file, it is usually `model.safetensors.index.json` in the repo,
+            which contains a `weight_map` that maps each SafeTensor parameter to the file
+            containing the weight. 2) For SafeTensor file, it is usually `model.safetensors`
+            in the repo, which contains all the parameters.
 
         extern_param_map : ExternMapping
-            Maps an MLC parameter to a list of PyTorch parameters.
+            Maps an MLC parameter to a list of SafeTensor parameters.
         """
         assert path.is_file()
         self.stats = Stats()
         self.extern_param_map = extern_param_map
         self.cached_files = {}
         self.param_to_path = {}
-        if path.suffix == ".bin":
+        if path.suffix == ".safetensors":
             self._load_file(path)
             for name in self.cached_files[path].keys():
                 self.param_to_path[name] = path
         elif path.suffix == ".json":
             with path.open("r", encoding="utf-8") as in_file:
-                torch_weight_map = json.load(in_file)["weight_map"]
-            for torch_name, path_str in torch_weight_map.items():
-                self.param_to_path[torch_name] = path.parent / path_str
+                safetensor_weight_map = json.load(in_file)["weight_map"]
+            for safetensor_name, path_str in safetensor_weight_map.items():
+                self.param_to_path[safetensor_name] = path.parent / path_str
         else:
             raise FileNotFoundError(f"Unknown file suffix: {path}")
         self._check_parameter_usage(set(self.param_to_path.keys()))
 
     def _load_shard(self, path: Path):
-        return load_torch(path)
+        return load_safetensor(path)
 
 
-__all__ = ["HFTorchLoader"]
+__all__ = ["SafeTensorLoader"]

--- a/python/mlc_chat/compiler/parameter/utils.py
+++ b/python/mlc_chat/compiler/parameter/utils.py
@@ -1,0 +1,37 @@
+"""Comman paramter loading/quantization utilities"""
+from pathlib import Path
+
+
+def load_safetensor(path: Path):
+    """Load SafeTensor format files.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        The Safetensor file path.
+    """
+    import safetensors  # pylint: disable=import-outside-toplevel
+
+    with safetensors.safe_open(path, framework="numpy", device="cpu") as in_file:
+        for name in in_file.keys():
+            param = in_file.get_tensor(name)
+            yield name, param
+
+
+def load_torch(path: Path):
+    """Load PyTorch format files.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        The Pytorch file path.
+    """
+    import torch  # pylint: disable=import-outside-toplevel
+
+    for name, param in torch.load(path, map_location=torch.device("cpu")).items():
+        param = param.detach().cpu()
+        dtype = str(param.dtype)
+        if dtype == "torch.bfloat16":
+            param = param.float()
+        param = param.numpy()
+        yield name, param

--- a/tests/python/parameter/test_safetensor_loader.py
+++ b/tests/python/parameter/test_safetensor_loader.py
@@ -1,0 +1,42 @@
+# pylint: disable=missing-docstring
+import logging
+from pathlib import Path
+
+import pytest
+from mlc_chat.compiler.model.llama import LlamaConfig
+from mlc_chat.compiler.model.llama_parameter import hf_safetensor
+from mlc_chat.compiler.parameter import SafeTensorLoader
+from mlc_chat.support import tqdm
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    style="{",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="[{asctime}] {levelname} {filename}:{lineno}: {message}",
+)
+
+
+@pytest.mark.parametrize(
+    "base_path",
+    [
+        "./dist/models/Llama-2-7b-hf",
+        "./dist/models/Llama-2-13b-hf",
+        "./dist/models/Llama-2-70b-hf",
+    ],
+)
+def test_load_llama(base_path: str):
+    base_path = Path(base_path)
+    path_config = base_path / "config.json"
+    path_params = base_path / "model.safetensors.index.json"
+
+    config = LlamaConfig.from_file(path_config)
+    loader = SafeTensorLoader(path=path_params, extern_param_map=hf_safetensor(config))
+    with tqdm.redirect():
+        for _name, _param in loader.load():
+            ...
+
+
+if __name__ == "__main__":
+    test_load_llama(base_path="./dist/models/Llama-2-7b-hf")
+    test_load_llama(base_path="./dist/models/Llama-2-13b-hf")
+    test_load_llama(base_path="./dist/models/Llama-2-70b-hf")


### PR DESCRIPTION
Loading safetensor is similar to the process of loading pytorch, so most of codes in HFTorchLoader could be reused in SafeTensor, or other future loaders. To enhanced code reusability, This PR introduces `BaseLoader`, a container for common helper functions used across multiple loaders. For different loaders, customization would focus on two methods, `__init__` and `_load_shard(self, path: Path)`. `_load_shard` loads parameters from `path` and yield their values.