### PR TITLE
[SLIM] Allow dynamic shape parameters

### DIFF
--- a/cpp/metadata/json_parser.h
+++ b/cpp/metadata/json_parser.h
@@ -51,8 +51,14 @@ inline tvm::runtime::ShapeTuple ShapeTupleFromArray(const picojson::array& shape
   std::vector<int64_t> result;
   result.reserve(shape.size());
   for (const picojson::value& dim : shape) {
-    CHECK(dim.is<int64_t>()) << "ValueError: shape has unexpected type";
-    result.push_back(dim.get<int64_t>());
+    if (dim.is<std::string>()) {
+      // TODO: Get concrete value of dynamic shape instead of using -1 by passing in a dictionary
+      // from llm_chat.cc (concrete values are stored in mlc-chat-config.json).
+      result.push_back(-1);
+    } else {
+      CHECK(dim.is<int64_t>()) << "ValueError: shape has unexpected type";
+      result.push_back(dim.get<int64_t>());
+    }
   }
   return tvm::runtime::ShapeTuple(std::move(result));
 }

--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -23,8 +23,9 @@ ModelMetadata::Param::Preproc ModelMetadata::Param::Preproc::FromJSON(const pico
 ModelMetadata::Param ModelMetadata::Param::FromJSON(const picojson::object& param) {
   Param result;
   result.name = json::Lookup<std::string>(param, "name");
-  result.shape = json::Lookup<ShapeTuple>(param, "shape");
   result.dtype = json::Lookup<DataType>(param, "dtype");
+  // A shape being `-1` means that it is dynamic
+  result.shape = json::Lookup<ShapeTuple>(param, "shape");
   picojson::array preprocs = json::Lookup<picojson::array>(param, "preprocs");
   result.preprocs.reserve(preprocs.size());
   for (int i = 0; i < preprocs.size(); i++) {

--- a/python/mlc_chat/interface/compile.py
+++ b/python/mlc_chat/interface/compile.py
@@ -101,7 +101,8 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
     def _get_param_metadata(name: str, param: nn.Parameter) -> Dict[str, Any]:
         return {
             "name": name,
-            "shape": list(param.shape),
+            # Record dynamic shape as -1 (e.g. vocab_size)
+            "shape": [s if isinstance(s, int) else -1 for s in param.shape],
             "dtype": param.dtype,
             "preprocs": param.attrs["preprocs"],
         }

--- a/python/mlc_chat/interface/compile.py
+++ b/python/mlc_chat/interface/compile.py
@@ -102,7 +102,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
         return {
             "name": name,
             # Record dynamic shape as -1 (e.g. vocab_size)
-            "shape": [s if isinstance(s, int) else -1 for s in param.shape],
+            "shape": [s if isinstance(s, int) else s.name for s in param.shape],
             "dtype": param.dtype,
             "preprocs": param.attrs["preprocs"],
         }

--- a/python/mlc_chat/loader/huggingface_loader.py
+++ b/python/mlc_chat/loader/huggingface_loader.py
@@ -173,6 +173,8 @@ class HuggingFaceLoader:  # pylint: disable=too-few-public-methods
             for name, param in load_func(path):
                 result[name] = param
                 self.stats.mem_add(param.nbytes)
+                if name not in self.extern_param_map.unused_params:
+                    self.stats.total_param_num += param.size
             self.cached_files[path] = result
 
     def _unload_file(self, path: Path) -> None:

--- a/python/mlc_chat/loader/stats.py
+++ b/python/mlc_chat/loader/stats.py
@@ -32,6 +32,9 @@ class Stats:
 
     max_memory_gb : float
         The maximum RAM usage in GB.
+
+    total_param_num: int
+        Total number of parameters (original non-MLC model weights), excluding unused params.
     """
 
     load_time_sec: float = 0.0
@@ -41,6 +44,8 @@ class Stats:
     current_memory_gb: float = 0.0
     total_memory_gb: float = 0.0
     max_memory_gb: float = 0.0
+
+    total_param_num: int = 0
 
     def timer(self, attr):
         """A context manager to time the scope and add the time to the attribute."""

--- a/python/mlc_chat/model/gpt2/gpt2_model.py
+++ b/python/mlc_chat/model/gpt2/gpt2_model.py
@@ -155,7 +155,7 @@ class GPT2Block(nn.Module):
 class GPT2Model(nn.Module):
     def __init__(self, config: GPT2Config):
         assert config.n_embd % config.n_head == 0
-        self.wte = nn.Embedding(config.vocab_size, config.n_embd)
+        self.wte = nn.Embedding("vocab_size", config.n_embd)
         self.wpe = nn.Embedding(config.context_window_size, config.n_embd)
         self.h = nn.ModuleList([GPT2Block(config, layer_idx=i) for i in range(config.n_layer)])
         self.ln_f = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
@@ -192,8 +192,7 @@ class GPT2Model(nn.Module):
 class GPT2LMHeadModel(nn.Module):
     def __init__(self, config: GPT2Config):
         self.transformer = GPT2Model(config)
-        self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
-        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.n_embd, "vocab_size", bias=False)
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):

--- a/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
+++ b/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
@@ -165,7 +165,7 @@ class GPTBigCodeBlock(nn.Module):
 class GPTBigCodeModel(nn.Module):
     def __init__(self, config: GPTBigCodeConfig):
         assert config.n_embd % config.n_head == 0
-        self.wte = nn.Embedding(config.vocab_size, config.n_embd)
+        self.wte = nn.Embedding("vocab_size", config.n_embd)
         self.wpe = nn.Embedding(config.n_positions, config.n_embd)
         self.h = nn.ModuleList([GPTBigCodeBlock(config) for _ in range(config.n_layer)])
         self.ln_f = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
@@ -206,8 +206,7 @@ class GPTBigCodeModel(nn.Module):
 class GPTBigCodeForCausalLM(nn.Module):
     def __init__(self, config: GPTBigCodeConfig):
         self.transformer = GPTBigCodeModel(config)
-        self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
-        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.n_embd, "vocab_size", bias=False)
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):

--- a/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
@@ -235,7 +235,7 @@ class GPTNeoXLayer(nn.Module):
 
 class GPTNeoXModel(nn.Module):
     def __init__(self, config: GPTNeoXConfig):
-        self.embed_in = nn.Embedding(num=config.vocab_size, dim=config.hidden_size)
+        self.embed_in = nn.Embedding(num="vocab_size", dim=config.hidden_size)
         self.layers = nn.ModuleList([GPTNeoXLayer(config) for _ in range(config.num_hidden_layers)])
         self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.tensor_parallel_shards = config.tensor_parallel_shards
@@ -256,7 +256,7 @@ class GPTNeoXForCausalLM(nn.Module):
         self.gpt_neox = GPTNeoXModel(config)
         self.embed_out = nn.Linear(
             in_features=config.hidden_size,
-            out_features=config.vocab_size,
+            out_features="vocab_size",
             bias=False,
             dtype="float32",
         )

--- a/python/mlc_chat/model/llama/llama_model.py
+++ b/python/mlc_chat/model/llama/llama_model.py
@@ -215,7 +215,7 @@ class LlamaDecoderLayer(nn.Module):
 class LlamaModel(nn.Module):
     def __init__(self, config: LlamaConfig):
         assert config.hidden_size % config.num_attention_heads == 0
-        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.embed_tokens = nn.Embedding("vocab_size", config.hidden_size)
         self.layers = nn.ModuleList(
             [LlamaDecoderLayer(config) for _ in range(config.num_hidden_layers)]
         )
@@ -244,7 +244,7 @@ class LlamaModel(nn.Module):
 class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attributes
     def __init__(self, config: LlamaConfig):
         self.model = LlamaModel(config)
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.lm_head = nn.Linear(config.hidden_size, "vocab_size", bias=False)
         self.num_hidden_layers = config.num_hidden_layers
         self.num_attention_heads = config.num_attention_heads
         self.num_key_value_heads = config.num_key_value_heads
@@ -425,7 +425,7 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
                 },
             },
             "softmax_with_temperature": {
-                "logits": nn.spec.Tensor(["batch_size", 1, self.vocab_size], "float32"),
+                "logits": nn.spec.Tensor(["batch_size", 1, "vocab_size"], "float32"),
                 "temperature": nn.spec.Tensor(["batch_size"], "float32"),
                 "$": {
                     "param_mode": "none",

--- a/python/mlc_chat/model/mistral/mistral_model.py
+++ b/python/mlc_chat/model/mistral/mistral_model.py
@@ -353,7 +353,7 @@ class MistralModel(nn.Module):
     def __init__(self, config: MistralConfig):
         assert config.hidden_size % config.num_attention_heads == 0
         rotary_embedding = RotaryEmbedding(config)
-        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.embed_tokens = nn.Embedding("vocab_size", config.hidden_size)
         self.layers = nn.ModuleList(
             [MistralDecoderLayer(config, rotary_embedding) for _ in range(config.num_hidden_layers)]
         )
@@ -385,8 +385,7 @@ class MistralForCasualLM(nn.Module):
 
     def __init__(self, config: MistralConfig):
         self.model = MistralModel(config)
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
-        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, "vocab_size", bias=False)
         self.sliding_window_size = config.sliding_window_size
         self.dtype = "float32"
 

--- a/python/mlc_chat/model/phi/phi_model.py
+++ b/python/mlc_chat/model/phi/phi_model.py
@@ -248,7 +248,7 @@ class PhiCausalLMHead(nn.Module):
         super().__init__()
 
         self.ln = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
-        self.linear = nn.Linear(config.n_embd, config.vocab_size)
+        self.linear = nn.Linear(config.n_embd, "vocab_size")
 
     def forward(self, hidden_states: Tensor):
         hidden_states = self.ln(hidden_states)
@@ -262,7 +262,7 @@ class PhiCausalLMHead(nn.Module):
 class PhiModel(nn.Module):
     def __init__(self, config: PhiConfig) -> None:
         super().__init__()
-        self.embd = nn.Embedding(config.vocab_size, config.n_embd)
+        self.embd = nn.Embedding("vocab_size", config.n_embd)
         self.h = nn.ModuleList([PhiParallelBlock(config) for i in range(config.n_layer)])
 
     def forward(self, input_ids: Tensor, total_seq_len: tir.Var, attention_mask: Tensor):


### PR DESCRIPTION
This PR adds support for dyanmic shape parameters, specifically substituting llama's appearance of `config.vocab_size` to `llama.vocab_size`. 

### Motivation
Models that share the same architecture may only differ in the vocab size, making us have to recompile a model library. With dynamic vocab size, we can use the same llama model library for llama-2, code-llama, wizardMath, wizardCoder, etc.

### Changes needed
1. Quantization
a. GroupQuantization: During `_dequantize()`, insetad of passing in `IntImm`, ~~pass in `tir.Var` when shape is not int~~ pass in weight's shape, which is a tir.Var (cannot initialize a new var since it would create `vocab_size_1` in script)
 b. No change is needed for AWQ since it does not seem to quantize the embedding layer nor the `lm_head`: https://github.com/mlc-ai/mlc-llm/blob/73c47628fb921eaab2a12ab43275e79d8f26cd60/python/mlc_chat/compiler/quantization/awq_quantization.py#L119-L121

2. `convert_weight.py`
  a. Modify `_check_param()` such that it allows dynamic shape
  b. ~~`_calc_total_params()` skips dynamic-shape parameters~~ Replace `_calc_total_params()` with `loader.stats.total_param_num`

3. Metadata
  a. For the `param` field in metadata, if dynamic, record ~~`["vocab_size", 4096]`~~ `[-1, 4096]`, rather than previously `[32000, 4096]`
b. ~~Skips the param reading~~ Read in `[-1, 4096]` in runtime `cpp/metadata/model.cc`

Depend on https://github.com/apache/tvm/pull/16284

### Performance
Tested on llama-2 on RTX 4090, virtually no performance degradation.
Before:
```
Statistics: ----------- prefill -----------
throughput: 325.278 tok/s
total tokens: 7 tok
total time: 0.022 s
------------ decode ------------
throughput: 183.725 tok/s
total tokens: 256 tok
total time: 1.393 s
```

After:
```
Statistics: ----------- prefill -----------
throughput: 325.510 tok/s
total tokens: 7 tok
total time: 0.022 s
------------ decode ------------
throughput: 185.398 tok/s
total tokens: 256 tok
total time: 1.381 s
```