### PR TITLE
 Add Attention Sinks (MLC Chat portion)

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -243,6 +243,8 @@ struct FunctionTable {
       support_backtracking_kv_ = false;
     }
     this->fkvcache_array_popn_ = get_global_func("vm.builtin.attention_kv_cache_array_popn");
+    this->kv_evict_with_sinks_ =
+        get_global_func("vm.builtin.attention_kv_cache_maybe_evict_with_sinks");
   }
 
   ObjectRef Empty(ShapeTuple shape, DataType dtype, Device device) const {
@@ -283,6 +285,7 @@ struct FunctionTable {
   PackedFunc softmax_func_;
   PackedFunc create_kv_cache_func_;
   PackedFunc reset_kv_cache_func_;
+  PackedFunc kv_evict_with_sinks_;
   bool support_backtracking_kv_;
   PackedFunc fkvcache_array_popn_;
   ModelMetadata model_metadata_;
@@ -352,6 +355,16 @@ class LLMChat {
     if (metadata.count("sliding_window")) {
       ICHECK(metadata["sliding_window"].is<int64_t>());
       sliding_window_ = std::min(sliding_window_, metadata["sliding_window"].get<int64_t>());
+    }
+    if (metadata.count("num_attention_sinks")) {
+      ICHECK(metadata["num_attention_sinks"].is<int64_t>());
+      num_attention_sinks_ =
+          std::min(num_attention_sinks_, metadata["num_attention_sinks"].get<int64_t>());
+      if (metadata.count("attention_sink_cache_size")) {
+        ICHECK(metadata["attention_sink_cache_size"].is<int64_t>());
+        attention_sink_cache_size_ = std::min(attention_sink_cache_size_,
+                                              metadata["attention_sink_cache_size"].get<int64_t>());
+      }
     }
   }
 
@@ -430,6 +443,15 @@ class LLMChat {
           << "Sliding window size needs to be -1 or positive";
       CHECK(config.count("prefill_chunk_size"))
           << "Need to specify chunk size if using sliding window attention.";
+    }
+    if (config.count("num_attention_sinks")) {
+      CHECK(config["num_attention_sinks"].is<int64_t>());
+      this->num_attention_sinks_ = config["num_attention_sinks"].get<int64_t>();
+      CHECK(this->num_attention_sinks_ > 0);
+      if (config.count("attention_sink_cache_size")) {
+        CHECK(config["attention_sink_cache_size"].is<int64_t>());
+        this->attention_sink_cache_size_ = config["attention_sink_cache_size"].get<int64_t>();
+      }
     }
     if (config.count("prefill_chunk_size")) {
       CHECK(config["prefill_chunk_size"].is<int64_t>());
@@ -624,6 +646,25 @@ class LLMChat {
     std::string all_prompt = GetConcatPrompt(prompts, 0, 0);
     std::vector<int32_t> encoded = this->tokenizer_->Encode(all_prompt);
     tokens.insert(tokens.end(), encoded.begin(), encoded.end());
+
+    if (this->num_attention_sinks_ > 0) {
+      // Trim the cache if it exceeds `attention_sink_cache_size_` (or `max_window_size_`, if that's
+      // not set). We trim it arbitrarily to 1/2 the threshold, so that the trimming logic doesn't
+      // run too frequently.
+      int64_t trim_threshold = this->attention_sink_cache_size_ > 0
+                                   ? this->attention_sink_cache_size_
+                                   : this->max_window_size_;
+      if (this->total_seq_len_ > trim_threshold) {
+        this->total_seq_len_ = this->EvictWithSinks(
+            // If there's a system command, keep the full system command.
+            std::max(trim_threshold / 2, this->system_prompt_len_),
+            this->system_prompt_len_ > 0 ? this->system_prompt_len_ : this->num_attention_sinks_);
+      }
+      // TODO: The current logic may result in caching more than `max_window_size_` tokens. Perhaps
+      // reuse the code below to not allow that to happen.
+      return tokens;
+    }
+
     if (this->sliding_window_ != -1 ||  // There is no max window size if we use sliding window
         this->total_seq_len_ + tokens.size() + gen_mean_gen_len < this->max_window_size_) {
       return tokens;
@@ -1331,8 +1372,15 @@ class LLMChat {
   // Clear kv cache
   void ResetKVCache() { ft_.reset_kv_cache_func_(kv_cache_); }
 
+  int64_t EvictWithSinks(int64_t desired_cache_size, int32_t num_attention_sinks) {
+    return ft_.kv_evict_with_sinks_(kv_cache_, desired_cache_size, num_attention_sinks);
+  }
+
   void ProcessSystemPrompts() {
+    ICHECK_EQ(this->total_seq_len_, 0) << "Processing system prompt, should have no tokens prior.";
     this->PrefillStep(/*inp=*/"", /*append_conversation=*/false, /*decode_next_token=*/false);
+    this->system_prompt_len_ = this->total_seq_len_;
+    LOG(INFO) << "Sys prompt len:" << this->system_prompt_len_;
   }
 
   // Utils
@@ -1369,10 +1417,13 @@ class LLMChat {
   Conversation conversation_;
   // total sequence len,
   int64_t total_seq_len_{0};
+  // length of the system prompt.
+  int64_t system_prompt_len_{0};
   // max window size, mean and max generation length, sliding window
   // If we use sliding window, max window size is its default max() value
   int64_t max_window_size_{std::numeric_limits<int64_t>::max()}, mean_gen_len_{128},
-      max_gen_len_{512}, sliding_window_{-1}, prefill_chunk_size_{-1};
+      max_gen_len_{512}, sliding_window_{-1}, prefill_chunk_size_{-1}, num_attention_sinks_{0},
+      attention_sink_cache_size_{0};
   // size of the vocab table
   int64_t vocab_size_;
   // number of shards in distributed inference

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -113,6 +113,13 @@ class BuildArgs:
         The chunk size during prefilling. By default, the chunk size is the same as
         max sequence length. Currently only useful when compiling Mistral.
 
+    num_attention_sinks: int
+        Number of Attention Sinks to use (https://arxiv.org/abs/2309.17453). 0 means disabled.
+
+    attention_sink_cache_size: int
+        When attention sinks is enabled, start trimming cache when it reaches this size.
+        By default, we will use max_window_size.
+
     cc_path: str
         ``/path/to/cross_compiler_path``; currently only used for cross-compile
         for nvidia/jetson device.
@@ -358,6 +365,23 @@ class BuildArgs:
                 "The chunk size during prefilling. By default, the chunk size is "
                 "the same as the sliding window size or the max sequence length. "
                 "Currently only useful when compiling Mistral."
+            ),
+        },
+    )
+    num_attention_sinks: int = field(
+        default=0,
+        metadata={
+            "help": (
+                "The number of Attention Sinks to use in cache. 0 means disabled."
+            ),
+        },
+    )
+    attention_sink_cache_size: int = field(
+        default=0,
+        metadata={
+            "help": (
+                "When attention sinks is enabled, start trimming cache when it reaches this size. "
+                "By default, we will use max_window_size."
             ),
         },
     )
@@ -701,6 +725,9 @@ def dump_mlc_chat_config(
         config["sliding_window"] = args.sliding_window
     else:
         config["max_window_size"] = max_window_size
+    if args.num_attention_sinks > 0:
+        config["num_attention_sinks"] = args.num_attention_sinks
+        config["attention_sink_cache_size"] = args.attention_sink_cache_size
 
     args.chat_config_path = os.path.join(args.params_path, "mlc-chat-config.json")
     with open(args.chat_config_path, "w", encoding="utf-8") as outfile:

--- a/mlc_llm/relax_model/stablelm_3b.py
+++ b/mlc_llm/relax_model/stablelm_3b.py
@@ -17,11 +17,6 @@ from .modules import ModuleList, RotaryEmbedding
 from .param_manager import ParamManager
 
 
-import tvm
-
-tvm.relax.expr
-
-
 @dataclass
 class StableLM3bConfig:
     def __init__(

--- a/mlc_llm/relax_model/stablelm_3b.py
+++ b/mlc_llm/relax_model/stablelm_3b.py
@@ -17,6 +17,11 @@ from .modules import ModuleList, RotaryEmbedding
 from .param_manager import ParamManager
 
 
+import tvm
+
+tvm.relax.expr
+
+
 @dataclass
 class StableLM3bConfig:
     def __init__(
@@ -36,6 +41,7 @@ class StableLM3bConfig:
         bos_token_id=0,
         eos_token_id=1,
         tie_word_embeddings=False,
+        num_attention_sinks=0,
         position_embedding_base=10000,
         combine_matmul=True,
         num_shards=1,
@@ -58,6 +64,7 @@ class StableLM3bConfig:
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.tie_word_embeddings = tie_word_embeddings
+        self.num_attention_sinks = num_attention_sinks
         self.position_embedding_base = position_embedding_base
         self.combine_matmul = combine_matmul
         if build_model_only and num_shards > 1:
@@ -152,6 +159,7 @@ class StableLM3bAttention(nn.Module):
         self.head_dim = self.hidden_size // config.num_attention_heads
         self.position_embedding_base = config.position_embedding_base
         self.rotary_embedding = rotary_embedding
+        self.num_attention_sinks = config.num_attention_sinks
 
         self.combine_matmul = config.combine_matmul
         if self.combine_matmul:
@@ -199,6 +207,7 @@ class StableLM3bAttention(nn.Module):
     ) -> Tuple[relax.Expr, Optional[relax.Expr], Optional[Tuple[relax.Expr]]]:
         from tvm.relax.op import (
             astype,
+            expand_dims,
             matmul,
             maximum,
             permute_dims,
@@ -251,53 +260,109 @@ class StableLM3bAttention(nn.Module):
 
         kv_seq_len = all_seq_len_shape.struct_info.values[0]
         offset = kv_seq_len - q_len
-        query_states, key_states = self.rotary_embedding(query_states, key_states, offset)
-        # [bsz, t, nh, hd]
+        if self.num_attention_sinks == 0:
+            query_states, key_states = self.rotary_embedding(query_states, key_states, offset)
+            # [bsz, t, nh, hd]
 
-        kv_states_shape = key_states.struct_info.shape
-        kv_states_dtype = key_states.struct_info.dtype
-        assert kv_states_shape[0] == 1  # bsz
-        kv_states_shape = R.shape(
-            [kv_states_shape[0], kv_seq_len, kv_states_shape[2], kv_states_shape[3]]
-        )
-        kv_cache_shape = R.shape([kv_seq_len, kv_states_shape[2], kv_states_shape[3]])
+            kv_states_shape = key_states.struct_info.shape
+            kv_states_dtype = key_states.struct_info.dtype
+            assert kv_states_shape[0] == 1  # bsz
+            kv_states_shape = R.shape(
+                [kv_states_shape[0], kv_seq_len, kv_states_shape[2], kv_states_shape[3]]
+            )
+            kv_cache_shape = R.shape([kv_seq_len, kv_states_shape[2], kv_states_shape[3]])
 
-        squeezed_key = nn.emit(squeeze(key_states, axis=0))
-        squeezed_value = nn.emit(squeeze(value_states, axis=0))
-        k_cache, v_cache = past_key_value
-        f_kv_cache_append = relax.extern("vm.builtin.attention_kv_cache_append")
-        k_cache = nn.emit(
-            relax.Call(
-                f_kv_cache_append,
-                args=[k_cache, squeezed_key],
-                sinfo_args=[relax.ObjectStructInfo()],
+            squeezed_key = nn.emit(squeeze(key_states, axis=0))
+            squeezed_value = nn.emit(squeeze(value_states, axis=0))
+            k_cache, v_cache = past_key_value
+            f_kv_cache_append = relax.extern("vm.builtin.attention_kv_cache_append")
+            k_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_append,
+                    args=[k_cache, squeezed_key],
+                    sinfo_args=[relax.ObjectStructInfo()],
+                )
             )
-        )
-        v_cache = nn.emit(
-            relax.Call(
-                f_kv_cache_append,
-                args=[v_cache, squeezed_value],
-                sinfo_args=[relax.ObjectStructInfo()],
+            v_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_append,
+                    args=[v_cache, squeezed_value],
+                    sinfo_args=[relax.ObjectStructInfo()],
+                )
             )
-        )
-        past_key_value = (k_cache, v_cache)
-        f_kv_cache_view = relax.extern("vm.builtin.attention_kv_cache_view")
-        k_cache = nn.emit(
-            relax.Call(
-                f_kv_cache_view,
-                args=[k_cache, kv_cache_shape],
-                sinfo_args=[R.Tensor(kv_cache_shape, kv_states_dtype)],
+            past_key_value = (k_cache, v_cache)
+            f_kv_cache_view = relax.extern("vm.builtin.attention_kv_cache_view")
+            k_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_view,
+                    args=[k_cache, kv_cache_shape],
+                    sinfo_args=[R.Tensor(kv_cache_shape, kv_states_dtype)],
+                )
             )
-        )
-        v_cache = nn.emit(
-            relax.Call(
-                f_kv_cache_view,
-                args=[v_cache, kv_cache_shape],
-                sinfo_args=[R.Tensor(kv_cache_shape, kv_states_dtype)],
+            v_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_view,
+                    args=[v_cache, kv_cache_shape],
+                    sinfo_args=[R.Tensor(kv_cache_shape, kv_states_dtype)],
+                )
             )
-        )
-        key_states = nn.emit(reshape(k_cache, kv_states_shape))
-        value_states = nn.emit(reshape(v_cache, kv_states_shape))
+            key_states = nn.emit(reshape(k_cache, kv_states_shape))
+            value_states = nn.emit(reshape(v_cache, kv_states_shape))
+        else:
+            # Main difference is to rotate keys *after* updating cache. Section 3.2 of the Attention
+            # Sinks paper (https://arxiv.org/pdf/2309.17453.pdf) explains the need to use positional
+            # information *within the cache*, versus *in the original text*.
+            query_states = self.rotary_embedding.rotate_tensor(query_states, offset)
+
+            kv_states_shape = key_states.struct_info.shape
+            kv_states_dtype = key_states.struct_info.dtype
+            assert kv_states_shape[0] == 1  # bsz
+            kv_states_shape = R.shape(
+                [kv_states_shape[0], kv_seq_len, kv_states_shape[2], kv_states_shape[3]]
+            )
+            kv_cache_shape = R.shape([kv_seq_len, kv_states_shape[2], kv_states_shape[3]])
+
+            squeezed_key = nn.emit(squeeze(key_states, axis=0))
+            squeezed_value = nn.emit(squeeze(value_states, axis=0))
+            k_cache, v_cache = past_key_value
+            f_kv_cache_append = relax.extern("vm.builtin.attention_kv_cache_append")
+            k_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_append,
+                    args=[k_cache, squeezed_key],
+                    sinfo_args=[relax.ObjectStructInfo()],
+                )
+            )
+            v_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_append,
+                    args=[v_cache, squeezed_value],
+                    sinfo_args=[relax.ObjectStructInfo()],
+                )
+            )
+            past_key_value = (k_cache, v_cache)
+
+            f_kv_cache_view = relax.extern("vm.builtin.attention_kv_cache_view")
+            k_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_view,
+                    args=[k_cache, kv_cache_shape],
+                    sinfo_args=[R.Tensor(kv_cache_shape, kv_states_dtype)],
+                )
+            )
+            k_cache = nn.emit(expand_dims(k_cache, 0))
+            key_states = self.rotary_embedding.rotate_tensor(
+                k_cache, tvm.tir.expr.IntImm("int64", 0)
+            )
+            v_cache = nn.emit(
+                relax.Call(
+                    f_kv_cache_view,
+                    args=[v_cache, kv_cache_shape],
+                    sinfo_args=[R.Tensor(kv_cache_shape, kv_states_dtype)],
+                )
+            )
+            value_states = nn.emit(reshape(v_cache, kv_states_shape))
+
         if self.num_key_value_heads != self.num_query_heads:
             n_rep = self.num_query_heads // self.num_key_value_heads
             key_states = nn.emit(relax.op.repeat(key_states, n_rep, axis=2))
@@ -791,6 +856,7 @@ def get_model(args, hf_config):
         num_shards=args.num_shards,
         build_model_only=args.build_model_only,
         convert_weights_only=args.convert_weights_only,
+        num_attention_sinks=args.num_attention_sinks,
     )
     if max_seq_len != -1:
         config.max_sequence_length = max_seq_len


### PR DESCRIPTION
The MLC Chat component to implementing Attention Sinks (https://arxiv.org/abs/2309.17453), with stablelm example of how cache append needs to be modified. See https://github.com/mlc-ai/mlc-llm/issues/1357

This change takes the approach of trimming the cache aggressively but infrequently (as opposed to trimming after every append), and tries to keep the full system command if it's used.