### PR TITLE
[Serving] Introducing EventTraceRecorder

### DIFF
--- a/cpp/serve/engine.h
+++ b/cpp/serve/engine.h
@@ -9,6 +9,7 @@
 #include <tvm/runtime/packed_func.h>
 
 #include "data.h"
+#include "event_trace_recorder.h"
 #include "request.h"
 
 namespace mlc {
@@ -54,6 +55,7 @@ class Engine {
    * \param kv_cache_config_json_str The KV cache config in JSON string.
    * \param request_stream_callback The request stream callback function to
    * stream back generated output for requests.
+   * \param trace_recorder Event trace recorder for requests.
    * \param model_infos The model info tuples. Each tuple contains
    * - the model library, which might be a path to the binary file or
    * an executable module that is pre-loaded,
@@ -64,6 +66,7 @@ class Engine {
   static std::unique_ptr<Engine> Create(
       int max_single_sequence_length, const String& tokenizer_path,
       const String& kv_cache_config_json_str, Optional<PackedFunc> request_stream_callback,
+      Optional<EventTraceRecorder> trace_recorder,
       const std::vector<std::tuple<TVMArgValue, String, DLDevice>>& model_infos);
 
   /*! \brief Reset the engine, clean up all running data and statistics. */

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -9,6 +9,7 @@
 
 #include "../config.h"
 #include "../engine_state.h"
+#include "../event_trace_recorder.h"
 #include "../model.h"
 #include "../sampler.h"
 
@@ -56,11 +57,13 @@ class EngineAction : public ObjectRef {
    * \param kv_cache_config The KV cache config to help decide prefill is doable.
    * \param max_single_sequence_length The max single sequence length to help
    * decide if prefill is doable.
+   * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction NewRequestPrefill(Array<Model> models, Sampler sampler,
                                         KVCacheConfig kv_cache_config,
-                                        int max_single_sequence_length);
+                                        int max_single_sequence_length,
+                                        Optional<EventTraceRecorder> trace_recorder);
   /*!
    * \brief Create the action that runs one-step decode for requests in the
    * `running_queue` of engine state. Preempt low-priority requests
@@ -71,9 +74,11 @@ class EngineAction : public ObjectRef {
    * \param models The model to run decode in. When there are multiple
    * models, the `Step` function of the created action will not take effect.
    * \param sampler The sampler to sample new tokens.
+   * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
-  static EngineAction BatchDecode(Array<Model> models, Sampler sampler);
+  static EngineAction BatchDecode(Array<Model> models, Sampler sampler,
+                                  Optional<EventTraceRecorder> trace_recorder);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(EngineAction, ObjectRef, EngineActionObj);
 };

--- a/cpp/serve/event_trace_recorder.cc
+++ b/cpp/serve/event_trace_recorder.cc
@@ -1,0 +1,163 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/event_trace_recorder.cc
+ */
+#define PICOJSON_USE_INT64
+
+#include "event_trace_recorder.h"
+
+#include <picojson.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+
+#include <algorithm>
+#include <chrono>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+namespace detail {
+
+struct PairHash {
+  template <class T1, class T2>
+  std::size_t operator()(const std::pair<T1, T2>& p) const {
+    auto h1 = std::hash<T1>{}(p.first);
+    auto h2 = std::hash<T2>{}(p.second);
+    return h1 ^ h2;
+  }
+};
+
+}  // namespace detail
+
+TVM_REGISTER_OBJECT_TYPE(EventTraceRecorderObj);
+
+/*! \brief The implementation of event trace recorder. */
+class EventTraceRecorderImpl : public EventTraceRecorderObj {
+ public:
+  void AddEvent(const String& request_id, const std::string& event) final {
+    double event_time = std::chrono::duration_cast<std::chrono::duration<double>>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      AddEventInternal(request_id, event, event_time);
+    }
+  }
+
+  void AddEvent(const Array<String>& request_ids, const std::string& event) final {
+    double event_time = std::chrono::duration_cast<std::chrono::duration<double>>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      for (const String& request_id : request_ids) {
+        AddEventInternal(request_id, event, event_time);
+      }
+    }
+  }
+
+  std::string DumpJSON() final {
+    std::unordered_map<std::string, std::vector<std::pair<std::string, double>>> local_events;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      local_events = events_;
+    }
+
+    auto fcmp_events = [](const std::pair<int64_t, picojson::value>& lhs,
+                          const std::pair<int64_t, picojson::value>& rhs) {
+      return lhs.first < rhs.first;
+    };
+
+    picojson::array event_array;
+    for (const std::string& request_id : request_id_in_order_) {
+      std::vector<std::pair<std::string, double>> event_pairs = local_events.at(request_id);
+      std::vector<std::pair<int64_t, picojson::value>> events_to_sort;
+      events_to_sort.reserve(event_pairs.size());
+      for (int i = 0; i < static_cast<int>(event_pairs.size()); ++i) {
+        std::string event = event_pairs[i].first;
+        double event_time = event_pairs[i].second;
+        std::string name;
+        std::string phase;
+        if (event.compare(0, 6, "start ") == 0) {
+          // Duration begin.
+          name = event.substr(6);
+          phase = "B";
+        } else if (event.compare(0, 7, "finish ") == 0) {
+          // Duration end.
+          name = event.substr(7);
+          phase = "E";
+        } else {
+          // Instant event.
+          name = event;
+          phase = "i";
+        }
+        int64_t event_time_in_ms = static_cast<int64_t>(event_time * 1e6);
+
+        picojson::object event_json;
+        event_json["name"] = picojson::value(name);
+        event_json["ph"] = picojson::value(phase);
+        event_json["ts"] = picojson::value(event_time_in_ms);
+        event_json["pid"] = picojson::value(static_cast<int64_t>(1));
+        event_json["tid"] = picojson::value(request_id);
+
+        events_to_sort.push_back({event_time_in_ms, picojson::value(event_json)});
+      }
+      std::sort(events_to_sort.begin(), events_to_sort.end(), fcmp_events);
+      for (auto [timestamp, event] : events_to_sort) {
+        event_array.push_back(std::move(event));
+      }
+    }
+    return picojson::value(event_array).serialize();
+  }
+
+  TVM_DECLARE_BASE_OBJECT_INFO(EventTraceRecorderImpl, EventTraceRecorderObj);
+
+ private:
+  /*! \brief The internal impl of AddEvent, taking the event time as input. */
+  void AddEventInternal(const std::string& request_id, const std::string& event,
+                        double event_time) {
+    if (std::find(request_id_in_order_.begin(), request_id_in_order_.end(), request_id) ==
+        request_id_in_order_.end()) {
+      request_id_in_order_.push_back(request_id);
+    }
+    int event_cnt = event_counter_[{request_id, event}]++;
+    events_[request_id].push_back({event + " (" + std::to_string(event_cnt) + ")", event_time});
+  }
+
+  /*! \brief The mutex ensuring only one thread can access critical regions. */
+  std::mutex mutex_;
+
+  /************** Critical Regions **************/
+  /*! \brief The request ids in time order. Each id only appears once. */
+  std::vector<std::string> request_id_in_order_;
+  /*! \brief The number of a certain event for a request. */
+  std::unordered_map<std::pair<std::string, std::string>, int, detail::PairHash> event_counter_;
+  /*! \brief The event list of each request together with the timestamps. */
+  std::unordered_map<std::string, std::vector<std::pair<std::string, double>>> events_;
+};
+
+EventTraceRecorder EventTraceRecorder::Create() {
+  return EventTraceRecorder(make_object<EventTraceRecorderImpl>());
+}
+
+TVM_REGISTER_GLOBAL("mlc.serve.EventTraceRecorder").set_body_typed([]() {
+  return EventTraceRecorder::Create();
+});
+
+TVM_REGISTER_GLOBAL("mlc.serve.EventTraceRecorderAddEvent")
+    .set_body_typed([](const EventTraceRecorder& trace_recorder, const String& request_id,
+                       const std::string& event) { trace_recorder->AddEvent(request_id, event); });
+
+TVM_REGISTER_GLOBAL("mlc.serve.EventTraceRecorderDumpJSON")
+    .set_body_method<EventTraceRecorder>(&EventTraceRecorderObj::DumpJSON);
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/event_trace_recorder.h
+++ b/cpp/serve/event_trace_recorder.h
@@ -1,0 +1,73 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/event_trace_recorder.h
+ * \brief The event trace recorder for requests in MLC LLM.
+ */
+#ifndef MLC_LLM_SERVE_EVENT_TRACE_RECORDER_H_
+#define MLC_LLM_SERVE_EVENT_TRACE_RECORDER_H_
+
+#include <tvm/runtime/container/array.h>
+#include <tvm/runtime/container/string.h>
+#include <tvm/runtime/object.h>
+
+#include <string>
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/*! \brief The event trace recorder for requests. */
+class EventTraceRecorderObj : public Object {
+ public:
+  /*!
+   * \brief Record a event for the the input request in the trace recorder.
+   * \param request_id The subject request of the event.
+   * \param event The event in a string name.
+   * It can have one of the following patterns:
+   * - "start xxx", which marks the start of event "xxx",
+   * - "finish xxx", which marks the finish of event "xxx",
+   * - "yyy", which marks the instant event "yyy".
+   * The "starts" and "finishes" will be automatically paired in the trace recorder.
+   */
+  virtual void AddEvent(const String& request_id, const std::string& event) = 0;
+
+  /*! \brief Record a event for the list of input requests. */
+  virtual void AddEvent(const Array<String>& request_ids, const std::string& event) = 0;
+
+  /*! \brief Dump the logged events in Chrome Trace Event Format in JSON string. */
+  virtual std::string DumpJSON() = 0;
+
+  static constexpr const char* _type_key = "mlc.serve.EventTraceRecorder";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(EventTraceRecorderObj, Object);
+};
+
+/*!
+ * \brief Managed reference to EventTraceRecorderObj.
+ * \sa EventTraceRecorderObj
+ */
+class EventTraceRecorder : public ObjectRef {
+ public:
+  /*! \brief Create an event trace recorder. */
+  static EventTraceRecorder Create();
+
+  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(EventTraceRecorder, ObjectRef,
+                                                    EventTraceRecorderObj);
+};
+
+/****************** Helper macro ******************/
+
+/*! \brief Record a event for the input request or list or requests. */
+#define RECORD_EVENT(trace_recorder, request_ids, event)  \
+  if (trace_recorder.defined()) {                         \
+    trace_recorder.value()->AddEvent(request_ids, event); \
+  }
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_EVENT_TRACE_RECORDER_H_

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -226,6 +226,7 @@ class ModelImpl : public ModelObj {
     } else {
       logits = Downcast<Array<NDArray>>(ret)[0];
     }
