### PR TITLE
Use SizeVar instead of Var for model definition

### DIFF
--- a/mlc_llm/relax_model/chatglm.py
+++ b/mlc_llm/relax_model/chatglm.py
@@ -484,7 +484,7 @@ class ChatGLMModel(nn.Module):
     def _prepare_decoder_attention_mask(self, input_shape, kv_sl, dtype):
         # create causal mask
         # [bsz, sl] -> [bsz, 1, sl, kv_sl]
-        if isinstance(input_shape[-1], tvm.tir.Var) or input_shape[-1] > 1:
+        if isinstance(input_shape[-1], tvm.tir.SizeVar) or input_shape[-1] > 1:
             bsz, sl = input_shape
 
             def min_max_triu_te():
@@ -615,8 +615,8 @@ def create_encoding_func(
     func_name = "prefill"
 
     bsz = tvm.tir.IntImm("int64", 1)
-    sl = tvm.tir.Var("n", "int64")
-    all_seq_len = tvm.tir.Var("m", "int64")
+    sl = tvm.tir.SizeVar("n", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
     with bb.function(func_name):
         model = ChatGLMForCausalLM(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
@@ -656,7 +656,7 @@ def create_decoding_func(
     func_name = "decode"
 
     bsz = 1
-    all_seq_len = tvm.tir.Var("m", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
 
     with bb.function(func_name):
         model = ChatGLMForCausalLM(config)

--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -167,7 +167,7 @@ def create_shard_transformation_func(param_manager, args, model_config) -> tvm.I
 
     bb = relax.BlockBuilder()  # pylint: disable=invalid-name
     with bb.function("transform_params"):
-        rank = tir.Var("rank", "int64")
+        rank = tir.SizeVar("rank", "int64")
         # TODO(Lunderberg): Support primitive inputs to relax
         # functions.  Currently, using a PrimStructInfo as the
         # argument results in an error thrown during

--- a/mlc_llm/relax_model/gpt_bigcode.py
+++ b/mlc_llm/relax_model/gpt_bigcode.py
@@ -64,7 +64,7 @@ class GPTBigCodeConfig:
 def _prepare_decoder_attention_mask(input_shape, src_len, dtype):
     # create causal mask
     # [bsz, seq_len] -> [bsz, tgt_seq_len, 1, src_seq_len]
-    if isinstance(input_shape[-1], tvm.tir.Var) or input_shape[-1] > 1:
+    if isinstance(input_shape[-1], tvm.tir.SizeVar) or input_shape[-1] > 1:
         bsz, tgt_len = input_shape
 
         def min_max_triu_te():
@@ -488,8 +488,8 @@ def create_encoding_func(
     func_name = "prefill"
 
     batch_size = tvm.tir.IntImm("int64", 1)
-    seq_len = tvm.tir.Var("n", "int64")
-    all_seq_len = tvm.tir.Var("m", "int64")
+    seq_len = tvm.tir.SizeVar("n", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
     with bb.function(func_name):
         model = GPTBigCodeForCausalLM(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
@@ -530,7 +530,7 @@ def create_decoding_func(
 
     bsz = tvm.tir.IntImm("int64", 1)
     seq_len = tvm.tir.IntImm("int64", 1)
-    all_seq_len = tvm.tir.Var("m", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
 
     with bb.function(func_name):
         model = GPTBigCodeForCausalLM(config)

--- a/mlc_llm/relax_model/gpt_neox.py
+++ b/mlc_llm/relax_model/gpt_neox.py
@@ -295,7 +295,7 @@ class GPTNeoXLayer(nn.Module):
 def _prepare_decoder_attention_mask(input_shape, src_len, dtype):
     # create causal mask
     # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
-    if isinstance(input_shape[-1], tvm.tir.Var) or input_shape[-1] > 1:
+    if isinstance(input_shape[-1], tvm.tir.SizeVar) or input_shape[-1] > 1:
         bsz, tgt_len = input_shape
 
         def min_max_triu_te():
@@ -500,7 +500,7 @@ def create_embed_func(
     func_name = "embed"
 
     bsz = 1
-    seq_len = tvm.tir.Var("m", "int64")
+    seq_len = tvm.tir.SizeVar("m", "int64")
     with bb.function(func_name):
         model = GPTNeoXEmbedTokensWrapper(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
@@ -527,8 +527,8 @@ def create_encoding_func(
     func_name = "prefill_with_embed" if sep_embed else "prefill"
 
     batch_size = tvm.tir.IntImm("int64", 1)
-    seq_len = tvm.tir.Var("n", "int64")
-    all_seq_len = tvm.tir.Var("m", "int64")
+    seq_len = tvm.tir.SizeVar("n", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
     hidden_size = config.hidden_size
     with bb.function(func_name):
         model = GPTNeoXForCausalLM(config, sep_embed)
@@ -578,7 +578,7 @@ def create_decoding_func(
 
     batch_size = tvm.tir.IntImm("int64", 1)
     seq_len = tvm.tir.IntImm("int64", 1)
-    all_seq_len = tvm.tir.Var("m", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
     with bb.function(func_name):
         model = GPTNeoXForCausalLM(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)

--- a/mlc_llm/relax_model/gptj.py
+++ b/mlc_llm/relax_model/gptj.py
@@ -280,7 +280,7 @@ class GPTJLayer(nn.Module):
 def _prepare_decoder_attention_mask(input_shape, src_len, dtype):
     # create causal mask
     # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
-    if isinstance(input_shape[-1], tvm.tir.Var) or input_shape[-1] > 1:
+    if isinstance(input_shape[-1], tvm.tir.SizeVar) or input_shape[-1] > 1:
         bsz, tgt_len = input_shape
         mask = full((tgt_len, tgt_len), _min_value(dtype))
         mask = triu(mask, k=1)
@@ -481,7 +481,7 @@ def create_embed_func(
     func_name = "embed"
 
     bsz = 1
-    seq_len = tvm.tir.Var("m", "int64")
+    seq_len = tvm.tir.SizeVar("m", "int64")
     with bb.function(func_name):
         model = GPTJEmbedTokensWrapper(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
@@ -508,8 +508,8 @@ def create_encoding_func(
     func_name = "prefill_with_embed" if sep_embed else "prefill"
 
     batch_size = tvm.tir.IntImm("int64", 1)
-    seq_len = tvm.tir.Var("n", "int64")
-    all_seq_len = tvm.tir.Var("m", "int64")
+    seq_len = tvm.tir.SizeVar("n", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
     hidden_size = config.hidden_size
     with bb.function(func_name):
         model = GPTJForCausalLM(config, sep_embed)
@@ -559,7 +559,7 @@ def create_decoding_func(
 
     batch_size = tvm.tir.IntImm("int64", 1)
     seq_len = tvm.tir.IntImm("int64", 1)
-    all_seq_len = tvm.tir.Var("m", "int64")
+    all_seq_len = tvm.tir.SizeVar("m", "int64")
     with bb.function(func_name):
         model = GPTJForCausalLM(config)
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)

--- a/mlc_llm/relax_model/rwkv.py
+++ b/mlc_llm/relax_model/rwkv.py
@@ -464,7 +464,7 @@ def create_func(
 ):
     if func_name not in ["prefill", "decode"]:
         raise ValueError(f"func_name must be 'prefill' or 'decode', got {func_name}")
-    seq_len = 1 if func_name == "decode" else tir.Var("n", "int64")
+    seq_len = 1 if func_name == "decode" else tir.SizeVar("n", "int64")
 
     with bb.function(func_name):
         model = RWKVForCausalLM(config)


### PR DESCRIPTION
Struct info inference can benefit from the implicit >= 0 bound of SizeVar.

cc @MasterJH5574 @tqchen @Hzfengsy 