### PR TITLE
[SLIM][Fix] Quick fix on sharding config for non supported models

### DIFF
--- a/python/mlc_chat/compiler/model/gpt2/gpt2_model.py
+++ b/python/mlc_chat/compiler/model/gpt2/gpt2_model.py
@@ -30,6 +30,7 @@ class GPT2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     context_window_size: int = 0
     prefill_chunk_size: int = 0
     scale_attn_by_inverse_layer_idx: bool = False
+    tensor_parallel_shards: int = 1
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -57,6 +58,7 @@ class GPT2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
         if self.prefill_chunk_size == 0:
             # chunk size same as context window size by default
             self.prefill_chunk_size = self.context_window_size
+        assert self.tensor_parallel_shards == 1, "GPT2 currently does not support sharding."
 
 
 # pylint: disable=invalid-name,missing-docstring,too-many-locals

--- a/python/mlc_chat/compiler/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_chat/compiler/model/gpt_neox/gpt_neox_model.py
@@ -33,6 +33,7 @@ class GPTNeoXConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     context_window_size: int = 0
     head_dim: int = 0
     prefill_chunk_size: int = 0
+    tensor_parallel_shards: int = 1
     ffn_out_dtype: str = "float32"
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
@@ -66,6 +67,8 @@ class GPTNeoXConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
         if self.prefill_chunk_size == 0:
             # chunk size same as context window size by default
             self.prefill_chunk_size = self.context_window_size
+
+        assert self.tensor_parallel_shards == 1, "GPTNeoX currently does not support sharding."
 
 
 # pylint: disable=invalid-name,missing-docstring


### PR DESCRIPTION
Otherwise: `gen_config` for gpt2 and gpt_neox runs into:
```
  File "mlc-llm/python/mlc_chat/compiler/gen_config.py", line 98, in gen_config
    tensor_parallel_shards=model_config.tensor_parallel_shards,
```