### PR TITLE
[Fix] Add prefix_tokens to `ConvConfig` in Python to match C++ implementation

### DIFF
--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -62,6 +62,8 @@ class ConvConfig:  # pylint: disable=too-many-instance-attributes
         When the ``stop_str`` is encountered, the model will stop generating output.
     stop_tokens : Optional[List[int]]
         A list of token IDs that act as stop tokens.
+    prefix_tokens : Optional[List[int]]
+        Token list prefixing the conversation.
     add_bos : Optional[bool]
         Determines whether a beginning-of-string (bos) token should be added
         before the input tokens.
@@ -78,6 +80,7 @@ class ConvConfig:  # pylint: disable=too-many-instance-attributes
     role_empty_sep: Optional[str] = None
     stop_str: Optional[str] = None
     stop_tokens: Optional[List[int]] = None
+    prefix_tokens: Optional[List[int]] = None
     add_bos: Optional[bool] = None
 
     def __post_init__(self):


### PR DESCRIPTION
During my Rust implementation of the project, I noticed an inconsistency between the Python and C++ implementations of `ConvConfig`. Specifically, the Python version lacks the `prefix_tokens` field, which is present in the C++ version.: https://github.com/mlc-ai/mlc-llm/blob/5e02cacd8ebba2e0206d5a447225a137de2dac0d/cpp/conversation.h#L69-L70.

This can cause the [`_load_json_override`](https://github.com/mlc-ai/mlc-llm/blob/5e02cacd8ebba2e0206d5a447225a137de2dac0d/python/mlc_chat/chat_module.py#L1062C26-L1062C26) fails to work in the `_prefill` function.

I think a simple unit test would help, I'd like to add a regression test if the CI has been set up.