### PR TITLE
Add `mlc_chat.__main__` as command line entrypoint

### DIFF
--- a/python/mlc_chat/__main__.py
+++ b/python/mlc_chat/__main__.py
@@ -21,7 +21,7 @@ def main():
         choices=["compile", "convert_weight", "gen_mlc_chat_config"],
         help="Subcommand to to run. (choices: %(choices)s)",
     )
-    parsed = parser.parse_args([sys.argv[1]])
+    parsed = parser.parse_args(sys.argv[1:2])
     # pylint: disable=import-outside-toplevel
     if parsed.subcommand == "compile":
         from mlc_chat.cli import compile as cli

--- a/python/setup.py
+++ b/python/setup.py
@@ -89,6 +89,11 @@ def main():
         keywords="machine learning",
         zip_safe=False,
         packages=find_packages(),
+        entry_points={
+            "console_scripts": [
+                "mlc_chat = mlc_chat.__main__:main",
+            ],
+        },
         package_dir={"mlc_chat": "mlc_chat"},
         install_requires=["fastapi", "uvicorn", "shortuuid"],
         distclass=BinaryDistribution,


### PR DESCRIPTION
This PR makes it possible to invoke mlc_chat subcommands directly.

Previously one has to use `python -m` as the prefix to invoke `mlc_chat`:

```bash
python -m mlc_chat compile \
  --model /models/Llama-2-7b-chat-hf \
  --quantization q4f16_1 \
  --max-sequence-length 4096 \
  -o ./llama.so
```

This PR makes is possible to use it without the `python -m` prefix:

```bash
mlc_chat compile \
  --model /models/Llama-2-7b-chat-hf \
  --quantization q4f16_1 \
  --max-sequence-length 4096 \
  -o ./llama.so
```