### PR TITLE
[iOS] OpenHermes-2.5-Mistral-7B support

### DIFF
--- a/ios/MLCChat/app-config.json
+++ b/ios/MLCChat/app-config.json
@@ -6,22 +6,38 @@
   ],
   "model_list": [
     {
-      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
-      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-OpenHermes-2.5-Mistral-7B-q3f16_1/",
+      "local_id": "OpenHermes-2.5-Mistral-7B-q3f16_1"
+    },
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Mistral-7B-Instruct-v0.1-q3f16_1/",
+      "local_id": "Mistral-7B-Instruct-v0.1-q3f16_1"
     },
     {
       "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1/",
       "local_id": "Llama-2-7b-chat-hf-q3f16_1"
+    },
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
     }
   ],
   "add_model_samples": [
     {
-      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
-      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-OpenHermes-2.5-Mistral-7B-q3f16_1/",
+      "local_id": "OpenHermes-2.5-Mistral-7B-q3f16_1"
+    },
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Mistral-7B-Instruct-v0.1-q3f16_1/",
+      "local_id": "Mistral-7B-Instruct-v0.1-q3f16_1"
     },
     {
       "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1/",
       "local_id": "Llama-2-7b-chat-hf-q3f16_1"
+    },
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
     }
   ]
 }

--- a/ios/prepare_params.sh
+++ b/ios/prepare_params.sh
@@ -6,7 +6,8 @@ rm -rf dist
 mkdir -p dist
 
 declare -a builtin_list=(
-	"Mistral-7B-Instruct-v0.1-q3f16_1"
+	"OpenHermes-2.5-Mistral-7B-q3f16_1"
+	# "Mistral-7B-Instruct-v0.1-q3f16_1"
 	# "Llama-2-7b-chat-hf-q3f16_1"
 	# "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
 	# "vicuna-v1-7b-q3f16_0"


### PR DESCRIPTION
note: OpenHermes-2.5-Mistral-7B is able to leverage the mistral_q3f16_1 lib

decoding: 6.0 tok/s (iphone 14 pro max)

<img src="https://github.com/mlc-ai/mlc-llm/assets/61968959/359b141b-1a13-4c74-a238-e6453e1201af" width="300"/>
