### PR TITLE
[Serving] OpenAI v1/completions REST API

### DIFF
--- a/ci/task/pylint.sh
+++ b/ci/task/pylint.sh
@@ -10,6 +10,7 @@ set -x
 
 # TVM Unity is a dependency to this testing
 pip install --quiet --pre -U -f https://mlc.ai/wheels mlc-ai-nightly requests
+pip install --quiet --pre -U pydantic fastapi uvicorn shortuuid
 
 pylint --jobs $NUM_THREADS ./python/
 pylint --jobs $NUM_THREADS --recursive=y ./tests/python/

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -117,8 +117,11 @@ class Engine {
   /*! \brief Abort the input request. */
   void AbortRequest(String request_id) {
     auto it_rstate = estate_->request_states.find(request_id);
-    CHECK(it_rstate != estate_->request_states.end())
-        << "The request to abort must have been added to the engine";
+    if (it_rstate == estate_->request_states.end()) {
+      // The request to abort does not exist.
+      return;
+    }
+
     RequestState rstate = it_rstate->second;
     Request request = rstate->request;
 
@@ -130,6 +133,7 @@ class Engine {
     ICHECK(it_running != estate_->running_queue.end() ||
            it_waiting != estate_->waiting_queue.end());
 
+    estate_->request_states.erase(request->id);
     if (it_running != estate_->running_queue.end()) {
       // The request to abort is in running queue
       int internal_req_id = it_running - estate_->running_queue.begin();
@@ -141,7 +145,6 @@ class Engine {
       // The request to abort is in waiting queue
       estate_->waiting_queue.erase(it_waiting);
     }
-    estate_->request_states.erase(request->id);
   }
 
   /*********************** Engine Action ***********************/

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -60,7 +60,7 @@ class EngineStateObj : public Object {
   /*! \brief The requests that have not started for process yet. */
   std::vector<Request> waiting_queue;
   /*! \brief The states of all requests. */
-  std::unordered_map<String, RequestState, ObjectPtrHash, ObjectPtrEqual> request_states;
+  std::unordered_map<String, RequestState> request_states;
   /*! \brief Runtime statistics. */
   EngineStats stats;
 

--- a/cpp/serve/request.h
+++ b/cpp/serve/request.h
@@ -55,13 +55,13 @@ class RequestNode : public Object {
   GenerationConfig generation_cfg;
   /*!
    * \brief The provided callback function to handle the generation
-   * output. It has the signature of `(String, TokenData, bool) -> None`,
+   * output. It has the signature of `(String, TokenData, Optional<String>) -> None`,
    * where
-   * - the string is the request id,
+   * - the first string is the request id,
    * - the TokenData contains the generated **delta** token ids since
    * the invocation of the callback on the specific request,
-   * - the boolean value denotes if the generation of the request is
-   * finished.
+   * - the optional string value denotes the finish reason if the
+   * generation of the request is finished, or None if it has not finished.
    */
   PackedFunc fcallback;
 

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -110,10 +110,13 @@ class RequestStateNode : public Object {
   std::chrono::_V2::system_clock::time_point tprefill_finish;
 
   /*!
-   * \brief Check if the request generation is finished.
+   * \brief Check if the request generation is finished and return the
+   * finish reason if finished.
    * \param max_single_sequence_length The maximum allowed single sequence length.
+   * \return The finish reason in string if the request is finished,
+   * or None if the request has not finished.
    */
-  bool GenerationFinished(int max_single_sequence_length) const;
+  Optional<String> GenerationFinishReason(int max_single_sequence_length) const;
 
   static constexpr const char* _type_key = "mlc.serve.RequestState";
   static constexpr const bool _type_has_method_sequal_reduce = false;

--- a/python/mlc_chat/__init__.py
+++ b/python/mlc_chat/__init__.py
@@ -2,6 +2,6 @@
 
 MLC Chat is the app runtime of MLC LLM.
 """
-from . import serve
+from . import protocol, serve
 from .chat_module import ChatConfig, ChatModule, ConvConfig, GenerationConfig
 from .libinfo import __version__

--- a/python/mlc_chat/interface/openai_api.py
+++ b/python/mlc_chat/interface/openai_api.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,fixme,import-error,too-few-public-methods
+# pylint: disable=missing-docstring,fixme,too-few-public-methods
 """
 Adapted from FastChat's OpenAI protocol:
 https://github.com/lm-sys/FastChat/blob/main/fastchat/protocol/openai_api_protocol.py

--- a/python/mlc_chat/protocol/__init__.py
+++ b/python/mlc_chat/protocol/__init__.py
@@ -1,0 +1,4 @@
+"""The protocols for MLC LLM server"""
+from . import openai_api_protocol
+
+RequestProtocol = openai_api_protocol.CompletionRequest

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -1,0 +1,119 @@
+"""Protocols in MLC LLM for OpenAI API.
+Adapted from FastChat's OpenAI protocol:
+https://github.com/lm-sys/FastChat/blob/main/fastchat/protocol/openai_api_protocol.py
+"""
+# pylint: disable=missing-class-docstring
+import time
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+from pydantic import BaseModel, Field
+
+from ..serve.config import GenerationConfig
+
+################ Commons ################
+
+
+class LogProbs(BaseModel):
+    pass
+
+
+class UsageInfo(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+    def __init__(self, prompt_tokens: int = 0, completion_tokens: int = 0):
+        super().__init__(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+
+
+################ v1/completions ################
+
+
+class CompletionRequest(BaseModel):
+    """OpenAI completion request protocol.
+    API reference: https://platform.openai.com/docs/api-reference/completions/create
+    """
+
+    model: str
+    prompt: Union[str, List[int], List[Union[str, List[int]]]]
+    best_of: int = 1
+    echo: bool = False
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    logit_bias: Optional[Dict[str, float]] = None
+    logprobs: Optional[int] = None
+    max_tokens: int = 16
+    n: int = 1
+    seed: Optional[int] = None
+    stop: Optional[Union[str, List[str]]] = None
+    stream: bool = False
+    suffix: Optional[str] = None
+    temperature: float = 1.0
+    top_p: float = 1.0
+    user: Optional[str] = None
+
+
+class CompletionResponseChoice(BaseModel):
+    finish_reason: Optional[Literal["stop", "length"]] = None
+    index: int = 0
+    logprobs: Optional[LogProbs] = None
+    text: str
+
+
+class CompletionResponse(BaseModel):
+    """OpenAI completion response protocol.
+    API reference: https://platform.openai.com/docs/api-reference/completions/object
+    """
+
+    id: str
+    choices: List[CompletionResponseChoice]
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    object: str = "text_completion"
+    usage: UsageInfo = Field(
+        default_factory=lambda: UsageInfo()  # pylint: disable=unnecessary-lambda
+    )
+
+
+# Right now we only have one request protocol.
+# When we have more protocols, change it to `Union[CompletionRequest, ...]`.
+OpenAIRequestProtocol = CompletionRequest
+
+
+def openai_api_get_unsupported_fields(request: OpenAIRequestProtocol) -> List[str]:
+    """Get the unsupported fields in the request."""
+    unsupport_field_values: List[Tuple[str, Any]] = [
+        ("best_of", 1),
+        ("frequency_penalty", 0.0),
+        ("presence_penalty", 0.0),
+        ("logit_bias", None),
+        ("logprobs", None),
+        ("n", 1),
+        ("seed", None),
+        ("stop", None),
+    ]
+
+    unsupported_fields: List[str] = []
+    for field, value in unsupport_field_values:
+        if hasattr(request, field) and getattr(request, field) != value:
+            unsupported_fields.append(field)
+    return unsupported_fields
+
+
+def openai_api_get_generation_config(request: OpenAIRequestProtocol) -> GenerationConfig:
+    """Create the generation config from the given request."""
+    kwargs = {}
+    arg_name_mapping = {
+        "temperature": "temperature",
+        "top_p": "top_p",
+        "max_tokens": "max_new_tokens",
+    }
+    for openai_name, mlc_name in arg_name_mapping.items():
+        kwargs[mlc_name] = getattr(request, openai_name)
+    if request.stop is not None:
+        kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
+    return GenerationConfig(**kwargs)

--- a/python/mlc_chat/protocol/protocol_utils.py
+++ b/python/mlc_chat/protocol/protocol_utils.py
@@ -1,0 +1,37 @@
+"""Utility functions for request protocols"""
+
+from typing import List
+
+from pydantic import BaseModel
+
+from ..serve.config import GenerationConfig
+from . import RequestProtocol
+from .openai_api_protocol import (
+    OpenAIRequestProtocol,
+    openai_api_get_generation_config,
+    openai_api_get_unsupported_fields,
+)
+
+
+class ErrorResponse(BaseModel):
+    """The class of error response."""
+
+    object: str = "error"
+    message: str
+    code: int = None
+
+
+def get_unsupported_fields(request: RequestProtocol) -> List[str]:
+    """Get the unsupported fields of the request.
+    Return the list of unsupported field names.
+    """
+    if isinstance(request, OpenAIRequestProtocol):
+        return openai_api_get_unsupported_fields(request)
+    raise RuntimeError("Cannot reach here")
+
+
+def get_generation_config(request: RequestProtocol) -> GenerationConfig:
+    """Create the generation config in MLC LLM out from the input request protocol."""
+    if isinstance(request, OpenAIRequestProtocol):
+        return openai_api_get_generation_config(request)
+    raise RuntimeError("Cannot reach here")

--- a/python/mlc_chat/rest.py
+++ b/python/mlc_chat/rest.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,fixme,import-error
+# pylint: disable=missing-docstring,fixme
 import argparse
 import asyncio
 import dataclasses

--- a/python/mlc_chat/serve/entrypoints/__init__.py
+++ b/python/mlc_chat/serve/entrypoints/__init__.py
@@ -1,0 +1,2 @@
+"""The entrypoints for MLC LLM server."""
+from . import openai_entrypoints

--- a/python/mlc_chat/serve/entrypoints/entrypoint_utils.py
+++ b/python/mlc_chat/serve/entrypoints/entrypoint_utils.py
@@ -1,0 +1,103 @@
+"""Utility functions for server entrypoints"""
+
+import uuid
+from http import HTTPStatus
+from typing import Callable, List, Optional, Union
+
+import fastapi
+
+from ...protocol import RequestProtocol
+from ...protocol.protocol_utils import ErrorResponse, get_unsupported_fields
+
+
+def random_uuid() -> str:
+    """Generate a random id in hexadecimal string."""
+    return uuid.uuid4().hex
+
+
+def create_error_response(status_code: HTTPStatus, message: str) -> fastapi.responses.JSONResponse:
+    """Create a JSON response that reports error with regarding the input message."""
+    return fastapi.responses.JSONResponse(
+        ErrorResponse(message=message, code=status_code.value).model_dump_json(),
+        status_code=status_code.value,
+    )
+
+
+def check_model_id(
+    request_model_id: str, hosted_model_id: str
+) -> Optional[fastapi.responses.JSONResponse]:
+    """Check if the requested model is the served model. Return an error if not."""
+    if request_model_id != hosted_model_id:
+        return create_error_response(
+            HTTPStatus.BAD_REQUEST, message="The requested model is not served."
+        )
+    return None
+
+
+def check_unsupported_fields(
+    request: RequestProtocol,
+) -> Optional[fastapi.responses.JSONResponse]:
+    """Check if the request has unsupported fields. Return an error if so."""
+    unsupported_fields = get_unsupported_fields(request)
+    if len(unsupported_fields) != 0:
+        unsupported_fields = [f'"{field}"' for field in unsupported_fields]
+        return create_error_response(
+            HTTPStatus.BAD_REQUEST,
+            message=f'Request fields {", ".join(unsupported_fields)} are not supported right now.',
+        )
+    return None
+
+
+def check_prompts_length(
+    prompts: List[List[int]], max_single_sequence_length: int
+) -> Optional[fastapi.responses.JSONResponse]:
+    """Check if the total prompt length exceeds the max single sequence
+    sequence length allowed by the served model. Return an error if so.
+    """
+    total_length = 0
+    for prompt in prompts:
+        total_length += len(prompt)
+    if total_length > max_single_sequence_length:
+        return create_error_response(
+            HTTPStatus.BAD_REQUEST,
+            message=f"Request prompt has {total_length} tokens in total,"
+            f" larger than the model capacity {max_single_sequence_length}.",
+        )
+    return None
+
+
+def process_prompts(
+    input_prompts: Union[str, List[int], List[Union[str, List[int]]]],
+    ftokenize: Callable[[str], List[int]],
+) -> Union[List[List[int]], fastapi.responses.JSONResponse]:
+    """Convert all input tokens to list of token ids with regard to the
+    given tokenization function.
+    For each input prompt, return the list of token ids after tokenization.
+    """
+    error_msg = f"Invalid request prompt {input_prompts}"
+
+    # Case 1. The prompt is a single string.
+    if isinstance(input_prompts, str):
+        return [ftokenize(input_prompts)]
+
+    assert isinstance(input_prompts, list)
+    if len(input_prompts) == 0:
+        return create_error_response(HTTPStatus.BAD_REQUEST, message=error_msg)
+
+    # Case 2. The prompt is a list of token ids.
+    if isinstance(input_prompts[0], int):
+        if not all(isinstance(token_id, int) for token_id in input_prompts):
+            return create_error_response(HTTPStatus.BAD_REQUEST, message=error_msg)
+        return [input_prompts]
+
+    # Case 3. A list of prompts.
+    output_prompts: List[List[int]] = []
+    for input_prompt in input_prompts:
+        is_str = isinstance(input_prompt, str)
+        is_token_ids = isinstance(input_prompt, list) and all(
+            isinstance(token_id, int) for token_id in input_prompt
+        )
+        if not (is_str or is_token_ids):
+            return create_error_response(HTTPStatus.BAD_REQUEST, message=error_msg)
+        output_prompts.append(ftokenize(input_prompt) if is_str else input_prompt)  # type: ignore
+    return output_prompts

--- a/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
@@ -1,0 +1,164 @@
+"""OpenAI API-compatible server entrypoints in MLC LLM"""
+# pylint: disable=too-many-locals,too-many-return-statements
+from http import HTTPStatus
+from typing import AsyncGenerator, Callable, List, Optional, Tuple
+
+import fastapi
+
+from ...protocol import protocol_utils
+from ...protocol.openai_api_protocol import (
+    CompletionRequest,
+    CompletionResponse,
+    CompletionResponseChoice,
+    UsageInfo,
+)
+from ..server_variables import engine, hosted_model_id
+from . import entrypoint_utils
+
+app = fastapi.APIRouter()
+
+
+@app.post("/v1/completions")
+async def request_completion(
+    request: CompletionRequest, raw_request: fastapi.Request
+) -> fastapi.responses.JSONResponse:
+    """OpenAI-compatible completion API.
+    API reference: https://platform.openai.com/docs/api-reference/completions/create
+    """
+    # - Check the model id.
+    # - Check if unsupported arguments are specified.
+    error_checks: List[Tuple[Callable, Tuple]] = [
+        (entrypoint_utils.check_model_id, (request.model, hosted_model_id)),
+        (entrypoint_utils.check_unsupported_fields, (request,)),
+    ]
+    for ferror_check, args in error_checks:
+        error = ferror_check(*args)
+        if error is not None:
+            return error
+
+    # - Process prompt and check validity.
+    prompts = entrypoint_utils.process_prompts(request.prompt, engine.engine.tokenize)
+    if isinstance(prompts, fastapi.responses.JSONResponse):
+        # Errored when processing the prompts
+        return prompts
+    if len(prompts) > 1:
+        return entrypoint_utils.create_error_response(
+            HTTPStatus.BAD_REQUEST,
+            message="Entrypoint /v1/completions only accept single prompt. "
+            f"However, {len(prompts)} prompts {prompts} are received.",
+        )
+    error = entrypoint_utils.check_prompts_length(prompts, engine.engine.max_single_sequence_length)
+    if error is not None:
+        return error
+    prompt = prompts[0]
+
+    # Process generation config. Create request id.
+    generation_cfg = protocol_utils.get_generation_config(request)
+    request_id = f"cmpl-{entrypoint_utils.random_uuid()}"
+
+    # Streaming response.
+    if request.stream:
+
+        async def completion_stream_generator() -> AsyncGenerator[str, None]:
+            assert request.n == 1
+            prev_text_len = 0
+
+            # - Echo back the prompt.
+            if request.echo:
+                text = engine.engine.detokenize(prompt)
+                prev_text_len = len(text)
+                response = CompletionResponse(
+                    id=request_id,
+                    choices=[CompletionResponseChoice(text=text)],
+                    model=hosted_model_id,
+                    usage=UsageInfo(
+                        prompt_tokens=len(prompt),
+                        completion_tokens=0,
+                    ),
+                )
+                yield f"data: {response.model_dump_json()}\n\n"
+
+            # - Generate new tokens.
+            tokens = list(prompt)
+            finish_reason = None
+            async for output_token, finish_reason in engine.generate(
+                prompt, generation_cfg, request_id
+            ):
+                tokens.append(output_token)
+                text = engine.engine.detokenize(tokens)
+                delta_text = text[prev_text_len:]
+                prev_text_len = len(text)
+
+                response = CompletionResponse(
+                    id=request_id,
+                    choices=[
+                        CompletionResponseChoice(
+                            finish_reason=finish_reason,
+                            text=delta_text,
+                        )
+                    ],
+                    model=hosted_model_id,
+                    usage=UsageInfo(
+                        prompt_tokens=len(prompt),
+                        completion_tokens=len(tokens) - len(prompt),
+                    ),
+                )
+                yield f"data: {response.model_dump_json()}\n\n"
+
+            # - Echo the suffix.
+            if request.suffix is not None:
+                assert finish_reason is not None
+                response = CompletionResponse(
+                    id=request_id,
+                    choices=[
+                        CompletionResponseChoice(
+                            finish_reason=finish_reason,
+                            text=request.suffix,
+                        )
+                    ],
+                    model=hosted_model_id,
+                    usage=UsageInfo(
+                        prompt_tokens=len(prompt),
+                        completion_tokens=len(tokens) - len(prompt),
+                    ),
+                )
+                yield f"data: {response.model_dump_json()}\n\n"
+
+            yield "data: [Done]\n\n"
+
+        return fastapi.responses.StreamingResponse(
+            completion_stream_generator(), media_type="text/event-stream"
+        )
+
+    # Normal response.
+    output_tokens = []
+    finish_reason: Optional[str] = None
+    async for output_token, finish_reason in engine.generate(prompt, generation_cfg, request_id):
+        if await raw_request.is_disconnected():
+            # In non-streaming cases, the engine will not be notified
+            # when the request is disconnected.
+            # Therefore, we check if it is disconnected each time,
+            # and abort the request from engine if so.
+            await engine.abort(request_id)
+            return entrypoint_utils.create_error_response(
+                HTTPStatus.BAD_REQUEST, message="The request has disconnected"
+            )
+        output_tokens.append(output_token)
+    assert finish_reason is not None
+    text = engine.engine.detokenize(prompt + output_tokens if request.echo else output_tokens)
+    suffix = request.suffix if request.suffix is not None else ""
+    response = CompletionResponse(
+        id=request_id,
+        choices=[
+            CompletionResponseChoice(
+                finish_reason=finish_reason,
+                text=text + suffix,
+            )
+        ],
+        model=hosted_model_id,
+        usage=UsageInfo(
+            prompt_tokens=len(prompt),
+            completion_tokens=len(output_tokens),
+        ),
+    )
+    return response

--- a/python/mlc_chat/serve/request.py
+++ b/python/mlc_chat/serve/request.py
@@ -1,5 +1,5 @@
 """The request class in MLC LLM serving"""
-from typing import Callable, List, Union
+from typing import Callable, List, Optional, Union
 
 import tvm._ffi
 from tvm.runtime import Object
@@ -28,15 +28,15 @@ class Request(Object):
         The sampling configuration which may contain temperature,
         top_p, repetition_penalty, max_gen_len, etc.
 
-    fcallback : Callable[[str, TokenData, bool], None]
+    fcallback : Callable[[str, TokenData, Optional[str]], None]
         The provided callback function to handle the generation
         output. It has the signature of `(str, TokenData, bool) -> None`,
         where
-        - the string is the request id,
+        - the first string is the request id,
         - the TokenData contains the generated **delta** token ids since
         the invocation of the callback on the specific request,
-        - the boolean value denotes if the generation of the request is
-        finished.
+        - the optional string value denotes the finish reason if the
+        generation of the request is finished, or None if it has not finished.
     """
 
     def __init__(
@@ -44,7 +44,7 @@ class Request(Object):
         request_id: str,
         inputs: Union[Data, List[Data]],
         generation_config: GenerationConfig,
-        fcallback: Callable[[str, TokenData, bool], None],
+        fcallback: Callable[[str, TokenData, Optional[str]], None],
     ):
         if not isinstance(inputs, list):
             inputs = [inputs]

--- a/python/mlc_chat/serve/server.py
+++ b/python/mlc_chat/serve/server.py
@@ -1,0 +1,26 @@
+"""RESTful HTTP request server in MLC LLM"""
+import argparse
+
+import fastapi
+import uvicorn
+from fastapi.middleware.cors import CORSMiddleware
+
+from .server_variables import parse_args_and_initialize
+
+if __name__ == "__main__":
+    # Parse the arguments and initialize the asynchronous engine.
+    args: argparse.Namespace = parse_args_and_initialize()
+    app = fastapi.FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Include the routers from subdirectories.
+    from .entrypoints import openai_entrypoints
+
+    app.include_router(openai_entrypoints.app)
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/python/mlc_chat/serve/server_variables.py
+++ b/python/mlc_chat/serve/server_variables.py
@@ -1,0 +1,55 @@
+"""Global server variables shared by multiple entrypoint files."""
+# pylint: disable=global-statement
+import argparse
+import json
+import os
+
+from . import async_engine, config
+
+engine: async_engine.AsyncEngine
+hosted_model_id: str
+
+
+def parse_args_and_initialize() -> argparse.Namespace:
+    """Parse the server arguments and initialize the engine."""
+
+    args = argparse.ArgumentParser()
+    args.add_argument("--model", type=str, required=True)
+    args.add_argument("--device", type=str, default="auto")
+    args.add_argument("--model-lib-path", type=str, default="")
+    args.add_argument("--batch-size", type=int, default=80)
+    args.add_argument("--max-total-seq-length", type=int, default=16800)
+
+    args.add_argument("--host", type=str, default="127.0.0.1", help="host name")
+    args.add_argument("--port", type=int, default=8000, help="port")
+    args.add_argument("--allow-credentials", action="store_true", help="allow credentials")
+    args.add_argument("--allowed-origins", type=json.loads, default=["*"], help="allowed origins")
+    args.add_argument("--allowed-methods", type=json.loads, default=["*"], help="allowed methods")
+    args.add_argument("--allowed-headers", type=json.loads, default=["*"], help="allowed headers")
+
+    parsed = args.parse_args()
+    assert parsed.batch_size % 16 == 0
+    assert parsed.max_total_seq_length >= 2048
+
+    global hosted_model_id
+    _, hosted_model_id = os.path.split(parsed.model)
+    if hosted_model_id == "":
+        raise ValueError(
+            f"Invalid model id {parsed.model}. "
+            "Please make sure the model id does not end with slash."
+        )
+
+    # Initialize model loading info and KV cache config
+    model_info = async_engine.ModelInfo(
+        model=parsed.model,
+        device=parsed.device,
+        model_lib_path=parsed.model_lib_path if parsed.model_lib_path != "" else None,
+    )
+    kv_cache_config = config.KVCacheConfig(
+        max_num_sequence=parsed.batch_size, max_total_sequence_length=parsed.max_total_seq_length
+    )
+    # Create engine and start the background loop
+    global engine
+    engine = async_engine.AsyncEngine(model_info, kv_cache_config)
+
+    return parsed

--- a/tests/python/serve/server/conftest.py
+++ b/tests/python/serve/server/conftest.py
@@ -1,0 +1,50 @@
+# pylint: disable=missing-module-docstring,missing-function-docstring
+# pylint: disable=redefined-outer-name,consider-using-with
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def served_model() -> str:
+    model = os.environ.get("MLC_SERVE_MODEL")
+    if model is None:
+        raise ValueError(
+            'Environment variable "MLC_SERVE_MODEL" not found. '
+            "Please set it to model compiled by MLC LLM (e.g., Llama-2-7b-chat-hf-q0f16)."
+        )
+    return model
+
+
+@pytest.fixture(scope="session")
+def launch_server(served_model):
+    """A pytest session-level fixture which launches the server in a subprocess."""
+
+    # Start your subprocess here
+    cmd = ["python"]
+    cmd += ["-m", "mlc_chat.serve.server"]
+    cmd += ["--model", f"{served_model}"]
+    cmd += ["--max-total-seq-length", "5120"]
+    process_path = str(Path(__file__).resolve().parents[4])
+    process = subprocess.Popen(cmd, cwd=process_path)
+    # NOTE: DO NOT USE `stdout=subprocess.PIPE, stderr=subprocess.PIPE`
+    # in subprocess.Popen here. PIPE may conflict with logging in TVM
+    # and cause subprocess hangs forever.
+
+    # Wait for the subprocess to be ready. This may take a while.
+    time.sleep(20)
+
+    process_return_code = process.poll()
+    if process_return_code is not None:
+        raise RuntimeError(
+            "The server fails to launch. "
+            f"Please check if {served_model} is a valid model compiled by MLC LLM."
+        )
+    yield
+
+    # Fixture teardown code.
+    process.terminate()
+    process.wait()

--- a/tests/python/serve/server/test_server.py
+++ b/tests/python/serve/server/test_server.py
@@ -1,0 +1,311 @@
+"""Server tests in MLC LLM.
+Before running any test, we use pytest fixtures to launch a
+test-session-wide server in a subprocess, and then execute the tests.
+
+The recommended way to run the tests is to use the following command:
+  MLC_SERVE_MODEL="YOUR_MODEL_ID" pytest -vv tests/python/serve/server/test_server.py
+
+Here "YOUR_MODEL_ID" can be a small model like `Llama-2-7b-chat-hf-q4f16_1`,
+as long as the model is built with batching and embedding separation enabled.
+
+To directly run the Python file (a.k.a., not using pytest), you need to
+launch the server in ahead before running this file. This can be done in
+two steps:
+- start a new shell session, run
+  python -m mlc_chat.serve.server --model "YOUR_MODEL_ID"
+- start another shell session, run this file
+  MLC_SERVE_MODEL="YOUR_MODEL_ID" python tests/python/serve/server/test_server.py
+"""
+# pylint: disable=missing-function-docstring,too-many-arguments,too-many-locals
+import json
+import os
+from typing import Dict, List, Optional
+
+import pytest
+import requests
+
+OPENAI_V1_COMPLETION_URL = "http://127.0.0.1:8000/v1/completions"
+
+
+def check_openai_nonstream_response(
+    response: Dict,
+    *,
+    model: str,
+    object_str: str,
+    num_choices: int,
+    finish_reason: str,
+    completion_tokens: Optional[int] = None,
+    echo_prompt: Optional[str] = None,
+    suffix: Optional[str] = None,
+):
+    assert response["model"] == model
+    assert response["object"] == object_str
+
+    choices = response["choices"]
+    assert isinstance(choices, list)
+    assert len(choices) == num_choices
+    for idx, choice in enumerate(choices):
+        assert choice["index"] == idx
+        assert choice["finish_reason"] == finish_reason
+        assert isinstance(choice["text"], str)
+        if echo_prompt is not None:
+            assert choice["text"].startswith(echo_prompt)
+        if suffix is not None:
+            assert choice["text"].endswith(suffix)
+
+    usage = response["usage"]
+    assert isinstance(usage, dict)
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+    assert usage["prompt_tokens"] > 0
+    if completion_tokens is not None:
+        assert usage["completion_tokens"] == completion_tokens
+
+
+def check_openai_stream_response(
+    responses: List[Dict],
+    *,
+    model: str,
+    object_str: str,
+    num_choices: int,
+    finish_reason: str,
+    completion_tokens: Optional[int] = None,
+    echo_prompt: Optional[str] = None,
+    suffix: Optional[str] = None,
+):
+    assert len(responses) > 0
+
+    finished = [False for _ in range(num_choices)]
+    outputs = ["" for _ in range(num_choices)]
+    for response in responses:
+        assert response["model"] == model
+        assert response["object"] == object_str
+
+        choices = response["choices"]
+        assert isinstance(choices, list)
+        assert len(choices) == num_choices
+        for idx, choice in enumerate(choices):
+            assert choice["index"] == idx
+            assert isinstance(choice["text"], str)
+            outputs[idx] += choice["text"]
+            if finished[idx]:
+                assert choice["finish_reason"] == finish_reason
+            elif choice["finish_reason"] is not None:
+                assert choice["finish_reason"] == finish_reason
+                finished[idx] = True
+
+        usage = response["usage"]
+        assert isinstance(usage, dict)
+        assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+        assert usage["prompt_tokens"] > 0
+        if completion_tokens is not None:
+            assert usage["completion_tokens"] <= completion_tokens
+
+    if completion_tokens is not None:
+        assert responses[-1]["usage"]["completion_tokens"] == completion_tokens
+
+    for output in outputs:
+        if echo_prompt is not None:
+            assert output.startswith(echo_prompt)
+        if suffix is not None:
+            assert output.endswith(suffix)
+
+
+def expect_error(response_str: str, msg_prefix: Optional[str] = None):
+    response = json.loads(response_str)
+    assert response["object"] == "error"
+    assert isinstance(response["message"], str)
+    if msg_prefix is not None:
+        assert response["message"].startswith(msg_prefix)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_openai_v1_completions(
+    served_model: str,
+    launch_server,  # pylint: disable=unused-argument
+    stream: bool,
+):
+    # `served_model` and `launch_server` are pytest fixture
+    # defined in conftest.py.
+
+    prompt = "What is the meaning of life?"
+    max_tokens = 256
+    payload = {
+        "model": served_model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "stream": stream,
+    }
+
+    response = requests.post(OPENAI_V1_COMPLETION_URL, json=payload, timeout=60)
+    if not stream:
+        check_openai_nonstream_response(
+            response.json(),
+            model=served_model,
+            object_str="text_completion",
+            num_choices=1,
+            finish_reason="length",
+            completion_tokens=max_tokens,
+        )
+    else:
+        responses = []
+        for chunk in response.iter_lines(chunk_size=512):
+            if not chunk or chunk == b"data: [Done]":
+                continue
+            responses.append(json.loads(chunk.decode("utf-8")[6:]))
+        check_openai_stream_response(
+            responses,
+            model=served_model,
+            object_str="text_completion",
+            num_choices=1,
+            finish_reason="length",
+            completion_tokens=max_tokens,
+        )
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_openai_v1_completions_echo(
+    served_model: str,
+    launch_server,  # pylint: disable=unused-argument
+    stream: bool,
+):
+    # `served_model` and `launch_server` are pytest fixture
+    # defined in conftest.py.
+
+    prompt = "What is the meaning of life?"
+    max_tokens = 256
+    payload = {
+        "model": served_model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "echo": True,
+        "stream": stream,
+    }
+
+    response = requests.post(OPENAI_V1_COMPLETION_URL, json=payload, timeout=60)
+    if not stream:
+        check_openai_nonstream_response(
+            response.json(),
+            model=served_model,
+            object_str="text_completion",
+            num_choices=1,
+            finish_reason="length",
+            completion_tokens=max_tokens,
+            echo_prompt=prompt,
+        )
+    else:
+        responses = []
+        for chunk in response.iter_lines(chunk_size=512):
+            if not chunk or chunk == b"data: [Done]":
+                continue
+            responses.append(json.loads(chunk.decode("utf-8")[6:]))
+        check_openai_stream_response(
+            responses,
+            model=served_model,
+            object_str="text_completion",
+            num_choices=1,
+            finish_reason="length",
+            completion_tokens=max_tokens,
+            echo_prompt=prompt,
+        )
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_openai_v1_completions_suffix(
+    served_model: str,
+    launch_server,  # pylint: disable=unused-argument
+    stream: bool,
+):
+    # `served_model` and `launch_server` are pytest fixture
+    # defined in conftest.py.
+
+    prompt = "What is the meaning of life?"
+    suffix = "Hello, world!"
+    max_tokens = 256
+    payload = {
+        "model": served_model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "suffix": suffix,
+        "stream": stream,
+    }
+
+    response = requests.post(OPENAI_V1_COMPLETION_URL, json=payload, timeout=60)
+    if not stream:
+        check_openai_nonstream_response(
+            response.json(),
+            model=served_model,
+            object_str="text_completion",
+            num_choices=1,
+            finish_reason="length",
+            completion_tokens=max_tokens,
+            suffix=suffix,
+        )
+    else:
+        responses = []
+        for chunk in response.iter_lines(chunk_size=512):
+            if not chunk or chunk == b"data: [Done]":
+                continue
+            responses.append(json.loads(chunk.decode("utf-8")[6:]))
+        check_openai_stream_response(
+            responses,
+            model=served_model,
+            object_str="text_completion",
+            num_choices=1,
+            finish_reason="length",
+            completion_tokens=max_tokens,
+            suffix=suffix,
+        )
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_openai_v1_completions_prompt_overlong(
+    served_model: str,
+    launch_server,  # pylint: disable=unused-argument
+    stream: bool,
+):
+    # `served_model` and `launch_server` are pytest fixture
+    # defined in conftest.py.
+
+    num_tokens = 17000
+    prompt = [128] * num_tokens
+    payload = {
+        "model": served_model,
+        "prompt": prompt,
+        "max_tokens": 256,
+        "stream": stream,
+    }
+
+    response = requests.post(OPENAI_V1_COMPLETION_URL, json=payload, timeout=60)
+    error_msg_prefix = (
+        f"Request prompt has {num_tokens} tokens in total, larger than the model capacity"
+    )
+    if not stream:
+        expect_error(response.json(), msg_prefix=error_msg_prefix)
+    else:
+        num_chunks = 0
+        for chunk in response.iter_lines(chunk_size=512):
+            if not chunk:
+                continue
+            num_chunks += 1
+            expect_error(json.loads(chunk.decode("utf-8")), msg_prefix=error_msg_prefix)
+        assert num_chunks == 1
+
+
+if __name__ == "__main__":
+    MODEL = os.environ.get("MLC_SERVE_MODEL")
+    if MODEL is None:
+        MODEL = "Llama-2-7b-chat-hf-q0f16"
+        print(
+            'WARNING: Variable "MLC_SERVE_MODEL" not found in environment, '
+            f"fallback to use model {MODEL}, which requires 16GB of VRAM. "
+            "Changing to use a quantized model can reduce the VRAM requirements."
+        )
+
+    test_openai_v1_completions(MODEL, None, stream=False)
+    test_openai_v1_completions(MODEL, None, stream=True)
+    test_openai_v1_completions_echo(MODEL, None, stream=False)
+    test_openai_v1_completions_echo(MODEL, None, stream=True)
+    test_openai_v1_completions_suffix(MODEL, None, stream=False)
+    test_openai_v1_completions_suffix(MODEL, None, stream=True)
+    test_openai_v1_completions_prompt_overlong(MODEL, None, stream=False)
+    test_openai_v1_completions_prompt_overlong(MODEL, None, stream=True)

--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -39,7 +39,9 @@ async def test_engine_generate():
     ):
         print(f"generate task for request {request_id}")
         rid = int(request_id)
-        async for token in async_engine.generate(prompt, generation_cfg, request_id=request_id):
+        async for token, finish_reason in async_engine.generate(
+            prompt, generation_cfg, request_id=request_id
+        ):
             outputs[rid].append(token)
 
     tasks = [

--- a/tests/python/serve/test_serve_engine.py
+++ b/tests/python/serve/test_serve_engine.py
@@ -23,7 +23,7 @@ prompts = [
 
 def create_requests(
     num_requests: int,
-    fcallback: Callable[[str, data.TokenData, bool], None],
+    fcallback: Callable[[str, data.TokenData, Optional[str]], None],
     stop_token: Optional[int] = None,
     temperature: float = 0.8,
     repetition_penalty: float = 1.0,
@@ -80,7 +80,7 @@ def test_engine_basic():
     engine = Engine(model, kv_cache_config)
 
     # Define the callback function for request generation results
-    def fcallback(request_id: str, token_data: data.TokenData, finished: bool):
+    def fcallback(request_id: str, token_data: data.TokenData, finish_reason: Optional[str]):
         outputs[int(request_id)] += token_data.token_ids
 
     # Create requests
@@ -141,9 +141,11 @@ def test_engine_continuous_batching_1():
     class CallbackTimer:
         timer: int = -1
 
-        def callback_getter(self) -> Callable[[str, data.TokenData, bool], None]:
-            def fcallback(request_id: str, token_data: data.TokenData, finished: bool):
-                if finished:
+        def callback_getter(self) -> Callable[[str, data.TokenData, Optional[str]], None]:
+            def fcallback(
+                request_id: str, token_data: data.TokenData, finish_reason: Optional[str]
+            ):
+                if finish_reason is not None:
                     print(f"Request {request_id} finished at step {self.timer}.")
                 outputs[int(request_id)] += token_data.token_ids
                 finish_time[int(request_id)] = self.timer
@@ -217,9 +219,11 @@ def test_engine_continuous_batching_2():
     class CallbackTimer:
         timer: int = -1
 
-        def callback_getter(self) -> Callable[[str, data.TokenData, bool], None]:
-            def fcallback(request_id: str, token_data: data.TokenData, finished: bool):
-                if finished:
+        def callback_getter(self) -> Callable[[str, data.TokenData, Optional[str]], None]:
+            def fcallback(
+                request_id: str, token_data: data.TokenData, finish_reason: Optional[str]
+            ):
+                if finish_reason is not None:
                     print(f"Request {request_id} finished at step {self.timer}.")
                 outputs[int(request_id)] += token_data.token_ids
                 finish_time[int(request_id)] = self.timer
@@ -294,9 +298,11 @@ def test_engine_continuous_batching_3():
         timer: int = -1
         finished_requests: int = 0
 
-        def callback_getter(self) -> Callable[[str, data.TokenData, bool], None]:
-            def fcallback(request_id: str, token_data: data.TokenData, finished: bool):
-                if finished:
+        def callback_getter(self) -> Callable[[str, data.TokenData, Optional[str]], None]:
+            def fcallback(
+                request_id: str, token_data: data.TokenData, finish_reason: Optional[str]
+            ):
+                if finish_reason is not None:
                     print(f"Request {request_id} finished at step {self.timer}.")
                     self.finished_requests += 1
                 outputs[int(request_id)] += token_data.token_ids


### PR DESCRIPTION
This PR supports the RESTful API server with OpenAI v1/completions compatibility. We have unit tests in
`tests/python/serve/server/test_server.py` that is designed for pytest testing.

Regarding the internal engine, this PR changes the callback function API to incorporate the request finish reason.