### PR TITLE
[Serving] Conversation template and OpenAI v1/chat/completions

### DIFF
--- a/ci/task/pylint.sh
+++ b/ci/task/pylint.sh
@@ -10,7 +10,7 @@ set -x
 
 # TVM Unity is a dependency to this testing
 pip install --quiet --pre -U -f https://mlc.ai/wheels mlc-ai-nightly requests
-pip install --quiet --pre -U pydantic fastapi uvicorn shortuuid
+pip install --quiet --pre -U pydantic fastapi uvicorn shortuuid openai
 
 pylint --jobs $NUM_THREADS ./python/
 pylint --jobs $NUM_THREADS --recursive=y ./tests/python/

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -24,9 +24,9 @@ class GenerationConfigNode : public Object {
   double top_p = 0.95;
   double repetition_penalty = 1.0;
 
-  int max_new_tokens = 128;
+  int max_tokens = 128;
   Array<String> stop_strs;
-  std::vector<int> stop_tokens;
+  std::vector<int> stop_token_ids;
 
   String AsJSONString() const;
 

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -62,12 +62,15 @@ Optional<String> RequestStateNode::GenerationFinished(int max_single_sequence_le
 
   // Case 1. Any of the stop tokens appears in the committed tokens ===> Finished
   if (std::any_of(
-          request->generation_cfg->stop_tokens.begin(), request->generation_cfg->stop_tokens.end(),
+          request->generation_cfg->stop_token_ids.begin(),
+          request->generation_cfg->stop_token_ids.end(),
           [&committed_tokens](int32_t token) { return token == committed_tokens.back(); })) {
     return String("stop");
   }
   // Case 2. Generation reaches the specified max generation length ==> Finished
-  if (static_cast<int>(committed_tokens.size()) >= request->generation_cfg->max_new_tokens) {
+  // `max_tokens` means the generation length is limited by model capacity.
+  if (request->generation_cfg->max_tokens >= 0 &&
+      static_cast<int>(committed_tokens.size()) >= request->generation_cfg->max_tokens) {
     return String("length");
   }
   // Case 3. Total length of the request reaches the maximum single sequence length ==> Finished

--- a/python/mlc_chat/conversation_template.py
+++ b/python/mlc_chat/conversation_template.py
@@ -1,0 +1,52 @@
+"""The conversation template registry and presets in MLC LLM"""
+
+from typing import Dict, Optional
+
+from .protocol.conversation_protocol import SYSTEM_MESSAGE_PLACEHOLDER, Conversation
+
+
+class ConvTemplateRegistry:
+    """Global conversation template registry for preset templates."""
+
+    _conv_templates: Dict[str, Conversation] = {}
+
+    @staticmethod
+    def register_conv_template(conv_template: Conversation, override: bool = False) -> None:
+        """Register a new conversation template in the global registry.
+        Using `override = True` to override the previously registered
+        template with the same name.
+        """
+        name = conv_template.name
+        if name is None:
+            raise ValueError("The template to register should have non-None name.")
+        if name in ConvTemplateRegistry._conv_templates and not override:
+            raise ValueError(
+                "The name of the template has been registered "
+                f"for {ConvTemplateRegistry._conv_templates[name].model_dump_json()}"
+            )
+        ConvTemplateRegistry._conv_templates[name] = conv_template
+
+    @staticmethod
+    def get_conv_template(name: str) -> Optional[Conversation]:
+        """Return the conversation template specified by the given name,
+        or None if the template is not registered.
+        """
+        return ConvTemplateRegistry._conv_templates.get(name, None)
+
+
+############## Preset Conversation Templates ##############
+
+# Llama2
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="llama-2",
+        system_template=f"[INST] <<SYS>>\n\n{SYSTEM_MESSAGE_PLACEHOLDER}\n<</SYS>>\n\n ",
+        system_message="You are a helpful, respectful and honest assistant.",
+        roles=("[INST]", "[/INST]"),
+        seps=[" "],
+        role_content_sep=" ",
+        role_empty_sep=" ",
+        stop_str=["[INST]"],
+        stop_token_ids=[2],
+    )
+)

--- a/python/mlc_chat/protocol/conversation_protocol.py
+++ b/python/mlc_chat/protocol/conversation_protocol.py
@@ -1,0 +1,90 @@
+"""The standard conversation protocol in MLC LLM"""
+
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel, Field, field_validator
+
+# The system message placeholder in the system message prompt.
+SYSTEM_MESSAGE_PLACEHOLDER = "{system_message}"
+
+
+class Conversation(BaseModel):
+    """Class that specifies the convention template of conversation
+    and contains the conversation history.
+
+    Given a conversation template, the corresponding prompt generated out
+    from it is usually in the following format:
+
+      <<system>><<messages[0][0]>><<role_content_sep>><<messages[0][1]>><<seps[0]>>
+                <<messages[1][0]>><<role_content_sep>><<messages[1][1]>><<seps[1]>>
+                ...
+                <<messages[2][0]>><<role_content_sep>><<messages[2][1]>><<seps[0]>>
+                <<roles[1]>><<role_empty_sep>>
+    """
+
+    # Optional name of the template.
+    name: Optional[str] = None
+    # The system prompt template, it optionally contains the system
+    # message placeholder, and the placeholder will be replaced with
+    # the system message below.
+    system_template: str = SYSTEM_MESSAGE_PLACEHOLDER
+    # The content of the system prompt (without the template format).
+    system_message: str = ""
+    # The system token ids to be prepended at the beginning of tokenized
+    # generated prompt.
+    system_prefix_token_ids: Optional[List[int]] = None
+
+    # The conversation roles.
+    roles: Tuple[str, str]
+    # The conversation history messages.
+    # Each message is a pair of strings, denoting "(role, content)".
+    # The content can be None.
+    messages: List[Tuple[str, Optional[str]]] = Field(default_factory=lambda: [])
+
+    # The separators between messages when concatenating into a single prompt.
+    # List size should be either 1 or 2.
+    # - When size is 1, the separator will be used between adjacent messages.
+    # - When size is 2, seps[0] is used after user message, and
+    #   seps[1] is used after assistant message.
+    seps: List[str]
+
+    # The separator between the role and the content in a message.
+    role_content_sep: str = ""
+    # The separator between the role and empty contents.
+    role_empty_sep: str = ""
+
+    # The stop criteria
+    stop_str: List[str] = Field(default_factory=lambda: [])
+    stop_token_ids: List[int] = Field(default_factory=lambda: [])
+
+    @field_validator("seps")
+    @classmethod
+    def check_message_seps(cls, seps: List[str]) -> List[str]:
+        """Check if the input message separators has size 1 or 2."""
+        if len(seps) == 0 or len(seps) > 2:
+            raise ValueError("seps should have size 1 or 2.")
+        return seps
+
+    def as_prompt(self) -> str:
+        """Convert the conversation template and history messages to
+        a single prompt.
+        """
+        # - Get the system message.
+        system_msg = self.system_template.replace(SYSTEM_MESSAGE_PLACEHOLDER, self.system_message)
+
+        # - Get the message strings.
+        message_list: List[str] = []
+        separators = list(self.seps)
+        if len(separators) == 1:
+            separators.append(separators[0])
+        for role, content in self.messages:  # pylint: disable=not-an-iterable
+            if role not in self.roles:
+                raise ValueError(f'Role "{role}" is not a supported role in {self.roles}')
+            separator = separators[role == self.roles[1]]
+            if content is not None:
+                message_string = role + self.role_content_sep + content + separator
+            else:
+                message_string = role + self.role_empty_sep
+            message_list.append(message_string)
+
+        return system_msg + separators[0] + "".join(message_list)

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -8,8 +8,6 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field
 
-from ..serve.config import GenerationConfig
-
 ################ Commons ################
 
 
@@ -98,14 +96,106 @@ class CompletionResponse(BaseModel):
     )
 
 
