### PR TITLE
[Serving] Switching to global request callback

### DIFF
--- a/cpp/serve/engine_actions/action_commons.h
+++ b/cpp/serve/engine_actions/action_commons.h
@@ -7,6 +7,7 @@
 #define MLC_LLM_SERVE_ENGINE_ACTIONS_ACTION_COMMONS_H_
 
 #include "../../tokenizers.h"
+#include "../engine.h"
 #include "../engine_state.h"
 #include "../model.h"
 
@@ -33,13 +34,12 @@ void RemoveRequestFromModel(EngineState estate, int req_id, Array<Model> models)
  * \param requests The requests to process.
  * \param estate The engine state.
  * \param models The models to remove the finished from.
- * \param tokenizer The tokenizer used to decode the generated tokens of requests.
+ * \param f_request_callback The request callback function.
  * \param max_single_sequence_length The max single sequence length to help decide
  * if a request is finished.
  */
 void ActionStepPostProcess(Array<Request> requests, EngineState estate, Array<Model> models,
-                           const std::unique_ptr<Tokenizer>& tokenizer,
-                           int max_single_sequence_length);
+                           FRequestCallback f_request_callback, int max_single_sequence_length);
 
 }  // namespace serve
 }  // namespace llm

--- a/cpp/serve/request.cc
+++ b/cpp/serve/request.cc
@@ -18,8 +18,7 @@ namespace serve {
 
 TVM_REGISTER_OBJECT_TYPE(RequestNode);
 
-Request::Request(String id, Array<Data> inputs, GenerationConfig generation_cfg,
-                 PackedFunc fcallback) {
+Request::Request(String id, Array<Data> inputs, GenerationConfig generation_cfg) {
   CHECK(!inputs.empty()) << "No input data is given.";
   // Compute the total input length, or fall back to "-1" which means
   // unknown due to the existence of untokenized data.
@@ -38,7 +37,6 @@ Request::Request(String id, Array<Data> inputs, GenerationConfig generation_cfg,
   n->inputs = std::move(inputs);
   n->input_total_length = input_total_length;
   n->generation_cfg = std::move(generation_cfg);
-  n->fcallback = std::move(fcallback);
   data_ = std::move(n);
 }
 
@@ -62,15 +60,14 @@ Request Request::FromUntokenized(Request request, const std::unique_ptr<Tokenize
     ICHECK_NE(request->input_total_length, -1);
     return request;
   } else {
-    return Request(request->id, std::move(inputs), request->generation_cfg, request->fcallback);
+    return Request(request->id, std::move(inputs), request->generation_cfg);
   }
 }
 
 TVM_REGISTER_GLOBAL("mlc.serve.Request")
-    .set_body_typed([](String id, Array<Data> inputs, String generation_cfg_json,
-                       PackedFunc fcallback) {
+    .set_body_typed([](String id, Array<Data> inputs, String generation_cfg_json) {
       return Request(std::move(id), std::move(inputs),
-                     GenerationConfig(std::move(generation_cfg_json)), std::move(fcallback));
+                     GenerationConfig(std::move(generation_cfg_json)));
     });
 
 TVM_REGISTER_GLOBAL("mlc.serve.RequestGetInputs").set_body_typed([](Request request) {

--- a/cpp/serve/request.h
+++ b/cpp/serve/request.h
@@ -25,8 +25,8 @@ using namespace tvm::runtime;
 
 /*!
  * \brief The user submitted text-generation request, which contains
- * a list of multi-modal inputs, a set of generation configuration
- * parameters and a callback function for request finish handling.
+ * a unique request id, a list of multi-modal inputs, a set of
+ * generation configuration parameters.
  * \note Request is immutable and can be re-dispatched to another
  * node and restart the request handling on the new one.
  */
@@ -53,17 +53,6 @@ class RequestNode : public Object {
    * top_p, repetition_penalty, max_gen_len, etc.
    */
   GenerationConfig generation_cfg;
-  /*!
-   * \brief The provided callback function to handle the generation
-   * output. It has the signature of `(String, TokenData, Optional<String>) -> None`,
-   * where
-   * - the first string is the request id,
-   * - the TokenData contains the generated **delta** token ids since
-   * the invocation of the callback on the specific request,
-   * - the optional string value denotes the finish reason if the
-   * generation of the request is finished, or None if it has not finished.
-   */
-  PackedFunc fcallback;
 
   static constexpr const char* _type_key = "mlc.serve.Request";
   static constexpr const bool _type_has_method_sequal_reduce = false;
@@ -73,8 +62,7 @@ class RequestNode : public Object {
 
 class Request : public ObjectRef {
  public:
-  explicit Request(String id, Array<Data> inputs, GenerationConfig generation_cfg,
-                   PackedFunc fcallback);
+  explicit Request(String id, Array<Data> inputs, GenerationConfig generation_cfg);
 
   /*!
    * \brief Return a request object with all text data tokenized,

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -45,7 +45,7 @@ RequestState::RequestState(Request request, int num_models) {
   data_ = std::move(n);
 }
 
-Optional<String> RequestStateNode::GenerationFinishReason(int max_single_sequence_length) const {
+Optional<String> RequestStateNode::GenerationFinished(int max_single_sequence_length) const {
   // - Case 0. There is remaining draft output ==> Unfinished
   //   All draft outputs are supposed to be processed before finish.
   for (RequestModelState mstate : mstates) {

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -116,7 +116,7 @@ class RequestStateNode : public Object {
    * \return The finish reason in string if the request is finished,
    * or None if the request has not finished.
    */
-  Optional<String> GenerationFinishReason(int max_single_sequence_length) const;
+  Optional<String> GenerationFinished(int max_single_sequence_length) const;
 
   static constexpr const char* _type_key = "mlc.serve.RequestState";
   static constexpr const bool _type_has_method_sequal_reduce = false;

--- a/python/mlc_chat/serve/request.py
+++ b/python/mlc_chat/serve/request.py
@@ -1,19 +1,19 @@
 """The request class in MLC LLM serving"""
-from typing import Callable, List, Optional, Union
+from typing import List, Union
 
 import tvm._ffi
 from tvm.runtime import Object
 
 from . import _ffi_api
 from .config import GenerationConfig
-from .data import Data, TokenData
+from .data import Data
 
 
 @tvm._ffi.register_object("mlc.serve.Request")  # pylint: disable=protected-access
 class Request(Object):
     """The user submitted text-generation request, which contains
-    a list of multi-modal inputs, a set of generation configuration
-    parameters and a callback function for request finish handling.
+    a unique request id, a list of multi-modal inputs, a set of
+    generation configuration parameters.
 
     Parameters
     ----------
@@ -27,16 +27,6 @@ class Request(Object):
     generation_config : GenerationConfig
         The sampling configuration which may contain temperature,
         top_p, repetition_penalty, max_gen_len, etc.
-
-    fcallback : Callable[[str, TokenData, Optional[str]], None]
-        The provided callback function to handle the generation
-        output. It has the signature of `(str, TokenData, bool) -> None`,
-        where
-        - the first string is the request id,
-        - the TokenData contains the generated **delta** token ids since
-        the invocation of the callback on the specific request,
-        - the optional string value denotes the finish reason if the
-        generation of the request is finished, or None if it has not finished.
     """
 
     def __init__(
@@ -44,7 +34,6 @@ class Request(Object):
         request_id: str,
         inputs: Union[Data, List[Data]],
         generation_config: GenerationConfig,
-        fcallback: Callable[[str, TokenData, Optional[str]], None],
     ):
         if not isinstance(inputs, list):
             inputs = [inputs]
@@ -53,7 +42,6 @@ class Request(Object):
             request_id,
             inputs,
             generation_config.asjson(),
-            fcallback,
         )
 
     @property


### PR DESCRIPTION
Prior to this PR, each request has its own callback function. This PR switches to using a global callback function that all requests share, so that the conversion of Python function to PackedFunc only happens once.

Additionally, this PR introduces the use of `call_soon_threadsafe` method of asyncio in AsyncEngine.