### PR TITLE
[CI] Clean workspace before build

### DIFF
--- a/ci/jenkinsfile.groovy
+++ b/ci/jenkinsfile.groovy
@@ -25,6 +25,7 @@ def per_exec_ws(folder) {
 }
 
 def init_git(submodule = false) {
+  cleanWs()
   checkout scm
   if (submodule) {
     retry(5) {


### PR DESCRIPTION
Cleaning the workspace before building, so that the previous corrupted directory will not affect the current CI build.

Used the `cleanWS` from here https://www.jenkins.io/doc/pipeline/steps/ws-cleanup/