### PR TITLE
[Serving] Update FlashInfer repo link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/mlc-ai/relax.git
 [submodule "3rdparty/flashinfer"]
 	path = 3rdparty/flashinfer
-	url = git@github.com:yzh119/flashinfer.git
+	url = https://github.com/flashinfer-ai/flashinfer.git


### PR DESCRIPTION
This PR updates the 3rdparty FlashInfer URL to its current location (https://github.com/flashinfer-ai/flashinfer).

Turn on `-USE_FLASHINFER=ON` when executing cmake to build MLC LLM runtime with FlashInfer enabled.