### PR TITLE
Bake in RAM Usage in the Generated DSO

### DIFF
--- a/python/mlc_chat/compiler/compiler_pass/estimate_memory_usage.py
+++ b/python/mlc_chat/compiler/compiler_pass/estimate_memory_usage.py
@@ -1,0 +1,77 @@
+"""Memory usage estimation analysis function for Relax functions."""
+from typing import Dict
+
+import tvm
+from tvm import relax
+from tvm.ir import IRModule, Op
+from tvm.relax.expr_functor import PyExprVisitor, visitor
+
+
+@tvm.transform.module_pass(opt_level=0, name="EstimateMemoryUsage")
+class EstimateMemoryUsage:  # pylint: disable=too-few-public-methods
+    """A pass that attaches the memory usage information as an IRModule attribute.
+
+    This pass relies on static analysis on each TVM Relax function in the specific IRModule.
+    It simply accumulates all memory allocation calls in a function, and does not consider
+    more dynamic runtime features like control flo "if" or function calls.
+    """
+
+    def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:
+        """Entry point of the pass."""
+        lowered_mod = tvm.transform.Sequential(
+            [
+                relax.transform.RewriteDataflowReshape(),
+                relax.transform.ToNonDataflow(),
+                relax.transform.RemovePurityChecking(),
+                relax.transform.CallTIRRewrite(),
+                relax.transform.StaticPlanBlockMemory(),
+            ],
+            name="relax.lower",
+        )(mod)
+        usage = _MemoryEstimator().run(lowered_mod)
+        return mod.with_attr("mlc_llm.memory_usage", usage)
+
+
+@visitor
+class _MemoryEstimator(PyExprVisitor):
+    """The IR visitor which estimates the memory usage of each Relax function."""
+
+    def __init__(self) -> None:
+        self.planned_alloc_mem = 0
+        self.planned_mem_num = 0
+        self._op_alloc_tensor = Op.get("relax.builtin.alloc_tensor")
+        self._op_alloc_storage = Op.get("relax.memory.alloc_storage")
+
+    def run(self, mod: IRModule) -> Dict[str, int]:
+        """Entry point of the visitor."""
+        result: Dict[str, int] = {}
+        for global_var, func in mod.functions_items():
+            if isinstance(func, relax.Function):
+                self.planned_alloc_mem = 0
+                self.planned_mem_num = 0
+                self.visit_expr(func)
+                result[global_var.name_hint] = self.planned_alloc_mem
+        return result
+
+    def visit_call_(self, call: relax.Call) -> None:  # pylint: disable=arguments-renamed
+        if call.op == self._op_alloc_tensor:
+            self._builtin_tensor_alloc(shape=call.args[0], dtype_str=call.args[1].value)
+        elif call.op == self._op_alloc_storage:
+            self._storage_alloc(size=call.args[0])
+        super().visit_call_(call)
+
+    def _builtin_tensor_alloc(self, shape: relax.Expr, dtype_str: str) -> None:
+        assert isinstance(shape, relax.ShapeExpr)
+        size = 1
+        for dim_len in shape.values:
+            if not isinstance(dim_len, tvm.tir.IntImm):
+                return
+            size *= dim_len.value
+        dtype = tvm.DataType(dtype_str)
+        self.planned_mem_num += 1
+        self.planned_alloc_mem += size * ((dtype.bits + 7) // 8) * dtype.lanes
+
+    def _storage_alloc(self, size: relax.Expr) -> None:
+        assert isinstance(size, relax.ShapeExpr)
+        self.planned_mem_num += 1
+        self.planned_alloc_mem += size.values[0].value

--- a/python/mlc_chat/compiler/compiler_pass/pipeline.py
+++ b/python/mlc_chat/compiler/compiler_pass/pipeline.py
@@ -7,6 +7,7 @@ from tvm import dlight as dl
 from tvm.relax import register_pipeline  # pylint: disable=no-name-in-module
 
 from .clean_up_tir_attrs import CleanUpTIRAttrs
+from .estimate_memory_usage import EstimateMemoryUsage
 from .fuse_dequantize_matmul_ewise import FuseDequantizeMatmulEwise
 from .fuse_dequantize_take import FuseDequantizeTake
 from .fuse_dequantize_transpose import FuseDequantizeTranspose
@@ -64,6 +65,7 @@ def _mlc_llm_pipeline():
                 _LogProgress("Running memory optimizations"),
                 LiftTIRGlobalBufferAlloc(),
                 tvm.tir.transform.ForceNarrowIndexToInt32(),
+                EstimateMemoryUsage(),
             ]
         )
         mod = seq(mod._move())  # pylint: disable=protected-access


### PR DESCRIPTION
With this PR, the metadata in a DSO file using `vm["_metadata"]()` now have information about the upper bound RAM estimate on each function. As an example, the JSON string now is:

```json
{
  "quantization": "q4f16_1",
  "model_type": "llama",
  "memory_usage": {
    "_initialize_effect": 0,
    "prefill": 136192,
    "softmax_with_temperature": 0,
    "decode": 218624
  },
  "params": [
    {"name": "model.embed_tokens.q_weight", "shape": [32000, 512], "dtype": "uint32"},
    {"name": "model.embed_tokens.q_scale", "shape": [32000, 128], "dtype": "float16"},
    ...
  ]
}
```

This helps the MLC runtime to better determine if a method is going to OOM and plan ahead, e.g. plan pre-allocated KVCache, accordingly.

The idea originates from @MasterJH5574's ancient PR that prints memory usage estimate as debugging information for demo purposes, and this PR further enhances it to IRModule-level attribute that can be used by the runtime.