### PR TITLE
[Fix] mistral `max_gen_len`

### DIFF
--- a/mlc_llm/relax_model/mistral.py
+++ b/mlc_llm/relax_model/mistral.py
@@ -939,6 +939,8 @@ def get_model(args, hf_config):
 
     if args.sliding_window != -1:
         hf_config["sliding_window"] = args.sliding_window
+    if args.max_seq_len != -1:
+        hf_config["max_sequence_length"] = args.max_seq_len
 
     config = MistralConfig(
         **hf_config,

--- a/mlc_llm/relax_model/mistral.py
+++ b/mlc_llm/relax_model/mistral.py
@@ -42,7 +42,7 @@ class MistralConfig:
         vocab_size=32000,
         dtype="float32",
         sliding_window_chunk_size=-1,
-        max_sequence_length=-1,  # Does not play a role, kept for compatibility.
+        max_sequence_length=16384,
         combine_matmul=True,
         build_model_only=False,
         num_shards=1,
@@ -70,7 +70,7 @@ class MistralConfig:
             self.sliding_window_chunk_size = self.sliding_window
         else:
             self.sliding_window_chunk_size = sliding_window_chunk_size
-        self.max_sequence_length = max_sequence_length
+        self.max_sequence_length = sliding_window * 4
         self.combine_matmul = combine_matmul
         if build_model_only and num_shards > 1:
             self.num_shards = num_shards


### PR DESCRIPTION
This PR fixes a bug with `max_gen_len` for the mistral-based models. #1249 introduced customizable `max_gen_len` based on the config's `max_sequence_length`, but mistral used to ignore `max_sequence_length` and this argument was set to -1. Consequently `max_gen_len` would also be set to -1 and the model would not generate outputs. As suggested in the Mistral paper, `max_sequence_length` can be set as `sliding_window * 4`.