### PR TITLE
[SLM] auto system lib prefix

### DIFF
--- a/python/mlc_chat/cli/compile.py
+++ b/python/mlc_chat/cli/compile.py
@@ -20,7 +20,7 @@ from ..support.auto_config import (
     detect_model_type,
     detect_quantization,
 )
-from ..support.auto_target import detect_target_and_host
+from ..support.auto_target import detect_target_and_host, detect_system_lib_prefix
 
 
 def main(argv):
@@ -85,7 +85,7 @@ def main(argv):
     parser.add_argument(
         "--system-lib-prefix",
         type=str,
-        default="",
+        default="auto",
         help=HELP["system_lib_prefix"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
@@ -105,6 +105,9 @@ def main(argv):
     target, build_func = detect_target_and_host(parsed.device, parsed.host)
     parsed.model_type = detect_model_type(parsed.model_type, parsed.model)
     parsed.quantization = detect_quantization(parsed.quantization, parsed.model)
+    parsed.system_lib_prefix = detect_system_lib_prefix(
+        parsed.device, parsed.system_lib_prefix, parsed.model_type.name, parsed.quantization.name
+    )
     with open(parsed.model, "r", encoding="utf-8") as config_file:
         config = json.load(config_file)
 

--- a/python/mlc_chat/cli/compile.py
+++ b/python/mlc_chat/cli/compile.py
@@ -20,7 +20,7 @@ from ..support.auto_config import (
     detect_model_type,
     detect_quantization,
 )
-from ..support.auto_target import detect_target_and_host, detect_system_lib_prefix
+from ..support.auto_target import detect_system_lib_prefix, detect_target_and_host
 
 
 def main(argv):

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -247,6 +247,34 @@ def _register_cuda_hook(target: Target):
         return ptx
 
 
+def detect_system_lib_prefix(
+    target_hint: str, prefix_hint: str, model_name: str, quantization: str
+) -> str:
+    """Detect the iOS / Android system lib prefix to identify the library needed to load the app.
+
+    Parameters
+    ----------
+    target_hint : str
+        The hint for the target device.
+
+    prefix_hint : str
+        The hint for the system lib prefix.
+    """
+    if prefix_hint == "auto" and target_hint in ["iphone", "android"]:
+        prefix = f"{model_name}_{quantization}_".replace("-", "_")
+        logger.warning(
+            "%s is automatically picked from the filename, %s, this allows us to use the filename "
+            "as the model_lib in android/iOS builds. Please avoid renaming the .tar file when "
+            "uploading the prebuilt.",
+            bold("--system-lib-prefix"),
+            bold(prefix),
+        )
+        return prefix
+    if not target_hint in ["iphone", "android"]:
+        return ""
+    return prefix_hint
+
+
 PRESET = {
     "iphone:generic": {
         "target": {


### PR DESCRIPTION
Item A6 from #1364. It enables the automatic creation of a system lib prefix (if not provided) typically required by Android and iOS libs