### PR TITLE
[API] ```llm-vscode``` extension support

### DIFF
--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -143,3 +143,18 @@ class EmbeddingsResponse(BaseModel):
     data: List[Dict[str, Any]]
     model: Optional[str] = None
     usage: UsageInfo
+
+
+class VisualStudioCodeCompletionParameters(BaseModel):
+    temperature: float = None
+    top_p: float = None
+    max_new_tokens: int = None
+
+
+class VisualStudioCodeCompletionRequest(BaseModel):
+    inputs: str
+    parameters: VisualStudioCodeCompletionParameters
+
+
+class VisualStudioCodeCompletionResponse(BaseModel):
+    generated_text: str

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -368,8 +368,8 @@ async def read_stats_verbose():
 @app.post("/v1/llm-vscode/completions")
 async def request_llm_vscode(request: VisualStudioCodeCompletionRequest):
     """
-    Creates a code completion for a given prompt.
-    Follows huggingface LSP: https://github.com/huggingface/llm-ls
+    Creates a vscode code completion for a given prompt.
+    Follows huggingface LSP (https://github.com/huggingface/llm-ls)
     """
     generation_config = GenerationConfig(
         temperature=request.parameters.temperature,

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -30,6 +30,8 @@ from .interface.openai_api import (
     EmbeddingsRequest,
     EmbeddingsResponse,
     UsageInfo,
+    VisualStudioCodeCompletionRequest,
+    VisualStudioCodeCompletionResponse,
 )
 
 
@@ -361,6 +363,23 @@ async def read_stats_verbose():
     Get the verbose runtime stats.
     """
     return session["chat_mod"].stats(verbose=True)
+
+
+@app.post("/v1/llm-vscode/completions")
+async def request_llm_vscode(request: VisualStudioCodeCompletionRequest):
+    """
+    Creates a code completion for a given prompt.
+    Follows huggingface LSP: https://github.com/huggingface/llm-ls
+    """
+    generation_config = GenerationConfig(
+        temperature=request.parameters.temperature,
+        top_p=request.parameters.top_p,
+        mean_gen_len=request.parameters.max_new_tokens,
+        max_gen_len=request.parameters.max_new_tokens,
+    )
+    msg = session["chat_mod"].generate(prompt=request.inputs, generation_config=generation_config)
+
+    return VisualStudioCodeCompletionResponse(generated_text=msg)
 
 
 ARGS = convert_args_to_argparser().parse_args()


### PR DESCRIPTION
This PR enables ```llm-vscode``` extension API support for copilot-like code completion, following [HF's LSP](https://github.com/huggingface/llm-ls). Fully compatible with ```CodeLlama``` and ```starcoder``` on mlc-llm. 

- https://github.com/huggingface/llm-vscode/pull/103 enhances extension user experience when used with mlc-llm rest api.

Thanks @pacman100, who came up with this on his latest blogpost: https://huggingface.co/blog/personal-copilot 