### PR TITLE
[Fix][SLM] Update q4f16 quantization with the new mutator name rule

### DIFF
--- a/python/mlc_chat/compiler/parameter/utils.py
+++ b/python/mlc_chat/compiler/parameter/utils.py
@@ -40,7 +40,6 @@ class ParamQuantizer:
             The quantized parameters, each with its name, returns None if the parameter is not
             quantized.
         """
-        name = f".{name}"
         if name not in self.quantize_map.param_map:
             return None
         assert name in self.quantize_map.map_func, f"Quantization function for {name} not found."


### PR DESCRIPTION
After https://github.com/apache/tvm/pull/16046, the top-level module's name would not begin with a dot (.) prefix.
