### PR TITLE
[SLM] rename `sliding_window` to `sliding_window_size`

### DIFF
--- a/python/mlc_chat/cli/gen_config.py
+++ b/python/mlc_chat/cli/gen_config.py
@@ -51,10 +51,10 @@ def main(argv):
         help=HELP["context_window_size"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
-        "--sliding-window",
+        "--sliding-window-size",
         type=int,
         default=None,
-        help=HELP["sliding_window"] + ' (default: "%(default)s")',
+        help=HELP["sliding_window_size"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
         "--prefill-chunk-size",
@@ -83,7 +83,7 @@ def main(argv):
         quantization=QUANTIZATION[parsed.quantization],
         conv_template=parsed.conv_template,
         context_window_size=parsed.context_window_size,
-        sliding_window=parsed.sliding_window,
+        sliding_window_size=parsed.sliding_window_size,
         prefill_chunk_size=parsed.prefill_chunk_size,
         tensor_parallel_shards=parsed.tensor_parallel_shards,
         output=parsed.output,

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -50,11 +50,11 @@ class CompileArgs:  # pylint: disable=too-many-instance-attributes
 
 
 def _attach_variable_bounds(mod, model_config):
-    if hasattr(model_config, "sliding_window"):
+    if hasattr(model_config, "sliding_window_size"):
         tir_bound_map = {
             "seq_len": model_config.prefill_chunk_size,
-            "rolling_cache_len": model_config.sliding_window,
-            "kv_seq_len": model_config.sliding_window + model_config.prefill_chunk_size,
+            "rolling_cache_len": model_config.sliding_window_size,
+            "kv_seq_len": model_config.sliding_window_size + model_config.prefill_chunk_size,
         }
     else:
         tir_bound_map = {
@@ -120,7 +120,7 @@ def _attach_metadata(
             ],
             "context_window_size": model_config.context_window_size,
             "prefill_chunk_size": model_config.prefill_chunk_size,
-            "sliding_window": getattr(model_config, "sliding_window", -1),
+            "sliding_window_size": getattr(model_config, "sliding_window_size", -1),
             "tensor_parallel_shards": model_config.tensor_parallel_shards,
             "memory_usage": {str(k): int(v) for k, v in mod.attrs["mlc_llm.memory_usage"].items()},
         }

--- a/python/mlc_chat/compiler/flags_model_config_override.py
+++ b/python/mlc_chat/compiler/flags_model_config_override.py
@@ -16,7 +16,7 @@ class ModelConfigOverride:
 
     context_window_size: Optional[int] = None
     prefill_chunk_size: Optional[int] = None
-    sliding_window: Optional[int] = None
+    sliding_window_size: Optional[int] = None
     max_batch_size: Optional[int] = None
     tensor_parallel_shards: Optional[int] = None
 
@@ -24,30 +24,30 @@ class ModelConfigOverride:
         out = StringIO()
         print(f"context_window_size={self.context_window_size}", file=out, end="")
         print(f";prefill_chunk_size={self.prefill_chunk_size}", file=out, end="")
-        print(f";sliding_window={self.sliding_window}", file=out, end="")
+        print(f";sliding_window_size={self.sliding_window_size}", file=out, end="")
         print(f";max_batch_size={self.max_batch_size}", file=out, end="")
         print(f";tensor_parallel_shards={self.tensor_parallel_shards}", file=out, end="")
         return out.getvalue().rstrip()
 
     def __post_init__(self):
-        # If `sliding_window` is set
+        # If `sliding_window_size` is set
         # - 1) Disable `context_window_size`
         # - 2) Require `prefill_chunk_size` to present
-        if self.sliding_window is not None:
+        if self.sliding_window_size is not None:
             self.context_window_size = -1
             logger.info(
                 "Setting %s to -1 (disabled), because %s is already set",
                 bold("context_window_size"),
-                bold("sliding_window"),
+                bold("sliding_window_size"),
             )
             if self.prefill_chunk_size is None:
                 logger.info(
                     "Default %s to %s (%d) because it is not provided",
                     bold("prefill_chunk_size"),
-                    bold("sliding_window"),
-                    self.sliding_window,
+                    bold("sliding_window_size"),
+                    self.sliding_window_size,
                 )
-                self.prefill_chunk_size = self.sliding_window
+                self.prefill_chunk_size = self.sliding_window_size
         elif self.context_window_size is not None:
             if self.prefill_chunk_size is None:
                 logger.info(
@@ -64,8 +64,8 @@ class ModelConfigOverride:
             _model_config_override(model_config, "context_window_size", self.context_window_size)
         if self.prefill_chunk_size is not None:
             _model_config_override(model_config, "prefill_chunk_size", self.prefill_chunk_size)
-        if self.sliding_window is not None:
-            _model_config_override(model_config, "sliding_window", self.sliding_window)
+        if self.sliding_window_size is not None:
+            _model_config_override(model_config, "sliding_window_size", self.sliding_window_size)
         if self.max_batch_size is not None:
             _model_config_override(model_config, "max_batch_size", self.max_batch_size)
         if self.tensor_parallel_shards is not None:
@@ -80,14 +80,14 @@ class ModelConfigOverride:
         parser = argparse.ArgumentParser(description="model config override values")
         parser.add_argument("--context_window_size", type=int, default=None)
         parser.add_argument("--prefill_chunk_size", type=int, default=None)
-        parser.add_argument("--sliding_window", type=int, default=None)
+        parser.add_argument("--sliding_window_size", type=int, default=None)
         parser.add_argument("--max_batch_size", type=int, default=None)
         parser.add_argument("--tensor_parallel_shards", type=int, default=None)
         results = parser.parse_args([f"--{i}" for i in source.split(";") if i])
         return ModelConfigOverride(
             context_window_size=results.context_window_size,
             prefill_chunk_size=results.prefill_chunk_size,
-            sliding_window=results.sliding_window,
+            sliding_window_size=results.sliding_window_size,
             max_batch_size=results.max_batch_size,
             tensor_parallel_shards=results.tensor_parallel_shards,
         )
@@ -107,5 +107,5 @@ def _model_config_override(model_config, field: str, value: Any) -> None:
             "%s: %s does not have %s",
             red("Warning"),
             bold(type(model_config).__name__),
-            bold("sliding_window"),
+            bold("sliding_window_size"),
         )

--- a/python/mlc_chat/compiler/gen_config.py
+++ b/python/mlc_chat/compiler/gen_config.py
@@ -28,7 +28,7 @@ class MLCChatConfig:  # pylint: disable=too-many-instance-attributes
     model_config: Dict[str, Any]
     vocab_size: int
     context_window_size: int
-    sliding_window: int
+    sliding_window_size: int
     prefill_chunk_size: int
     tensor_parallel_shards: int
     # Control the behavior of the runtime
@@ -73,7 +73,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
     quantization: Quantization,
     conv_template: str,
     context_window_size: Optional[int],
-    sliding_window: Optional[int],
+    sliding_window_size: Optional[int],
     prefill_chunk_size: Optional[int],
     tensor_parallel_shards: Optional[int],
     output: Path,
@@ -83,7 +83,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
     model_config = model.config.from_file(config)
     ModelConfigOverride(
         context_window_size=context_window_size,
-        sliding_window=sliding_window,
+        sliding_window_size=sliding_window_size,
         prefill_chunk_size=prefill_chunk_size,
         tensor_parallel_shards=tensor_parallel_shards,
     ).apply(model_config)
@@ -93,7 +93,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
         model_config=model_config.asdict(),
         vocab_size=model_config.vocab_size,
         context_window_size=model_config.context_window_size,
-        sliding_window=getattr(model_config, "sliding_window", -1),
+        sliding_window_size=getattr(model_config, "sliding_window_size", -1),
         prefill_chunk_size=model_config.prefill_chunk_size,
         tensor_parallel_shards=model_config.tensor_parallel_shards,
         conv_template=conv_template,

--- a/python/mlc_chat/compiler/help.py
+++ b/python/mlc_chat/compiler/help.py
@@ -92,9 +92,9 @@ Conversation template. It depends on how the model is tuned. Use "LM" for vanill
 The output directory for generated configurations, including `mlc-chat-config.json` and tokenizer
 configuration.
 """.strip(),
-    "sliding_window": """
+    "sliding_window_size": """
 (Experimental) The sliding window size in sliding window attention (SWA).
-This optional field overrides the `sliding_window` in config.json for
+This optional field overrides the `sliding_window_size` in config.json for
 those models that use SWA. Currently only useful when compiling Mistral.
 This flag subjects to future refactoring.
 """.strip(),
@@ -108,7 +108,7 @@ Number of shards to split the model into in tensor parallelism multi-gpu inferen
 """.strip(),
     "overrides": """
 Model configuration override. Configurations to override `mlc-chat-config.json`. Supports
-`context_window_size`, `prefill_chunk_size`, `sliding_window`, `max_batch_size` and
+`context_window_size`, `prefill_chunk_size`, `sliding_window_size`, `max_batch_size` and
 `tensor_parallel_shards`. Meanwhile, model config could be explicitly specified via details
 knobs, e.g. --overrides "context_window_size=1024;prefill_chunk_size=128".
 """.strip(),

--- a/python/mlc_chat/compiler/model/model.py
+++ b/python/mlc_chat/compiler/model/model.py
@@ -295,7 +295,7 @@ MODEL_PRESETS: Dict[str, Any] = {
         "transformers_version": "4.34.0.dev0",
         "use_cache": True,
         "vocab_size": 32000,
-        "sliding_window": 4096,
+        "sliding_window_size": 4096,
         "prefill_chunk_size": 128,
     },
     "gpt2": {


### PR DESCRIPTION
Rename `sliding_window` to `sliding_window_size` to be consistent with `context_window_size` and `prefill_chunk_size` https://github.com/mlc-ai/mlc-llm/issues/1364#issuecomment-1837914257

Note: only renaming on SLM, runtime should be updated, as well as prebuilts metadata and mlc-chat-config.json, when making SLM default