### PR TITLE
[Serving] Benchmark script enhancement

### DIFF
--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -96,11 +96,17 @@ struct RequestState {
   /*! \brief The decoded text string output. */
   std::string output = "";
 
+  /*! \brief The time of adding the request to engine. */
+  std::chrono::_V2::system_clock::time_point tadd;
+  /*! \brief The time of finishing prefill stage. */
+  std::chrono::_V2::system_clock::time_point tprefill_finish;
+
   explicit RequestState(int num_models, Array<Data> inputs) {
     mstates.reserve(num_models);
     for (int i = 0; i < num_models; ++i) {
       mstates.push_back(RequestModelState(i, inputs));
     }
+    tadd = std::chrono::high_resolution_clock::now();
   }
 };
 

--- a/python/mlc_chat/serve/engine.py
+++ b/python/mlc_chat/serve/engine.py
@@ -1,6 +1,7 @@
 """The MLC LLM Serving Engine."""
+import json
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import tvm
 
@@ -212,6 +213,24 @@ class Engine:
         generation results for those finished requests.
         """
         self._step_func()
+
+    def reset(self) -> None:
+        """Reset the engine, clean up all running data and statistics."""
+        self._reset_engine_func()
+
+    def stats(self) -> Dict[str, float]:
+        """The engine runtime statistics.
+        We collect the following entries:
+        - prefill token latency (s/tok)
+            avg latency of processing one token in prefill
+        - decode token latency (s/tok)
+            avg latency of processing one token in decode
+        - token throughput (tok/s)
+            avg number of tokens processed per second (prefill + decode)
+        """
+        stats_json_str = self._get_stats_func()
+        stats = json.loads(stats_json_str)
+        return stats
 
     def _reload(self, models: List[ModelInfo], kv_cache_config: KVCacheConfig):
         """Internal method for engine to load models and kv cache config."""


### PR DESCRIPTION
This PR improves the benchmark scripts.

With this commit, we benchmark with 5 metrics:
* end-to-end latency (sec) of processing an entire batch,
* end-to-end request throughput (req/min),
* prefill per-token latency (ms/tok),
* decode per-token latency (ms/tok),
* token throughput (tok/s), including both prefill and decode.

The benchmark input initialization so far is still in a fixed pattern (only supports generating all requests to a same length). This part will be improved in follow-up PRs.