### PR TITLE
[Feature] Prefill chunking for non-SWA models

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -512,9 +512,8 @@ class LLMChat {
     // so there is no explicit abi dependency on these extra
     // classes other than basic tvm runtime.
     this->ft_.Init(reload_lib, device_, this->num_shards_);
-    // UpdateConfigFromMetadata(); TODO
+    UpdateConfigFromMetadata();
     if (this->sliding_window_ == -1) {
-      UpdateConfigFromMetadata();
       CHECK(max_window_size_ != std::numeric_limits<int64_t>::max())
           << "Key \"max_window_size\" not found.";
     }

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -798,9 +798,8 @@ class LLMChat {
       if (ft_.use_disco) {
         LOG(FATAL) << "NotImplementedError: Distributed inference is not supported for this model";
       }
-      // TODO: FIX sep_emb with chunking
       if (this->prefill_chunk_size_ != -1) {
-        LOG(FATAL) << "NotImplementedError: Chunking does not support separate embedding";
+        LOG(FATAL) << "NotImplementedError: Separate embedding does not support chunking";
       }
       NDArray embedding = Downcast<NDArray>(
           EmbedStep(inp, append_conversation, place_in_prompt, generation_config_str));

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -834,6 +834,7 @@ class LLMChat {
       ICHECK_EQ(new_seq_len, total_seq_len_ + token_len) << "Expect chunking process all tokens";
     } else {
       // Otherwise, prefill entire prompt at once.
+      CHECK(sliding_window_ == -1) << "Expect chunking with sliding window attention";
       new_seq_len += token_len;
       logits_on_device = this->ForwardTokens(prompt_tokens, new_seq_len);
     }

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -815,7 +815,6 @@ def build_model_from_args(args: argparse.Namespace):
 
         if args.model_category == "mistral":
             args.sliding_window = model_config.sliding_window
-            # args.prefill_chunk_size = model_config.prefill_chunk_size
 
         for qspec_updater_class in param_manager.qspec_updater_classes:
             qspec_updater = qspec_updater_class(param_manager)

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -7,15 +7,9 @@ import pickle
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Dict, Optional
 
+import mlc_llm
 import tvm
 import tvm.relax.backend.contrib.cublas as _
-from tvm import dlight as dl
-from tvm import relax
-from tvm.contrib.nvcc import parse_compute_version
-from tvm.relax.backend import get_patterns_with_prefix
-from tvm.relax.backend.contrib.cutlass import annotate_workspace
-
-import mlc_llm
 from mlc_llm import utils
 from mlc_llm.relax_model import (
     chatglm,
@@ -30,12 +24,20 @@ from mlc_llm.relax_model import (
     rwkv,
     stablelm_3b,
 )
-from mlc_llm.relax_model.commons import create_shard_info_func, create_shard_transformation_func
+from mlc_llm.relax_model.commons import (
+    create_shard_info_func,
+    create_shard_transformation_func,
+)
 from mlc_llm.relax_model.param_manager import (
-    transform_params_for_each_rank,
     chain_parameter_transforms,
+    transform_params_for_each_rank,
 )
 from mlc_llm.transform import fuse_split_rotary_embedding, rewrite_attention
+from tvm import dlight as dl
+from tvm import relax
+from tvm.contrib.nvcc import parse_compute_version
+from tvm.relax.backend import get_patterns_with_prefix
+from tvm.relax.backend.contrib.cutlass import annotate_workspace
 
 
 @dataclass
@@ -107,9 +109,9 @@ class BuildArgs:
         overrides the `sliding_window` in config.json for those models that use SWA.
         Currently only useful when compiling Mistral.
 
-    sliding_window_chunk_size: int
-        The chunk size in sliding window attention (SWA) during prefilling. By default,
-        the chunk size is the same as sliding window. Currently only useful when compiling Mistral.
+    prefill_chunk_size: int
+        The chunk size during prefilling. By default, the chunk size is the same as
+        max sequence length. Currently only useful when compiling Mistral.
 
     cc_path: str
         ``/path/to/cross_compiler_path``; currently only used for cross-compile
@@ -349,12 +351,12 @@ class BuildArgs:
             ),
         },
     )
