### PR TITLE
Introduce mlc_chat subcommands

### DIFF
--- a/python/mlc_chat/__main__.py
+++ b/python/mlc_chat/__main__.py
@@ -1,0 +1,44 @@
+"""Entrypoint of all CLI commands from MLC LLM"""
+import logging
+import sys
+
+from mlc_chat.support.argparse import ArgumentParser
+
+logging.basicConfig(
+    level=logging.INFO,
+    style="{",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="[{asctime}] {levelname} {filename}:{lineno}: {message}",
+)
+
+
+def main():
+    """Entrypoint of all CLI commands from MLC LLM"""
+    parser = ArgumentParser("MLC LLM Command Line Interface.")
+    parser.add_argument(
+        "subcommand",
+        type=str,
+        choices=["compile", "convert_weight", "gen_mlc_chat_config"],
+        help="Subcommand to to run. (choices: %(choices)s)",
+    )
+    parsed = parser.parse_args([sys.argv[1]])
+    # pylint: disable=import-outside-toplevel
+    if parsed.subcommand == "compile":
+        from mlc_chat.cli import compile as cli
+
+        cli.main(sys.argv[2:])
+    elif parsed.subcommand == "convert_weight":
+        from mlc_chat.cli import convert_weight as cli
+
+        cli.main(sys.argv[2:])
+    elif parsed.subcommand == "gen_mlc_chat_config":
+        from mlc_chat.cli import gen_mlc_chat_config as cli
+
+        cli.main(sys.argv[2:])
+    else:
+        raise ValueError(f"Unknown subcommand {parsed.subcommand}")
+    # pylint: enable=import-outside-toplevel
+
+
+if __name__ == "__main__":
+    main()

--- a/python/mlc_chat/cli/compile.py
+++ b/python/mlc_chat/cli/compile.py
@@ -1,6 +1,5 @@
 """Command line entrypoint of compilation."""
 import argparse
-import logging
 import re
 from pathlib import Path
 from typing import Union
@@ -17,22 +16,15 @@ from ..support.argparse import ArgumentParser
 from ..support.auto_config import detect_config, detect_model_type
 from ..support.auto_target import detect_target_and_host
 
-logging.basicConfig(
-    level=logging.INFO,
-    style="{",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    format="[{asctime}] {levelname} {filename}:{lineno}: {message}",
-)
 
-
-def main():
+def main(argv):
     """Parse command line argumennts and call `mlc_llm.compiler.compile`."""
 
     def _parse_output(path: Union[str, Path]) -> Path:
         path = Path(path)
         parent = path.parent
         if not parent.is_dir():
-            raise ValueError(f"Directory does not exist: {parent}")
+            raise argparse.ArgumentTypeError(f"Directory does not exist: {parent}")
         return path
 
     def _check_prefix_symbols(prefix: str) -> str:
@@ -103,7 +95,7 @@ def main():
         required=True,
         help=HELP["output_compile"] + " (required)",
     )
-    parsed = parser.parse_args()
+    parsed = parser.parse_args(argv)
     target, build_func = detect_target_and_host(parsed.device, parsed.host)
     parsed.model_type = detect_model_type(parsed.model_type, parsed.config)
     compile(
@@ -117,7 +109,3 @@ def main():
         output=parsed.output,
         max_sequence_length=parsed.max_sequence_length,
     )
-
-
-if __name__ == "__main__":
-    main()

--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -1,6 +1,5 @@
 """Command line entrypoint of weight conversion."""
 import argparse
-import logging
 from pathlib import Path
 from typing import Union
 
@@ -11,15 +10,8 @@ from ..support.auto_config import detect_config, detect_model_type
 from ..support.auto_target import detect_device
 from ..support.auto_weight import detect_weight
 
-logging.basicConfig(
-    level=logging.INFO,
-    style="{",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    format="[{asctime}] {levelname} {filename}:{lineno}: {message}",
-)
 
-
-def main():
+def main(argv):
     """Parse command line argumennts and apply quantization."""
 
     def _parse_source(path: Union[str, Path], config_path: Path) -> Path:
@@ -85,7 +77,7 @@ def main():
         help=HELP["output_quantize"] + " (required)",
     )
 
-    parsed = parser.parse_args()
+    parsed = parser.parse_args(argv)
     parsed.source, parsed.source_format = detect_weight(
         weight_path=_parse_source(parsed.source, parsed.config),
         config_json_path=parsed.config,
@@ -101,7 +93,3 @@ def main():
         source_format=parsed.source_format,
         output=parsed.output,
     )
-
-
-if __name__ == "__main__":
-    main()

--- a/python/mlc_chat/cli/gen_mlc_chat_config.py
+++ b/python/mlc_chat/cli/gen_mlc_chat_config.py
@@ -1,5 +1,4 @@
 """Command line entrypoint of configuration generation."""
-import logging
 from pathlib import Path
 from typing import Union
 
@@ -8,15 +7,8 @@ from mlc_chat.compiler import CONV_TEMPLATES, HELP, MODELS, QUANTIZATION, gen_co
 from ..support.argparse import ArgumentParser
 from ..support.auto_config import detect_config, detect_model_type
 
-logging.basicConfig(
-    level=logging.INFO,
-    style="{",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    format="[{asctime}] {levelname} {filename}:{lineno}: {message}",
-)
 
-
-def main():
+def main(argv):
     """Parse command line argumennts and call `mlc_llm.compiler.gen_config`."""
     parser = ArgumentParser("MLC LLM Configuration Generator")
 
@@ -67,7 +59,7 @@ def main():
         required=True,
         help=HELP["output_gen_mlc_chat_config"] + " (required)",
     )
-    parsed = parser.parse_args()
+    parsed = parser.parse_args(argv)
     model = detect_model_type(parsed.model_type, parsed.config)
     gen_config(
         config=parsed.config,
@@ -77,7 +69,3 @@ def main():
         max_sequence_length=parsed.max_sequence_length,
         output=parsed.output,
     )
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
This PR makes it possible to use subcommands of `mlc_chat` package to control quantization and compilation. Example:

```bash
python -m mlc_chat convert_weight \
    --model ./dist/models/Llama-2-7b-hf \
    --quantization q4f16_1 \
    -o ./dist/new-llama/

python -m mlc_chat gen_mlc_chat_config \
    --model ./dist/models/Llama-2-7b-hf \
    --quantization q4f16_1 \
    --max-sequence-length 4096 \
    --conv-template LM \
    -o ./dist/new-llama \

python -m mlc_chat compile \
    --model ./dist/models/Llama-2-7b-hf \
    --quantization q4f16_1 \
    --max-sequence-length 4096 \
    -o ./dist/new-llama/llama.so
```

It slightly simplifies the workflow.