### PR TITLE
[Minor][SLM][AutoLLM] Fix Quantization Parameter Naming

### DIFF
--- a/python/mlc_chat/compiler/parameter/utils.py
+++ b/python/mlc_chat/compiler/parameter/utils.py
@@ -40,8 +40,8 @@ class ParamQuantizer:
             The quantized parameters, each with its name, returns None if the parameter is not
             quantized.
         """
-        name = f".{name}"
         if name not in self.quantize_map.param_map:
+            """The parameter is not quantized"""
             return None
         assert name in self.quantize_map.map_func, f"Quantization function for {name} not found."
         quantized_names = self.quantize_map.param_map[name]

--- a/python/mlc_chat/compiler/parameter/utils.py
+++ b/python/mlc_chat/compiler/parameter/utils.py
@@ -41,7 +41,7 @@ class ParamQuantizer:
             quantized.
         """
         if name not in self.quantize_map.param_map:
-            """The parameter is not quantized"""
+            # The parameter is not quantized
             return None
         assert name in self.quantize_map.map_func, f"Quantization function for {name} not found."
         quantized_names = self.quantize_map.param_map[name]


### PR DESCRIPTION
This PR removes extra dot in quantized parameter naming, it requires a patch from Relax side: https://github.com/apache/tvm/pull/16047

A sample output in command line quantization process looks like the following snippet:
```bash
[2023-11-02 21:19:31] INFO huggingface_loader.py:171:   Parameter: "model.layers.33.self_attn.qkv_proj.weight", shape: (15360, 5120), dtype: float16              
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.33.self_attn.qkv_proj.q_weight", shape: (15360, 640), dtype: uint32    
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.33.self_attn.qkv_proj.q_scale", shape: (15360, 160), dtype: float16    
[2023-11-02 21:19:31] INFO huggingface_loader.py:171:   Parameter: "model.layers.33.self_attn.o_proj.weight", shape: (5120, 5120), dtype: float16                 
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.33.self_attn.o_proj.q_weight", shape: (5120, 640), dtype: uint32       
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.33.self_attn.o_proj.q_scale", shape: (5120, 160), dtype: float16       
[2023-11-02 21:19:31] INFO huggingface_loader.py:171:   Parameter: "model.layers.34.input_layernorm.weight", shape: (5120,), dtype: float16                       
[2023-11-02 21:19:31] INFO huggingface_loader.py:126:   Skipped Quantizing Parameter: "model.layers.34.input_layernorm.weight", shape: (5120,), dtype: float16    
[2023-11-02 21:19:31] INFO huggingface_loader.py:171:   Parameter: "model.layers.34.mlp.down_proj.weight", shape: (5120, 13824), dtype: float16                   
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.34.mlp.down_proj.q_weight", shape: (5120, 1728), dtype: uint32         
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.34.mlp.down_proj.q_scale", shape: (5120, 432), dtype: float16          
[2023-11-02 21:19:31] INFO huggingface_loader.py:171:   Parameter: "model.layers.34.mlp.gate_up_proj.weight", shape: (27648, 5120), dtype: float16                
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.34.mlp.gate_up_proj.q_weight", shape: (27648, 640), dtype: uint32      
[2023-11-02 21:19:31] INFO huggingface_loader.py:135:   Quantized Parameter: "model.layers.34.mlp.gate_up_proj.q_scale", shape: (27648, 160), dtype: float16      
[2023-11-02 21:19:31] INFO huggingface_loader.py:171:   Parameter: "model.layers.34.post_attention_layernorm.weight", shape: (5120,), dtype: float16              
[2023-11-02 21:19:31] INFO huggingface_loader.py:126:   Skipped Quantizing Parameter: "model.layers.34.post_attention_layernorm.weight", shape: (5120,), dtype: float16
```

CC: @cyx-6 @LeshengJin @junrushao 