### PR TITLE
Support loglikelihood mechanism

### DIFF
--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -52,8 +52,9 @@ Conversation LlamaDefault() {
 Conversation Llama2() {
   Conversation conv;
   conv.name = "llama-2";
-  conv.system =
-      ("[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n ");
+  // TODO(vvchernov): return system prompt, it was hidden for loglikelihood calculation (need redo)
+  // conv.system =
+  //     ("[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n ");
   conv.roles = {"[INST]", "[/INST]"};
   conv.messages = {};
   conv.offset = 0;

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -904,7 +904,7 @@ class LLMChat {
     std::vector<int32_t> prompt_tokens =
         this->PrepareBeforeEmbedding(inp, append_conversation, place_in_prompt, generation_config);
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
-    if (token_len == 0) return nullptr;
+    if (token_len == 0) return std::make_pair(std::numeric_limits<float>::min(), false);
     if (ft_.use_disco) {
       // exclude load shard time from prefill
       this->ft_.sess->SyncWorker(0);

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -915,13 +915,22 @@ class LLMChat {
 
     std::vector<int32_t> continuation_tokens = this->tokenizer_->Encode(continuation);
     // TODO(vvchernov): strange token is added in front of continuation after encoding,
-    // quick remove it, but need study reason and fix it
-    continuation_tokens.erase(continuation_tokens.begin());
+    // There is advanced fix for any cases, but need study reason and fix it
+    int64_t i = 1;
+    int64_t cont_token_length = continuation_tokens.size();
+    for (;i <= cont_token_length;++i) {
+      if (prompt_tokens[token_len - i] != continuation_tokens[cont_token_length - i]) {
+        break;
+      }
+    }
+    for (int64_t j = 0; j < cont_token_length + 1 - i;++j) {
+      continuation_tokens.erase(continuation_tokens.begin());
+    }
 
     std::vector<int32_t> cut_tokens = prompt_tokens;
     cut_tokens.pop_back();
 
-    int32_t new_seq_len = total_seq_len_ + token_len -1;
+    int64_t new_seq_len = total_seq_len_ + token_len - 1;
     NDArray logits_on_device = this->ForwardTokens(cut_tokens, new_seq_len);
     total_seq_len_ = new_seq_len;
 

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1170,8 +1170,9 @@ class LLMChat {
 
     // Calculate log probs sum for continuation_tokens indeces
     float sum = 0;
-    for (int32_t i = 0; i < seq_length; ++i) {
-      int32_t index = i * vocab_length + continuation_tokens[i];
+    int32_t offset_index = offset * vocab_length;
+    for (int32_t i = 0; i < continuation_length; ++i) {
+      int32_t index = offset_index + i * vocab_length + continuation_tokens[i];
       sum += data[index];
     }
 

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -890,8 +890,7 @@ class LLMChat {
 
   std::string LogLikelihoodStep(
       const std::string& context, const std::string& continuation,
-      String generation_config_str = "", bool append_conversation = true,
-      PlaceInPrompt place_in_prompt = PlaceInPrompt::kAll) {
+      String generation_config_str = "") {
     // process generation settings
     picojson::object generation_config = picojson::object();
     if(!generation_config_str.empty()) {
@@ -901,8 +900,7 @@ class LLMChat {
     }
 
     std::string inp = context + continuation;
-    std::vector<int32_t> prompt_tokens =
-        this->PrepareBeforeEmbedding(inp, append_conversation, place_in_prompt, generation_config);
+    std::vector<int32_t> prompt_tokens = this->tokenizer_->Encode(inp);
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
     if (token_len == 0) {
       picojson::object config;

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -904,7 +904,7 @@ class LLMChat {
     std::vector<int32_t> prompt_tokens =
         this->PrepareBeforeEmbedding(inp, append_conversation, place_in_prompt, generation_config);
     int64_t token_len = static_cast<int64_t>(prompt_tokens.size());
-    if (token_len == 0) return;
+    if (token_len == 0) return nullptr;
     if (ft_.use_disco) {
       // exclude load shard time from prefill
       this->ft_.sess->SyncWorker(0);
@@ -1169,7 +1169,7 @@ class LLMChat {
       sum += data[index];
     }
 
-    std::pair<float, bool> res = std::make_pair<float, bool>(sum, is_greedy);
+    auto res = std::make_pair(sum, is_greedy);
     return res;
   }
 

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1443,7 +1443,9 @@ class LLMChat {
     ICHECK(logits_on_cpu_.defined()) << "logits_on_cpu_ is not defined";
     ICHECK_EQ(logits_on_cpu_->ndim, 3) << "logits_on_cpu_ should be 3D";
     ICHECK_EQ(logits_on_cpu_->shape[0], 1) << "logits_on_cpu_ should be 1 batch";
-    return flog_softmax_(logits_on_cpu_);
+    auto log_probs = NDArray::Empty(logits_on_cpu_.Shape(), logits_on_cpu_.DataType(), DLDevice{kDLCPU, 0});
+    flog_softmax_(logits_on_cpu_, log_probs);
+    return log_probs;
   }
 
   //----------------------------

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1184,12 +1184,12 @@ class LLMChat {
   /*!
    * \brief Argmax calculated for logprobs
    */
-  std::vector<int32_t> LogProbsArgmax(const float* logprobs, size_t seq_length, int32_t vocab_length) {
+  std::vector<int32_t> LogProbsArgmax(const float* in_logprobs, size_t seq_length, int32_t vocab_length) {
     std::vector<int32_t> res(seq_length);
 
     for (size_t seq_ind = 0; seq_ind < seq_length; ++seq_ind){
       // Find max and its index in the slice
-      const float* logprobs = logprobs + vocab_length*seq_ind;
+      const float* logprobs = in_logprobs + vocab_length*seq_ind;
       float max_value = logprobs[0];
       int32_t maxarg_ind = 0;
       for (int32_t i = 0; i < vocab_length; ++i) {

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1170,22 +1170,20 @@ class LLMChat {
    */
   std::vector<int32_t> LogProbsArgmax(const float* logprobs, size_t seq_length, int32_t vocab_length) {
     std::vector<int32_t> res(seq_length);
-    std::vector<std::pair<float, int32_t>> data;
-    data.resize(vocab_length);
 
     for (size_t seq_ind = 0; seq_ind < seq_length; ++seq_ind){
-      data.clear();
-      const float* logprobs_ptr = logprobs + vocab_length*seq_ind;
+      // Find max and its index in the slice
+      const float* logprobs = logprobs + vocab_length*seq_ind;
+      float max_value = logprobs[0];
+      int32_t maxarg_ind = 0;
       for (int32_t i = 0; i < vocab_length; ++i) {
-        data[i] = std::make_pair(logprobs_ptr[i], i);
+        if (max_value < logprobs[i]) {
+          max_value = logprobs[i];
+          maxarg_ind = i;
+        }
       }
 
-      // sort by logprobs from largest to smallest
-      std::sort(data.begin(), data.end(), [](const std::pair<float, int>& lhs, const std::pair<float, int>& rhs) {
-        return lhs.first > rhs.first;
-      });
-
-      res[seq_ind] = data[0].second;  // it is maximum after sorting
+      res[seq_ind] = maxarg_ind;
     }
     return res;
   }

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -914,6 +914,9 @@ class LLMChat {
     }
 
     std::vector<int32_t> continuation_tokens = this->tokenizer_->Encode(continuation);
+    // TODO(vvchernov): strange token is added in front of continuation after encoding,
+    // quick remove it, but need study reason and fix it
+    continuation_tokens.erase(continuation_tokens.begin());
 
     std::vector<int32_t> cut_tokens = prompt_tokens;
     cut_tokens.pop_back();

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -852,6 +852,8 @@ class LlamaForCausalLM(nn.Module):
                 last_logits = nn.emit_te(te_slicing, logits, primfunc_name_hint="slice")
             else:
                 last_logits = relax.op.take(logits, logit_positions, axis=1)
+        else:
+            last_logits = logits
 
         return last_logits, key_value_cache, logits
 

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -835,6 +835,8 @@ class LlamaForCausalLM(nn.Module):
             past_key_values=past_key_values,
         )
 
+        # TODO(vvchernov): all logits are needed for loglikelihood calculation
+        # Need update chat part to correct work, it expects the last logits only
         # def te_slicing(x: te.Tensor):
         #     return te.compute(
         #         shape=(1, 1, x.shape[-1]),

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -754,6 +754,7 @@ class ChatModule:  # pylint: disable=too-many-instance-attributes
         self._embed_func = chat_mod["embed"]
         self._prefill_with_embed_func = chat_mod["prefill_with_embed"]
         self._decode_func = chat_mod["decode"]
+        self._logprob_func = chat_mod["loglikelihood"]
         self._raw_generate_func = chat_mod["raw_generate"]
         self._reset_chat_func = chat_mod["reset_chat"]
         self._load_json_override_func = chat_mod["load_json_override"]
@@ -1137,6 +1138,33 @@ class ChatModule:  # pylint: disable=too-many-instance-attributes
         generation_config = _get_generation_config(self.chat_config, generation_config)
         generation_config_str = _convert_generation_config_to_json_str(generation_config)
         self._decode_func(generation_config_str)
+
+    def _logprob(
+        self,
+        context: str,
+        continuation: str,
+        generation_config: Optional[GenerationConfig] = None,
+    ):
+        r"""Generate log probes for given context and continuation.
+        Return logprobes and is_greedy boolean
+
+        Parameters
+        ----------
+        context : str
+            The user input context string.
+        continuation : str
+            The user input continuation string.
+        generation_config: Optional[GenerationConfig]
+            The generation config to override the ChatConfig generation settings.
+
+        Returns
+        -------
+        {"logprobes": float, "is_greedy": bool} : dict
+        """
+        generation_config = _get_generation_config(self.chat_config, generation_config)
+        generation_config_str = _convert_generation_config_to_json_str(generation_config)
+
+        return self._logprob_func(context, continuation, generation_config_str)
 
     def _stopped(self) -> bool:
         r"""Check if the stop condition is met for the current round.

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -83,8 +83,6 @@ class ChatCompletionStreamResponse(BaseModel):
 class CompletionRequest(BaseModel):
     model: str
     prompt: str | list[str]
-    context: str        # TODO(vvchernov): temporal solution
-    continuation: str   # TODO(vvchernov): temporal solution
     stream: bool | None = False
     temperature: float = None
     repetition_penalty: float = None
@@ -98,11 +96,7 @@ class CompletionRequest(BaseModel):
     # suffix
     # max_tokens: Optional[int]
     # n: Optional[int] = 1
-    # TODO(vvchernov): in deprecated OpenAI API logprobs: int
-    # They plan to return logprobs, but API is not known for it
-    # if it remains the same it is needed to developed chat/completion pipeline
-    # Currently we use it for loglikelihood calculations in separated pipeline
-    logprobs: bool = False
+    # logprobs
     # echo
     # stop: Optional[Union[str, List[str]]] = None
     # best_of
@@ -138,6 +132,10 @@ class CompletionStreamResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     choices: List[CompletionResponseStreamChoice]
 
+# TODO(vvchernov): in deprecated OpenAI API logprobs: int
+# They plan to return logprobs, but API is not known for it
+# if it remains the same it is needed to developed chat/completion pipeline
+# Currently we use it for loglikelihood calculations in separated pipeline
 class LogprobRequest(BaseModel):
     model: str
     context: str

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -82,8 +82,10 @@ class ChatCompletionStreamResponse(BaseModel):
 
 class CompletionRequest(BaseModel):
     model: str
-    prompt: Union[str, List[str]]
-    stream: Optional[bool] = False
+    prompt: str | list[str]
+    context: str        # TODO(vvchernov): temporal solution
+    continuation: str   # TODO(vvchernov): temporal solution
+    stream: bool | None = False
     temperature: float = None
     repetition_penalty: float = None
     top_p: float = None
@@ -96,7 +98,11 @@ class CompletionRequest(BaseModel):
     # suffix
     # max_tokens: Optional[int]
     # n: Optional[int] = 1
-    # logprobs
+    # TODO(vvchernov): in deprecated OpenAI API logprobs: int
+    # They plan to return logprobs, but API is not known for it
+    # if it remains the same it is needed to developed chat/completion pipeline
+    # Currently we use it for loglikelihood calculations in separated pipeline
+    logprobs: bool = False
     # echo
     # stop: Optional[Union[str, List[str]]] = None
     # best_of

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -82,8 +82,8 @@ class ChatCompletionStreamResponse(BaseModel):
 
 class CompletionRequest(BaseModel):
     model: str
-    prompt: str | list[str]
-    stream: bool | None = False
+    prompt: Union[str, List[str]]
+    stream: Optional[bool] = False
     temperature: float = None
     repetition_penalty: float = None
     top_p: float = None

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -132,6 +132,7 @@ class CompletionStreamResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     choices: List[CompletionResponseStreamChoice]
 
+
 # TODO(vvchernov): in deprecated OpenAI API logprobs: int
 # They plan to return logprobs, but API is not known for it
 # if it remains the same it is needed to developed chat/completion pipeline
@@ -141,6 +142,7 @@ class LogprobRequest(BaseModel):
     context: str
     continuation: str
 
+
 class LogprobResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"cmpl-{shortuuid.random()}")
     object: str = "text_logprobe"
@@ -148,6 +150,7 @@ class LogprobResponse(BaseModel):
     logprob: float
     is_greedy: bool
     usage: UsageInfo
+
 
 class EmbeddingsRequest(BaseModel):
     model: Optional[str] = None

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -138,6 +138,18 @@ class CompletionStreamResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     choices: List[CompletionResponseStreamChoice]
 
+class LogprobRequest(BaseModel):
+    model: str
+    context: str
+    continuation: str
+
+class LogprobResponse(BaseModel):
+    id: str = Field(default_factory=lambda: f"cmpl-{shortuuid.random()}")
+    object: str = "text_logprobe"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    logprob: float
+    is_greedy: bool
+    usage: UsageInfo
 
 class EmbeddingsRequest(BaseModel):
     model: Optional[str] = None

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -334,6 +334,34 @@ async def request_completion(request: CompletionRequest):
             )
 
 
+@app.post("/v1/logprob")
+async def request_completion(request: LogprobRequest):
+    """
+    Creates a logprob for a given context and continuation.
+    """
+
+    generation_config = GenerationConfig()
+
+    session["chat_mod"].reset_chat()
+
+    logprob_dict_str = session["chat_mod"]._logprob(
+        context=request.context,
+        continuation=request.continuation,
+        generation_config=generation_config
+    )
+    import json
+    logprob_dict = json.loads(logprob_dict_str)
+    logprob = logprob_dict["logprobes"]
+    is_greedy = logprob_dict["is_greedy"]
+
+    return LogprobResponse(
+        logprob=logprob,
+        is_greedy=is_greedy,
+        # TODO: Fill in correct usage info
+        usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+    )
+
+
 @app.post("/v1/embeddings")
 async def request_embeddings(request: EmbeddingsRequest):
     """

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -285,10 +285,6 @@ async def request_completion(request: CompletionRequest):
     else:
         prompt = request.prompt
 
-    # TODO(vvchernov): possibly in OpenAI API format the logprobs can be calculated in stream
-    if request.stream and request.logprobs:
-        raise ValueError("Logprobs calculation is not supported in stream regime")
-
     if request.stream:
         session["chat_mod"]._prefill(  # pylint: disable=protected-access
             input=prompt,
@@ -313,25 +309,12 @@ async def request_completion(request: CompletionRequest):
 
         return StreamingResponse(iter_response(), media_type="text/event-stream")
     else:
-        if request.logprobs:
-            logprob_dict_str = session["chat_mod"]._logprob(
-                context=request.context,
-                continuation=request.continuation,
-                generation_config=generation_config
-            )
-            import json
-            return CompletionResponse(
-                choices=[CompletionResponseChoice(index=0, text=logprob_dict_str)],
-                # TODO: Fill in correct usage info
-                usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
-            )
-        else:
-            msg = session["chat_mod"].generate(prompt=prompt, generation_config=generation_config)
-            return CompletionResponse(
-                choices=[CompletionResponseChoice(index=0, text=msg)],
-                # TODO: Fill in correct usage info
-                usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
-            )
+        msg = session["chat_mod"].generate(prompt=prompt, generation_config=generation_config)
+        return CompletionResponse(
+            choices=[CompletionResponseChoice(index=0, text=msg)],
+            # TODO: Fill in correct usage info
+            usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+        )
 
 
 @app.post("/v1/logprob")

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -330,9 +330,10 @@ async def request_completion(request: LogprobRequest):
     logprob_dict_str = session["chat_mod"]._logprob(
         context=request.context,
         continuation=request.continuation,
-        generation_config=generation_config
+        generation_config=generation_config,
     )
     import json
+
     logprob_dict = json.loads(logprob_dict_str)
     logprob = logprob_dict["logprobes"]
     is_greedy = logprob_dict["is_greedy"]

--- a/tests/logprobe_test.py
+++ b/tests/logprobe_test.py
@@ -4,23 +4,15 @@ import json
 # Get a response using a prompt without streaming
 payload = {
    "model": "Llama-2-7b-chat-hf-q0f16",
-   "prompt": "",    # required parameter, do it dummy
    "context": "Cheerleading: A group of cheerleaders are seen walking on stage while the audience cheers. The group",
    "continuation": " start performing cheer roping on a fake stage while many watch from the stands.",
-   "stream": False,
-   "logprobs": True
 }
-response = requests.post("http://127.0.0.1:8000/v1/completions", json=payload)
+response = requests.post("http://127.0.0.1:8000/v1/logprob", json=payload)
 
 if response.status_code != 200:
    print(f"Error: {response.status_code} - {response.text}")
 
 response = json.loads(response.text)
-logprob_dict = json.loads(response['choices'][0]['text'])
-log_probes = logprob_dict["logprobes"]
-is_greedy = logprob_dict["is_greedy"]
+log_probes = response["logprob"]       # expected -84.03089141845703
+is_greedy = response["is_greedy"]      # expected False
 print(f"Logprobs: {log_probes}; Is_greedy: {is_greedy}")
-
-# Get the latest runtime stats
-r = requests.get("http://127.0.0.1:8000/stats")
-print(f"Runtime stats: {r.json()}\n")

--- a/tests/logprobe_test.py
+++ b/tests/logprobe_test.py
@@ -1,0 +1,26 @@
+import requests
+import json
+
+# Get a response using a prompt without streaming
+payload = {
+   "model": "Llama-2-7b-chat-hf-q0f16",
+   "prompt": "",    # required parameter, do it dummy
+   "context": "Cheerleading: A group of cheerleaders are seen walking on stage while the audience cheers. The group",
+   "continuation": " start performing cheer roping on a fake stage while many watch from the stands.",
+   "stream": False,
+   "logprobs": True
+}
+response = requests.post("http://127.0.0.1:8000/v1/completions", json=payload)
+
+if response.status_code != 200:
+   print(f"Error: {response.status_code} - {response.text}")
+
+response = json.loads(response.text)
+logprob_dict = json.loads(response['choices'][0]['text'])
+log_probes = logprob_dict["logprobes"]
+is_greedy = logprob_dict["is_greedy"]
+print(f"Logprobs: {log_probes}; Is_greedy: {is_greedy}")
+
+# Get the latest runtime stats
+r = requests.get("http://127.0.0.1:8000/stats")
+print(f"Runtime stats: {r.json()}\n")


### PR DESCRIPTION
Loglikelihood approach is needed to check accuracy of a model on popular datasets and tasks like MMLU and BigBench. Particularly HuggingFace leaderboard bases on such tasks only.

**Notes:**
1. Log softmax calculation is transferred onto TVM side. It should be up-streamed before merge. Just now the branch with method implementation is started from tvm/unity, but current 3d-party tvm is gotten from mlc-ai/relax. They have some conflicts and need additional efforts for upstreaming. Need to discuss.
2. Loglikelihood requires sequence of logits after prefill-like inference. But in mlc-llm on the model topology side the last logits set is splitted from all. I've skipped split op on topology side for all models excluding rwkv (need help there). Split has been implemented in mlc-llm

**TEST:**
Tests were performed with lm-evaluation-harness (master branch) on samples from Hellaswag task and Llama2-7b from HF and on mlc-llm side with on Llama2-7b-q0f16. Logprobes for context and four continuation:
Lm-evaluation-harness:
"logit_0": -83.95526123046875,
"logit_1": -40.397254943847656,
"logit_2": -48.10240173339844,
"logit_3": -70.90489196777344,
Mlc-llm:
"logit_0": -84.0309,
"logit_1": -40.476,
"logit_2": -48.3609,
"logit_3": -70.8229,