-    sliding_window_chunk_size: int = field(
+    prefill_chunk_size: int = field(
         default=-1,
         metadata={
             "help": (
-                "The chunk size in sliding window attention (SWA) during prefilling. "
-                "By default, the chunk size is the same as sliding window. "
+                "The chunk size during prefilling. By default, the chunk size is "
+                "the same as the sliding window size or the max sequence length. "
                 "Currently only useful when compiling Mistral."
             ),
         },
@@ -688,10 +690,10 @@ def dump_mlc_chat_config(
     config["model_category"] = args.model_category
     config["model_name"] = args.model
     config["vocab_size"] = vocab_size
+    config["prefill_chunk_size"] = args.prefill_chunk_size
     if args.sliding_window != -1:
         # Do not add max window size if use sliding window
         config["sliding_window"] = args.sliding_window
-        config["sliding_window_chunk_size"] = args.sliding_window_chunk_size
     else:
         config["max_window_size"] = max_window_size
 
@@ -813,7 +815,7 @@ def build_model_from_args(args: argparse.Namespace):
 
         if args.model_category == "mistral":
             args.sliding_window = model_config.sliding_window
-            args.sliding_window_chunk_size = model_config.sliding_window_chunk_size
+            # args.prefill_chunk_size = model_config.prefill_chunk_size
 
         for qspec_updater_class in param_manager.qspec_updater_classes:
             qspec_updater = qspec_updater_class(param_manager)

--- a/mlc_llm/relax_model/chatglm.py
+++ b/mlc_llm/relax_model/chatglm.py
@@ -1,37 +1,31 @@
-import math
 import argparse
+import math
 from dataclasses import dataclass
-from typing import Tuple, List
-
-from .commons import create_metadata_func
+from typing import List, Tuple
 
 import tvm
 from tvm import relax, te, tir
-from tvm.relax.testing import nn
-from tvm.relax.op.nn import softmax, silu
-from tvm.script import relax as R
 from tvm.relax.op import (
+    astype,
     broadcast_to,
-    permute_dims,
     expand_dims,
+    matmul,
     maximum,
     minimum,
-    reshape,
-    squeeze,
-    astype,
-    matmul,
-    split,
+    permute_dims,
     repeat,
+    reshape,
+    split,
+    squeeze,
 )
+from tvm.relax.op.nn import silu, softmax
+from tvm.relax.testing import nn
+from tvm.script import relax as R
 
 from ..quantization import ParamQuantKind, QuantizationScheme
+from .commons import create_metadata_func
+from .modules import Embedding, Linear, ModuleList, RotaryEmbedding
 from .param_manager import ParamManager
-from .modules import (
-    ModuleList,
-    Embedding,
-    Linear,
-    RotaryEmbedding,
-)
 
 
 @dataclass
@@ -92,11 +86,7 @@ class RMSNorm(nn.Module):
             is_float32 = x.dtype == "float32"
 
             def f_square(x):
-                return (
-                    tir.Cast("float32", x) * tir.Cast("float32", x)
-                    if not is_float32
-                    else x * x
-                )
+                return tir.Cast("float32", x) * tir.Cast("float32", x) if not is_float32 else x * x
 
             k = te.reduce_axis((0, x.shape[2]), name="k")
             square_sum = te.compute(
@@ -137,9 +127,7 @@ class CoreAttention(nn.Module):
 
         # Per attention head and per partition values.
         self.hidden_size_per_partition = projection_size
-        self.hidden_size_per_attention_head = (
-            projection_size // config.num_attention_heads
-        )
+        self.hidden_size_per_attention_head = projection_size // config.num_attention_heads
         self.num_attention_heads_per_partition = config.num_attention_heads
 
         self.norm_factor = math.sqrt(self.hidden_size_per_attention_head)
@@ -206,9 +194,7 @@ class SelfAttention(nn.Module):
         self.projection_size = config.kv_channels * config.num_attention_heads
 
         # Per attention head and per partition values.
-        self.hidden_size_per_attention_head = (
-            self.projection_size // config.num_attention_heads
-        )
+        self.hidden_size_per_attention_head = self.projection_size // config.num_attention_heads
         self.num_attention_heads_per_partition = config.num_attention_heads
 
         # Multi-query attention config
@@ -256,8 +242,7 @@ class SelfAttention(nn.Module):
             split(
                 self.query_key_value(hidden_states),
                 indices_or_sections=[
-                    self.num_attention_heads_per_partition
-                    * self.hidden_size_per_attention_head,
+                    self.num_attention_heads_per_partition * self.hidden_size_per_attention_head,
                     (
                         self.num_attention_heads_per_partition
                         + self.num_multi_query_groups_per_partition
@@ -294,9 +279,7 @@ class SelfAttention(nn.Module):
         q, k = self.rotary_pos_emb(q, k, kv_sl - sl)
 
         assert k.struct_info.shape[0] == 1 and v.struct_info.shape[0] == 1
-        squeezed_k, squeezed_v = nn.emit(squeeze(k, axis=0)), nn.emit(
-            squeeze(v, axis=0)
-        )
+        squeezed_k, squeezed_v = nn.emit(squeeze(k, axis=0)), nn.emit(squeeze(v, axis=0))
 
         k_cache, v_cache = past_key_value
         f_kv_cache_append = relax.extern("vm.builtin.attention_kv_cache_append")
@@ -335,10 +318,7 @@ class SelfAttention(nn.Module):
             )
         )
 
-        n_rep = (
-            self.num_attention_heads_per_partition
-            // self.num_multi_query_groups_per_partition
-        )
+        n_rep = self.num_attention_heads_per_partition // self.num_multi_query_groups_per_partition
         kv_attn_shape = R.shape(
             [
                 bsz,
@@ -440,9 +420,7 @@ class GLMTransformer(nn.Module):
     def __init__(self, config: ChatGLMConfig, rotary_pos_emb: RotaryEmbedding):
         self.num_layers = config.num_layers
 
-        self.layers = ModuleList(
-            [GLMBlock(config, rotary_pos_emb) for _ in range(self.num_layers)]
-        )
+        self.layers = ModuleList([GLMBlock(config, rotary_pos_emb) for _ in range(self.num_layers)])
         self.final_layernorm = RMSNorm(
             hidden_size=config.hidden_size,
             dtype=config.dtype,
@@ -617,9 +595,7 @@ class ChatGLMForCausalLM(nn.Module):
         return lm_logits, key_value_cache
 
 
-def get_param_quant_kind(
-    name: str, param_info: relax.TensorStructInfo
-) -> ParamQuantKind:
+def get_param_quant_kind(name: str, param_info: relax.TensorStructInfo) -> ParamQuantKind:
     if "embedding.weight" in name:
         return ParamQuantKind.embedding_table
     elif "transformer.output_layer.weight" in name:
@@ -643,19 +619,13 @@ def create_encoding_func(
     all_seq_len = tvm.tir.Var("m", "int64")
     with bb.function(func_name):
         model = ChatGLMForCausalLM(config)
-        param_manager.register_params(
-            model, func_name, quant_scheme, get_param_quant_kind
-        )
+        param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, sl), dtype="int32", name="input_ids")
-        all_seq_len_shape = relax.Var(
-            "all_seq_len", relax.ShapeStructInfo((all_seq_len,))
-        )
+        all_seq_len_shape = relax.Var("all_seq_len", relax.ShapeStructInfo((all_seq_len,)))
         past_key_values = relax.Var(
             "kv_cache",
-            relax.TupleStructInfo(
-                [relax.ObjectStructInfo() for _ in range(config.num_layers * 2)]
-            ),
+            relax.TupleStructInfo([relax.ObjectStructInfo() for _ in range(config.num_layers * 2)]),
         )
 
         with bb.dataflow():
@@ -686,23 +656,17 @@ def create_decoding_func(
     func_name = "decode"
 
     bsz = 1
-    all_seq_len = tvm.tir.Var("n", "int64")
+    all_seq_len = tvm.tir.Var("m", "int64")
 
     with bb.function(func_name):
         model = ChatGLMForCausalLM(config)
-        param_manager.register_params(
-            model, func_name, quant_scheme, get_param_quant_kind
-        )
+        param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, 1), dtype="int32", name="input_ids")
-        all_seq_len_shape = relax.Var(
-            "all_seq_len", relax.ShapeStructInfo((all_seq_len,))
-        )
+        all_seq_len_shape = relax.Var("all_seq_len", relax.ShapeStructInfo((all_seq_len,)))
         past_key_values = relax.Var(
             "kv_cache",
-            relax.TupleStructInfo(
-                [relax.ObjectStructInfo() for _ in range(config.num_layers * 2)]
-            ),
+            relax.TupleStructInfo([relax.ObjectStructInfo() for _ in range(config.num_layers * 2)]),
         )
         with bb.dataflow():
             logits, key_value_cache = model(
@@ -752,9 +716,7 @@ def create_kv_cache_func(bb: relax.BlockBuilder, config: ChatGLMConfig) -> None:
 
 def create_softmax_func(bb: relax.BlockBuilder, config: ChatGLMConfig) -> None:
     with bb.function("softmax_with_temperature"):
-        logits = nn.Placeholder(
-            (1, 1, config.padded_vocab_size), dtype="float32", name="logits"
-        )
+        logits = nn.Placeholder((1, 1, config.padded_vocab_size), dtype="float32", name="logits")
         temperature = nn.Placeholder((), dtype="float32", name="temperature")
         with bb.dataflow():
             div = bb.emit(relax.op.divide(logits, temperature))
@@ -773,6 +735,11 @@ def get_model(args: argparse.Namespace, hf_config):
             dtype=dtype,
         )
 
+        # prefill chunk size same as max sequence length by default
+        prefill_chunk_size = args.prefill_chunk_size
+        if prefill_chunk_size < 1:
+            prefill_chunk_size = config.max_sequence_length
+
         param_manager = ParamManager()
         bb = relax.BlockBuilder()
         create_encoding_func(bb, param_manager, config, args.quantization)
@@ -785,6 +752,7 @@ def get_model(args: argparse.Namespace, hf_config):
             max_window_size=config.max_sequence_length,
             stop_tokens=[0],
             add_prefix_space=False,
+            prefill_chunk_size=prefill_chunk_size,
         )
 
         mod = bb.get()
@@ -794,7 +762,7 @@ def get_model(args: argparse.Namespace, hf_config):
                 mod[gv] = func.with_attr(
                     "tir_var_upper_bound",
                     {
-                        "n": config.max_sequence_length,
+                        "n": prefill_chunk_size,
                         "m": config.max_sequence_length,
                     },
                 )
@@ -805,9 +773,7 @@ def get_model(args: argparse.Namespace, hf_config):
         def f_convert_pname_fwd(pname: str) -> List[str]:
             if "transformer.embedding" in pname:
                 return [
-                    pname.replace(
-                        "transformer.embedding", "transformer.embedding.word_embeddings"
-                    )
+                    pname.replace("transformer.embedding", "transformer.embedding.word_embeddings")
                 ]
             else:
                 return [pname]

--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -1,10 +1,9 @@
 import json
-from typing import List, Optional, Dict
-
-import tvm
-from tvm import relax, tir, te, topi
+from typing import Dict, List, Optional
 
 import mlc_llm
+import tvm
+from tvm import relax, te, tir, topi
 
 
 def create_metadata_func(
@@ -13,8 +12,8 @@ def create_metadata_func(
     max_window_size: int,
     stop_tokens: List[int],
     add_prefix_space: bool,
+    prefill_chunk_size: int = -1,
     sliding_window: int = -1,
-    sliding_window_chunk_size: int = -1,
 ):
     metadata = json.dumps(
         {
@@ -22,8 +21,8 @@ def create_metadata_func(
             "max_window_size": max_window_size,
             "stop_tokens": stop_tokens,
             "add_prefix_space": add_prefix_space,
+            "prefill_chunk_size": prefill_chunk_size,
             "sliding_window": sliding_window,
-            "sliding_window_chunk_size": sliding_window_chunk_size,
         }
     )
     with bb.function("get_metadata", params=[]):

--- a/mlc_llm/relax_model/gpt_bigcode.py
+++ b/mlc_llm/relax_model/gpt_bigcode.py
@@ -617,11 +617,6 @@ def get_model(args: argparse.Namespace, hf_config):
         elif config.max_sequence_length is None:
             config.max_sequence_length = 2048
 
-        # prefill chunk size same as max sequence length by default
-        prefill_chunk_size = args.prefill_chunk_size
-        if prefill_chunk_size < 1:
-            prefill_chunk_size = config.max_sequence_length
-
         param_manager = ParamManager()
         bb = relax.BlockBuilder()
         create_encoding_func(bb, param_manager, config, args.quantization)
@@ -634,20 +629,20 @@ def get_model(args: argparse.Namespace, hf_config):
             max_window_size=config.max_sequence_length,
             stop_tokens=[0],
             add_prefix_space=False,
-            prefill_chunk_size=prefill_chunk_size,
+            prefill_chunk_size=args.prefill_chunk_size,
         )
 
         mod = bb.get()
+
+        tir_bound_map = dict()
+        tir_bound_map["n"] = (
+            args.prefill_chunk_size if args.prefill_chunk_size > 0 else config.max_sequence_length
+        )
+        tir_bound_map["m"] = config.max_sequence_length
         for gv in mod.functions:
             func = mod[gv]
             if isinstance(func, relax.Function):
-                mod[gv] = func.with_attr(
-                    "tir_var_upper_bound",
-                    {
-                        "n": prefill_chunk_size,
-                        "m": config.max_sequence_length,
-                    },
-                )
+                mod[gv] = func.with_attr("tir_var_upper_bound", tir_bound_map)
 
         if args.build_model_only:
             return mod, param_manager, None, config

--- a/mlc_llm/relax_model/gpt_bigcode.py
+++ b/mlc_llm/relax_model/gpt_bigcode.py
@@ -1,29 +1,28 @@
-import math
 import argparse
+import math
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
-from .commons import create_metadata_func
-
 import tvm
 from tvm import relax, te
-from tvm.relax.testing import nn
-from tvm.relax.op.nn import gelu, softmax, layer_norm
-from tvm.script import relax as R
 from tvm.relax.op import (
+    astype,
     broadcast_to,
-    permute_dims,
     expand_dims,
+    matmul,
     maximum,
     minimum,
+    permute_dims,
     reshape,
     squeeze,
-    astype,
-    matmul,
 )
+from tvm.relax.op.nn import gelu, layer_norm, softmax
+from tvm.relax.testing import nn
+from tvm.script import relax as R
 
 from ..quantization import ParamQuantKind, QuantizationScheme
-from .modules import ModuleList, Embedding, Linear
+from .commons import create_metadata_func
+from .modules import Embedding, Linear, ModuleList
 from .param_manager import ParamManager
 
 
@@ -167,9 +166,7 @@ class GPTBigCodeAttention(nn.Module):
         self.n_head = config.n_head
         self.head_dim = config.n_embd // config.n_head
 
-        self.c_attn = Linear(
-            self.n_embd, self.n_embd + 2 * self.head_dim, config.dtype, bias=True
-        )
+        self.c_attn = Linear(self.n_embd, self.n_embd + 2 * self.head_dim, config.dtype, bias=True)
         self.c_proj = Linear(self.n_embd, self.n_embd, config.dtype, bias=True)
 
         self.dtype = config.dtype
@@ -198,9 +195,7 @@ class GPTBigCodeAttention(nn.Module):
 
         query_key_value = self.c_attn(hidden_states)
         # queries: [batch_size, seq_len, n_embd]
-        q = nn.emit_te(
-            te_slice, query_key_value, 0, self.n_embd, primfunc_name_hint="slice"
-        )
+        q = nn.emit_te(te_slice, query_key_value, 0, self.n_embd, primfunc_name_hint="slice")
         # keys: [batch_size, seq_len, head_dim]
         k = nn.emit_te(
             te_slice,
@@ -473,9 +468,7 @@ class GPTBigCodeForCausalLM(nn.Module):
         return logits, key_value_cache
 
 
-def get_param_quant_kind(
-    name: str, param_info: relax.TensorStructInfo
-) -> ParamQuantKind:
+def get_param_quant_kind(name: str, param_info: relax.TensorStructInfo) -> ParamQuantKind:
     if "wte.weight" in name:
         return ParamQuantKind.embedding_table
     elif "lm_head.weight" in name:
@@ -499,21 +492,13 @@ def create_encoding_func(
     all_seq_len = tvm.tir.Var("m", "int64")
     with bb.function(func_name):
         model = GPTBigCodeForCausalLM(config)
-        param_manager.register_params(
-            model, func_name, quant_scheme, get_param_quant_kind
-        )
+        param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
-        input_ids = nn.Placeholder(
-            (batch_size, seq_len), dtype="int32", name="input_ids"
-        )
-        all_seq_len_shape = relax.Var(
-            "all_seq_len", relax.ShapeStructInfo((all_seq_len,))
-        )
+        input_ids = nn.Placeholder((batch_size, seq_len), dtype="int32", name="input_ids")
+        all_seq_len_shape = relax.Var("all_seq_len", relax.ShapeStructInfo((all_seq_len,)))
         past_key_values = relax.Var(
             "kv_cache",
-            relax.TupleStructInfo(
-                [relax.ObjectStructInfo() for _ in range(config.n_layer * 2)]
-            ),
+            relax.TupleStructInfo([relax.ObjectStructInfo() for _ in range(config.n_layer * 2)]),
         )
 
         with bb.dataflow():
@@ -545,23 +530,17 @@ def create_decoding_func(
 
     bsz = tvm.tir.IntImm("int64", 1)
     seq_len = tvm.tir.IntImm("int64", 1)
-    all_seq_len = tvm.tir.Var("n", "int64")
+    all_seq_len = tvm.tir.Var("m", "int64")
 
     with bb.function(func_name):
         model = GPTBigCodeForCausalLM(config)
-        param_manager.register_params(
-            model, func_name, quant_scheme, get_param_quant_kind
-        )
+        param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, seq_len), dtype="int32", name="input_ids")
-        all_seq_len_shape = relax.Var(
-            "all_seq_len", relax.ShapeStructInfo((all_seq_len,))
-        )
+        all_seq_len_shape = relax.Var("all_seq_len", relax.ShapeStructInfo((all_seq_len,)))
         past_key_values = relax.Var(
             "kv_cache",
-            relax.TupleStructInfo(
-                [relax.ObjectStructInfo() for _ in range(config.n_layer * 2)]
-            ),
+            relax.TupleStructInfo([relax.ObjectStructInfo() for _ in range(config.n_layer * 2)]),
         )
         with bb.dataflow():
             logits, key_value_cache = model(
@@ -610,9 +589,7 @@ def create_kv_cache_func(bb: relax.BlockBuilder, config: GPTBigCodeConfig) -> No
 
 def create_softmax_func(bb: relax.BlockBuilder, config: GPTBigCodeConfig) -> None:
     with bb.function("softmax_with_temperature"):
-        logits = nn.Placeholder(
-            (1, 1, config.vocab_size), dtype="float32", name="logits"
-        )
+        logits = nn.Placeholder((1, 1, config.vocab_size), dtype="float32", name="logits")
         temperature = nn.Placeholder((), dtype="float32", name="temperature")
         with bb.dataflow():
             div = bb.emit(relax.op.divide(logits, temperature))
@@ -640,6 +617,11 @@ def get_model(args: argparse.Namespace, hf_config):
         elif config.max_sequence_length is None:
             config.max_sequence_length = 2048
 
+        # prefill chunk size same as max sequence length by default
+        prefill_chunk_size = args.prefill_chunk_size
+        if prefill_chunk_size < 1:
+            prefill_chunk_size = config.max_sequence_length
+
         param_manager = ParamManager()
         bb = relax.BlockBuilder()
         create_encoding_func(bb, param_manager, config, args.quantization)
@@ -652,6 +634,7 @@ def get_model(args: argparse.Namespace, hf_config):
             max_window_size=config.max_sequence_length,
             stop_tokens=[0],
             add_prefix_space=False,
+            prefill_chunk_size=prefill_chunk_size,
         )
 
         mod = bb.get()
@@ -661,7 +644,7 @@ def get_model(args: argparse.Namespace, hf_config):
                 mod[gv] = func.with_attr(
                     "tir_var_upper_bound",
                     {
-                        "n": config.max_sequence_length,
+                        "n": prefill_chunk_size,
                         "m": config.max_sequence_length,
                     },
                 )

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -21,13 +21,7 @@ from tvm.script import relax as R
 
 from ..quantization import ParamQuantKind, QuantizationScheme
 from .commons import create_metadata_func
-from .modules import (
-    Embedding,
-    LayerNorm,
-    Linear,
-    ModuleList,
-    RotaryEmbedding,
-)
+from .modules import Embedding, LayerNorm, Linear, ModuleList, RotaryEmbedding
 from .param_manager import ParamManager
 
 
@@ -506,7 +500,7 @@ def create_embed_func(
     func_name = "embed"
 
     bsz = 1
-    seq_len = tvm.tir.Var("n", "int64")
+    seq_len = tvm.tir.Var("m", "int64")
     with bb.function(func_name):
         model = GPTNeoXEmbedTokensWrapper(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
@@ -584,7 +578,7 @@ def create_decoding_func(
 
     batch_size = tvm.tir.IntImm("int64", 1)
     seq_len = tvm.tir.IntImm("int64", 1)
-    all_seq_len = tvm.tir.Var("n", "int64")
+    all_seq_len = tvm.tir.Var("m", "int64")
     with bb.function(func_name):
         model = GPTNeoXForCausalLM(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
@@ -688,6 +682,11 @@ def get_model(
         ffn_out_dtype=ffn_out_dtype,
     )
 
+    # prefill chunk size same as max sequence length by default
+    prefill_chunk_size = args.prefill_chunk_size
+    if prefill_chunk_size < 1:
+        prefill_chunk_size = config.max_sequence_length
+
     param_manager = ParamManager()
     bb = relax.BlockBuilder()
     if sep_embed:
@@ -702,6 +701,7 @@ def get_model(
         max_window_size=config.max_sequence_length,
         stop_tokens=stop_tokens,
         add_prefix_space=False,
+        prefill_chunk_size=prefill_chunk_size,
     )
     mod = bb.get()
     for gv in mod.functions:
@@ -710,7 +710,7 @@ def get_model(
             mod[gv] = func.with_attr(
                 "tir_var_upper_bound",
                 {
-                    "n": config.max_sequence_length,
+                    "n": prefill_chunk_size,
                     "m": config.max_sequence_length,
                 },
             )

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -682,11 +682,6 @@ def get_model(
         ffn_out_dtype=ffn_out_dtype,
     )
 
-    # prefill chunk size same as max sequence length by default
-    prefill_chunk_size = args.prefill_chunk_size
-    if prefill_chunk_size < 1:
-        prefill_chunk_size = config.max_sequence_length
-
     param_manager = ParamManager()
     bb = relax.BlockBuilder()
     if sep_embed:
@@ -701,19 +696,19 @@ def get_model(
         max_window_size=config.max_sequence_length,
         stop_tokens=stop_tokens,
         add_prefix_space=False,
-        prefill_chunk_size=prefill_chunk_size,
+        prefill_chunk_size=args.prefill_chunk_size,
     )
     mod = bb.get()
+
+    tir_bound_map = dict()
+    tir_bound_map["n"] = (
+        args.prefill_chunk_size if args.prefill_chunk_size > 0 else config.max_sequence_length
+    )
+    tir_bound_map["m"] = config.max_sequence_length
     for gv in mod.functions:
         func = mod[gv]
         if isinstance(func, relax.Function):
-            mod[gv] = func.with_attr(
-                "tir_var_upper_bound",
-                {
-                    "n": prefill_chunk_size,
-                    "m": config.max_sequence_length,
-                },
-            )
+            mod[gv] = func.with_attr("tir_var_upper_bound", tir_bound_map)
 
     if args.build_model_only:
         return mod, param_manager, None, config

--- a/mlc_llm/relax_model/gptj.py
+++ b/mlc_llm/relax_model/gptj.py
@@ -23,13 +23,7 @@ from tvm.script import relax as R
 from ..quantization import ParamQuantKind, QuantizationScheme
 from .commons import create_metadata_func
 from .gpt_neox import create_kv_cache_func
-from .modules import (
-    Embedding,
-    LayerNorm,
-    Linear,
-    ModuleList,
-    RotaryEmbedding,
-)
+from .modules import Embedding, LayerNorm, Linear, ModuleList, RotaryEmbedding
 from .param_manager import ParamManager
 
 
@@ -459,21 +453,15 @@ class GPTJForCausalLM(nn.Module):
 
 def check_parameters(param_dict, param_list):
     relax_shape_to_list = lambda _: [s.value for s in _.values]
-    shape_dict_0 = {
-        k: relax_shape_to_list(v.struct_info.shape) for k, v in param_dict.items()
-    }
+    shape_dict_0 = {k: relax_shape_to_list(v.struct_info.shape) for k, v in param_dict.items()}
     shape_dict_1 = {k: list(v.shape) for (k, v) in param_list}
     assert len(shape_dict_0) == len(shape_dict_1)
     for k, v in shape_dict_0.items():
         assert k in shape_dict_1, "{}".format(k)
-        assert v == shape_dict_1[k], "key={}, shape_0={}, shape_1={}".format(
-            k, v, shape_dict_1[k]
-        )
+        assert v == shape_dict_1[k], "key={}, shape_0={}, shape_1={}".format(k, v, shape_dict_1[k])
 
 
-def get_param_quant_kind(
-    name: str, param_info: relax.TensorStructInfo
-) -> ParamQuantKind:
+def get_param_quant_kind(name: str, param_info: relax.TensorStructInfo) -> ParamQuantKind:
     if "wte.weight" in name:
         return ParamQuantKind.embedding_table
     elif "lm_head.weight" in name:
@@ -493,12 +481,10 @@ def create_embed_func(
     func_name = "embed"
 
     bsz = 1
-    seq_len = tvm.tir.Var("n", "int64")
+    seq_len = tvm.tir.Var("m", "int64")
     with bb.function(func_name):
         model = GPTJEmbedTokensWrapper(config)
-        param_manager.register_params(
-            model, func_name, quant_scheme, get_param_quant_kind
-        )
+        param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, seq_len), dtype="int32", name="input_ids")
         with bb.dataflow():
@@ -527,9 +513,7 @@ def create_encoding_func(
     hidden_size = config.hidden_size
     with bb.function(func_name):
         model = GPTJForCausalLM(config, sep_embed)
-        param_manager.register_params(
-            model, func_name, quant_scheme, get_param_quant_kind
-        )
+        param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         inputs = (
             nn.Placeholder(
@@ -540,9 +524,7 @@ def create_encoding_func(
             if sep_embed
             else nn.Placeholder((batch_size, seq_len), dtype="int32", name="input_ids")
         )
-        all_seq_len_shape = relax.Var(
-            "all_seq_len", relax.ShapeStructInfo((all_seq_len,))
-        )
+        all_seq_len_shape = relax.Var("all_seq_len", relax.ShapeStructInfo((all_seq_len,)))
         past_key_values = relax.Var(
             "kv_cache",
             relax.TupleStructInfo(
@@ -577,16 +559,12 @@ def create_decoding_func(
 
     batch_size = tvm.tir.IntImm("int64", 1)
     seq_len = tvm.tir.IntImm("int64", 1)
-    all_seq_len = tvm.tir.Var("n", "int64")
+    all_seq_len = tvm.tir.Var("m", "int64")
     with bb.function(func_name):
         model = GPTJForCausalLM(config)
-        param_manager.register_params(
-            model, func_name, quant_scheme, get_param_quant_kind
-        )
+        param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
-        input_ids = nn.Placeholder(
-            (batch_size, seq_len), dtype="int32", name="input_ids"
-        )
+        input_ids = nn.Placeholder((batch_size, seq_len), dtype="int32", name="input_ids")
         all_seq_len_shape = relax.Var(
             "all_seq_len",
             relax.ShapeStructInfo((all_seq_len,)),
@@ -617,9 +595,7 @@ def create_decoding_func(
 
 def create_softmax_func(bb: relax.BlockBuilder, config: GPTJConfig) -> None:
     with bb.function("softmax_with_temperature"):
-        logits = nn.Placeholder(
-            (1, 1, config.vocab_size), dtype="float32", name="logits"
-        )
+        logits = nn.Placeholder((1, 1, config.vocab_size), dtype="float32", name="logits")
         temperature = nn.Placeholder((), dtype="float32", name="temperature")
         with bb.dataflow():
             div = bb.emit(relax.op.divide(logits, temperature))
@@ -643,6 +619,11 @@ def get_model(args, hf_config):
     if max_seq_len != -1:
         config.max_sequence_length = max_seq_len
 
+    # prefill chunk size same as max sequence length by default
+    prefill_chunk_size = args.prefill_chunk_size
+    if prefill_chunk_size < 1:
+        prefill_chunk_size = config.max_sequence_length
+
     param_manager = ParamManager()
     bb = relax.BlockBuilder()
     if sep_embed:
@@ -657,6 +638,7 @@ def get_model(args, hf_config):
         max_window_size=config.max_sequence_length,
         stop_tokens=stop_tokens,
         add_prefix_space=True,
+        prefill_chunk_size=prefill_chunk_size,
     )
     mod = bb.get()
     for gv in mod.functions:
@@ -665,7 +647,7 @@ def get_model(args, hf_config):
             mod[gv] = func.with_attr(
                 "tir_var_upper_bound",
                 {
-                    "n": config.max_sequence_length,
+                    "n": prefill_chunk_size,
                     "m": config.max_sequence_length,
                 },
             )
@@ -684,9 +666,7 @@ def get_model(args, hf_config):
 
     hidden_size = config.hidden_size
 
-    def f_convert_param_bkwd(
-        torch_pname: str, torch_param
-    ) -> Optional[List[Tuple[str, Any]]]:
+    def f_convert_param_bkwd(torch_pname: str, torch_param) -> Optional[List[Tuple[str, Any]]]:
         # torch_param: numpy.ndarray
         if torch_pname.endswith("qkv_proj.weight"):
             assert torch_param.ndim == 2

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -875,7 +875,7 @@ def create_embed_func(
 ) -> None:
     func_name = "embed"
 
-    seq_len = tvm.tir.Var("n", "int64")
+    seq_len = tvm.tir.Var("m", "int64")
     with bb.function(func_name):
         model = LlamaEmbedTokensWrapper(config, tvm.tir.Var("vocab_size", "int64"))
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
@@ -949,7 +949,7 @@ def create_prefill_func_for_batching(
     func_name = "prefill_with_embed"
 
     bsz = tir.Var("nseq", "int64")
-    total_seq_len = tvm.tir.Var("n", "int64")
+    total_seq_len = tvm.tir.Var("m", "int64")
     hidden_size = config.hidden_size
     with bb.function(func_name):
         model = LlamaForCausalLM(
@@ -987,7 +987,7 @@ def create_decoding_func_for_single_seq(
     func_name = "decode"
 
     bsz = 1
-    all_seq_len = tvm.tir.Var("n", "int64")
+    all_seq_len = tvm.tir.Var("m", "int64")
 
     with bb.function(func_name):
         model = LlamaForCausalLM(config, tvm.tir.Var("vocab_size", "int64"))
@@ -1338,6 +1338,11 @@ def get_model(args, hf_config):
     if args.max_seq_len != -1:
         config.max_sequence_length = args.max_seq_len
 
+    # prefill chunk size same as max sequence length by default
+    prefill_chunk_size = args.prefill_chunk_size
+    if prefill_chunk_size < 1:
+        prefill_chunk_size = config.max_sequence_length
+
     param_manager = ParamManager()
     bb = relax.BlockBuilder()
 
@@ -1362,12 +1367,13 @@ def get_model(args, hf_config):
         max_window_size=config.max_sequence_length,
         stop_tokens=[2],
         add_prefix_space=False,
+        prefill_chunk_size=prefill_chunk_size,
     )
 
     mod = bb.get()
 
     tir_bound_map = dict()
-    tir_bound_map["n"] = config.max_sequence_length
+    tir_bound_map["n"] = prefill_chunk_size
     tir_bound_map["m"] = config.max_sequence_length
     tir_bound_map["vocab_size"] = args.max_vocab_size
     if enable_batching:

--- a/mlc_llm/relax_model/stablelm_3b.py
+++ b/mlc_llm/relax_model/stablelm_3b.py
@@ -795,11 +795,6 @@ def get_model(args, hf_config):
     if max_seq_len != -1:
         config.max_sequence_length = max_seq_len
 
-    # prefill chunk size same as max sequence length by default
-    prefill_chunk_size = args.prefill_chunk_size
-    if prefill_chunk_size < 1:
-        prefill_chunk_size = config.max_sequence_length
-
     param_manager = ParamManager()
     bb = relax.BlockBuilder()
     emit_shard3d(bb)
@@ -816,20 +811,20 @@ def get_model(args, hf_config):
         max_window_size=config.max_sequence_length,
         stop_tokens=[2],
         add_prefix_space=False,
-        prefill_chunk_size=prefill_chunk_size,
+        prefill_chunk_size=args.prefill_chunk_size,
     )
 
     mod = bb.get()
+
+    tir_bound_map = dict()
+    tir_bound_map["n"] = (
+        args.prefill_chunk_size if args.prefill_chunk_size > 0 else config.max_sequence_length
+    )
+    tir_bound_map["m"] = config.max_sequence_length
     for gv in mod.functions:
         func = mod[gv]
         if isinstance(func, relax.Function):
-            mod[gv] = func.with_attr(
-                "tir_var_upper_bound",
-                {
-                    "n": prefill_chunk_size,
-                    "m": config.max_sequence_length,
-                },
-            )
+            mod[gv] = func.with_attr("tir_var_upper_bound", tir_bound_map)
 
     if args.build_model_only:
         return mod, param_manager, None, config

--- a/python/mlc_chat/cli/compile.py
+++ b/python/mlc_chat/cli/compile.py
@@ -102,10 +102,10 @@ def main(argv):
         help=HELP["sliding_window"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
-        "--sliding-window-chunk-size",
+        "--prefill-chunk-size",
         type=int,
         default=None,
-        help=HELP["sliding_window_chunk_size"] + ' (default: "%(default)s")',
+        help=HELP["prefill_chunk_size"] + ' (default: "%(default)s")',
     )
     parsed = parser.parse_args(argv)
     target, build_func = detect_target_and_host(parsed.device, parsed.host)
@@ -121,5 +121,5 @@ def main(argv):
         output=parsed.output,
         context_window_size=parsed.context_window_size,
         sliding_window=parsed.sliding_window,
-        sliding_window_chunk_size=parsed.sliding_window_chunk_size,
+        prefill_chunk_size=parsed.prefill_chunk_size,
     )

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -85,11 +85,12 @@ def _attach_auxiliary_methods(
 def _attach_variable_bounds(mod, model_config):
     tir_bound_map = {}
     tir_bound_map["seq_len"] = model_config.prefill_chunk_size
-    if model_config.context_window_size != -1:
-        tir_bound_map["total_seq_len"] = model_config.context_window_size
+
     if hasattr(model_config, "sliding_window"):
         tir_bound_map["rolling_cache_len"] = model_config.sliding_window
         tir_bound_map["kv_seq_len"] = model_config.sliding_window + model_config.prefill_chunk_size
+    else:
+        tir_bound_map["total_seq_len"] = model_config.context_window_size
 
     for g_var, func in mod.functions_items():
         if isinstance(func, relax.Function):

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -83,7 +83,7 @@ def _attach_auxiliary_methods(
 
 
 def _attach_variable_bounds(mod, model_config):
-    tir_bound_map = dict()
+    tir_bound_map = {}
     tir_bound_map["seq_len"] = model_config.prefill_chunk_size
     if model_config.context_window_size != -1:
         tir_bound_map["total_seq_len"] = model_config.context_window_size

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -83,15 +83,17 @@ def _attach_auxiliary_methods(
 
 
 def _attach_variable_bounds(mod, model_config):
+    tir_bound_map = dict()
+    tir_bound_map["seq_len"] = model_config.prefill_chunk_size
+    if model_config.context_window_size != -1:
+        tir_bound_map["total_seq_len"] = model_config.context_window_size
+    if hasattr(model_config, "sliding_window"):
+        tir_bound_map["rolling_cache_len"] = model_config.sliding_window
+        tir_bound_map["kv_seq_len"] = model_config.sliding_window + model_config.prefill_chunk_size
+
     for g_var, func in mod.functions_items():
         if isinstance(func, relax.Function):
-            mod[g_var] = func.with_attr(
-                "tir_var_upper_bound",
-                {
-                    "seq_len": model_config.context_window_size,
-                    "total_seq_len": model_config.context_window_size,
-                },
-            )
+            mod[g_var] = func.with_attr("tir_var_upper_bound", tir_bound_map)
 
 
 def _compile(args: CompileArgs):
@@ -124,7 +126,7 @@ def compile(  # pylint: disable=too-many-arguments,redefined-builtin
     output: Path,
     context_window_size: Optional[int],
     sliding_window: Optional[int],
-    sliding_window_chunk_size: Optional[int],
+    prefill_chunk_size: Optional[int],
 ):
     """Compile a model given its configuration and quantization format to a specific target."""
     args = CompileArgs(
@@ -139,7 +141,7 @@ def compile(  # pylint: disable=too-many-arguments,redefined-builtin
         ModelConfigOverride(
             context_window_size=context_window_size,
             sliding_window=sliding_window,
-            sliding_window_chunk_size=sliding_window_chunk_size,
+            prefill_chunk_size=prefill_chunk_size,
         ),
     )
     args.display()

--- a/python/mlc_chat/compiler/flags_model_config_override.py
+++ b/python/mlc_chat/compiler/flags_model_config_override.py
@@ -16,7 +16,7 @@ class ModelConfigOverride:
     max_batch_size: Optional[int] = None
     num_shards: Optional[int] = None
     sliding_window: Optional[int] = None
-    sliding_window_chunk_size: Optional[int] = None
+    prefill_chunk_size: Optional[int] = None
 
     def apply(self, model_config):
         """Apply the overrides to the given model config."""
@@ -42,19 +42,19 @@ class ModelConfigOverride:
                 self.sliding_window,
             )
             model_config.sliding_window = self.sliding_window
-            if self.sliding_window_chunk_size is None:
+            if self.prefill_chunk_size is None:
                 logger.info(
                     "Provided %s but did not provide %s, setting both to %d",
                     bold("sliding_window"),
-                    bold("sliding_window_chunk_size"),
+                    bold("prefill_chunk_size"),
                     model_config.sliding_window,
                 )
-                model_config.sliding_window_chunk_size = self.sliding_window_chunk_size
-        if self.sliding_window_chunk_size is not None:
+                model_config.prefill_chunk_size = self.prefill_chunk_size
+        if self.prefill_chunk_size is not None:
             logger.info(
                 "Overriding %s from %d to %d",
-                bold("sliding_window_chunk_size"),
-                model_config.sliding_window_chunk_size,
-                self.sliding_window_chunk_size,
+                bold("prefill_chunk_size"),
+                model_config.prefill_chunk_size,
+                self.prefill_chunk_size,
             )
-            model_config.sliding_window_chunk_size = self.sliding_window_chunk_size
+            model_config.prefill_chunk_size = self.prefill_chunk_size

--- a/python/mlc_chat/compiler/help.py
+++ b/python/mlc_chat/compiler/help.py
@@ -95,9 +95,9 @@ This optional field overrides the `sliding_window` in config.json for
 those models that use SWA. Currently only useful when compiling Mistral.
 This flag subjects to future refactoring.
 """.strip(),
-    "sliding_window_chunk_size": """
-(Experimental) The chunk size in sliding window attention (SWA) during prefilling. By default,
-the chunk size is the same as sliding window. Currently only useful when compiling Mistral.
+    "prefill_chunk_size": """
+(Experimental) The chunk size during prefilling. By default,
+the chunk size is the same as sliding window or max sequence length.
 This flag subjects to future refactoring.
 """.strip(),
 }

--- a/python/mlc_chat/compiler/model/llama/llama_model.py
+++ b/python/mlc_chat/compiler/model/llama/llama_model.py
@@ -31,6 +31,7 @@ class LlamaConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     context_window_size: int = 0
     num_key_value_heads: int = 0
     head_dim: int = 0
+    prefill_chunk_size: int = 0
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -62,6 +63,10 @@ class LlamaConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
             self.head_dim = self.hidden_size // self.num_attention_heads
         assert self.num_attention_heads % self.num_key_value_heads == 0
         assert self.head_dim * self.num_attention_heads == self.hidden_size
+
+        if self.prefill_chunk_size == 0:
+            # chunk size same as context window size by default
+            self.prefill_chunk_size = self.context_window_size
 
 
 # pylint: disable=invalid-name,missing-docstring

--- a/python/mlc_chat/compiler/model/mistral/mistral_model.py
+++ b/python/mlc_chat/compiler/model/mistral/mistral_model.py
@@ -371,7 +371,9 @@ class MistralForCasualLM(nn.Module):
             b, s, d = x.shape
             return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
 
-        hidden_states = self.model(inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask)
+        hidden_states = self.model(
+            inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask
+        )
         hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
         logits = self.lm_head(hidden_states)
         if logits.dtype != "float32":
@@ -379,7 +381,11 @@ class MistralForCasualLM(nn.Module):
         return logits
 
     def prefill(
-        self, inputs: Tensor, total_seq_len: tir.Var, rolling_cache_len: tir.Var, kv_seq_len: tir.Var
+        self,
+        inputs: Tensor,
+        total_seq_len: tir.Var,
+        rolling_cache_len: tir.Var,
+        kv_seq_len: tir.Var,
     ):
         """
         Prefilling the prompt.
@@ -428,7 +434,11 @@ class MistralForCasualLM(nn.Module):
         return self.forward(inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask)
 
     def decode(
-        self, inputs: Tensor, total_seq_len: tir.Var, rolling_cache_len: tir.Var, kv_seq_len: tir.Var
+        self,
+        inputs: Tensor,
+        total_seq_len: tir.Var,
+        rolling_cache_len: tir.Var,
+        kv_seq_len: tir.Var,
     ):
         """Decoding step."""
         batch_size, seq_len = inputs.shape

--- a/python/mlc_chat/compiler/model/mistral/mistral_model.py
+++ b/python/mlc_chat/compiler/model/mistral/mistral_model.py
@@ -32,7 +32,7 @@ class MistralConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     num_key_value_heads: int = 0
     head_dim: int = 0
     sliding_window: int = 4096
-    sliding_window_chunk_size: int = 0
+    prefill_chunk_size: int = 0
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -65,9 +65,9 @@ class MistralConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
         assert self.num_attention_heads % self.num_key_value_heads == 0
         assert self.head_dim * self.num_attention_heads == self.hidden_size
 
-        if self.sliding_window_chunk_size == 0:
+        if self.prefill_chunk_size == 0:
             # chunk size same as sliding window by default
-            self.sliding_window_chunk_size = self.sliding_window
+            self.prefill_chunk_size = self.sliding_window
         self.context_window_size = -1
         logger.info(
             "Using sliding window attention, setting %s to -1",
@@ -159,27 +159,27 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         v_cur: Tensor,
         total_seq_len: tir.Var,
         kv_seq_len: tir.Var,
-        cache_len: tir.Var,
+        rolling_cache_len: tir.Var,
     ):
         """Unrotate and concatenate currunt and cached k and v"""
         d, _, h_kv = self.head_dim, self.num_q_heads, self.num_kv_heads
-        t, kv_s, c = total_seq_len, kv_seq_len, cache_len
+        t, kv_s, c = total_seq_len, kv_seq_len, rolling_cache_len
         b, s, _, _ = k_cur.shape
         cache_offset = (t - s) % self.sliding_window
 
         k_cached = op.reshape(self.k_cache.view(c), (b, c, h_kv, d))
         v_cached = op.reshape(self.v_cache.view(c), (b, c, h_kv, d))
 
-        def _unrotate_concat(x_cur, x_cached, cache_offset, cache_len):
+        def _unrotate_concat(x_cur, x_cached, cache_offset, rolling_cache_len):
             return te.compute(
                 (b, kv_s, h_kv, d),
                 lambda xb, xs, xh, xd: te.if_then_else(
-                    xs < cache_len - cache_offset,
+                    xs < rolling_cache_len - cache_offset,
                     x_cached[xb, cache_offset + xs, xh, xd],
                     te.if_then_else(
-                        xs < cache_len,
-                        x_cached[xb, xs + cache_offset - cache_len, xh, xd],
-                        x_cur[xb, xs - cache_len, xh, xd],
+                        xs < rolling_cache_len,
+                        x_cached[xb, xs + cache_offset - rolling_cache_len, xh, xd],
+                        x_cur[xb, xs - rolling_cache_len, xh, xd],
                     ),
                 ),
                 name="unrotate_concat_te",
@@ -206,8 +206,8 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         hidden_states: Tensor,
         attention_mask: Tensor,
         total_seq_len: tir.Var,  # Number of already-processed tokens plus ``seq_len``.
-        cache_len: tir.Var,  # Number of elements currently in the cache.
-        kv_seq_len: tir.Var,  # Equals to ``seq_len + cache_len``.
+        rolling_cache_len: tir.Var,  # Number of elements currently in the cache.
+        kv_seq_len: tir.Var,  # Equals to ``seq_len + rolling_cache_len``.
     ):
         """Forward pass of MistralAttention, performing QKV."""
         d, h_q, h_kv, t = self.head_dim, self.num_q_heads, self.num_kv_heads, total_seq_len
@@ -220,7 +220,7 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         v_cur = op.reshape(v_cur, (b, s, h_kv, d))
         q, k_cur = self.rotary_embedding(q, k_cur, t - s)
 
-        k, v = self.interleave_kv(k_cur, v_cur, total_seq_len, kv_seq_len, cache_len)
+        k, v = self.interleave_kv(k_cur, v_cur, total_seq_len, kv_seq_len, rolling_cache_len)
 
         if h_kv != h_q:
             k = k.repeat(h_q // h_kv, axis=2)
@@ -294,7 +294,7 @@ class MistralDecoderLayer(nn.Module):
         hidden_states: Tensor,
         attention_mask: Tensor,
         total_seq_len: tir.Var,
-        cache_len: tir.Var,
+        rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
     ):
         """Forward pass of a decoder layer; calculate attention, and add an residual connection."""
@@ -303,7 +303,7 @@ class MistralDecoderLayer(nn.Module):
                 self.input_layernorm(hidden_states),
                 attention_mask,
                 total_seq_len,
-                cache_len,
+                rolling_cache_len,
                 kv_seq_len,
             )
             + hidden_states
@@ -328,7 +328,7 @@ class MistralModel(nn.Module):
         self,
         inputs: Tensor,
         total_seq_len: tir.Var,
-        cache_len: tir.Var,
+        rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
         attention_mask: Tensor,
     ):
@@ -336,7 +336,7 @@ class MistralModel(nn.Module):
         hidden_states = self.embed_tokens(inputs)
         for layer in self.layers:
             hidden_states = layer(
-                hidden_states, attention_mask, total_seq_len, cache_len, kv_seq_len
+                hidden_states, attention_mask, total_seq_len, rolling_cache_len, kv_seq_len
             )
         hidden_states = self.norm(hidden_states)
         return hidden_states
@@ -361,7 +361,7 @@ class MistralForCasualLM(nn.Module):
         self,
         inputs: Tensor,
         total_seq_len: tir.Var,
-        cache_len: tir.Var,
+        rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
         attention_mask: Tensor,
     ):
@@ -371,7 +371,7 @@ class MistralForCasualLM(nn.Module):
             b, s, d = x.shape
             return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
 
-        hidden_states = self.model(inputs, total_seq_len, cache_len, kv_seq_len, attention_mask)
+        hidden_states = self.model(inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask)
         hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
         logits = self.lm_head(hidden_states)
         if logits.dtype != "float32":
@@ -379,7 +379,7 @@ class MistralForCasualLM(nn.Module):
         return logits
 
     def prefill(
-        self, inputs: Tensor, total_seq_len: tir.Var, cache_len: tir.Var, kv_seq_len: tir.Var
+        self, inputs: Tensor, total_seq_len: tir.Var, rolling_cache_len: tir.Var, kv_seq_len: tir.Var
     ):
         """
         Prefilling the prompt.
@@ -392,21 +392,21 @@ class MistralForCasualLM(nn.Module):
         total_seq_len: tir.Var
             Number of already-processed tokens plus ``seq_len``.
 
-        cache_len: tir.Var
+        rolling_cache_len: tir.Var
             Number of elements currently in the cache.
 
         kv_seq_len: tir.Var
-            Equals to ``seq_len + cache_len``.
+            Equals to ``seq_len + rolling_cache_len``.
         """
 
         def _sliding_window_attention_mask(
-            batch_size, seq_len, cache_len, kv_seq_len, sliding_window
+            batch_size, seq_len, rolling_cache_len, kv_seq_len, sliding_window
         ):
             # See `tests/legacy-python/test_sliding_window_mask.py` for its behavior
             return te.compute(
                 (batch_size, 1, seq_len, kv_seq_len),
                 lambda b, _, i, j: tir.Select(
-                    tir.all(i + cache_len >= j, i + cache_len - j < sliding_window),
+                    tir.all(i + rolling_cache_len >= j, i + rolling_cache_len - j < sliding_window),
                     tir.max_value(self.dtype),
                     tir.min_value(self.dtype),
                 ),
@@ -420,15 +420,15 @@ class MistralForCasualLM(nn.Module):
             args=[
                 batch_size,
                 seq_len,
-                cache_len,
+                rolling_cache_len,
                 kv_seq_len,
                 self.sliding_window,
             ],
         )
-        return self.forward(inputs, total_seq_len, cache_len, kv_seq_len, attention_mask)
+        return self.forward(inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask)
 
     def decode(
-        self, inputs: Tensor, total_seq_len: tir.Var, cache_len: tir.Var, kv_seq_len: tir.Var
+        self, inputs: Tensor, total_seq_len: tir.Var, rolling_cache_len: tir.Var, kv_seq_len: tir.Var
     ):
         """Decoding step."""
         batch_size, seq_len = inputs.shape
@@ -437,7 +437,7 @@ class MistralForCasualLM(nn.Module):
             fill_value=tir.max_value(self.dtype),
             dtype=self.dtype,
         )
-        return self.forward(inputs, total_seq_len, cache_len, kv_seq_len, attention_mask)
+        return self.forward(inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask)
 
     def softmax_with_temperature(self, logits: Tensor, temperature: Tensor):
         """Softmax."""
@@ -450,7 +450,7 @@ class MistralForCasualLM(nn.Module):
             "prefill": {
                 "inputs": nn.spec.Tensor([batch_size, "seq_len"], "int32"),
                 "total_seq_len": int,
-                "cache_len": int,
+                "rolling_cache_len": int,
                 "kv_seq_len": int,
                 "$": {
                     "param_mode": "packed",
@@ -460,7 +460,7 @@ class MistralForCasualLM(nn.Module):
             "decode": {
                 "inputs": nn.spec.Tensor([batch_size, 1], "int32"),
                 "total_seq_len": int,
-                "cache_len": int,
+                "rolling_cache_len": int,
                 "kv_seq_len": int,
                 "$": {
                     "param_mode": "packed",


### PR DESCRIPTION
Prior to this PR, only Mistral supported chunking the prompt during the prefill step. Chunking allows memory reduction, typically during the QK computation, in all models since the prefill is bound to chunk size. As of now, chunking is not restricted to SWA anymore. For instance, with `max_seq_len = 4096` llama goes from roughly 9GB to 6GB of VRAM consumption (chunk_size=128). This option was renamed to `--prefill-chunk-size`.

cc @CharlieFRuan @junrushao 