### PR TITLE
[SLIM] Support out dtype for quantizeLinear

### DIFF
--- a/python/mlc_chat/compiler/quantization/group_quantization.py
+++ b/python/mlc_chat/compiler/quantization/group_quantization.py
@@ -262,7 +262,7 @@ class GroupQuantize:  # pylint: disable=too-many-instance-attributes
         return quantized_weight, scale
 
 
-class GroupQuantizeLinear(nn.Module):
+class GroupQuantizeLinear(nn.Module):  # pylint: disable=too-many-instance-attributes
     """An nn.Linear module with group quantization"""
 
     def __init__(  # pylint: disable=too-many-arguments

--- a/python/mlc_chat/compiler/quantization/group_quantization.py
+++ b/python/mlc_chat/compiler/quantization/group_quantization.py
@@ -284,7 +284,9 @@ class GroupQuantizeLinear(nn.Module):
         )
         self.q_scale = nn.Parameter((out_features, num_group), config.model_dtype)
         if bias:
-            self.bias = nn.Parameter((out_features,), config.model_dtype)
+            self.bias = nn.Parameter(
+                (out_features,), config.model_dtype if out_dtype is None else out_dtype
+            )
         else:
             self.bias = None
 
@@ -349,6 +351,18 @@ class GroupQuantizeLinear(nn.Module):
         if self.bias is not None:
             x = x + self.bias
         return x
+
+    def to(self, dtype: Optional[str] = None) -> None:
+        """
+        Override to() such that we do not convert bias if there is an out_dtype.
+        Otherwise, we might run into dtype mismatch when computing x + self.bias.
+        """
+        self.q_weight.to(dtype=dtype)
+        self.q_scale.to(dtype=dtype)
+        if self.bias is not None and self.out_dtype is None:
+            self.bias.to(dtype=dtype)
+        if dtype is not None and isinstance(getattr(self, "dtype", None), str):
+            self.dtype = dtype  # pylint: disable=attribute-defined-outside-init
 
 
 class GroupQuantizeEmbedding(nn.Module):


### PR DESCRIPTION
This PR solves the same issue as https://github.com/apache/tvm/pull/16220, but for the quantized linear; motivated by trying to support GPTNeoX in SLIM.

Tested GroupQuantLinear with:
- llama q4f16, q4f32 (multilinear, no bias)
- RedPajama q4f16, q4f32 (linear, has bias, with out_dtype being float32)
- gpt2 q4f16, q4f32 (linear, no bias)

Did not test with awq quantization but same idea should apply.