### PR TITLE
Make the help info consistent with program name

### DIFF
--- a/cpp/cli_main.cc
+++ b/cpp/cli_main.cc
@@ -480,7 +480,7 @@ void Chat(ChatModule* chat, const std::string& device_name, std::string local_id
 }
 
 int main(int argc, char* argv[]) {
-  argparse::ArgumentParser args("mlc_chat");
+  argparse::ArgumentParser args("mlc_chat_cli");
 
   args.add_description(
       "MLCChat CLI is the command line tool to run MLC-compiled LLMs out of the box.\n"


### PR DESCRIPTION
When user use command `mlc_chat_cli --help`, the output will be something like

Usage: `mlc_chat` [--help] ...

That's because the program name specified in `cli_main.cc` is "mlc_chat".   
It will be less confusing if the output of help info shows

Usage: `mlc_chat_cli `[--help] ...