### PR TITLE
[Bugfix] Ignore exit code in device detection

### DIFF
--- a/python/mlc_chat/cli/check_device.py
+++ b/python/mlc_chat/cli/check_device.py
@@ -1,20 +1,29 @@
 """Check if a device exists."""
 import sys
 
-import tvm
+from tvm.runtime import Device
+from tvm.runtime import device as as_device
+
+
+def _check_device(device: Device) -> bool:
+    try:
+        return bool(device.exist)
+    except:  # pylint: disable=bare-except
+        return False
 
 
 def main():
     """Entrypoint for device check."""
     device_str = sys.argv[1]
-    try:
-        device = tvm.runtime.device(device_str)
-        if device.exist:
-            print("1")
+    device_ids = []
+    i = 0
+    while True:
+        if _check_device(as_device(device_str, i)):
+            device_ids.append(i)
+            i += 1
         else:
-            print("0")
-    except:  # pylint: disable=bare-except
-        print("0")
+            break
+    print(f"check_device:{','.join(str(i) for i in device_ids)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TVM's Vulkan runtime emits a non-zero exit code on certain Windows drivers on DLL offloading. While there is definitely a way to fix this, for now, we quickly get around this by not checking the exit code in device detection.

This PR also improves clarify when multiple GPUs presents by emitting logging messages on all GPUs available, rather than only GPU 0.