-# Right now we only have one request protocol.
-# When we have more protocols, change it to `Union[CompletionRequest, ...]`.
-OpenAIRequestProtocol = CompletionRequest
+################ v1/chat/completions ################
 
 
-def openai_api_get_unsupported_fields(request: OpenAIRequestProtocol) -> List[str]:
+class ChatFunction(BaseModel):
+    description: Optional[str] = None
+    name: str
+    parameters: Dict
+
+
+class ChatFunctionCall(BaseModel):
+    name: str
+    arguments: str
+
+
+class ChatToolCall(BaseModel):
+    id: str
+    type: Literal["function"]
+    function: ChatFunctionCall
+
+
+class ChatCompletionMessage(BaseModel):
+    content: Optional[Union[str, List[Dict[str, str]]]] = None
+    role: Literal["system", "user", "assistant", "tool"]
+    name: Optional[str] = None
+    tool_calls: Optional[List[ChatToolCall]] = None
+    tool_call_id: Optional[str] = None
+
+
+class ChatCompletionRequest(BaseModel):
+    """OpenAI chat completion request protocol.
+    API reference: https://platform.openai.com/docs/api-reference/chat/create
+    """
+
+    messages: List[ChatCompletionMessage]
+    model: str
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    logit_bias: Optional[Dict[str, float]] = None
+    max_tokens: Optional[int] = None
+    n: int = 1
+    response_format: Literal["text", "json_object"] = "text"
+    seed: Optional[int] = None
+    stop: Optional[Union[str, List[str]]] = None
+    stream: bool = False
+    temperature: float = 1.0
+    top_p: float = 1.0
+    tools: Optional[List[ChatFunction]] = None
+    tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None
+    user: Optional[str] = None
+
+
+class ChatCompletionResponseChoice(BaseModel):
+    finish_reason: Optional[Literal["stop", "length", "tool_calls"]] = None
+    index: int = 0
+    message: ChatCompletionMessage
+
+
+class ChatCompletionStreamResponseChoice(BaseModel):
+    finish_reason: Optional[Literal["stop", "length", "tool_calls"]] = None
+    index: int = 0
+    delta: ChatCompletionMessage
+
+
+class ChatCompletionResponse(BaseModel):
+    """OpenAI completion response protocol.
+    API reference: https://platform.openai.com/docs/api-reference/chat/object
+    """
+
+    id: str
+    choices: List[ChatCompletionResponseChoice]
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    system_fingerprint: str
+    object: Literal["chat.completion"] = "chat.completion"
+    usage: UsageInfo = Field(
+        default_factory=lambda: UsageInfo()  # pylint: disable=unnecessary-lambda
+    )
+
+
+class ChatCompletionStreamResponse(BaseModel):
+    """OpenAI completion stream response protocol.
+    API reference: https://platform.openai.com/docs/api-reference/chat/streaming
+    """
+
+    id: str
+    choices: List[ChatCompletionStreamResponseChoice]
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    system_fingerprint: str
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+
+
+################################################
+
+
+def openai_api_get_unsupported_fields(
+    request: Union[CompletionRequest, ChatCompletionRequest]
+) -> List[str]:
     """Get the unsupported fields in the request."""
