### PR TITLE
remove ndk referencce from mali build target

### DIFF
--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -623,11 +623,6 @@ def parse_target(args: argparse.Namespace) -> None:
         )
         args.target_kind = "android"
     elif args.target in ["mali"]:
-        from tvm.contrib import ndk
-
-        args.export_kwargs = {
-            "fcompile": ndk.create_shared,
-        }
         target = tvm.target.Target(
             "opencl -device=mali",
             host="llvm -mtriple=aarch64-linux-gnu",

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -623,6 +623,11 @@ def parse_target(args: argparse.Namespace) -> None:
         )
         args.target_kind = "android"
     elif args.target in ["mali"]:
+        if "TVM_NDK_CC" in os.environ:
+            from tvm.contrib import ndk
+            args.export_kwargs = {
+                "fcompile": ndk.create_shared,
+            }
         target = tvm.target.Target(
             "opencl -device=mali",
             host="llvm -mtriple=aarch64-linux-gnu",


### PR DESCRIPTION
This removes the ndk reference for mali targets when building and fixes the error folks may run into below.

When I tried compiling this on my Orange Pi, I ran into this error when trying to build for mali since I didnt have the NDK setup on it:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/x/DEV/LLM/mlc-llm/mlc_llm/build.py", line 47, in <module>
    main()
  File "/home/x/DEV/LLM/mlc-llm/mlc_llm/build.py", line 43, in main
    core.build_model_from_args(parsed_args)
  File "/home/x/DEV/LLM/mlc-llm/mlc_llm/core.py", line 910, in build_model_from_args
    build(mod, args)
  File "/home/x/DEV/LLM/mlc-llm/mlc_llm/core.py", line 755, in build
    ex.export_library(args.lib_path, **args.export_kwargs)
  File "/home/x/DEV/LLM/tvm_unity/python/tvm/relax/vm_build.py", line 146, in export_library
    return self.mod.export_library(
  File "/home/x/DEV/LLM/tvm_unity/python/tvm/runtime/module.py", line 624, in export_library
    return fcompile(file_name, files, **kwargs)
  File "/home/x/DEV/LLM/tvm_unity/python/tvm/contrib/ndk.py", line 44, in create_shared
    raise RuntimeError(
RuntimeError: Require environment variable TVM_NDK_CC to be the NDK standalone compiler
```