### PR TITLE
Fix Android app Permission denied error on Android 10 

### DIFF
--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/AppViewModel.kt
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/AppViewModel.kt
@@ -171,7 +171,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
                 val url = URL("${modelUrl}${ModelUrlSuffix}${ModelConfigFilename}")
                 val tempId = UUID.randomUUID().toString()
                 val tempFile = File(
-                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                    application.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
                     tempId
                 )
                 url.openStream().use {


### PR DESCRIPTION
This PR fixes #1122 
Current MLCChat android app downloads model config to a temp file in Downloads directory. 
Android 10 introduced Scoped Storage, so our app does not have write access to Downloads directory. Android 11 introduced write access to Downloads, but only files written by our app can be read. So the error occurs only in Android 10. 

Changed logic to download model config in app's scoped storage instead of Downloads directory.