### PR TITLE
[iOS] Mistral support

### DIFF
--- a/ios/MLCChat/app-config.json
+++ b/ios/MLCChat/app-config.json
@@ -1,5 +1,6 @@
 {
   "model_libs": [
+    "Mistral-7B-Instruct-v0.1-q3f16_1",
     "Llama-2-7b-chat-hf-q3f16_1",
     "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
   ],
@@ -7,12 +8,20 @@
     {
       "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
       "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+    },
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1/",
+      "local_id": "Llama-2-7b-chat-hf-q3f16_1"
     }
   ],
   "add_model_samples": [
     {
       "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
       "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+    },
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1/",
+      "local_id": "Llama-2-7b-chat-hf-q3f16_1"
     }
   ]
 }

--- a/ios/prepare_params.sh
+++ b/ios/prepare_params.sh
@@ -6,7 +6,8 @@ rm -rf dist
 mkdir -p dist
 
 declare -a builtin_list=(
-	"Llama-2-7b-chat-hf-q3f16_1"
+	"Mistral-7B-Instruct-v0.1-q3f16_1"
+	# "Llama-2-7b-chat-hf-q3f16_1"
 	# "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
 	# "vicuna-v1-7b-q3f16_0"
 	# "rwkv-raven-1b5-q8f16_0"


### PR DESCRIPTION
This PR concludes Mistral support on iOS (q3f16) with sliding window attention. Tested on iPhone 14 pro max. Uses full context (4K SW tokens) with 128 of chunk size, making it consume less than 4GB of memory.

Mistral iphone lib: https://github.com/mlc-ai/binary-mlc-llm-libs/blob/main/Mistral-7B-Instruct-v0.1-q3f16_1-iphone.tar
Mistral q3f16 weights: https://huggingface.co/mlc-ai/mlc-chat-Mistral-7B-Instruct-v0.1-q3f16_1