-    unsupport_field_values: List[Tuple[str, Any]] = [
+    unsupported_field_default_values: List[Tuple[str, Any]] = [
         ("best_of", 1),
         ("frequency_penalty", 0.0),
         ("presence_penalty", 0.0),
@@ -113,25 +203,30 @@ def openai_api_get_unsupported_fields(request: OpenAIRequestProtocol) -> List[st
         ("logprobs", None),
         ("n", 1),
         ("seed", None),
+        ("response_format", "text"),
+        ("tools", None),
+        ("tool_choice", None),
     ]
 
     unsupported_fields: List[str] = []
-    for field, value in unsupport_field_values:
+    for field, value in unsupported_field_default_values:
         if hasattr(request, field) and getattr(request, field) != value:
             unsupported_fields.append(field)
     return unsupported_fields
 
 
-def openai_api_get_generation_config(request: OpenAIRequestProtocol) -> GenerationConfig:
+def openai_api_get_generation_config(
+    request: Union[CompletionRequest, ChatCompletionRequest]
+) -> Dict[str, Any]:
     """Create the generation config from the given request."""
-    kwargs = {}
-    arg_name_mapping = {
-        "temperature": "temperature",
-        "top_p": "top_p",
-        "max_tokens": "max_new_tokens",
-    }
-    for openai_name, mlc_name in arg_name_mapping.items():
-        kwargs[mlc_name] = getattr(request, openai_name)
+    kwargs: Dict[str, Any] = {}
+    arg_names = ["temperature", "top_p", "max_tokens"]
+    for arg_name in arg_names:
+        kwargs[arg_name] = getattr(request, arg_name)
+    if kwargs["max_tokens"] is None:
+        # Setting to -1 means the generation will not stop until
+        # exceeding model capability or hit any stop criteria.
+        kwargs["max_tokens"] = -1
     if request.stop is not None:
         kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
-    return GenerationConfig(**kwargs)
+    return kwargs

--- a/python/mlc_chat/protocol/protocol_utils.py
+++ b/python/mlc_chat/protocol/protocol_utils.py
@@ -1,13 +1,14 @@
 """Utility functions for request protocols"""
 
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
 from ..serve.config import GenerationConfig
 from . import RequestProtocol
+from .openai_api_protocol import ChatCompletionRequest as OpenAIChatCompletionRequest
+from .openai_api_protocol import CompletionRequest as OpenAICompletionRequest
 from .openai_api_protocol import (
-    OpenAIRequestProtocol,
     openai_api_get_generation_config,
     openai_api_get_unsupported_fields,
 )
@@ -25,13 +26,33 @@ def get_unsupported_fields(request: RequestProtocol) -> List[str]:
     """Get the unsupported fields of the request.
     Return the list of unsupported field names.
     """
-    if isinstance(request, OpenAIRequestProtocol):
+    if isinstance(request, (OpenAICompletionRequest, OpenAIChatCompletionRequest)):
         return openai_api_get_unsupported_fields(request)
     raise RuntimeError("Cannot reach here")
 
 
-def get_generation_config(request: RequestProtocol) -> GenerationConfig:
+def get_generation_config(
+    request: RequestProtocol,
+    extra_stop_token_ids: Optional[List[int]] = None,
+    extra_stop_str: Optional[List[str]] = None,
+) -> GenerationConfig:
     """Create the generation config in MLC LLM out from the input request protocol."""
-    if isinstance(request, OpenAIRequestProtocol):
-        return openai_api_get_generation_config(request)
-    raise RuntimeError("Cannot reach here")
+    kwargs: Dict[str, Any]
+    if isinstance(request, (OpenAICompletionRequest, OpenAIChatCompletionRequest)):
+        kwargs = openai_api_get_generation_config(request)
+    else:
+        raise RuntimeError("Cannot reach here")
+
+    if extra_stop_token_ids is not None:
+        stop_token_ids = kwargs.get("stop_token_ids", [])
+        assert isinstance(stop_token_ids, list)
+        stop_token_ids += extra_stop_token_ids
+        kwargs["stop_token_ids"] = stop_token_ids
+
+    if extra_stop_str is not None:
+        stop_strs = kwargs.get("stop_strs", [])
+        assert isinstance(stop_strs, list)
+        stop_strs += extra_stop_str
+        kwargs["stop_strs"] = stop_strs
+
+    return GenerationConfig(**kwargs)

--- a/python/mlc_chat/serve/async_engine.py
+++ b/python/mlc_chat/serve/async_engine.py
@@ -219,7 +219,7 @@ class AsyncRequestTracker:
         return len(self._request_tools) == 0
 
 
-class AsyncEngine:
+class AsyncEngine:  # pylint: disable=too-many-instance-attributes
     """The asynchronous engine for generate text asynchronously.
 
     This class wraps a synchronous engine inside and exports the
@@ -243,6 +243,7 @@ class AsyncEngine:
         self._background_engine = Engine(models, kv_cache_config, self._request_stream_callback)
         self.tokenizer = self._background_engine.tokenizer
         self.max_single_sequence_length = self._background_engine.max_single_sequence_length
+        self.conv_template_name = self._background_engine.conv_template_name
 
         self._request_tracker = AsyncRequestTracker(self.tokenizer)
         self._background_loop_unshielded: Optional[asyncio.Task] = None
@@ -412,7 +413,7 @@ class AsyncEngine:
         self._request_tracker.abort_request(request_id)
 
 
-class AsyncThreadedEngine:
+class AsyncThreadedEngine:  # pylint: disable=too-many-instance-attributes
     """
     The asynchronous engine backed by ThreadedEngine: the only
     difference between AsyncEngine and AsyncThreadedEngine is that
@@ -425,7 +426,12 @@ class AsyncThreadedEngine:
     def __init__(
         self, models: Union[ModelInfo, List[ModelInfo]], kv_cache_config: KVCacheConfig
     ) -> None:
-        model_args, tokenizer_path, self.max_single_sequence_length = _process_model_args(models)
+        (
+            model_args,
+            tokenizer_path,
+            self.max_single_sequence_length,
+            self.conv_template_name,
+        ) = _process_model_args(models)
         self._ffi = _create_tvm_module(
             "mlc.serve.create_threaded_engine",
             ffi_funcs=[

--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -1,7 +1,7 @@
 """Configuration dataclasses used in MLC LLM serving"""
 import json
 from dataclasses import asdict, dataclass, field
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -20,23 +20,25 @@ class GenerationConfig:
     repetition_penalty : float
         The penalty term that applies to logits to control token repetition in generation.
 
-    max_new_tokens : int
-        The maximum number of generated tokens.
+    max_tokens : Optional[int]
+        The maximum number of generated tokens,
+        or None, in which case the generation will not stop
+        until exceeding model capability or hit any stop criteria.
 
     stop_strs : List[str]
         The list of strings that mark the end of generation.
 
-    stop_tokens : List[int]
-        The list of tokens that mark the end of generation.
+    stop_token_ids : List[int]
+        The list of token ids that mark the end of generation.
     """
 
     temperature: float = 0.8
     top_p: float = 0.95
     repetition_penalty: float = 1.0
 
-    max_new_tokens: int = 128
+    max_tokens: Optional[int] = 128
     stop_strs: List[str] = field(default_factory=list)
-    stop_tokens: List[int] = field(default_factory=list)
+    stop_token_ids: List[int] = field(default_factory=list)
 
     def asjson(self) -> str:
         """Return the config in string of JSON format."""

--- a/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
@@ -1,12 +1,18 @@
 """OpenAI API-compatible server entrypoints in MLC LLM"""
 # pylint: disable=too-many-locals,too-many-return-statements
 from http import HTTPStatus
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator, List, Optional
 
 import fastapi
 
 from ...protocol import protocol_utils
 from ...protocol.openai_api_protocol import (
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatCompletionStreamResponse,
+    ChatCompletionStreamResponseChoice,
     CompletionRequest,
     CompletionResponse,
     CompletionResponseChoice,
@@ -19,6 +25,8 @@ from . import entrypoint_utils
 
 app = fastapi.APIRouter()
 
+################ v1/models ################
+
 
 @app.get("/v1/models")
 async def request_models():
@@ -26,6 +34,9 @@ async def request_models():
     API reference: https://platform.openai.com/docs/api-reference/models
     """
     return ListResponse(data=[ModelResponse(id=model) for model in ServerContext.get_model_list()])
+
+
+################ v1/completions ################
 
 
 @app.post("/v1/completions")
@@ -92,6 +103,10 @@ async def request_completion(request: CompletionRequest, raw_request: fastapi.Re
                 prompt, generation_cfg, request_id
             ):
                 num_completion_tokens += num_delta_tokens
+                if delta_text == "":
+                    # Ignore empty delta text -- do not yield.
+                    continue
+
                 response = CompletionResponse(
                     id=request_id,
                     choices=[
@@ -127,7 +142,7 @@ async def request_completion(request: CompletionRequest, raw_request: fastapi.Re
                 )
                 yield f"data: {response.model_dump_json()}\n\n"
 
-            yield "data: [Done]\n\n"
+            yield "data: [DONE]\n\n"
 
         return fastapi.responses.StreamingResponse(
             completion_stream_generator(), media_type="text/event-stream"
@@ -168,3 +183,157 @@ async def request_completion(request: CompletionRequest, raw_request: fastapi.Re
         ),
     )
     return response
+
+
+################ v1/chat/completions ################
+
+
+def chat_completion_check_message_validity(
+    messages: List[ChatCompletionMessage],
+) -> Optional[str]:
+    """Check if the given chat messages are valid. Return error message if invalid."""
+    for i, message in enumerate(messages):
+        if message.role == "system" and i != 0:
+            return f"System prompt at position {i} in the message list is invalid."
+        if message.role == "tool":
+            return "Tool as the message author is not supported yet."
+        if message.tool_call_id is not None:
+            if message.role != "tool":
+                return "Non-tool message having `tool_call_id` is invalid."
+        if isinstance(message.content, list):
+            if message.role != "user":
+                return "Non-user message having a list of content is invalid."
+            return "User message having a list of content is not supported yet."
+        if message.tool_calls is not None:
+            if message.role != "assistant":
+                return "Non-assistant message having `tool_calls` is invalid."
+            return "Assistant message having `tool_calls` is not supported yet."
+    return None
+
+
+@app.post("/v1/chat/completions")
+async def request_chat_completion(request: ChatCompletionRequest, raw_request: fastapi.Request):
+    """OpenAI-compatible chat completion API.
+    API reference: https://platform.openai.com/docs/api-reference/chat
+    """
+    # - Check the requested model.
+    async_engine = ServerContext.get_engine(request.model)
+    if async_engine is None:
+        return entrypoint_utils.create_error_response(
+            HTTPStatus.BAD_REQUEST, message=f'The requested model "{request.model}" is not served.'
+        )
+    # - Check if the model supports chat conversation.
+    conv_template = ServerContext.get_conv_template(request.model)
+    if conv_template is None:
+        return entrypoint_utils.create_error_response(
+            HTTPStatus.BAD_REQUEST,
+            message=f'The requested model "{request.model}" does not support chat.',
+        )
+
+    # - Check if unsupported arguments are specified.
+    error = entrypoint_utils.check_unsupported_fields(request)
+    if error is not None:
+        return error
+
+    # - Process messages and update the conversation template in three steps:
+    #   i. Check the message validity.
+    #  ii. Add the input messages to the conversation template.
+    # iii. Add the additional message for the assistant.
+    error_msg = chat_completion_check_message_validity(request.messages)
+    if error_msg is not None:
+        return entrypoint_utils.create_error_response(HTTPStatus.BAD_REQUEST, message=error_msg)
+    for message in request.messages:
+        role = message.role
+        content = message.content
+        assert isinstance(content, str), "Internal error: content is not a string."
+        if role == "system":
+            conv_template.system_message = content if content is not None else ""
+            continue
+
+        assert role != "tool", "Internal error: tool role."
+        conv_template.messages.append((conv_template.roles[role == "assistant"], content))
+    conv_template.messages.append((conv_template.roles[1], None))
+
+    # - Get the prompt from template, and encode to token ids.
+    # - Check prompt length
+    prompts = entrypoint_utils.process_prompts(
+        conv_template.as_prompt(), async_engine.tokenizer.encode
+    )
+    assert isinstance(prompts, list) and len(prompts) == 1, "Internal error"
+    if conv_template.system_prefix_token_ids is not None:
+        prompts[0] = conv_template.system_prefix_token_ids + prompts[0]
+    error = entrypoint_utils.check_prompts_length(prompts, async_engine.max_single_sequence_length)
+    if error is not None:
+        return error
+    prompt = prompts[0]
+
+    # Process generation config. Create request id.
+    generation_cfg = protocol_utils.get_generation_config(
+        request,
+        extra_stop_token_ids=conv_template.stop_token_ids,
+        extra_stop_str=conv_template.stop_str,
+    )
+    request_id = f"chatcmpl-{entrypoint_utils.random_uuid()}"
+
+    # Streaming response.
+    if request.stream:
+
+        async def completion_stream_generator() -> AsyncGenerator[str, None]:
+            assert request.n == 1
+            async for delta_text, _, finish_reason in async_engine.generate(
+                prompt, generation_cfg, request_id
+            ):
+                if delta_text == "":
+                    # Ignore empty delta text -- do not yield.
+                    continue
+
+                response = ChatCompletionStreamResponse(
+                    id=request_id,
+                    choices=[
+                        ChatCompletionStreamResponseChoice(
+                            finish_reason=finish_reason,
+                            delta=ChatCompletionMessage(content=delta_text, role="assistant"),
+                        )
+                    ],
+                    model=request.model,
+                    system_fingerprint="",
+                )
+                yield f"data: {response.model_dump_json()}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return fastapi.responses.StreamingResponse(
+            completion_stream_generator(), media_type="text/event-stream"
+        )
+
+    # Normal response.
+    output_text = ""
+    num_completion_tokens = 0
+    finish_reason: Optional[str] = None
+    async for delta_text, num_delta_tokens, finish_reason in async_engine.generate(
+        prompt, generation_cfg, request_id
+    ):
+        if await raw_request.is_disconnected():
+            # In non-streaming cases, the engine will not be notified
+            # when the request is disconnected.
+            # Therefore, we check if it is disconnected each time,
+            # and abort the request from engine if so.
+            await async_engine.abort(request_id)
+            return entrypoint_utils.create_error_response(
+                HTTPStatus.BAD_REQUEST, message="The request has disconnected"
+            )
+        output_text += delta_text
+        num_completion_tokens += num_delta_tokens
+    assert finish_reason is not None
+
+    return ChatCompletionResponse(
+        id=request_id,
+        choices=[
+            ChatCompletionResponseChoice(
+                finish_reason=finish_reason,
+                message=ChatCompletionMessage(role="assistant", content=output_text),
+            )
+        ],
+        model=request.model,
+        system_fingerprint="",
+        usage=UsageInfo(prompt_tokens=len(prompt), completion_tokens=num_completion_tokens),
+    )

--- a/python/mlc_chat/serve/server_context.py
+++ b/python/mlc_chat/serve/server_context.py
@@ -1,6 +1,8 @@
 """Server context that shared by multiple entrypoint files."""
 from typing import Dict, List, Optional, Union
 
+from ..conversation_template import ConvTemplateRegistry
+from ..protocol.conversation_protocol import Conversation
 from . import async_engine
 
 EngineClass = Union[async_engine.AsyncEngine, async_engine.AsyncThreadedEngine]
@@ -12,6 +14,7 @@ class ServerContext:
     """
 
     _models: Dict[str, EngineClass] = {}
+    _conv_templates: Dict[str, Conversation] = {}
 
     @staticmethod
     def add_model(hosted_model: str, engine: EngineClass) -> None:
@@ -20,10 +23,24 @@ class ServerContext:
             raise RuntimeError(f"Model {hosted_model} already running.")
         ServerContext._models[hosted_model] = engine
 
+        # Get the conversation template.
+        if engine.conv_template_name is not None:
+            conv_template = ConvTemplateRegistry.get_conv_template(engine.conv_template_name)
+            if conv_template is not None:
+                ServerContext._conv_templates[hosted_model] = conv_template
+
     @staticmethod
     def get_engine(model: str) -> Optional[EngineClass]:
         """Get the async engine of the requested model."""
         return ServerContext._models.get(model, None)
+
+    @staticmethod
+    def get_conv_template(model: str) -> Optional[Conversation]:
+        """Get the conversation template of the requested model."""
+        conv_template = ServerContext._conv_templates.get(model, None)
+        if conv_template is not None:
+            return conv_template.model_copy(deep=True)
+        return None
 
     @staticmethod
     def get_model_list() -> List[str]:

--- a/tests/python/serve/benchmark.py
+++ b/tests/python/serve/benchmark.py
@@ -80,7 +80,7 @@ def sample_requests(
     # Construct generation config.
     prompts = [prompt for prompt, _, _ in sampled_requests]
     generation_config_list = [
-        GenerationConfig(temperature=1.0, top_p=1.0, max_new_tokens=output_len)
+        GenerationConfig(temperature=1.0, top_p=1.0, max_tokens=output_len)
         for _, _, output_len in sampled_requests
     ]
     return prompts, generation_config_list

--- a/tests/python/serve/evaluate_engine.py
+++ b/tests/python/serve/evaluate_engine.py
@@ -33,7 +33,7 @@ def generate_requests(
             token_ids.append(random.randint(0, 30000))
         prompt_ids.append(token_ids)
     generation_config_list = [
-        GenerationConfig(temperature=1.0, top_p=1.0, max_new_tokens=output_length)
+        GenerationConfig(temperature=1.0, top_p=1.0, max_tokens=output_length)
     ] * num_requests
     return prompt_ids, generation_config_list
 

--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -29,8 +29,8 @@ async def test_engine_generate(async_engine_cls: Type[Union[AsyncEngine, AsyncTh
     async_engine = async_engine_cls(model, kv_cache_config)
 
     num_requests = 10
-    max_new_tokens = 256
-    generation_cfg = GenerationConfig(max_new_tokens=max_new_tokens)
+    max_tokens = 256
+    generation_cfg = GenerationConfig(max_tokens=max_tokens)
 
     outputs: List[str] = ["" for _ in range(num_requests)]
 


### PR DESCRIPTION
This PR supports the `v1/chat/completions` entrypoint of OpenAI API:
* protocol: `python/mlc_chat/protocol/openai_api_protocol.py`,
* entrypoint: `python/mlc_chat/serve/entrypoints/openai_entrypoints.py`

To support the chat functionality, this PR introduces the conversation template definition and register on Python side in `python/mlc_chat/serve/conversation.py`.
Compared with the current implementation of conversation template in C++, this version supports overriding the content of the system prompt without changing formatting texts (like the `[INST]` string in Llama2).

This PR adds a series of tests:
* temperature test for `v1/completions`,
* three different history message tests for `v1/chat/completions`,
* `max_tokens` test for `v1/chat/completions`,
* "wrong system prompt" position test for `v1/chat/completions`,
* the `openai` package test for both `v1/completions` and `v1/chat/completions`.