### PR TITLE
[Mistral][SWA] Add sliding window to metadata

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -397,10 +397,16 @@ class LLMChat {
       CHECK(!config.count("max_window_size"))
           << "Cannot specify both sliding_window and max_window_size.";
       this->sliding_window_ = config["sliding_window"].get<int64_t>();
+      CHECK(this->sliding_window_ > 0) << "Sliding window size needs to be positive";
+      CHECK(config.count("sliding_window_chunk_size"))
+          << "Need to specify chunk size if using sliding window attention.";
     }
     if (config.count("sliding_window_chunk_size")) {
       CHECK(config["sliding_window_chunk_size"].is<int64_t>());
       this->sliding_window_chunk_size_ = config["sliding_window_chunk_size"].get<int64_t>();
+      CHECK(this->sliding_window_chunk_size_ > 0)
+          << "Sliding window chunk size needs to be positive";
+      CHECK(config.count("sliding_window")) << "Need to specify sliding window size.";
     }
     if (config.count("model_name")) {
       CHECK(config["model_name"].is<std::string>());
@@ -816,13 +822,8 @@ class LLMChat {
     NDArray logits_on_device;
     if (this->sliding_window_ != -1) {
       // Use chunking if we use sliding window attention (see Mistral paper figure 3).
-      int64_t sliding_window_chunk_size = this->sliding_window_chunk_size_;
-      if (this->sliding_window_chunk_size_ == -1) {
-        // One chunk if chunk size not specified
-        sliding_window_chunk_size = token_len;
-      }
-      for (int64_t begin = 0; begin < token_len; begin += sliding_window_chunk_size) {
-        int64_t end = std::min(token_len, begin + sliding_window_chunk_size);
+      for (int64_t begin = 0; begin < token_len; begin += this->sliding_window_chunk_size_) {
+        int64_t end = std::min(token_len, begin + this->sliding_window_chunk_size_);
         std::vector<int32_t> chunk =
             std::vector<int32_t>(prompt_tokens.begin() + begin, prompt_tokens.begin() + end);
         new_seq_len += static_cast<int64_t>(chunk.size());

--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -10,6 +10,8 @@ def create_metadata_func(
     max_window_size: int,
     stop_tokens: List[int],
     add_prefix_space: bool,
+    sliding_window: int = -1,
+    sliding_window_chunk_size: int = -1,
 ):
     metadata = json.dumps(
         {
@@ -17,6 +19,8 @@ def create_metadata_func(
             "max_window_size": max_window_size,
             "stop_tokens": stop_tokens,
             "add_prefix_space": add_prefix_space,
+            "sliding_window": sliding_window,
+            "sliding_window_chunk_size": sliding_window_chunk_size,
         }
     )
     with bb.function("get_metadata", params=[]):

--- a/mlc_llm/relax_model/mistral.py
+++ b/mlc_llm/relax_model/mistral.py
@@ -949,6 +949,9 @@ def get_model(args, hf_config):
         sliding_window_chunk_size=args.sliding_window_chunk_size,
     )
 
+    assert config.sliding_window != -1
+    assert config.sliding_window_chunk_size != -1
+
     param_manager = ParamManager()
     bb = relax.BlockBuilder()
 
@@ -962,6 +965,8 @@ def get_model(args, hf_config):
         max_window_size=config.max_sequence_length,
         stop_tokens=[2],
         add_prefix_space=False,
+        sliding_window=config.sliding_window,
+        sliding_window_chunk_size=config.sliding_window_chunk_size,
     )
 
     mod = bb.get()


### PR DESCRIPTION
This PR adds sliding window size and sliding window chunk size to metadata, so that we can read such info from the model library instead of the `mlc-chat-config.json` in huggingface. Related to https://github.com/mlc-ai/web-llm/pull/208.

In addition, there are some small changes in the invariants for `sliding_window` and `sliding_window_chunk_size` in `llm_chat.cc`. In runtime, we assume that both parameters are valid. We cannot use one-chunk-prefill (with an unspecified chunk size) since that way there is no limit on the input's sequence length.

cc @davidpissarra 