### PR TITLE
Update mlc-chat-config.json

### DIFF
--- a/python/mlc_chat/compiler/gen_mlc_chat_config.py
+++ b/python/mlc_chat/compiler/gen_mlc_chat_config.py
@@ -90,8 +90,8 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments
     # Step 3. Copy tokenizer configuration
     for filename in TOKENIZER_FILES:
         file = config.parent / filename
-        mlc_chat_config.tokenizer_files.append(filename)
         if file.exists():
+            mlc_chat_config.tokenizer_files.append(filename)
             dest = output / filename
             shutil.copy(file, dest)
             logger.info("%s tokenizer config: %s. Copying to %s", FOUND, file, bold(str(dest)))

--- a/python/mlc_chat/support/auto_config.py
+++ b/python/mlc_chat/support/auto_config.py
@@ -36,7 +36,8 @@ def detect_config(config: Union[str, Path]) -> Path:
 
     if isinstance(config, str) and config in MODEL_PRESETS:
         logger.info("%s preset model: %s", FOUND, config)
-        content = MODEL_PRESETS[config]
+        content = MODEL_PRESETS[config].copy()
+        content["model_preset_tag"] = config
         temp_file = tempfile.NamedTemporaryFile(  # pylint: disable=consider-using-with
             suffix=".json",
             delete=False,


### PR DESCRIPTION
This PR updates two fields:
* `tokenizer_files`, which now non-existent files are removed from this list;
* `model_preset_tag` added to `model_config`, which helps the system to conveniently identify if a model configuration is already part of the system's built-in model preset.