### PR TITLE
ensure that max_gen_len is set properly in mlc_chat_config

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -825,6 +825,7 @@ def build_model_from_args(args: argparse.Namespace):
                     args,
                     vocab_size=config["vocab_size"],
                     max_window_size=model_config.max_sequence_length,
+                    max_gen_len=model_config.max_sequence_length,
                     top_p=0.6,
                     temperature=1.2,
                     repetition_penalty=0.996,
@@ -835,6 +836,7 @@ def build_model_from_args(args: argparse.Namespace):
                     args,
                     vocab_size=config["vocab_size"],
                     max_window_size=model_config.max_sequence_length,
+                    max_gen_len=model_config.max_sequence_length,
                 )
 
         if args.convert_weight_only:


### PR DESCRIPTION
Currently, `max_gen_len` defaults to 512 in `dump_mlc_chat_config`. However, the instantiations of `dump_mlc_chat_config` within `mlc-llm.build` currently omit the `max_gen_len` argument (even when it's specified in the HF config), so the default of 512 gets set for every `mlc-chat-config.json` that is created by `mlc-llm.build`. This PR fixes the issue.