### PR TITLE
[SLM][AutoLLM] Allow Weight Data Type Casting During Quantization

### DIFF
--- a/python/mlc_chat/compiler/quantization/group_quantization.py
+++ b/python/mlc_chat/compiler/quantization/group_quantization.py
@@ -1,10 +1,9 @@
 """The group quantization config"""
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
-import logging
 import numpy as np
-
 import tvm
 from tvm import DataType, DataTypeCode
 from tvm import dlight as dl


### PR DESCRIPTION
Previously quantization model data type is enfored, i.e., the weight given in original model before quantization is specified and cannot be casted, this PR allows casting original weight to quantization config model data type and give a warning. After this PR, models using fp32 can also be allowed to use group quant.

CC: @cyx-6 @junrushao 