### PR TITLE
Final Token for finish_reason

### DIFF
--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -680,6 +680,7 @@ class ChatModule:  # pylint: disable=too-many-instance-attributes
         self._reset_chat_func = chat_mod["reset_chat"]
         self._load_json_override_func = chat_mod["load_json_override"]
         self._stopped_func = chat_mod["stopped"]
+        self._final_token_func = chat_mod["final_token"]
         self._get_message_func = chat_mod["get_message"]
         self._runtime_stats_text_func = chat_mod["runtime_stats_text"]
         self._verbose_runtime_stats_text_func = chat_mod["verbose_runtime_stats_text"]
@@ -1068,6 +1069,15 @@ class ChatModule:  # pylint: disable=too-many-instance-attributes
         stopped : bool
         """
         return self._stopped_func() != 0
+    
+    def final_token(self):
+        r"""Returns the final token
+
+        Returns
+        -------
+        final_token : int
+        """
+        return self._final_token_func()
 
     def _get_message(self) -> str:
         r"""Get the output message in the current round.


### PR DESCRIPTION
This PR adds the support to return the final token of generation for the users to figure out the finish_reason, like in the openai [response](https://platform.openai.com/docs/guides/text-generation/chat-completions-response-format)

The final token can let the user know if the generation stopped due to stop_token, length etc.,

@junrushao, I envision this is to be the start point of verbose generation for python (basically generation response having all the additional information that openai serves). For now I've added it a final_token function. 

Please guide if you have ideas to make this generic.

Or we could just have a flag to include final token in the output as well, which is probably simpler.  Please suggest on how to go about this.

cc: @tqchen