### PR TITLE
[SLIM] Add info to metadata in SLIM and make compatible with llm_chat.cc

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -322,9 +322,12 @@ class LLMChat {
       return;
     }
 
-    PackedFunc fget_metadata = ft_.mod_get_func("get_metadata");
+    PackedFunc fget_metadata = ft_.mod_get_func("_metadata");  // name in SLIM
     if (fget_metadata == nullptr) {
-      return;
+      fget_metadata = ft_.mod_get_func("get_metadata");  // backward-compatible name
+      if (fget_metadata == nullptr) {
+        return;  // Skip if neither exists
+      }
     }
     ObjectRef ret = fget_metadata();
     std::string metadata_str = std::string(Downcast<String>(ret));

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -79,10 +79,12 @@ def _attach_auxiliary_methods(
         "model_type": args.model.name,
         "memory_usage": _get_memory_usage(),
         "params": _get_param_info(),
-        "max_window_size": model_config.context_window_size,
-        "prefill_chunk_size": model_config.prefill_chunk_size,
     }
 
+    if hasattr(model_config, "context_window_size"):
+        metadata["max_window_size"] = model_config.context_window_size
+    if hasattr(model_config, "prefill_chunk_size"):
+        metadata["prefill_chunk_size"] = model_config.prefill_chunk_size
     if hasattr(model_config, "sliding_window"):
         metadata["sliding_window"] = model_config.sliding_window
 

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -10,6 +10,7 @@ from tvm import IRModule, relax
 from tvm.relax.frontend import nn
 from tvm.target import Target
 
+from ..support.config import ConfigBase
 from ..support.style import bold
 from .flags_model_config_override import ModelConfigOverride
 from .flags_optimization import OptimizationFlags
@@ -52,6 +53,7 @@ def _attach_auxiliary_methods(
     mod: IRModule,
     named_params: List[Tuple[str, nn.Parameter]],
     args: CompileArgs,
+    model_config: ConfigBase,
 ) -> None:
     def _get_memory_usage():
         return {str(k): int(v) for k, v in mod.attrs["mlc_llm.memory_usage"].items()}
@@ -72,14 +74,19 @@ def _attach_auxiliary_methods(
             bb.emit_func_output(relax.StringImm(json.dumps(metadata)))
         return bb.get()["main"]
 
-    mod["_metadata"] = _emit_metadata(
-        metadata={
-            "quantization": args.quantization.name,
-            "model_type": args.model.name,
-            "memory_usage": _get_memory_usage(),
-            "params": _get_param_info(),
-        }
-    )
+    metadata = {
+        "quantization": args.quantization.name,
+        "model_type": args.model.name,
+        "memory_usage": _get_memory_usage(),
+        "params": _get_param_info(),
+        "max_window_size": model_config.context_window_size,
+        "prefill_chunk_size": model_config.prefill_chunk_size,
+    }
+
+    if hasattr(model_config, "sliding_window"):
+        metadata["sliding_window"] = model_config.sliding_window
+
+    mod["_metadata"] = _emit_metadata(metadata)
 
 
 def _attach_variable_bounds(mod, model_config):
@@ -110,7 +117,7 @@ def _compile(args: CompileArgs):
     _attach_variable_bounds(mod, model_config)
     with args.target:
         mod = relax.get_pipeline("mlc_llm")(mod)
-    _attach_auxiliary_methods(mod, named_params, args)
+    _attach_auxiliary_methods(mod, named_params, args, model_config)
     logger.info("Generating code using TVM Unity")
     args.build_func(mod, args)
     logger.info("Generated: %s", bold(str(args.output)))


### PR DESCRIPTION
Currently, when running a SLIM-compiled model with `llm_chat.cc`, we cannot read information like `max_window_size`, `sliding_window`, or `prefill_chunk_size`.  We add such info to `_metadata`, which is also needed for web-llm.