### PR TITLE
[SLM][AutoLLM] Enable Command Line Weight Conversion

### DIFF
--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -6,12 +6,11 @@ from typing import Union
 
 from mlc_chat.compiler import MODELS, QUANTIZATION
 from mlc_chat.compiler.parameter import HuggingFaceLoader
-
 from tvm.contrib import tvmjs
 
 from ..support.auto_config import detect_config, detect_model_type
-from ..support.auto_weight import detect_weight
 from ..support.auto_target import detect_target_and_host
+from ..support.auto_weight import detect_weight
 
 logging.basicConfig(
     level=logging.INFO,

--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -123,11 +123,14 @@ def main():
     _, quantize_map = model.quantize[quantization_config.kind](model_config, quantization_config)
 
     # loader setup
-    loader = HuggingFaceLoader(
-        path=parsed.params,
-        extern_param_map=model.source[parsed.source_format](model_config, None),
-        quantize_param_map=quantize_map,
-    )
+    if parsed.source_format in ("huggingface-torch", "huggingface-safetensor"):
+        loader = HuggingFaceLoader(
+            path=parsed.params,
+            extern_param_map=model.source[parsed.source_format](model_config, None),
+            quantize_param_map=quantize_map,
+        )
+    else:
+        raise ValueError(f"Unsupported loader source format: {parsed.source_format}")
 
     # load and quantize
     with quantization_target:

--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -101,7 +101,9 @@ def main():
     # parse arguments
     parsed = parser.parse_args()
     parsed.source = _parse_source(parsed.source, parsed.config)
-    parsed.params, parsed.source_format = detect_weight(parsed.source, parsed.source_format)
+    parsed.params, parsed.source_format = detect_weight(
+        parsed.source, parsed.config, weight_format=parsed.source_format
+    )
     model = detect_model_type(parsed.model_type, parsed.config)
 
     # detect quantization target

--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -4,10 +4,9 @@ import logging
 from pathlib import Path
 from typing import Union
 
+import tvm
 from mlc_chat.compiler import MODELS, QUANTIZATION
 from mlc_chat.compiler.parameter import HuggingFaceLoader
-
-import tvm
 from tvm.contrib import tvmjs
 
 from ..support.auto_config import detect_config, detect_model_type

--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -1,0 +1,132 @@
+"""Command line entrypoint of weight conversion."""
+import argparse
+import logging
+from pathlib import Path
+from typing import Union
+
+from ..support.auto_config import detect_config, detect_model_type
+from ..support.auto_target import detect_target_and_host
+
+from tvm.contrib import tvmjs
+from mlc_chat.compiler import MODELS, QUANTIZATION
+
+from mlc_chat.compiler.parameter import HuggingFaceLoader
+
+logging.basicConfig(
+    level=logging.INFO,
+    style="{",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="[{asctime}] {levelname} {filename}:{lineno}: {message}",
+)
+
+
+def main():
+    """Parse command line argumennts and apply quantization."""
+
+    def _parse_config(path: Union[str, Path]) -> Path:
+        try:
+            return detect_config(path)
+        except ValueError as err:
+            raise argparse.ArgumentTypeError(f"No valid config.json in: {path}. Error: {err}")
+
+    def _parse_source(path: Union[str, Path], config_path: Path) -> Path:
+        if path == "auto":
+            return config_path.parent
+        path = Path(path)
+        if not path.is_dir():
+            raise argparse.ArgumentTypeError(f"Directory does not exist: {path}")
+        return path
+
+    def _parse_output(path: Union[str, Path]) -> Path:
+        path = Path(path)
+        if not path.is_dir():
+            path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    parser = argparse.ArgumentParser("MLC AutoLLM Quantization Framework")
+    parser.add_argument(
+        "--config",
+        type=_parse_config,
+        required=True,
+        help="Path to config.json file or to the directory that contains config.json, which is "
+        "a HuggingFace standard that defines model architecture, for example, "
+        "https://huggingface.co/codellama/CodeLlama-7b-Instruct-hf/blob/main/config.json",
+    )
+    parser.add_argument(
+        "--source",
+        type=str,
+        required=False,
+        default="auto",
+        help="The path to original model weight, infer from `config` if missing",
+    )
+    parser.add_argument(
+        "--source-format",
+        type=str,
+        required=False,
+        # todo support auto
+        choices=["huggingface-torch", "huggingface-safetensor"],  # "auto"
+        default="huggingface-safetensor",  # "auto"
+        help="The format of source model weight, infer from `config` if missing",
+    )
+    parser.add_argument(
+        "--quantization",
+        type=str,
+        required=True,
+        choices=list(QUANTIZATION.keys()),
+        help="Quantization format, for example `q4f16_1`.",
+    )
+    parser.add_argument(
+        "--model-type",
+        type=str,
+        default="auto",
+        choices=["auto"] + list(MODELS.keys()),
+        help="Model architecture, for example, llama. If not set, it is inferred "
+        "from the config.json file.",
+    )
+    # TODO: support device, currently cuda only
+    # parser.add_argument(
+    #     "--device",
+    #     type=str,
+    #     default="auto",
+    #     help="The device used to do quantization, for example `auto` / `cuda:0` / `cuda --arch sm86`",
+    # )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=_parse_output,
+        required=True,
+        help="The output directory to save the quantized model weight, will contain `params_shard_*.bin` and `ndarray-cache.json`.",
+    )
+    parsed = parser.parse_args()
+    parsed.source = _parse_source(parsed.source, parsed.config)
+    parsed.params = parsed.source / "model.safetensors.index.json"
+    model = detect_model_type(parsed.model_type, parsed.config)
+    # todo: support device, currently cuda only
+    # target, build_func = detect_target_and_host(parsed.device, "llvm")
+
+    # model config & quantization config
+    model_config = model.config.from_file(parsed.config)
+    quantization_config = QUANTIZATION[parsed.quantization]
+    quantize_model, quantize_map = model.quantize[quantization_config.kind](
+        model_config, quantization_config
+    )
+
+    # loader setup
+    loader = HuggingFaceLoader(
+        path=parsed.params,
+        extern_param_map=model.source[parsed.source_format](model_config, None),
+        quantize_param_map=quantize_map,
+    )
+
+    # dump params
+    param_dict = {name: param for name, param in loader.load()}
+    tvmjs.dump_ndarray_cache(
+        param_dict,
+        f"{parsed.output}/params",
+        meta_data={"ParamSize": len(param_dict)},
+        encode_format="raw",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -7,6 +7,7 @@ from typing import Union
 import tvm
 from mlc_chat.compiler import MODELS, QUANTIZATION
 from mlc_chat.compiler.parameter import HuggingFaceLoader
+from mlc_chat.support import tqdm
 from tvm.contrib import tvmjs
 
 from ..support.auto_config import detect_config, detect_model_type
@@ -133,7 +134,7 @@ def main():
         raise ValueError(f"Unsupported loader source format: {parsed.source_format}")
 
     # load and quantize
-    with quantization_target:
+    with quantization_target, tqdm.redirect():
         param_dict = dict(loader.load(device=device))
 
     # dump to output directory

--- a/python/mlc_chat/compiler/model/llama_quantization.py
+++ b/python/mlc_chat/compiler/model/llama_quantization.py
@@ -19,6 +19,6 @@ def group_quant(
     model = quantization.quantize_model(
         model,
         quant_map,
-        "model",
+        "",
     )
     return model, quant_map

--- a/python/mlc_chat/compiler/model/llama_quantization.py
+++ b/python/mlc_chat/compiler/model/llama_quantization.py
@@ -2,8 +2,6 @@
 from typing import Tuple
 
 from tvm.relax.frontend import nn
-from tvm.target import Target
-from tvm.runtime import Device
 
 from ..parameter import QuantizeMapping
 from ..quantization import GroupQuantize

--- a/python/mlc_chat/compiler/model/llama_quantization.py
+++ b/python/mlc_chat/compiler/model/llama_quantization.py
@@ -2,6 +2,8 @@
 from typing import Tuple
 
 from tvm.relax.frontend import nn
+from tvm.target import Target
+from tvm.runtime import Device
 
 from ..parameter import QuantizeMapping
 from ..quantization import GroupQuantize

--- a/python/mlc_chat/compiler/parameter/huggingface_loader.py
+++ b/python/mlc_chat/compiler/parameter/huggingface_loader.py
@@ -9,8 +9,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 from tqdm import tqdm
-from tvm.target import Target
-from tvm.runtime import NDArray, Device
+from tvm.runtime import NDArray
 from tvm.runtime.ndarray import array as as_ndarray
 
 from .mapping import ExternMapping, QuantizeMapping

--- a/python/mlc_chat/compiler/parameter/huggingface_loader.py
+++ b/python/mlc_chat/compiler/parameter/huggingface_loader.py
@@ -5,7 +5,7 @@ import json
 import logging
 from collections import OrderedDict, defaultdict
 from pathlib import Path
-from typing import Dict, List, Tuple, Iterator, Optional
+from typing import Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 from tqdm import tqdm

--- a/python/mlc_chat/compiler/parameter/huggingface_loader.py
+++ b/python/mlc_chat/compiler/parameter/huggingface_loader.py
@@ -5,11 +5,11 @@ import json
 import logging
 from collections import OrderedDict, defaultdict
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, List, Tuple, Iterator, Optional
 
 import numpy as np
 from tqdm import tqdm
-from tvm.runtime import NDArray
+from tvm.runtime import Device, NDArray
 from tvm.runtime.ndarray import array as as_ndarray
 
 from .mapping import ExternMapping, QuantizeMapping
@@ -100,11 +100,23 @@ class HuggingFaceLoader:  # pylint: disable=too-few-public-methods
             raise FileNotFoundError(f"Unknown file suffix: {path}")
         check_parameter_usage(extern_param_map, set(self.torch_to_path.keys()))
 
-    def load(self) -> Iterator[Tuple[str, NDArray]]:
-        """Load the parameters and yield the MLC parameter and its value."""
+    def load(self, device: Optional[Device] = None) -> Iterator[Tuple[str, NDArray]]:
+        """Load the parameters and yield the MLC parameter and its value.
+
+        Parameters
+        ----------
+        device : Optional[Device]
+            The device to store the parameter, default to None, which means using CPU.
+
+        Yields
+        ------
+        Tuple[str, NDArray]
+            The MLC parameter name and its value, quantized if quantization mapping is provided.
+        """
         mlc_names = _loading_order(self.extern_param_map, self.torch_to_path)
         for mlc_name in tqdm(mlc_names):
-            param = self._load_mlc_param(mlc_name)
+            param = self._load_mlc_param(mlc_name, device=device)
+
             if self.quantize_param_map:
                 with self.stats.timer("quant_time_sec"):
                     quantized_params = ParamQuantizer(self.quantize_param_map).quantize(
@@ -135,7 +147,7 @@ class HuggingFaceLoader:  # pylint: disable=too-few-public-methods
         self.stats.log_time_info("HF")
         self.stats.log_mem_usage()
 
-    def _load_mlc_param(self, mlc_name: str) -> np.ndarray:
+    def _load_mlc_param(self, mlc_name: str, device: Optional[Device]) -> NDArray:
         torch_names = self.extern_param_map.param_map[mlc_name]
         files_required = {self.torch_to_path[p] for p in torch_names}
         files_existing = set(self.cached_files.keys())
@@ -157,8 +169,9 @@ class HuggingFaceLoader:  # pylint: disable=too-few-public-methods
         with self.stats.timer("map_time_sec"):
             param = self.extern_param_map.map_func[mlc_name](*torch_params)
         logger.info('  Parameter: "%s", shape: %s, dtype: %s', mlc_name, param.shape, param.dtype)
-        param = as_ndarray(param)
-        return param
+        if device:
+            return as_ndarray(param, device=device)
+        return as_ndarray(param)
 
     def _load_file(self, path: Path) -> None:
         logger.info("Loading HF parameters from: %s", path)

--- a/python/mlc_chat/compiler/parameter/huggingface_loader.py
+++ b/python/mlc_chat/compiler/parameter/huggingface_loader.py
@@ -9,7 +9,8 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 from tqdm import tqdm
-from tvm.runtime import NDArray
+from tvm.target import Target
+from tvm.runtime import NDArray, Device
 from tvm.runtime.ndarray import array as as_ndarray
 
 from .mapping import ExternMapping, QuantizeMapping

--- a/python/mlc_chat/compiler/parameter/huggingface_loader.py
+++ b/python/mlc_chat/compiler/parameter/huggingface_loader.py
@@ -110,14 +110,23 @@ class HuggingFaceLoader:  # pylint: disable=too-few-public-methods
                     quantized_params = ParamQuantizer(self.quantize_param_map).quantize(
                         mlc_name, param
                     )
-                for quantized_name, quantized_param in quantized_params:
+                if not quantized_params:
                     logger.info(
-                        '  Quantized Parameter: "%s", shape: %s, dtype: %s',
-                        quantized_name,
-                        quantized_param.shape,
-                        quantized_param.dtype,
+                        '  Skipped Quantizing Parameter: "%s", shape: %s, dtype: %s',
+                        mlc_name,
+                        param.shape,
+                        param.dtype,
                     )
-                    yield quantized_name, quantized_param
+                    yield mlc_name, param
+                else:
+                    for quantized_name, quantized_param in quantized_params:
+                        logger.info(
+                            '  Quantized Parameter: "%s", shape: %s, dtype: %s',
+                            quantized_name,
+                            quantized_param.shape,
+                            quantized_param.dtype,
+                        )
+                        yield quantized_name, quantized_param
             else:
                 yield mlc_name, param
         cached_files = list(self.cached_files.keys())

--- a/python/mlc_chat/compiler/parameter/utils.py
+++ b/python/mlc_chat/compiler/parameter/utils.py
@@ -2,7 +2,7 @@
 # pylint: disable=too-few-public-methods
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, Set, Tuple
+from typing import TYPE_CHECKING, Iterator, Set, Tuple, Optional
 
 import numpy as np
 
@@ -24,7 +24,7 @@ class ParamQuantizer:
     def __init__(self, quantize_map: "QuantizeMapping") -> None:
         self.quantize_map = quantize_map
 
-    def quantize(self, name: str, param: "NDArray") -> Iterator[Tuple[str, "NDArray"]]:
+    def quantize(self, name: str, param: "NDArray") -> Optional[Iterator[Tuple[str, "NDArray"]]]:
         """Apply quantization to the given parameters
 
         Parameters
@@ -36,11 +36,14 @@ class ParamQuantizer:
 
         Returns
         -------
-        List[Tuple[str, NDArray]]
-            The quantized parameters, each with its name
+        Optional[Iterator[Tuple[str, "NDArray"]]]
+            The quantized parameters, each with its name, returns None if the parameter is not
+            quantized.
         """
-
-        assert name in self.quantize_map.param_map
+        name = f".{name}"
+        if name not in self.quantize_map.param_map:
+            return None
+        assert name in self.quantize_map.map_func, f"Quantization function for {name} not found."
         quantized_names = self.quantize_map.param_map[name]
         quantized_params = self.quantize_map.map_func[name](param)
         return zip(quantized_names, quantized_params)

--- a/python/mlc_chat/compiler/parameter/utils.py
+++ b/python/mlc_chat/compiler/parameter/utils.py
@@ -2,7 +2,7 @@
 # pylint: disable=too-few-public-methods
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, Set, Tuple, Optional
+from typing import TYPE_CHECKING, Iterator, Optional, Set, Tuple
 
 import numpy as np
 

--- a/python/mlc_chat/compiler/quantization/group_quantization.py
+++ b/python/mlc_chat/compiler/quantization/group_quantization.py
@@ -2,11 +2,8 @@
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-<<<<<<< HEAD
 import numpy as np
-=======
-import tvm
->>>>>>> Fix auto detects.
+
 from tvm import DataType, DataTypeCode
 from tvm import dlight as dl
 from tvm import relax, te, tir
@@ -14,7 +11,6 @@ from tvm.relax.frontend import nn
 from tvm.runtime import NDArray
 from tvm.target import Target
 
-from ...support.auto_target import detect_tvm_device
 from ..parameter import QuantizeMapping
 
 
@@ -198,7 +194,7 @@ class GroupQuantize:  # pylint: disable=too-many-instance-attributes
             target = "llvm"
             mod = relax.transform.LegalizeOps()(mod)
         else:
-            raise NotImplementedError
+            raise NotImplementedError(f"Device type {device_type} is not supported")
         ex = relax.build(mod, target)
         vm = relax.VirtualMachine(ex, dev)  # pylint: disable=invalid-name
         self.prebuilt_quantize_func[key] = vm["quantize"]

--- a/python/mlc_chat/compiler/quantization/group_quantization.py
+++ b/python/mlc_chat/compiler/quantization/group_quantization.py
@@ -2,7 +2,11 @@
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+<<<<<<< HEAD
 import numpy as np
+=======
+import tvm
+>>>>>>> Fix auto detects.
 from tvm import DataType, DataTypeCode
 from tvm import dlight as dl
 from tvm import relax, te, tir
@@ -11,6 +15,7 @@ from tvm.runtime import NDArray
 from tvm.target import Target
 
 from ..parameter import QuantizeMapping
+from ...support.auto_target import detect_tvm_device
 
 
 @dataclass

--- a/python/mlc_chat/compiler/quantization/group_quantization.py
+++ b/python/mlc_chat/compiler/quantization/group_quantization.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
-
 from tvm import DataType, DataTypeCode
 from tvm import dlight as dl
 from tvm import relax, te, tir

--- a/python/mlc_chat/compiler/quantization/group_quantization.py
+++ b/python/mlc_chat/compiler/quantization/group_quantization.py
@@ -14,8 +14,8 @@ from tvm.relax.frontend import nn
 from tvm.runtime import NDArray
 from tvm.target import Target
 
-from ..parameter import QuantizeMapping
 from ...support.auto_target import detect_tvm_device
+from ..parameter import QuantizeMapping
 
 
 @dataclass

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Callable, Optional, Tuple
 from tvm import IRModule, relax
 from tvm._ffi import register_func
 from tvm.contrib import tar, xcode
-from tvm.runtime import Device, cpu, cuda
 from tvm.target import Target
 
 from .style import bold, green, red

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -45,26 +45,6 @@ def detect_target_and_host(target_hint: str, host_hint: str = "auto") -> Tuple[T
     return target, build_func
 
 
-def detect_tvm_device(target: Target) -> Device:
-    """Detect the TVM device from the target device.
-
-    Parameters
-    ----------
-    target : Target
-        The target device.
-
-    Returns
-    -------
-    device : Device
-        The TVM device.
-    """
-    if target.kind.name == "llvm":
-        return cpu()
-    if target.kind.name == "cuda":
-        return cuda()
-    raise ValueError(f"Unsupported device type from {target}")
-
-
 def _detect_target_gpu(hint: str) -> Tuple[Target, BuildFunc]:
     if hint in ["iphone", "android", "webgpu", "mali", "opencl"]:
         hint += ":generic"

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Callable, Optional, Tuple
 from tvm import IRModule, relax
 from tvm._ffi import register_func
 from tvm.contrib import tar, xcode
-from tvm.target import Target
 from tvm.runtime import Device, cpu, cuda
+from tvm.target import Target
 
 from .style import bold, green, red
 
@@ -60,10 +60,9 @@ def detect_tvm_device(target: Target) -> Device:
     """
     if target.kind.name == "llvm":
         return cpu()
-    elif target.kind.name == "cuda":
+    if target.kind.name == "cuda":
         return cuda()
-    else:
-        raise ValueError(f"Unsupported device type from {target}")
+    raise ValueError(f"Unsupported device type from {target}")
 
 
 def _detect_target_gpu(hint: str) -> Tuple[Target, BuildFunc]:

--- a/python/mlc_chat/support/auto_weight.py
+++ b/python/mlc_chat/support/auto_weight.py
@@ -2,7 +2,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Optional, List
 
 from .style import green, red
 
@@ -33,15 +33,16 @@ def detect_weight(
         Otherwise, check the weights are in that format.
         Available weight formats:
             - auto (guess the weight format)
-            - PyTorch (validate via checking pytorch_model.bin.index.json)
-            - SafeTensor (validate via checking model.safetensors.index.json)
-            - AWQ
-            - GGML/GGUF
+            - huggingface-torch (validate via checking pytorch_model.bin.index.json)
+            - huggingface-safetensor (validate via checking model.safetensors.index.json)
+            - awq
+            - ggml
+            - gguf
 
     Returns
     -------
-    weight_path : pathlib.Path
-        The path that points to the weights.
+    weight_config_path : pathlib.Path
+        The path that points to the weights config file or the weights directory.
 
     weight_format : str
         The valid weight format.
@@ -72,7 +73,7 @@ def detect_weight(
     # weight_format = "auto", guess the weight format.
     # otherwise, check the weight format is valid.
     if weight_format == "auto":
-        weight_format = _guess_weight_format(weight_path)
+        return _guess_weight_format(weight_path)
 
     if weight_format not in AVAILABLE_WEIGHT_FORMAT:
         raise ValueError(
@@ -80,53 +81,54 @@ def detect_weight(
         )
     if weight_format in CHECK_FORMAT_METHODS:
         check_func = CHECK_FORMAT_METHODS[weight_format]
-        if not check_func(weight_path):
+        weight_config_path = check_func(weight_path)
+        if not weight_config_path:
             raise ValueError(f"The weight is not in {weight_format} format.")
-    return weight_path, weight_format
+    return weight_config_path, weight_format
 
 
-def _guess_weight_format(weight_path: Path):
-    possible_formats = []
+def _guess_weight_format(weight_path: Path) -> Tuple[Path, str]:
+    possible_formats: List[Tuple[Path, str]] = []
     for weight_format, check_func in CHECK_FORMAT_METHODS.items():
-        if check_func(weight_path):
-            possible_formats.append(weight_format)
+        weight_config_path = check_func(weight_path)
+        if weight_config_path:
+            possible_formats.append((weight_config_path, weight_format))
 
     if len(possible_formats) == 0:
         raise ValueError(
             "Fail to detect weight format. Use `--weight-format` to manually specify the format."
         )
 
-    selected_format = possible_formats[0]
+    weight_config_path, selected_format = possible_formats[0]
     logger.info(
         "Using %s format now. Use `--weight-format` to manually specify the format.",
         selected_format,
     )
-    return selected_format
+    return weight_config_path, selected_format
 
 
-def _check_pytorch(weight_path: Path):
+def _check_pytorch(weight_path: Path) -> Optional[Path]:
     pytorch_json_path = weight_path / "pytorch_model.bin.index.json"
-    result = pytorch_json_path.exists()
-    if result:
+    if pytorch_json_path.exists():
         logger.info("%s Huggingface PyTorch: %s", FOUND, pytorch_json_path)
-    else:
-        logger.info("%s Huggingface PyTorch", NOT_FOUND)
-    return result
+        return pytorch_json_path
+    logger.info("%s Huggingface PyTorch", NOT_FOUND)
+    return None
 
 
-def _check_safetensor(weight_path: Path):
+def _check_safetensor(weight_path: Path) -> Optional[Path]:
     safetensor_json_path = weight_path / "model.safetensors.index.json"
-    result = safetensor_json_path.exists()
-    if result:
-        logger.info("%s SafeTensor: %s", FOUND, safetensor_json_path)
-    else:
-        logger.info("%s SafeTensor", NOT_FOUND)
-    return result
+    if safetensor_json_path.exists():
+        logger.info("%s Huggingface Safetensor: %s", FOUND, safetensor_json_path)
+        return safetensor_json_path
+    logger.info("%s Huggingface Safetensor", NOT_FOUND)
+    return None
 
 
 CHECK_FORMAT_METHODS = {
-    "PyTorch": _check_pytorch,
-    "SafeTensor": _check_safetensor,
+    "huggingface-torch": _check_pytorch,
+    "huggingface-safetensor": _check_safetensor,
 }
 
-AVAILABLE_WEIGHT_FORMAT = ["PyTorch", "SafeTensor", "GGML", "GGUF", "AWQ"]
+# "awq", "ggml", "gguf" are not supported yet.
+AVAILABLE_WEIGHT_FORMAT = ["huggingface-torch", "huggingface-safetensor"]

--- a/python/mlc_chat/support/auto_weight.py
+++ b/python/mlc_chat/support/auto_weight.py
@@ -2,7 +2,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Tuple, Optional, List
+from typing import List, Optional, Tuple
 
 from .style import green, red
 

--- a/tests/python/support/test_auto_weight.py
+++ b/tests/python/support/test_auto_weight.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 from mlc_chat.support.auto_weight import detect_weight
 
+import tvm
+
 logging.basicConfig(
     level=logging.INFO,
     style="{",
@@ -24,13 +26,13 @@ def _create_json_file(json_path, data):
 @pytest.mark.parametrize(
     "weight_format, index_filename, result",
     [
-        ("PyTorch", "pytorch_model.bin.index.json", "PyTorch"),
-        ("SafeTensor", "model.safetensors.index.json", "SafeTensor"),
-        ("GGML", None, "GGML"),
-        ("GGUF", None, "GGUF"),
-        ("AWQ", None, "AWQ"),
-        ("auto", "pytorch_model.bin.index.json", "PyTorch"),
-        ("auto", "model.safetensors.index.json", "SafeTensor"),
+        ("huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"),
+        ("huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"),
+        # ("ggml", None, "ggml"),
+        # ("gguf", None, "gguf"),
+        # ("awq", None, "awq"),
+        ("auto", "pytorch_model.bin.index.json", "huggingface-torch"),
+        ("auto", "model.safetensors.index.json", "huggingface-safetensor"),
     ],
 )
 def test_detect_weight(weight_format, index_filename, result):
@@ -39,19 +41,19 @@ def test_detect_weight(weight_format, index_filename, result):
         if index_filename is not None:
             weight_index_file = base_path / index_filename
             _create_json_file(weight_index_file, {})
-        assert detect_weight(base_path, None, weight_format) == (base_path, result)
+        assert detect_weight(base_path, None, weight_format) == (weight_index_file, result)
 
 
 @pytest.mark.parametrize(
     "weight_format, index_filename, result",
     [
-        ("PyTorch", "pytorch_model.bin.index.json", "PyTorch"),
-        ("SafeTensor", "model.safetensors.index.json", "SafeTensor"),
-        ("GGML", None, "GGML"),
-        ("GGUF", None, "GGUF"),
-        ("AWQ", None, "AWQ"),
-        ("auto", "pytorch_model.bin.index.json", "PyTorch"),
-        ("auto", "model.safetensors.index.json", "SafeTensor"),
+        ("huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"),
+        ("huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"),
+        # ("ggml", None, "ggml"),
+        # ("gguf", None, "gguf"),
+        # ("awq", None, "awq"),
+        ("auto", "pytorch_model.bin.index.json", "huggingface-torch"),
+        ("auto", "model.safetensors.index.json", "huggingface-safetensor"),
     ],
 )
 def test_detect_weight_in_config_json(weight_format, index_filename, result):
@@ -64,19 +66,19 @@ def test_detect_weight_in_config_json(weight_format, index_filename, result):
             weight_index_file = weight_path / index_filename
             _create_json_file(weight_index_file, {})
 
-        assert detect_weight(None, config_json_path, weight_format) == (weight_path, result)
+        assert detect_weight(None, config_json_path, weight_format) == (weight_index_file, result)
 
 
 @pytest.mark.parametrize(
     "weight_format, index_filename, result",
     [
-        ("PyTorch", "pytorch_model.bin.index.json", "PyTorch"),
-        ("SafeTensor", "model.safetensors.index.json", "SafeTensor"),
-        ("GGML", None, "GGML"),
-        ("GGUF", None, "GGUF"),
-        ("AWQ", None, "AWQ"),
-        ("auto", "pytorch_model.bin.index.json", "PyTorch"),
-        ("auto", "model.safetensors.index.json", "SafeTensor"),
+        ("huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"),
+        ("huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"),
+        # ("ggml", None, "ggml"),
+        # ("gguf", None, "gguf"),
+        # ("awq", None, "awq"),
+        ("auto", "pytorch_model.bin.index.json", "huggingface-torch"),
+        ("auto", "model.safetensors.index.json", "huggingface-safetensor"),
     ],
 )
 def test_detect_weight_same_dir_config_json(weight_format, index_filename, result):
@@ -85,42 +87,21 @@ def test_detect_weight_same_dir_config_json(weight_format, index_filename, resul
         config_json_path = base_path / "config.json"
         _create_json_file(config_json_path, {})
         if index_filename is not None:
-            weight_index_file = os.path.join(tmpdir, index_filename)
+            weight_index_file = Path(os.path.join(tmpdir, index_filename))
             _create_json_file(weight_index_file, {})
-        assert detect_weight(None, config_json_path, weight_format) == (base_path, result)
+        assert detect_weight(None, config_json_path, weight_format) == (weight_index_file, result)
 
 
 def test_find_weight_fail():
     with tempfile.TemporaryDirectory() as tmpdir:
         base_path = Path(tmpdir)
         with pytest.raises(ValueError):
-            detect_weight(Path("do/not/exist"), base_path, "AWQ")
+            detect_weight(Path("do/not/exist"), base_path, "awq")
     with pytest.raises(AssertionError):
-        detect_weight(None, Path("do/not/exist"), "AWQ")
+        detect_weight(None, Path("do/not/exist"), "awq")
 
 
 if __name__ == "__main__":
-    test_detect_weight("PyTorch", "pytorch_model.bin.index.json", "PyTorch")
-    test_detect_weight("SafeTensor", "model.safetensors.index.json", "SafeTensor")
-    test_detect_weight("GGML", None, "GGML")
-    test_detect_weight("GGUF", None, "GGUF")
-    test_detect_weight("AWQ", None, "AWQ")
-    test_detect_weight("auto", "pytorch_model.bin.index.json", "PyTorch")
-    test_detect_weight("auto", "model.safetensors.index.json", "SafeTensor")
-    test_detect_weight_in_config_json("PyTorch", "pytorch_model.bin.index.json", "PyTorch")
-    test_detect_weight_in_config_json("SafeTensor", "model.safetensors.index.json", "SafeTensor")
-    test_detect_weight_in_config_json("GGML", None, "GGML")
-    test_detect_weight_in_config_json("GGUF", None, "GGUF")
-    test_detect_weight_in_config_json("AWQ", None, "AWQ")
-    test_detect_weight_in_config_json("auto", "pytorch_model.bin.index.json", "PyTorch")
-    test_detect_weight_in_config_json("auto", "model.safetensors.index.json", "SafeTensor")
-    test_detect_weight_same_dir_config_json("PyTorch", "pytorch_model.bin.index.json", "PyTorch")
-    test_detect_weight_same_dir_config_json(
-        "SafeTensor", "model.safetensors.index.json", "SafeTensor"
-    )
-    test_detect_weight_same_dir_config_json("GGML", None, "GGML")
-    test_detect_weight_same_dir_config_json("GGUF", None, "GGUF")
-    test_detect_weight_same_dir_config_json("AWQ", None, "AWQ")
-    test_detect_weight_same_dir_config_json("auto", "pytorch_model.bin.index.json", "PyTorch")
-    test_detect_weight_same_dir_config_json("auto", "model.safetensors.index.json", "SafeTensor")
-    test_find_weight_fail()
+    from tvm import testing
+
+    testing.main()

--- a/tests/python/support/test_auto_weight.py
+++ b/tests/python/support/test_auto_weight.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 from mlc_chat.support.auto_weight import detect_weight
-from tvm import testing
 
 logging.basicConfig(
     level=logging.INFO,
@@ -27,9 +26,6 @@ def _create_json_file(json_path, data):
     [
         ("huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"),
         ("huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"),
-        # ("ggml", None, "ggml"),
-        # ("gguf", None, "gguf"),
-        # ("awq", None, "awq"),
         ("auto", "pytorch_model.bin.index.json", "huggingface-torch"),
         ("auto", "model.safetensors.index.json", "huggingface-safetensor"),
     ],
@@ -48,9 +44,6 @@ def test_detect_weight(weight_format, index_filename, result):
     [
         ("huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"),
         ("huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"),
-        # ("ggml", None, "ggml"),
-        # ("gguf", None, "gguf"),
-        # ("awq", None, "awq"),
         ("auto", "pytorch_model.bin.index.json", "huggingface-torch"),
         ("auto", "model.safetensors.index.json", "huggingface-safetensor"),
     ],
@@ -73,9 +66,6 @@ def test_detect_weight_in_config_json(weight_format, index_filename, result):
     [
         ("huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"),
         ("huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"),
-        # ("ggml", None, "ggml"),
-        # ("gguf", None, "gguf"),
-        # ("awq", None, "awq"),
         ("auto", "pytorch_model.bin.index.json", "huggingface-torch"),
         ("auto", "model.safetensors.index.json", "huggingface-safetensor"),
     ],
@@ -101,4 +91,32 @@ def test_find_weight_fail():
 
 
 if __name__ == "__main__":
-    testing.main()
+    test_detect_weight("huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch")
+    test_detect_weight(
+        "huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"
+    )
+    test_detect_weight("auto", "pytorch_model.bin.index.json", "huggingface-torch")
+    test_detect_weight("auto", "model.safetensors.index.json", "huggingface-safetensor")
+    test_detect_weight_in_config_json(
+        "huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"
+    )
+    test_detect_weight_in_config_json(
+        "huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"
+    )
+    test_detect_weight_in_config_json("auto", "pytorch_model.bin.index.json", "huggingface-torch")
+    test_detect_weight_in_config_json(
+        "auto", "model.safetensors.index.json", "huggingface-safetensor"
+    )
+    test_detect_weight_same_dir_config_json(
+        "huggingface-torch", "pytorch_model.bin.index.json", "huggingface-torch"
+    )
+    test_detect_weight_same_dir_config_json(
+        "huggingface-safetensor", "model.safetensors.index.json", "huggingface-safetensor"
+    )
+    test_detect_weight_same_dir_config_json(
+        "auto", "pytorch_model.bin.index.json", "huggingface-torch"
+    )
+    test_detect_weight_same_dir_config_json(
+        "auto", "model.safetensors.index.json", "huggingface-safetensor"
+    )
+    test_find_weight_fail()

--- a/tests/python/support/test_auto_weight.py
+++ b/tests/python/support/test_auto_weight.py
@@ -7,8 +7,7 @@ from pathlib import Path
 
 import pytest
 from mlc_chat.support.auto_weight import detect_weight
-
-import tvm
+from tvm import testing
 
 logging.basicConfig(
     level=logging.INFO,
@@ -102,6 +101,4 @@ def test_find_weight_fail():
 
 
 if __name__ == "__main__":
-    from tvm import testing
-
     testing.main()


### PR DESCRIPTION
This PR enables weight conversion in command line.
Sample command: `python3 -m mlc_chat.cli.convert_weight --config dist/models/llama-2-13b-chat-hf/ --quantization "q4f16_1" --output dist/test/`

CC: @cyx-6 @junrushao @LeshengJin 