### PR TITLE
[Rust] Prepare for publishing

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,12 +1,21 @@
 [package]
 name = "mlc-llm"
 version = "0.1.0"
+license = "Apache-2.0"
+description = "Rust API for MLC LLM."
+homepage = "https://llm.mlc.ai/"
+readme = "README.md"
+keywords = ["rust", "mlc", "llm", "tvm", "AI"]
+authors = ["MLC Contributors"]
+repository = "https://github.com/mlc-ai/mlc-llm"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tvm-rt = { path = "../3rdparty/tvm/rust/tvm-rt", features = ["dynamic-linking"] }
+tvm-rt = { path = "../3rdparty/tvm/rust/tvm-rt", version = "0.1.0-alpha", features = [
+    "dynamic-linking",
+] }
 tracing = "0.1.32"
 derive_builder = "0.12.0"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    let mlc_home = env!("MLC_HOME");
+
     println!("cargo:rustc-link-lib=dylib=mlc_llm_module");
-    println!("cargo:rustc-link-search=native={}/build", env!("MLC_HOME"));
+    println!("cargo:rustc-link-search=native={}/build", mlc_home);
 }


### PR DESCRIPTION
Adding metadata to the crate.

I am planning to publish the mlc-llm rust package on [create.io](http://create.io/) so that more developers can find/install it, and most importantly the code documentation can be generated and published to [docs.rs](http://docs.rs/). Everything is ready, but is blocked on a stale dependency of Heim crate in tvm-build: https://github.com/octoml/tvm-build/pull/14. Once it's fixed, we can publish the crate.