+    TVMSynchronize(device_.device_type, device_.device_id, nullptr);
     ICHECK_EQ(logits->ndim, 3);
     ICHECK_EQ(logits->shape[0], 1);
     ICHECK_EQ(logits->shape[1], num_sequences);
@@ -264,6 +265,7 @@ class ModelImpl : public ModelObj {
     } else {
       logits = Downcast<Array<NDArray>>(ret)[0];
     }
+    TVMSynchronize(device_.device_type, device_.device_id, nullptr);
     // logits: (b, 1, v)
     ICHECK_EQ(logits->ndim, 3);
     ICHECK_EQ(logits->shape[0], embeddings->shape[0]);

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -13,8 +13,9 @@ namespace serve {
 
 TVM_REGISTER_OBJECT_TYPE(RequestModelStateNode);
 
-RequestModelState::RequestModelState(int model_id, Array<Data> inputs) {
+RequestModelState::RequestModelState(Request request, int model_id, Array<Data> inputs) {
   ObjectPtr<RequestModelStateNode> n = make_object<RequestModelStateNode>();
+  n->request = std::move(request);
   n->model_id = model_id;
   n->request_id = -1;
   n->inputs = std::move(inputs);
@@ -36,7 +37,7 @@ RequestState::RequestState(Request request, int num_models) {
   Array<RequestModelState> mstates;
   mstates.reserve(num_models);
   for (int i = 0; i < num_models; ++i) {
-    mstates.push_back(RequestModelState(i, request->inputs));
+    mstates.push_back(RequestModelState(request, i, request->inputs));
   }
   n->request = std::move(request);
   n->mstates = std::move(mstates);

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -29,6 +29,8 @@ using namespace tvm::runtime;
  */
 class RequestModelStateNode : public Object {
  public:
+  /*! \brief The request that this state corresponds to. */
+  Request request;
   /*!
    * \brief The internal request id of this state.
    * It is the **physical index** of the request in the running request queue.
@@ -84,7 +86,7 @@ class RequestModelStateNode : public Object {
 
 class RequestModelState : public ObjectRef {
  public:
-  explicit RequestModelState(int model_id, Array<Data> inputs);
+  explicit RequestModelState(Request request, int model_id, Array<Data> inputs);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(RequestModelState, ObjectRef, RequestModelStateNode);
 };

--- a/cpp/serve/sampler.h
+++ b/cpp/serve/sampler.h
@@ -11,6 +11,7 @@
 #include <tvm/runtime/module.h>
 
 #include "../base.h"
+#include "event_trace_recorder.h"
 #include "model.h"
 #include "request_state.h"
 
@@ -55,9 +56,11 @@ class Sampler : public ObjectRef {
   /*!
    * \brief Create the runtime sampler module.
    * \param sampler_kind The sampler name denoting which sampler to create.
+   * \param trace_recorder The event trace recorder for requests.
    * \return The created runtime module.
    */
-  TVM_DLL static Sampler Create(std::string sampler_kind);
+  TVM_DLL static Sampler Create(std::string sampler_kind,
+                                Optional<EventTraceRecorder> trace_recorder);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Sampler, ObjectRef, SamplerObj);
 };

--- a/python/mlc_chat/serve/entrypoints/__init__.py
+++ b/python/mlc_chat/serve/entrypoints/__init__.py
@@ -1,2 +1,2 @@
 """The entrypoints for MLC LLM server."""
-from . import openai_entrypoints
+from . import debug_entrypoints, openai_entrypoints

--- a/python/mlc_chat/serve/entrypoints/debug_entrypoints.py
+++ b/python/mlc_chat/serve/entrypoints/debug_entrypoints.py
@@ -1,0 +1,48 @@
+"""MLC LLM server debug entrypoints"""
+import json
+from http import HTTPStatus
+
+import fastapi
+
+from ..server import ServerContext
+from . import entrypoint_utils
+
+app = fastapi.APIRouter()
+
+################ /debug/dump_event_trace ################
+
+
+@app.post("/debug/dump_event_trace")
+async def debug_dump_event_trace(request: fastapi.Request):
+    """Return the recorded events in Chrome Trace Event Format in JSON string.
+    The input request payload should have only one field, specifying the
+    model to query. For example: `{"model": "Llama-2-7b-chat-hf-q0f16"}`.
+    """
+    # Get the raw request body as bytes
+    request_raw_data = await request.body()
+    request_json_str = request_raw_data.decode("utf-8")
+    try:
+        # Parse the JSON string
+        request_dict = json.loads(request_json_str)
+    except json.JSONDecodeError:
+        return entrypoint_utils.create_error_response(
+            HTTPStatus.BAD_REQUEST, message=f"Invalid request {request_json_str}"
+        )
+    if "model" not in request_dict:
+        return entrypoint_utils.create_error_response(
+            HTTPStatus.BAD_REQUEST, message=f"Invalid request {request_json_str}"
+        )
+
+    # - Check the requested model.
+    model = request_dict["model"]
+    async_engine = ServerContext.get_engine(model)
+    if async_engine is None:
+        return entrypoint_utils.create_error_response(
+            HTTPStatus.BAD_REQUEST, message=f'The requested model "{model}" is not served.'
+        )
+    if async_engine.trace_recorder is None:
+        return entrypoint_utils.create_error_response(
+            HTTPStatus.BAD_REQUEST, message=f'The requested model "{model}" does not enable tracing'
+        )
+
+    return json.loads(async_engine.trace_recorder.dump_json())

--- a/python/mlc_chat/serve/event_trace_recorder.py
+++ b/python/mlc_chat/serve/event_trace_recorder.py
@@ -1,0 +1,41 @@
+"""The event trace recorder in MLC LLM serving"""
+
+import tvm._ffi
+from tvm.runtime import Object
+
+from . import _ffi_api
+
+
+@tvm._ffi.register_object("mlc.serve.EventTraceRecorder")  # pylint: disable=protected-access
+class EventTraceRecorder(Object):
+    """The event trace recorder for requests."""
+
+    def __init__(self) -> None:
+        """Initialize a trace recorder."""
+        self.__init_handle_by_constructor__(
+            _ffi_api.EventTraceRecorder  # type: ignore  # pylint: disable=no-member
+        )
+
+    def add_event(self, request_id: str, event: str) -> None:
+        """Record a event for the the input request in the trace recorder.
+
+        Parameters
+        ----------
+        request_id : str
+            The subject request of the event.
+
+        event : str
+            The event in a string name.
+            It can have one of the following patterns:
+            - "start xxx", which marks the start of event "xxx",
+            - "finish xxx", which marks the finish of event "xxx",
+            - "yyy", which marks the instant event "yyy".
+            The "starts" and "finishes" will be automatically paired in the trace recorder.
+        """
+        return _ffi_api.EventTraceRecorderAddEvent(  # type: ignore  # pylint: disable=no-member
+            self, request_id, event
+        )
+
+    def dump_json(self) -> str:
+        """Dump the logged events in Chrome Trace Event Format in JSON string."""
+        return _ffi_api.EventTraceRecorderDumpJSON(self)  # type: ignore  # pylint: disable=no-member

--- a/python/mlc_chat/serve/server/popen_server.py
+++ b/python/mlc_chat/serve/server/popen_server.py
@@ -21,6 +21,7 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         use_threaded_engine: bool = True,
         max_batch_size: int = 80,
         max_total_sequence_length: int = 16800,
+        enable_tracing: bool = False,
         host: str = "127.0.0.1",
         port: int = 8000,
     ) -> None:
@@ -32,6 +33,7 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         self.use_threaded_engine = use_threaded_engine
         self.max_batch_size = max_batch_size
         self.max_total_sequence_length = max_total_sequence_length
+        self.enable_tracing = enable_tracing
         self.host = host
         self.port = port
         self._proc: Optional[subprocess.Popen] = None
@@ -49,6 +51,8 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         cmd += ["--max-total-seq-length", str(self.max_total_sequence_length)]
         if self.use_threaded_engine:
             cmd += ["--use-threaded-engine"]
+        if self.enable_tracing:
+            cmd += ["--enable-tracing"]
 
         cmd += ["--host", self.host]
         cmd += ["--port", str(self.port)]

--- a/tests/python/serve/server/conftest.py
+++ b/tests/python/serve/server/conftest.py
@@ -24,6 +24,7 @@ def launch_server(served_model):  # pylint: disable=redefined-outer-name
         served_model,
         max_total_sequence_length=5120,
         use_threaded_engine=True,
+        enable_tracing=True,
     )
     server.start()
     yield

--- a/tests/python/serve/server/test_server.py
+++ b/tests/python/serve/server/test_server.py
@@ -19,6 +19,7 @@ two steps:
 # pylint: disable=missing-function-docstring,too-many-arguments,too-many-locals,too-many-branches
 import json
 import os
+from http import HTTPStatus
 from typing import Dict, List, Optional
 
 import pytest
@@ -29,6 +30,7 @@ OPENAI_BASE_URL = "http://127.0.0.1:8000/v1"
 OPENAI_V1_MODELS_URL = "http://127.0.0.1:8000/v1/models"
 OPENAI_V1_COMPLETION_URL = "http://127.0.0.1:8000/v1/completions"
 OPENAI_V1_CHAT_COMPLETION_URL = "http://127.0.0.1:8000/v1/chat/completions"
+DEBUG_DUMP_EVENT_TRACE_URL = "http://127.0.0.1:8000/debug/dump_event_trace"
 
 
 def check_openai_nonstream_response(
@@ -776,6 +778,16 @@ def test_openai_v1_chat_completions_unsupported_args(
     expect_error(response.json(), msg_prefix=error_msg_prefix)
 
 
+def test_debug_dump_event_trace(
+    served_model: str,
+    launch_server,  # pylint: disable=unused-argument
+):
+    # We only check that the request does not fail.
+    payload = {"model": served_model}
+    response = requests.post(DEBUG_DUMP_EVENT_TRACE_URL, json=payload, timeout=60)
+    assert response.status_code == HTTPStatus.OK
+
+
 if __name__ == "__main__":
     MODEL = os.environ.get("MLC_SERVE_MODEL")
     if MODEL is None:
@@ -816,3 +828,5 @@ if __name__ == "__main__":
     test_openai_v1_chat_completions_system_prompt_wrong_pos(MODEL, None, stream=False)
     test_openai_v1_chat_completions_system_prompt_wrong_pos(MODEL, None, stream=True)
     test_openai_v1_chat_completions_unsupported_args(MODEL, None)
+
+    test_debug_dump_event_trace(MODEL, None)

--- a/tests/python/serve/test_event_trace_recorder.py
+++ b/tests/python/serve/test_event_trace_recorder.py
@@ -1,0 +1,44 @@
+# pylint: disable=missing-module-docstring,missing-function-docstring
+import json
+
+from mlc_chat.serve.event_trace_recorder import EventTraceRecorder
+
+
+def test_event_trace_recorder():
+    trace_recorder = EventTraceRecorder()
+    request_ids = ["x", "y"]
+    num_decode = 5
+
+    for request_id in request_ids:
+        trace_recorder.add_event(request_id, event="start tokenization")
+        trace_recorder.add_event(request_id, event="finish tokenization")
+        trace_recorder.add_event(request_id, event="add request")
+        trace_recorder.add_event(request_id, event="start embed")
+        trace_recorder.add_event(request_id, event="finish embed")
+        trace_recorder.add_event(request_id, event="start prefill")
+        trace_recorder.add_event(request_id, event="finish prefill")
+
+    for _ in range(num_decode):
+        for request_id in request_ids:
+            trace_recorder.add_event(request_id, event="start decode")
+            trace_recorder.add_event(request_id, event="finish decode")
+    for request_id in request_ids:
+        trace_recorder.add_event(request_id, event="start detokenization")
+        trace_recorder.add_event(request_id, event="finish detokenization")
+
+    events = json.loads(trace_recorder.dump_json())
+    decode_count = {}
+    for event in events:
+        request_id = event["tid"]
+        if event["name"].startswith("decode"):
+            if request_id not in decode_count:
+                decode_count[request_id] = 1
+            else:
+                decode_count[request_id] += 1
+
+    for _, decode_cnt in decode_count.items():
+        assert decode_cnt == num_decode * 2, decode_cnt
+
+
+if __name__ == "__main__":
+    test_event_trace_recorder()


### PR DESCRIPTION
This PR introduces the EventTraceRecorder in MLC LLM serving, which can
record event times for each request on invocation, and can dump
all the recorded events to Chrome Trace Event format, so that
we can visualize the events and the timeline of all requests.

This PR brings the optional flag `enable_tracing` to Engine,
AsyncEngine/AsyncThreadedEngine, server entry and PopenServer.
This flag defaults to `False`, in which case we do not enable
tracing.

This PR introduces a new server entrypoint `/debug/dump_event_trace`,
under file `python/mlc_chat/serve/entrypoints/debug_entrypoints.py`.
This entrypoint accepts a model name, and returns the dumped events
in Chrome Trace Event format (in JSON string).

This PR contains a basic EventTraceRecorder test and a basic test for
entrypoint `/debug/dump_event_trace`.