### PR TITLE
[AWQ] e2e awq-quantized model

### DIFF
--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -31,8 +31,8 @@ def main():
         if path == "auto":
             return config_path.parent
         path = Path(path)
-        if not path.is_dir():
-            raise argparse.ArgumentTypeError(f"Directory does not exist: {path}")
+        if not path.exists():
+            raise argparse.ArgumentTypeError(f"Model source does not exist: {path}")
         return path
 
     def _parse_output(path: Union[str, Path]) -> Path:
@@ -60,7 +60,7 @@ def main():
     parser.add_argument(
         "--source-format",
         type=str,
-        choices=["auto", "huggingface-torch", "huggingface-safetensor"],
+        choices=["auto", "huggingface-torch", "huggingface-safetensor", "awq"],
         default="auto",
         help="The format of source model weight, infer from `config` if missing. "
         "(default: %(default)s)",

--- a/python/mlc_chat/compiler/loader/loader.py
+++ b/python/mlc_chat/compiler/loader/loader.py
@@ -8,4 +8,5 @@ Loader = Any
 LOADER: Dict[str, Any] = {
     "huggingface-torch": HuggingFaceLoader,
     "huggingface-safetensor": HuggingFaceLoader,
+    "awq": HuggingFaceLoader,
 }

--- a/python/mlc_chat/compiler/model/model.py
+++ b/python/mlc_chat/compiler/model/model.py
@@ -62,6 +62,7 @@ MODELS: Dict[str, Model] = {
         },
         quantize={
             "group-quant": llama_quantization.group_quant,
+            "awq": llama_quantization.awq_quant,
         },
     )
 }

--- a/python/mlc_chat/compiler/quantization/awq_quantization.py
+++ b/python/mlc_chat/compiler/quantization/awq_quantization.py
@@ -159,7 +159,7 @@ class AWQQuantize:  # pylint: disable=too-many-instance-attributes
                 tir.subtract(float_weight[i, j], float_zeros[i, j // self.group_size]),
                 scale[i, j // self.group_size],
             ),
-            name="decode",
+            name="dequantize",
         )
 
 
@@ -250,7 +250,7 @@ class AWQQuantizeLinear(nn.Module):  # pylint: disable=too-many-instance-attribu
                 scale,
                 [tir.IntImm("int64", self.out_features), tir.IntImm("int64", self.in_features)],
             ),
-            name_hint="decode",
+            name_hint="dequantize",
             args=[self.qweight, self.qzeros, self.scales],
         )
         w = nn.op.permute_dims(w)  # pylint: disable=invalid-name
@@ -356,7 +356,7 @@ class AWQQuantizeMultiLinear(nn.Module):  # pylint: disable=too-many-instance-at
                     tir.IntImm("int64", self.in_features),
                 ],
             ),
-            name_hint="decode",
+            name_hint="dequantize",
             args=[self.qweight, self.qzeros, self.scales],
         )
         w = nn.op.permute_dims(w)  # pylint: disable=invalid-name

--- a/python/mlc_chat/support/auto_weight.py
+++ b/python/mlc_chat/support/auto_weight.py
@@ -84,6 +84,8 @@ def detect_weight(
         weight_config_path = check_func(weight_path)
         if not weight_config_path:
             raise ValueError(f"The weight is not in {weight_format} format.")
+    else:
+        weight_config_path = weight_path
     return weight_config_path, weight_format
 
 
@@ -143,5 +145,5 @@ CHECK_FORMAT_METHODS = {
     "huggingface-safetensor": _check_safetensor,
 }
 
-# "awq", "ggml", "gguf" are not supported yet.
-AVAILABLE_WEIGHT_FORMAT = ["huggingface-torch", "huggingface-safetensor"]
+# "ggml", "gguf" are not supported yet.
+AVAILABLE_WEIGHT_FORMAT = ["huggingface-torch", "huggingface-safetensor", "awq"]


### PR DESCRIPTION
## Run awq quantized Llama-2 7B.

### Preparation: get the weight
Follow the instructions in [llm-awq](https://github.com/mit-han-lab/llm-awq#usage) to generate the quantized weights.

### Compile the model

```
python -m mlc_chat.cli.compile --config llama2_7b --quantization q4f16_awq -o ./dist/new-llama-awq/llama.so --max-sequence-length 4096
```

### Load the model weight, convert it into ndarray

```
python -m mlc_chat.cli.convert_weight --quantization q4f16_awq -o ./dist/new-llama-awq --config ../models/Llama-2-7b-chat-hf/config.json --source-format awq --source dist/models/llama-2-7b-chat-w4-g128-awq.pt
```

### Test the model

```
python -m mlc_chat.cli.benchmark --model ./dist/new-llama-awq/ --model-lib ./dist/new-llama-awq/llama.so --device "cuda:3" --prompt "What is the meaning of life?" --generate-length 256
```

![Screenshot 2023-11-09 at 2 48 10 PM](https://github.com/mlc-ai/mlc-llm/assets/34279105/8f73e041-7f03-4dbe-85d9-ac43c91ddb05)