### PR TITLE
[SLIM][AWQ] AWQ GEMM support

### DIFF
--- a/python/mlc_chat/compiler/model/llama/llama_loader.py
+++ b/python/mlc_chat/compiler/model/llama/llama_loader.py
@@ -122,7 +122,10 @@ def awq(model_config: LlamaConfig, quantization: Quantization) -> ExternMapping:
                     f"{attn}.v_proj.{quantize_suffix}",
                 ],
                 functools.partial(
-                    lambda q, k, v, dtype: np.concatenate([q, k, v], axis=0).astype(dtype),
+                    lambda q, k, v, dtype: np.concatenate(
+                        [q, k, v],
+                        axis=1,  # AWQ GEMM would transpose the weight
+                    ).astype(dtype),
                     dtype=mlc_param.dtype,
                 ),
             )
@@ -140,7 +143,10 @@ def awq(model_config: LlamaConfig, quantization: Quantization) -> ExternMapping:
                     f"{mlp}.up_proj.{quantize_suffix}",
                 ],
                 functools.partial(
-                    lambda gate, up, dtype: np.concatenate([gate, up], axis=0).astype(dtype),
+                    lambda gate, up, dtype: np.concatenate(
+                        [gate, up],
+                        axis=1,  # AWQ GEMM would transpose the weight
+                    ).astype(dtype),
                     dtype=mlc_param.dtype,
                 ),
             )

--- a/python/mlc_chat/compiler/quantization/quantization.py
+++ b/python/mlc_chat/compiler/quantization/quantization.py
@@ -59,8 +59,8 @@ QUANTIZATION: Dict[str, Quantization] = {
         storage_dtype="uint32",
         model_dtype="float32",
     ),
-    "q4f16_awq": AWQQuantize(
-        name="q4f16_awq",
+    "q4f16_autoawq": AWQQuantize(
+        name="q4f16_autoawq",
         kind="awq",
         group_size=128,
         quantize_dtype="int4",


### PR DESCRIPTION
Previously #1229, we only supported loading INT4-GEMV-awq weights quantized by [the original repo](https://github.com/mit-han-lab/llm-awq#usage). This pr supports loading INT4-GEMM format weights quantized by [AutoAWQ](https://github.com/casper-hansen/AutoAWQ). Here is an example that loads from [TheBloke/Llama-2-7b-Chat-AWQ](https://huggingface.co/TheBloke/Llama-2-7B-Chat-AWQ) and runs the benchmark.

```bash
MODEL_PATH=/opt/models/llama-2/llama-2-7b-chat-hf/
OUTPUT_PATH=./dist/new-llama-awq/
QUANT=q4f16_autoawq

python -m mlc_chat gen_config $MODEL_PATH/config.json --quantization $QUANT -o $OUTPUT_PATH --conv-template llama-2

python -m mlc_chat compile $OUTPUT_PATH -o $OUTPUT_PATH/llama.so

python -m mlc_chat convert_weight $MODEL_PATH --quantization $QUANT -o $OUTPUT_PATH --source-format awq --source ../Llama-2-7B-Chat-AWQ/model.safetensors

python -m mlc_chat.cli.benchmark --model $OUTPUT_PATH --model-lib $OUTPUT_PATH/llama.so --device "cuda:0" --prompt "What is the meaning of life?" --generate-length 256
```

Note:
Q: What is difference between INT4-GEMV and INT4-GEMM?
A: https://github.com/casper-hansen/AutoAWQ#int4-gemm-vs-int4-gemv-vs-fp16