### PR TITLE
[SLIM] Skip None param when loading rather than failing

### DIFF
--- a/python/mlc_chat/compiler/loader/utils.py
+++ b/python/mlc_chat/compiler/loader/utils.py
@@ -39,6 +39,9 @@ def load_torch_shard(path: Path) -> Iterator[Tuple[str, np.ndarray]]:
     import torch  # pylint: disable=import-outside-toplevel
 
     for name, param in torch.load(path, map_location=torch.device("cpu")).items():
+        if param is None:
+            logger.warning("Encountered None param, skipping it: %s", name)
+            continue
         param = param.detach().cpu()
         dtype = str(param.dtype)
         if dtype == "torch.bfloat16":


### PR DESCRIPTION
When converting weight for some huggingface models, (https://huggingface.co/stanford-crfm/music-medium-800k in this case), the pretrained weight contains empty entries, leading to error shown below.

This PR skips such None param, logs a warning, and continues. Though this may be an error on the model releaser's end, perhaps we could make the weight conversion more tolerant.
```
  File "python/mlc_chat/cli/convert_weight.py", line 87, in main
    convert_weight(
  File "python/mlc_chat/compiler/convert_weight.py", line 146, in convert_weight
    _convert_args(args)
  File "python/mlc_chat/compiler/convert_weight.py", line 97, in _convert_args
    for name, param in LOADER[args.source_format](
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python/mlc_chat/compiler/loader/huggingface_loader.py", line 87, in __init__
    self._load_file(path)
  File "python/mlc_chat/compiler/loader/huggingface_loader.py", line 173, in _load_file
    for name, param in load_func(path):
  File "python/mlc_chat/compiler/loader/utils.py", line 45, in load_torch_shard
    param = param.detach().cpu()
            ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'detach'
```

<img width="631" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/53290280/a5bc24a3-794f-4660-bef7-e937ecb5aadc">
