### PR TITLE
Update attention layer

### DIFF
--- a/python/mlc_chat/support/auto_config.py
+++ b/python/mlc_chat/support/auto_config.py
@@ -35,12 +35,13 @@ def detect_config(config: Union[str, Path]) -> Path:
     )
 
     if isinstance(config, str) and config in MODEL_PRESETS:
+        logger.info("%s preset model: %s", FOUND, config)
         content = MODEL_PRESETS[config]
         temp_file = tempfile.NamedTemporaryFile(  # pylint: disable=consider-using-with
             suffix=".json",
             delete=False,
         )
-        logger.info("%s preset model configuration: %s", FOUND, temp_file.name)
+        logger.info("Dumping config to: %s", temp_file.name)
         config_path = Path(temp_file.name)
         with config_path.open("w", encoding="utf-8") as config_file:
             json.dump(content, config_file, indent=2)


### PR DESCRIPTION
Existing dlight optimization only works for NT matmul, but not NN. As a result, the new `nn.Module`-based implementation, which uses NN matmul, fails compilation at HEAD for now. This PR fixes this issue by tweaking `k` to the preferred layout.

The following commands now work with the new compilation pipeline:

```bash
python -m mlc_chat.cli.compile --config llama2_7b  --quantization q4f16_1 -o /tmp/1.so
python -m mlc_chat.cli.compile --config llama2_13b --quantization q4f16_1 -o /tmp/1.so
python -m mlc_chat.cli.compile --config llama2_70b --quantization q4f16_1 -o /tmp/1.so
```

Note that the quantization algorithm per se, `q4f16_1`, has not been implemented yet, meaning this code path is not yet ready for use so far.