### PR TITLE
Detect Driver/Device in a Separate Process

### DIFF
--- a/python/mlc_chat/cli/check_device.py
+++ b/python/mlc_chat/cli/check_device.py
@@ -1,0 +1,21 @@
+"""Check if a device exists."""
+import sys
+
+import tvm
+
+
+def main():
+    """Entrypoint for device check."""
+    device_str = sys.argv[1]
+    try:
+        device = tvm.runtime.device(device_str)
+        if device.exist:
+            print("1")
+        else:
+            print("0")
+    except:  # pylint: disable=bare-except
+        print("0")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/mlc_chat/support/auto_device.py
+++ b/python/mlc_chat/support/auto_device.py
@@ -1,5 +1,8 @@
 """Automatic detection of the device available on the local machine."""
 import logging
+import subprocess
+import sys
+from typing import Dict
 
 import tvm
 from tvm.runtime import Device
@@ -9,6 +12,7 @@ from .style import bold, green, red
 FOUND = green("Found")
 NOT_FOUND = red("Not found")
 AUTO_DETECT_DEVICES = ["cuda", "rocm", "metal", "vulkan", "opencl"]
+_RESULT_CACHE: Dict[str, bool] = {}
 
 
 logger = logging.getLogger(__name__)
@@ -20,22 +24,42 @@ def detect_device(device_hint: str) -> Device:
         device = None
         for device_type in AUTO_DETECT_DEVICES:
             cur_device = tvm.device(dev_type=device_type, dev_id=0)
-            if cur_device.exist:
-                logger.info("%s device: %s:0", FOUND, device_type)
+            if _device_exists(cur_device):
                 if device is None:
                     device = cur_device
-            else:
-                logger.info("%s device: %s:0", NOT_FOUND, device_type)
         if device is None:
             logger.info("%s: No available device detected. Falling back to CPU", NOT_FOUND)
             return tvm.device("cpu:0")
-        device_str = f"{tvm.runtime.Device.MASK2STR[device.device_type]}:{device.device_id}"
-        logger.info("Using device: %s. Use `--device` to override.", bold(device_str))
+        logger.info("Using device: %s. Use `--device` to override.", bold(_device_to_str(device)))
         return device
     try:
         device = tvm.device(device_hint)
     except Exception as err:
         raise ValueError(f"Invalid device name: {device_hint}") from err
-    if not device.exist:
+    if not _device_exists(device):
         raise ValueError(f"Device is not found on your local environment: {device_hint}")
     return device
+
+
+def _device_to_str(device: Device) -> str:
+    return f"{tvm.runtime.Device.MASK2STR[device.device_type]}:{device.device_id}"
+
+
+def _device_exists(device: Device) -> bool:
+    device_str = _device_to_str(device)
+    if device_str in _RESULT_CACHE:
+        return _RESULT_CACHE[device_str]
+    cmd = [
+        sys.executable,
+        "-m",
+        "mlc_chat.cli.check_device",
+        device_str,
+    ]
+    result = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode("utf-8")
+    result_bool = result.strip() == "1"
+    if result_bool:
+        logger.info("%s device: %s", FOUND, device_str)
+    else:
+        logger.info("%s device: %s", NOT_FOUND, device_str)
+    _RESULT_CACHE[device_str] = result_bool
+    return result_bool


### PR DESCRIPTION
This PR separates the device detection into separate subprocesses.

The change is because the device detection will setup the driver, which consumes some GPU VRAM (for example, `tvm.device("opencl", 0).exist` consumes 390MB of VRAM on RTX 4090). Consider the case we detect if CUDA, Vulkan and OpenCL are available. When they are all available, each detection holds some VRAM, larger than 430MB altogether.

If the device detection is in the same process as the main process, the VRAM consumed by device detection will never be released. This means that in the example above, we detect CUDA, Vulkan and OpenCL, while in the end we prioritize the CUDA device. Consequently, the memory held by Vulkan and OpenCL detection will never be released.

Motivated by this issue, we separate the detection into subprocess, so that the held VRAM can be successfully released after detection.

CC: @MasterJH5574 