### PR TITLE
[Tokenizer] Prioritize huggingface tokenizer.json, generate one if not included

### DIFF
--- a/cpp/tokenizers.cc
+++ b/cpp/tokenizers.cc
@@ -45,11 +45,17 @@ std::unique_ptr<Tokenizer> TokenizerFromPath(const std::string& _path) {
     huggingface = path.parent_path() / "tokenizer.json";
     rwkvworld = path.parent_path() / "tokenizer_model";
   }
-  if (std::filesystem::exists(sentencepiece)) {
-    return Tokenizer::FromBlobSentencePiece(LoadBytesFromFile(sentencepiece.string()));
-  }
   if (std::filesystem::exists(huggingface)) {
     return Tokenizer::FromBlobJSON(LoadBytesFromFile(huggingface.string()));
+  }
+  if (std::filesystem::exists(sentencepiece)) {
+    LOG(WARNING)
+        << "Using `tokenizer.model` since we cannot locate `tokenizer.json`.\n"
+        << "It is recommended to use `tokenizer.json` to ensure all token mappings are included, "
+        << "since currently, files like `added_tokens.json`, `tokenizer_config.json` are ignored.\n"
+        << "Consider converting `tokenizer.model` to `tokenizer.json` by compiling the model "
+        << "with MLC again, or see if MLC's huggingface provides this file.";
+    return Tokenizer::FromBlobSentencePiece(LoadBytesFromFile(sentencepiece.string()));
   }
   if (std::filesystem::exists(rwkvworld)) {
     return Tokenizer::FromBlobRWKVWorld(rwkvworld.string());

--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -8,16 +8,25 @@ import shutil
 from typing import Any, Dict, List, Optional, Set
 
 import numpy as np
-
 import tvm
 from tvm import relax
 
 from .quantization import quantization_schemes
 from .relax_model import param_manager
 
-
 supported_model_types = set(
-    ["llama", "gpt_neox", "gpt_bigcode", "minigpt", "moss", "rwkv", "gptj", "chatglm", "mistral", "stablelm_epoch"]
+    [
+        "llama",
+        "gpt_neox",
+        "gpt_bigcode",
+        "minigpt",
+        "moss",
+        "rwkv",
+        "gptj",
+        "chatglm",
+        "mistral",
+        "stablelm_epoch",
+    ]
 )
 
 
@@ -295,8 +304,10 @@ def save_params(params: List[tvm.nd.NDArray], artifact_path: str, num_presharded
 
         param_dict[param_name] = nd
 
-    total_size_bytes = sum(math.prod(param.shape) * np.dtype(param.dtype).itemsize for param in params)
-    total_size_gb = total_size_bytes / (1024 ** 3)
+    total_size_bytes = sum(
+        math.prod(param.shape) * np.dtype(param.dtype).itemsize for param in params
+    )
+    total_size_gb = total_size_bytes / (1024**3)
     print(f"Total param size: {total_size_gb} GB")
     tvmjs.dump_ndarray_cache(
         param_dict, f"{artifact_path}/params", meta_data=meta_data, encode_format="raw"
@@ -327,6 +338,34 @@ def copy_tokenizer(args: argparse.Namespace) -> None:
             shutil.copy(
                 os.path.join(args.model_path, filename),
                 os.path.join(args.artifact_path, "params"),
+            )
+
+    # If we have `tokenizer.model` but not `tokenizer.json`, try convert it to
+    # `tokenizer.json` with `transformers`.
+    tokenizer_json_path = os.path.join(args.model_path, "tokenizer.json")
+    tokenizer_model_path = os.path.join(args.model_path, "tokenizer.model")
+    if os.path.exists(tokenizer_model_path) and (not os.path.exists(tokenizer_json_path)):
+        print("Attempting to convert `tokenizer.model` to `tokenizer.json`.")
+        try:
+            # pylint: disable=import-outside-toplevel
+            from transformers import AutoTokenizer
+
+            tokenizer_json_save_dest = os.path.join(args.artifact_path, "params/tokenizer.json")
+            fast_tokenizer = AutoTokenizer.from_pretrained(args.model_path, use_fast=True)
+            fast_tokenizer.backend_tokenizer.save(tokenizer_json_save_dest)
+            print(f"Succesfully converted `tokenizer.model` to: {tokenizer_json_save_dest}")
+        except ImportError:
+            print(
+                "WARNING: The model has `tokenizer.model` but not `tokenizer.json`. It is"
+                + "recommended to use `tokenizer.json`, so we try convert it with `transformers`.\n"
+                + "However, we were unable to import `transformers`, hence skipping this step."
+            )
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            print(
+                "WARNING: The model has `tokenizer.model` but not `tokenizer.json`. It is"
+                + "recommended to use `tokenizer.json`, so we try convert it with `transformers`.\n"
+                + "However, we are skipping this due to an error:\n",
+                error,
             )
 
 
@@ -627,6 +666,7 @@ def parse_target(args: argparse.Namespace) -> None:
     elif args.target in ["mali"]:
         if "TVM_NDK_CC" in os.environ:
             from tvm.contrib import ndk
+
             args.export_kwargs = {
                 "fcompile": ndk.create_shared,
             }

--- a/python/mlc_chat/compiler/gen_mlc_chat_config.py
+++ b/python/mlc_chat/compiler/gen_mlc_chat_config.py
@@ -46,7 +46,7 @@ class MLCChatConfig:  # pylint: disable=too-many-instance-attributes
     tokenizer_files: List[str] = dataclasses.field(default_factory=list)
 
 
-def gen_config(  # pylint: disable=too-many-locals,too-many-arguments
+def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-branches
     config: Path,
     model: Model,
     quantization: Quantization,

--- a/python/mlc_chat/compiler/gen_mlc_chat_config.py
+++ b/python/mlc_chat/compiler/gen_mlc_chat_config.py
@@ -88,6 +88,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments
     else:
         logger.info("%s generation_config.json: %s", NOT_FOUND, generation_config)
     # Step 3. Copy tokenizer configuration
+    # 3.1. Copy over the files and populate mlc_chat_config
     for filename in TOKENIZER_FILES:
         file = config.parent / filename
         if file.exists():
@@ -97,6 +98,34 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments
             logger.info("%s tokenizer config: %s. Copying to %s", FOUND, file, bold(str(dest)))
         else:
             logger.info("%s tokenizer config: %s", NOT_FOUND, file)
+    # 3.2. If we have `tokenizer.model` but not `tokenizer.json`, try convert it to
+    # `tokenizer.json` with `transformers`.
+    tokenizer_json_file = config.parent / "tokenizer.json"
+    tokenizer_model_file = config.parent / "tokenizer.model"
+    if tokenizer_model_file.exists() and (not tokenizer_json_file.exists()):
+        logger.info("Attempting to convert `tokenizer.model` to `tokenizer.json`.")
+        try:
+            # pylint: disable=import-outside-toplevel
+            from transformers import AutoTokenizer
+
+            tokenizer_json_save_dest = output / "tokenizer.json"
+            fast_tokenizer = AutoTokenizer.from_pretrained(str(config.parent), use_fast=True)
+            fast_tokenizer.backend_tokenizer.save(str(tokenizer_json_save_dest))
+            mlc_chat_config.tokenizer_files.append("tokenizer.json")
+            logger.info("Succesfully converted `tokenizer.model` to: %s", tokenizer_json_save_dest)
+        except ImportError:
+            logger.warning(
+                "The model has `tokenizer.model` but not `tokenizer.json`. It is"
+                + "recommended to use `tokenizer.json`, so we try convert it with `transformers`.\n"
+                + "However, we were unable to import `transformers`, hence skipping this step."
+            )
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "The model has `tokenizer.model` but not `tokenizer.json`. It is"
+                + "recommended to use `tokenizer.json`, so we try convert it with `transformers`.\n"
+                + "However, we are skipping this due to an error:\n",
+                error,
+            )
     # Step 4. Load system default value
     for key, value in DEFAULT_CONFIGS.items():
         if getattr(mlc_chat_config, key) is None:


### PR DESCRIPTION
Fix the issue of tokenizer not recognizing special vocabs like `</s>`.

### Before
<img width="200" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/53290280/aff04ceb-b2b7-4fe7-91b3-689f3752d45c">


Currently, mlc-llm prioritizes using `tokenizer.model` with sentencepiece. However, using this alone misses other token mappings such as the stop token `</s>` -- instead we have been relying on registering `</s>` as a `stop_str`. This is experienced in models like Llama-2 and Mistral (probably most models), mentioned in https://github.com/mlc-ai/mlc-llm/issues/1315.

This is probably due to how [tokenizer.cc](https://github.com/mlc-ai/mlc-llm/blob/main/cpp/tokenizers.cc) only uses `tokenizer.model` and not other files like `added_tokens.json`, `tokenizer_config.json`, etc.

### After:
<img width="300" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/53290280/73c317af-a04a-4d86-aa54-59cc463fea46">

Instead, we prioritize using `tokenizer.json` with huggingface's "Fast tokenizer".

For models that do not come with `tokenizer.model` (e.g. [OpenHermes-2.5-Mistral-7B](https://huggingface.co/teknium/OpenHermes-2.5-Mistral-7B/tree/main)), we try to convert it to `tokenizer.json` using `transformers` (happens in `build.py` in the current workflow, and `gen_mlc_chat_config` in the new workflow). We can think of this step as serializing `tokenizer.model`, `added_tokens.json`, etc. into a single `tokenizer.json`. This saves us from replicating transformer's entire logic of dealing with all the tokenizer files.