### PR TITLE
Add a downloader from HuggingFace

### DIFF
--- a/ci/task/mypy.sh
+++ b/ci/task/mypy.sh
@@ -8,4 +8,4 @@ export PYTHONPATH="./python:$PYTHONPATH"
 
 set -x
 
-mypy ./python/ ./tests/python/
+mypy --install-types --non-interactive ./python/ ./tests/python/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ show_error_context = true
 follow_imports = "skip"
 ignore_errors = false
 strict_optional = false
-install_types = true
 
 [tool.pylint.messages_control]
 max-line-length = 100

--- a/python/mlc_chat/support/download.py
+++ b/python/mlc_chat/support/download.py
@@ -1,0 +1,145 @@
+"""Common utilities for downloading files from HuggingFace or other URLs online."""
+import concurrent.futures as cf
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+import requests  # pylint: disable=import-error
+
+from . import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def get_cache_dir() -> Path:
+    """Return the path to the cache directory."""
+
+    if os.getenv("MLC_CACHE_DIR"):
+        result = Path(os.getenv("MLC_CACHE_DIR"))
+    elif sys.platform == "win32":
+        result = Path(os.environ["LOCALAPPDATA"])
+        result = result / "mlc_chat"
+    elif os.getenv("XDG_CACHE_HOME", None) is not None:
+        result = Path(os.getenv("XDG_CACHE_HOME"))
+        result = result / "mlc_chat"
+    else:
+        result = Path(os.path.expanduser("~/.cache"))
+        result = result / "mlc_chat"
+    result.mkdir(parents=True, exist_ok=True)
+    if not result.is_dir():
+        raise ValueError(
+            f"The default cache directory is not a directory: {result}. "
+            "Use environment variable MLC_CACHE_DIR to specify a valid cache directory."
+        )
+    return result
+
+
+def _ensure_directory_not_exist(path: Path, force_redo: bool) -> None:
+    if path.exists():
+        if force_redo:
+            logger.info("Deleting existing directory: %s", path)
+            shutil.rmtree(path)
+        else:
+            raise ValueError(f"Directory already exists: {path}")
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def git_clone(url: str, destination: Path) -> None:
+    """Clone a git repository into a directory."""
+    repo_name = ".tmp"
+    command = ["git", "clone", url, repo_name]
+    _ensure_directory_not_exist(destination, force_redo=False)
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            logger.info("Cloning git repo %s to %s", url, destination)
+            subprocess.run(
+                command,
+                env={"GIT_LFS_SKIP_SMUDGE": "1"},
+                cwd=tmp_dir,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            shutil.move(os.path.join(tmp_dir, repo_name), str(destination))
+    except subprocess.CalledProcessError as error:
+        raise ValueError(
+            f"Git clone failed with return code {error.returncode}: {error.stderr}. "
+            f"The command was: {command}"
+        ) from error
+
+
+def download_file(
+    url: str,
+    destination: Path,
+    md5sum: Optional[str],
+) -> Tuple[str, Path]:
+    """Download a file from a URL to a destination file."""
+    with requests.get(url, stream=True, timeout=30) as response:
+        response.raise_for_status()
+        with destination.open("wb") as file:
+            for chunk in response.iter_content(chunk_size=8192):
+                file.write(chunk)
+    if md5sum is not None:
+        hash_md5 = hashlib.md5()
+        with destination.open("rb") as file:
+            for chunk in iter(lambda: file.read(8192), b""):
+                hash_md5.update(chunk)
+        file_md5 = hash_md5.hexdigest()
+        if file_md5 != md5sum:
+            raise ValueError(
+                f"MD5 checksum mismatch for downloaded file: {destination}. "
+                f"Expected {md5sum}, got {file_md5}"
+            )
+    return url, destination
+
+
+def download_mlc_weights(  # pylint: disable=too-many-locals
+    model_url: str,
+    num_processes: int = 4,
+    force_redo: bool = False,
+) -> None:
+    """Download weights for a model from the HuggingFace Git LFS repo."""
+    mlc_prefix = "HF://"
+    git_url_template = "https://huggingface.co/{user}/{repo}.git"
+    bin_url_template = "https://huggingface.co/{user}/{repo}/resolve/main/{record_name}"
+
+    if model_url.count("/") != 1 + mlc_prefix.count("/") or not model_url.startswith(mlc_prefix):
+        raise ValueError(f"Invalid model URL: {model_url}")
+    assert model_url.startswith(mlc_prefix)
+    user, repo = model_url[len(mlc_prefix) :].split("/")
+    git_dir = get_cache_dir() / "model_weights" / repo
+    try:
+        _ensure_directory_not_exist(git_dir, force_redo=force_redo)
+    except ValueError:
+        logger.info("Weights already downloaded: %s", git_dir)
+        return
+    with tempfile.TemporaryDirectory() as tmp_dir_prefix:
+        tmp_dir = Path(tmp_dir_prefix) / "tmp"
+        git_url = git_url_template.format(user=user, repo=repo)
+        git_clone(git_url, tmp_dir)
+        shutil.rmtree(tmp_dir / ".git", ignore_errors=True)
+        with (tmp_dir / "ndarray-cache.json").open(encoding="utf-8") as in_file:
+            param_metadata = json.load(in_file)["records"]
+        with cf.ProcessPoolExecutor(max_workers=num_processes) as executor:
+            futures = []
+            for record in param_metadata:
+                record_name = record["dataPath"]
+                file_url = bin_url_template.format(user=user, repo=repo, record_name=record_name)
+                file_dest = tmp_dir / record_name
+                file_md5 = record.get("md5sum", None)
+                futures.append(executor.submit(download_file, file_url, file_dest, file_md5))
+            with tqdm.redirect():
+                for future in tqdm.tqdm(cf.as_completed(futures), total=len(futures)):
+                    file_url, file_dest = future.result()
+                    logger.info("Downloaded %s to %s", file_url, file_dest)
+        logger.info("Moving %s to %s", tmp_dir, git_dir)
+        shutil.move(str(tmp_dir), str(git_dir))
+        shutil.move(str(tmp_dir), str(git_dir))


### PR DESCRIPTION
This PR allows programmably downloading from HuggingFace to MLC's cache
directory, which locates in `$HOME/.cache/mlc_chat/model_weights/` by
default.

This PR relies on Git to clone the metadata, and Python's requests
library to fetch concrete weights as large files instead of the less
reliable Git LFS.

The example demonstrates downloading the 4-bit quantized Llama2-7B
model:

```python
from mlc_chat.support.download import download_mlc_weights

download_mlc_weights("HF://mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1")
```

Screenshot:

<img width="1913" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/22515877/3ac50594-4971-4216-bb17-47710b4af1dd">