### PR TITLE
Consolidate Logics for GPU Detection

### DIFF
--- a/python/mlc_chat/cli/convert_weight.py
+++ b/python/mlc_chat/cli/convert_weight.py
@@ -7,7 +7,7 @@ from mlc_chat.compiler import HELP, MODELS, QUANTIZATION, convert_weight
 
 from ..support.argparse import ArgumentParser
 from ..support.auto_config import detect_config, detect_model_type
-from ..support.auto_target import detect_device
+from ..support.auto_device import detect_device
 from ..support.auto_weight import detect_weight
 
 

--- a/python/mlc_chat/support/auto_device.py
+++ b/python/mlc_chat/support/auto_device.py
@@ -1,0 +1,41 @@
+"""Automatic detection of the device available on the local machine."""
+import logging
+
+import tvm
+from tvm.runtime import Device
+
+from .style import bold, green, red
+
+FOUND = green("Found")
+NOT_FOUND = red("Not found")
+AUTO_DETECT_DEVICES = ["cuda", "rocm", "metal", "vulkan", "opencl"]
+
+
+logger = logging.getLogger(__name__)
+
+
+def detect_device(device_hint: str) -> Device:
+    """Detect locally available device from string hint."""
+    if device_hint == "auto":
+        device = None
+        for device_type in AUTO_DETECT_DEVICES:
+            cur_device = tvm.device(dev_type=device_type, dev_id=0)
+            if cur_device.exist:
+                logger.info("%s device: %s:0", FOUND, device_type)
+                if device is None:
+                    device = cur_device
+            else:
+                logger.info("%s device: %s:0", NOT_FOUND, device_type)
+        if device is None:
+            logger.info("%s: No available device detected. Falling back to CPU", NOT_FOUND)
+            return tvm.device("cpu:0")
+        device_str = f"{tvm.runtime.Device.MASK2STR[device.device_type]}:{device.device_id}"
+        logger.info("Using device: %s. Use `--device` to override.", bold(device_str))
+        return device
+    try:
+        device = tvm.device(device_hint)
+    except Exception as err:
+        raise ValueError(f"Invalid device name: {device_hint}") from err
+    if not device.exist:
+        raise ValueError(f"Device is not found on your local environment: {device_hint}")
+    return device

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -3,13 +3,12 @@ import logging
 import os
 from typing import TYPE_CHECKING, Callable, Optional, Tuple
 
-import tvm
 from tvm import IRModule, relax
 from tvm._ffi import get_global_func, register_func
 from tvm.contrib import tar, xcode
-from tvm.runtime import Device
 from tvm.target import Target
 
+from .auto_device import AUTO_DETECT_DEVICES
 from .style import bold, green, red
 
 if TYPE_CHECKING:
@@ -43,33 +42,6 @@ def detect_target_and_host(target_hint: str, host_hint: str = "auto") -> Tuple[T
     if target.kind.name == "cuda":
         _register_cuda_hook(target)
     return target, build_func
-
-
-def detect_device(device_hint: str) -> Device:
-    """Detect locally available device from string hint."""
-    if device_hint == "auto":
-        device = None
-        for device_type in AUTO_DETECT_DEVICES:
-            cur_device = tvm.device(dev_type=device_type, dev_id=0)
-            if cur_device.exist:
-                logger.info("%s device: %s:0", FOUND, device_type)
-                if device is None:
-                    device = cur_device
-            else:
-                logger.info("%s device: %s:0", NOT_FOUND, device_type)
-        if device is None:
-            logger.info("%s: No available device detected. Falling back to CPU", NOT_FOUND)
-            return tvm.device("cpu:0")
-        device_str = f"{tvm.runtime.Device.MASK2STR[device.device_type]}:{device.device_id}"
-        logger.info("Using device: %s. Use `--device` to override.", bold(device_str))
-        return device
-    try:
-        device = tvm.device(device_hint)
-    except Exception as err:
-        raise ValueError(f"Invalid device name: {device_hint}") from err
-    if not device.exist:
-        raise ValueError(f"Device is not found on your local environment: {device_hint}")
-    return device
 
 
 def _detect_target_gpu(hint: str) -> Tuple[Target, BuildFunc]:
@@ -286,8 +258,6 @@ def _register_cuda_hook(target: Target):
             ptx = nvcc.compile_cuda(code, target_format="fatbin", arch=arch)
         return ptx
 
-
-AUTO_DETECT_DEVICES = ["cuda", "rocm", "metal", "vulkan"]
 
 PRESET = {
     "iphone:generic": {


### PR DESCRIPTION
This PR unifies automatic device detection logic by using `mlc_chat.support.auto_device`, which comes with detailed logging and fallback mechanisms.

CC: @MasterJH5574 