### PR TITLE
Enable Jenkins CI

### DIFF
--- a/ci/jenkinsfile.groovy
+++ b/ci/jenkinsfile.groovy
@@ -18,7 +18,7 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 image = 'mlcaidev/ci-cpu:caab922'
-docker_run = 'ci/bash.sh ${image}'
+docker_run = 'bash ci/bash.sh ${image}'
 
 def per_exec_ws(folder) {
   return "workspace/exec_${env.EXECUTOR_NUMBER}/" + folder

--- a/ci/jenkinsfile.groovy
+++ b/ci/jenkinsfile.groovy
@@ -27,7 +27,7 @@ def per_exec_ws(folder) {
 def lint_common(cmd) {
   node('CPU-SMALL') {
     ws(per_exec_ws('mlc-llm-lint')) {
-      sh(script: "ls", label: 'List files')
+      sh(script: "ls", label: 'debug')
       sh(script: "${docker_run} conda env export --name ci-lint", label: 'Checkout version')
       sh(script: "${docker_run} ${cmd}", label: 'Lint')
     }

--- a/ci/jenkinsfile.groovy
+++ b/ci/jenkinsfile.groovy
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+
+image = 'mlcaidev/ci-cpu:caab922'
+docker_run = 'ci/bash.sh ${image}'
+
+def per_exec_ws(folder) {
+  return "workspace/exec_${env.EXECUTOR_NUMBER}/" + folder
+}
+
+def lint_common(cmd) {
+  node('CPU-SMALL') {
+    ws(per_exec_ws('mlc-llm-lint')) {
+      sh(script: "${docker_run} conda env export --name ci-lint", label: 'Checkout version')
+      sh(script: "${docker_run} ${cmd}", label: 'Lint')
+    }
+  }
+}
+
+stage('Lint') {
+  // No need to checkout submodule for lint
+  parallel(
+    'isort': {
+      lint_common('bash ci/task/isort.sh')
+    },
+    'black': {
+      lint_common('bash ci/task/black.sh')
+    },
+    'mypy': {
+      lint_common('bash ci/task/mypy.sh')
+    },
+    'pylint': {
+      lint_common('bash ci/task/pylint.sh')
+    },
+    'clang-format': {
+      lint_common('bash ci/task/clang-format.sh')
+    },
+  )
+}

--- a/ci/jenkinsfile.groovy
+++ b/ci/jenkinsfile.groovy
@@ -18,7 +18,7 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 image = 'mlcaidev/ci-cpu:caab922'
-docker_run = 'bash ci/bash.sh ${image}'
+docker_run = "bash ci/bash.sh ${image}"
 
 def per_exec_ws(folder) {
   return "workspace/exec_${env.EXECUTOR_NUMBER}/" + folder
@@ -26,11 +26,6 @@ def per_exec_ws(folder) {
 
 def init_git(submodule = false) {
   checkout scm
-  // Add more info about job node
-  sh(
-    script: "echo NODE_NAME=${env.NODE_NAME}",
-    label: 'Show executor node info',
-  )
   if (submodule) {
     retry(5) {
       timeout(time: 2, unit: 'MINUTES') {
@@ -41,6 +36,7 @@ def init_git(submodule = false) {
 }
 
 def lint_common(cmd) {
+  // No need to checkout submodule for lint
   node('CPU-SMALL') {
     ws(per_exec_ws('mlc-llm-lint')) {
       init_git()
@@ -52,7 +48,6 @@ def lint_common(cmd) {
 }
 
 stage('Lint') {
-  // No need to checkout submodule for lint
   parallel(
     'isort': {
       lint_common('bash ci/task/isort.sh')

--- a/ci/jenkinsfile.groovy
+++ b/ci/jenkinsfile.groovy
@@ -27,6 +27,7 @@ def per_exec_ws(folder) {
 def lint_common(cmd) {
   node('CPU-SMALL') {
     ws(per_exec_ws('mlc-llm-lint')) {
+      sh(script: "ls", label: 'List files')
       sh(script: "${docker_run} conda env export --name ci-lint", label: 'Checkout version')
       sh(script: "${docker_run} ${cmd}", label: 'Lint')
     }


### PR DESCRIPTION
Initialize Jenkins CI files. The current CI file is duplicated from GitHub Actions and can depreciate later.

cc @junrushao @tqchen 