### PR TITLE
[SLM] Support `q0f16` and `q0f32`

### DIFF
--- a/python/mlc_chat/compiler/model/llama_quantization.py
+++ b/python/mlc_chat/compiler/model/llama_quantization.py
@@ -5,7 +5,7 @@ from typing import Tuple
 from tvm.relax.frontend import nn
 
 from ..loader import QuantizeMapping
-from ..quantization import AWQQuantize, GroupQuantize
+from ..quantization import AWQQuantize, GroupQuantize, NoQuantize
 from .llama_model import LlamaConfig, LlamaForCasualLM
 
 
@@ -38,4 +38,15 @@ def awq_quant(
         quant_map,
         "",
     )
+    return model, quant_map
+
+
+def no_quant(
+    model_config: LlamaConfig,
+    quantization: NoQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a Llama2 model without quantization."""
+    model: nn.Module = LlamaForCasualLM(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
     return model, quant_map

--- a/python/mlc_chat/compiler/model/model.py
+++ b/python/mlc_chat/compiler/model/model.py
@@ -61,6 +61,7 @@ MODELS: Dict[str, Model] = {
             "awq": llama_loader.awq,
         },
         quantize={
+            "no-quant": llama_quantization.no_quant,
             "group-quant": llama_quantization.group_quant,
             "awq": llama_quantization.awq_quant,
         },

--- a/python/mlc_chat/compiler/quantization/__init__.py
+++ b/python/mlc_chat/compiler/quantization/__init__.py
@@ -1,4 +1,5 @@
 """A subpackage for quantization and dequantization algorithms"""
 from .awq_quantization import AWQQuantize
 from .group_quantization import GroupQuantize
+from .no_quantization import NoQuantize
 from .quantization import QUANTIZATION, Quantization

--- a/python/mlc_chat/compiler/quantization/no_quantization.py
+++ b/python/mlc_chat/compiler/quantization/no_quantization.py
@@ -1,0 +1,17 @@
+"""The no quantization config"""
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NoQuantize:  # pylint: disable=too-many-instance-attributes
+    """Configuration for no quantization"""
+
+    name: str
+    kind: str
+    model_dtype: str  # "float16", "float32"
+
+    def __post_init__(self):
+        assert self.kind == "no-quant"

--- a/python/mlc_chat/compiler/quantization/quantization.py
+++ b/python/mlc_chat/compiler/quantization/quantization.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 from .awq_quantization import AWQQuantize
 from .group_quantization import GroupQuantize
+from .no_quantization import NoQuantize
 
 Quantization = Any
 """Quantization is an object that represents an quantization algorithm. It is required to
@@ -24,6 +25,16 @@ It is also required to have the following method:
 """
 
 QUANTIZATION: Dict[str, Quantization] = {
+    "q0f16": NoQuantize(
+        name="q0f16",
+        kind="no-quant",
+        model_dtype="float16",
+    ),
+    "q0f32": NoQuantize(
+        name="q0f32",
+        kind="no-quant",
+        model_dtype="float32",
+    ),
     "q3f16_1": GroupQuantize(
         name="q3f16_1",
         kind="group-quant",

--- a/tests/python/model/test_llama_quantization.py
+++ b/tests/python/model/test_llama_quantization.py
@@ -10,12 +10,12 @@ from mlc_chat.compiler.quantization.group_quantization import (
 
 
 @pytest.mark.parametrize(
-    "model_name, quant_name",
-    [
-        ("llama2_7b", "q4f16_1"),
-        ("llama2_13b", "q4f16_1"),
-        ("llama2_70b", "q4f16_1"),
-    ],
+    "model_name",
+    ["llama2_7b", "llama2_13b", "llama2_70b"],
+)
+@pytest.mark.parametrize(
+    "quant_name",
+    ["q3f16_1", "q4f16_1", "q4f32_1"],
 )
 def test_llama2_group_quantization(model_name: str, quant_name: str):
     model_info = MODELS["llama"]
@@ -49,6 +49,22 @@ def test_llama2_group_quantization(model_name: str, quant_name: str):
             model.model.layers[i].mlp.down_proj,  # type: ignore[attr-defined]
             GroupQuantizeLinear,
         )
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["llama2_7b", "llama2_13b", "llama2_70b"],
+)
+@pytest.mark.parametrize(
+    "quant_name",
+    ["q0f16", "q0f32"],
+)
+def test_llama2_no_quantization(model_name: str, quant_name: str):
+    model_info = MODELS["llama"]
+    config = model_info.config.from_dict(MODEL_PRESETS[model_name])
+    _, quant_map = model_info.quantize["no-quant"](config, QUANTIZATION[quant_name])
+    assert len(quant_map.param_map) == 0
+    assert len(quant_map.map_func) == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the support of `q0f16` and `q0f32`, and change `RMSNorm` to `nn.RMSNorm`.