### PR TITLE
[Feature] Attention sinks kvcache on mistral

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -432,9 +432,9 @@ class LLMChat {
       CHECK(config["prefill_chunk_size"].is<int64_t>());
       this->prefill_chunk_size_ = config["prefill_chunk_size"].get<int64_t>();
     }
-    if (config.count("num_attention_sinks")) {
-      CHECK(config["num_attention_sinks"].is<int64_t>());
-      this->num_attention_sinks_ = config["num_attention_sinks"].get<int64_t>();
+    if (config.count("attention_sink_size")) {
+      CHECK(config["attention_sink_size"].is<int64_t>());
+      this->attention_sink_size_ = config["attention_sink_size"].get<int64_t>();
     }
     if (config.count("top_p")) {
       CHECK(config["top_p"].is<double>());
@@ -858,10 +858,10 @@ class LLMChat {
             sliding_window_cache_offset_ =
                 std::max((sliding_window_cache_offset_ + static_cast<int64_t>(chunk.size())) %
                              sliding_window_,
-                         num_attention_sinks_);
+                         attention_sink_size_);
           } else {
             sliding_window_cache_offset_ += static_cast<int64_t>(chunk.size());
-            sink_triggered_ = sliding_window_cache_offset_ >= num_attention_sinks_;
+            sink_triggered_ = sliding_window_cache_offset_ >= attention_sink_size_;
           }
         }
       }
@@ -907,10 +907,10 @@ class LLMChat {
     if (this->sliding_window_ != -1) {
       if (sink_triggered_) {
         sliding_window_cache_offset_ =
-            std::max((sliding_window_cache_offset_ + 1) % sliding_window_, num_attention_sinks_);
+            std::max((sliding_window_cache_offset_ + 1) % sliding_window_, attention_sink_size_);
       } else {
         sliding_window_cache_offset_ += 1;
-        sink_triggered_ = sliding_window_cache_offset_ >= num_attention_sinks_;
+        sink_triggered_ = sliding_window_cache_offset_ >= attention_sink_size_;
       }
     }
 
@@ -1401,7 +1401,7 @@ class LLMChat {
   // max window size, mean and max generation length, sliding window
   // If we use sliding window, max window size is its default max() value
   int64_t max_window_size_{std::numeric_limits<int64_t>::max()}, mean_gen_len_{128},
-      max_gen_len_{512}, sliding_window_{-1}, prefill_chunk_size_{-1}, num_attention_sinks_{0};
+      max_gen_len_{512}, sliding_window_{-1}, prefill_chunk_size_{-1}, attention_sink_size_{0};
   // size of the vocab table
   int64_t vocab_size_;
   // number of shards in distributed inference

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -432,6 +432,10 @@ class LLMChat {
       CHECK(config["prefill_chunk_size"].is<int64_t>());
       this->prefill_chunk_size_ = config["prefill_chunk_size"].get<int64_t>();
     }
+    if (config.count("num_attention_sinks")) {
+      CHECK(config["num_attention_sinks"].is<int64_t>());
+      this->num_attention_sinks_ = config["num_attention_sinks"].get<int64_t>();
+    }
     if (config.count("top_p")) {
       CHECK(config["top_p"].is<double>());
       this->top_p_ = config["top_p"].get<double>();
@@ -560,6 +564,8 @@ class LLMChat {
     this->ResetRuntimeStats();
     this->ResetKVCache();
     this->total_seq_len_ = 0;
+    this->sliding_window_cache_offset_ = 0;
+    this->sink_triggered_ = false;
   }
 
   /*! \brief reset the runtime stats. */
@@ -845,6 +851,19 @@ class LLMChat {
             std::vector<int32_t>(prompt_tokens.begin() + begin, prompt_tokens.begin() + end);
         new_seq_len += static_cast<int64_t>(chunk.size());
         logits_on_device = this->ForwardTokens(chunk, new_seq_len);
+
+        // update window cache offset (prefill)
+        if (this->sliding_window_ != -1) {
+          if (sink_triggered_) {
+            sliding_window_cache_offset_ =
+                std::max((sliding_window_cache_offset_ + static_cast<int64_t>(chunk.size())) %
+                             sliding_window_,
+                         num_attention_sinks_);
+          } else {
+            sliding_window_cache_offset_ += static_cast<int64_t>(chunk.size());
+            sink_triggered_ = sliding_window_cache_offset_ >= num_attention_sinks_;
+          }
+        }
       }
       ICHECK_EQ(new_seq_len, total_seq_len_ + token_len) << "Expect chunking process all tokens";
     } else {
@@ -883,6 +902,17 @@ class LLMChat {
 
     NDArray logits_on_device = this->ForwardTokens({last_token}, total_seq_len_ + 1);
     total_seq_len_ += 1;
+
+    // update window cache offset (decoding)
+    if (this->sliding_window_ != -1) {
+      if (sink_triggered_) {
+        sliding_window_cache_offset_ =
+            std::max((sliding_window_cache_offset_ + 1) % sliding_window_, num_attention_sinks_);
+      } else {
+        sliding_window_cache_offset_ += 1;
+        sink_triggered_ = sliding_window_cache_offset_ >= num_attention_sinks_;
+      }
+    }
 
     int32_t next_token = this->SampleTokenFromLogits(logits_on_device, generation_config);
 
@@ -1215,7 +1245,8 @@ class LLMChat {
         int64_t cache_len = std::min(this->sliding_window_, cur_pos - seq_len);
         ShapeTuple cache_len_shape = ShapeTuple({cache_len});
         ShapeTuple kv_seq_len_shape = ShapeTuple({cache_len + seq_len});
-        ret = ft_.prefill_func_(input_data, cur_pos_shape, cache_len_shape, kv_seq_len_shape,
+        ShapeTuple cache_offset_shape = ShapeTuple({sliding_window_cache_offset_});
+        ret = ft_.prefill_func_(input_data, cache_len_shape, kv_seq_len_shape, cache_offset_shape,
                                 kv_cache_, params_);
       }
     } else {
@@ -1240,7 +1271,8 @@ class LLMChat {
           int64_t cache_len = std::min(this->sliding_window_, pos - seq_len);
           ShapeTuple cache_len_shape = ShapeTuple({cache_len});
           ShapeTuple kv_seq_len_shape = ShapeTuple({cache_len + seq_len});
-          ret = ft_.decode_func_(input_data, pos_shape, cache_len_shape, kv_seq_len_shape,
+          ShapeTuple cache_offset_shape = ShapeTuple({sliding_window_cache_offset_});
+          ret = ft_.decode_func_(input_data, cache_len_shape, kv_seq_len_shape, cache_offset_shape,
                                  kv_cache_, params_);
         }
       }
@@ -1369,7 +1401,7 @@ class LLMChat {
   // max window size, mean and max generation length, sliding window
   // If we use sliding window, max window size is its default max() value
   int64_t max_window_size_{std::numeric_limits<int64_t>::max()}, mean_gen_len_{128},
-      max_gen_len_{512}, sliding_window_{-1}, prefill_chunk_size_{-1};
+      max_gen_len_{512}, sliding_window_{-1}, prefill_chunk_size_{-1}, num_attention_sinks_{0};
   // size of the vocab table
   int64_t vocab_size_;
   // number of shards in distributed inference
@@ -1398,6 +1430,10 @@ class LLMChat {
   std::string output_message_;
   // Whether encounter stop str
   bool stop_triggered_{false};
+  // Whether sink is in action
+  bool sink_triggered_{false};
+  // sliding window cache offset
+  int64_t sliding_window_cache_offset_{0};
   //----------------------------
   // Tokenizer
   //----------------------------

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -113,6 +113,10 @@ class BuildArgs:
         The chunk size during prefilling. By default, the chunk size is the same as
         max sequence length. Currently only useful when compiling Mistral.
 
+    num_attention_sinks: int
+        Number of attention sinks (https://arxiv.org/abs/2309.17453).
+        Only supported on mistral yet.
+
     cc_path: str
         ``/path/to/cross_compiler_path``; currently only used for cross-compile
         for nvidia/jetson device.
@@ -358,6 +362,15 @@ class BuildArgs:
                 "The chunk size during prefilling. By default, the chunk size is "
                 "the same as the sliding window size or the max sequence length. "
                 "Currently only useful when compiling Mistral."
+            ),
+        },
+    )
+    num_attention_sinks: int = field(
+        default=0,
+        metadata={
+            "help": (
+                "The number of attention sinks to keep in cache."
+                "Only supported on mistral yet."
             ),
         },
     )
@@ -699,6 +712,10 @@ def dump_mlc_chat_config(
     if args.sliding_window != -1:
         # Do not add max window size if use sliding window
         config["sliding_window"] = args.sliding_window
+
+        # only use sinks if sliding window enabled
+        if args.num_attention_sinks > 0:
+            config["num_attention_sinks"] = args.num_attention_sinks
     else:
         config["max_window_size"] = max_window_size
 
@@ -820,6 +837,7 @@ def build_model_from_args(args: argparse.Namespace):
 
         if args.model_category == "mistral":
             args.sliding_window = model_config.sliding_window
+            args.num_attention_sinks = model_config.num_attention_sinks
 
         for qspec_updater_class in param_manager.qspec_updater_classes:
             qspec_updater = qspec_updater_class(param_manager)

--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -113,7 +113,7 @@ class BuildArgs:
         The chunk size during prefilling. By default, the chunk size is the same as
         max sequence length. Currently only useful when compiling Mistral.
 
-    num_attention_sinks: int
+    attention_sink_size: int
         Number of attention sinks (https://arxiv.org/abs/2309.17453).
         Only supported on mistral yet.
 
@@ -365,7 +365,7 @@ class BuildArgs:
             ),
         },
     )
-    num_attention_sinks: int = field(
+    attention_sink_size: int = field(
         default=0,
         metadata={
             "help": (
@@ -714,8 +714,8 @@ def dump_mlc_chat_config(
         config["sliding_window"] = args.sliding_window
 
         # only use sinks if sliding window enabled
-        if args.num_attention_sinks > 0:
-            config["num_attention_sinks"] = args.num_attention_sinks
+        if args.attention_sink_size > 0:
+            config["attention_sink_size"] = args.attention_sink_size
     else:
         config["max_window_size"] = max_window_size
 
@@ -837,7 +837,7 @@ def build_model_from_args(args: argparse.Namespace):
 
         if args.model_category == "mistral":
             args.sliding_window = model_config.sliding_window
-            args.num_attention_sinks = model_config.num_attention_sinks
+            args.attention_sink_size = model_config.attention_sink_size
 
         for qspec_updater_class in param_manager.qspec_updater_classes:
             qspec_updater = qspec_updater_class(param_manager)

--- a/mlc_llm/relax_model/mistral.py
+++ b/mlc_llm/relax_model/mistral.py
@@ -38,6 +38,7 @@ class MistralConfig:
         rms_norm_eps=1e-5,
         rope_theta=10000.0,
         sliding_window=4096,
+        num_attention_sinks=0,
         tie_word_embeddings=False,
         vocab_size=32000,
         dtype="float32",
@@ -61,6 +62,7 @@ class MistralConfig:
         self.rms_norm_eps = rms_norm_eps
         self.rope_theta = rope_theta
         self.sliding_window = sliding_window
+        self.num_attention_sinks = num_attention_sinks
         self.tie_word_embeddings = tie_word_embeddings
         self.vocab_size = vocab_size
         self.dtype = dtype
@@ -198,7 +200,7 @@ class MistralMLP(nn.Module):
         return result
 
 
-def apply_rotary_pos_emb(q, k, base, offset: int = 0):
+def apply_rotary_pos_emb(q, k, base, q_offset):
     def f_rotary_embedding(tensor, offset):
         dtype = tensor.dtype
         head_dim = tensor.shape[-1]
@@ -224,8 +226,8 @@ def apply_rotary_pos_emb(q, k, base, offset: int = 0):
 
         return tvm.te.compute(tensor.shape, rotary_compute, name="rotary")
 
-    q_embed = nn.emit_te(f_rotary_embedding, q, offset, primfunc_name_hint="rotary_embedding")
-    k_embed = nn.emit_te(f_rotary_embedding, k, offset, primfunc_name_hint="rotary_embedding")
+    q_embed = nn.emit_te(f_rotary_embedding, q, q_offset, primfunc_name_hint="rotary_embedding")
+    k_embed = nn.emit_te(f_rotary_embedding, k, 0, primfunc_name_hint="rotary_embedding")
     return q_embed, k_embed
 
 
@@ -241,6 +243,7 @@ class MistralAttention(nn.Module):
         self.head_dim = self.hidden_size // config.num_attention_heads
         self.rope_theta = config.rope_theta
         self.sliding_window = config.sliding_window
+        self.num_attention_sinks = config.num_attention_sinks
 
         self.combine_matmul = config.combine_matmul
         if self.combine_matmul:
@@ -288,9 +291,43 @@ class MistralAttention(nn.Module):
         kv_seq_len: int,
         rolling_cache_len: int,
         cache_offset: int,
+        num_attention_sinks: int,
         past_key_value: Tuple[relax.Expr],
     ):
-        from tvm.relax.op import reshape, squeeze
+        from tvm.relax.op import reshape
+
+        def te_cache_unrotate(x_cached, cache_offset, rolling_cache_len):
+            return te.compute(
+                (kv_cur_shape[0], rolling_cache_len, kv_cur_shape[2], kv_cur_shape[3]),
+                lambda b, s, h, d: te.if_then_else(
+                    s < num_attention_sinks,
+                    x_cached[b, s, h, d],
+                    te.if_then_else(
+                        s < rolling_cache_len - cache_offset + num_attention_sinks,
+                        x_cached[b, s + cache_offset - num_attention_sinks, h, d],
+                        x_cached[b, s + cache_offset - rolling_cache_len, h, d],
+                    ),
+                ),
+                name="te_cache_unrotate",
+            )
+
+        def te_cache_cur_concat(x, x_cached, kv_seq_len, rolling_cache_len):
+            return te.compute(
+                (kv_cur_shape[0], kv_seq_len, kv_cur_shape[2], kv_cur_shape[3]),
+                lambda b, s, h, d: te.if_then_else(
+                    s < rolling_cache_len,
+                    x_cached[b, s, h, d],
+                    x[b, s - rolling_cache_len, h, d],
+                ),
+                name="te_cache_cur_concat",
+            )
+
+        def te_squeeze(x):
+            return te.compute(
+                x.shape[1:],
+                lambda s, h, d: x[0, s, h, d],
+                name="squeeze_te",
+            )
 
         # [bsz, t, nh, hd]
         kv_cur_shape = key_cur.struct_info.shape
@@ -322,66 +359,67 @@ class MistralAttention(nn.Module):
         key_cached = nn.emit(reshape(key_cached, kv_batched_cache_shape))
         value_cached = nn.emit(reshape(value_cached, kv_batched_cache_shape))
 
-        def te_unrotate_concat(x, x_cached, cache_offset, rolling_cache_len):
-            return te.compute(
-                (kv_cur_shape[0], kv_seq_len, kv_cur_shape[2], kv_cur_shape[3]),
-                lambda b, s, h, d: te.if_then_else(
-                    s < rolling_cache_len - cache_offset,
-                    x_cached[b, cache_offset + s, h, d],
-                    te.if_then_else(
-                        s < rolling_cache_len,
-                        x_cached[b, s + cache_offset - rolling_cache_len, h, d],
-                        x[b, s - rolling_cache_len, h, d],
-                    ),
-                ),
-                name="unrotate_concat_te",
-            )
-
-        key = nn.emit_te(
-            te_unrotate_concat,
-            key_cur,
+        key_cached = nn.emit_te(
+            te_cache_unrotate,
             key_cached,
             cache_offset,
             rolling_cache_len,
-            primfunc_name_hint="te_unrotate_concat_key",
+            primfunc_name_hint="te_cache_unrotate_key",
         )
-        value = nn.emit_te(
-            te_unrotate_concat,
-            value_cur,
+        key = nn.emit_te(
+            te_cache_cur_concat,
+            key_cur,
+            key_cached,
+            kv_seq_len,
+            rolling_cache_len,
+            primfunc_name_hint="te_cache_cur_concat_key",
+        )
+
+        value_cached = nn.emit_te(
+            te_cache_unrotate,
             value_cached,
             cache_offset,
             rolling_cache_len,
-            primfunc_name_hint="te_unrotate_concat_value",
+            primfunc_name_hint="te_cache_unrotate_value",
         )
-
-        # # update cache
-        # k_cache, v_cache = past_key_value
-        # squeezed_key = nn.emit(squeeze(key_cur))
-        # squeezed_value = nn.emit(squeeze(value_cur))
-
-        def te_squeeze(x):
-            return te.compute(
-                x.shape[1:],
-                lambda s, h, d: x[0, s, h, d],
-                name="squeeze_te",
-            )
+        value = nn.emit_te(
+            te_cache_cur_concat,
+            value_cur,
+            value_cached,
+            kv_seq_len,
+            rolling_cache_len,
+            primfunc_name_hint="te_cache_cur_concat_value",
+        )
 
         # update cache
         squeezed_key = nn.emit_te(te_squeeze, key_cur)
         squeezed_value = nn.emit_te(te_squeeze, value_cur)
 
-        f_kv_cache_override = relax.extern("vm.builtin.attention_kv_cache_window_override")
+        assert num_attention_sinks >= 0
+        f_kv_cache_override = relax.extern(
+            "vm.builtin.attention_kv_cache_window_override_with_sinks"
+        )
         k_cache = nn.emit(
             relax.Call(
                 f_kv_cache_override,
-                args=[k_cache, squeezed_key, relax.PrimValue(self.sliding_window)],
+                args=[
+                    k_cache,
+                    squeezed_key,
+                    relax.PrimValue(self.sliding_window),
+                    relax.PrimValue(num_attention_sinks),
+                ],
                 sinfo_args=[relax.ObjectStructInfo()],
             )
         )
         v_cache = nn.emit(
             relax.Call(
                 f_kv_cache_override,
-                args=[v_cache, squeezed_value, relax.PrimValue(self.sliding_window)],
+                args=[
+                    v_cache,
+                    squeezed_value,
+                    relax.PrimValue(self.sliding_window),
+                    relax.PrimValue(num_attention_sinks),
+                ],
                 sinfo_args=[relax.ObjectStructInfo()],
             )
         )
@@ -391,9 +429,9 @@ class MistralAttention(nn.Module):
     def forward(
         self,
         hidden_states: relax.Expr,
-        all_seq_len_shape: relax.Expr,
         cache_len_shape: relax.Expr,
         kv_seq_len_shape: relax.Expr,
+        cache_offset_shape: relax.Expr,
         past_key_value: Tuple[relax.Expr],
         attention_mask: Optional[relax.Expr] = None,
     ) -> Tuple[relax.Expr, Optional[relax.Expr], Optional[Tuple[relax.Expr]]]:
@@ -442,21 +480,26 @@ class MistralAttention(nn.Module):
             ),
         )
 
-        all_seq_len = all_seq_len_shape.struct_info.values[0]
-        offset = all_seq_len - q_len
-        query, key_cur = apply_rotary_pos_emb(
-            query,
-            key_cur,
-            self.rope_theta,
-            offset=offset,
-        )
-
         # concat current kv with cached kv (unrotating the cache)
         rolling_cache_len = cache_len_shape.struct_info.values[0]
         kv_seq_len = kv_seq_len_shape.struct_info.values[0]
-        cache_offset = (all_seq_len - q_len) % self.sliding_window
+        cache_offset = cache_offset_shape.struct_info.values[0]
         key, value, updated_key_value = self.interleave_kv(
-            key_cur, value_cur, kv_seq_len, rolling_cache_len, cache_offset, past_key_value
+            key_cur,
+            value_cur,
+            kv_seq_len,
+            rolling_cache_len,
+            cache_offset,
+            self.num_attention_sinks,
+            past_key_value,
+        )
+
+        # cache relative position embeddings (after KV Cache)
+        query, key = apply_rotary_pos_emb(
+            query,
+            key,
+            self.rope_theta,
+            q_offset=rolling_cache_len,
         )
 
         if self.num_key_value_heads != self.num_query_heads:
@@ -522,9 +565,9 @@ class MistralDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: relax.Expr,
-        all_seq_len_shape: relax.Expr,
         cache_len_shape: relax.Expr,
         kv_seq_len_shape: relax.Expr,
+        cache_offset_shape: relax.Expr,
         past_key_value: Tuple[relax.Expr],
         attention_mask: Optional[relax.Expr] = None,
     ) -> Tuple[relax.Expr, Optional[Tuple[relax.Expr, relax.Expr]]]:
@@ -537,9 +580,9 @@ class MistralDecoderLayer(nn.Module):
             hidden_states=hidden_states,
             past_key_value=past_key_value,
             attention_mask=attention_mask,
-            all_seq_len_shape=all_seq_len_shape,
             cache_len_shape=cache_len_shape,
             kv_seq_len_shape=kv_seq_len_shape,
+            cache_offset_shape=cache_offset_shape,
         )
         if self.self_attn.num_shards > 1:
             residual = nn.emit(
@@ -638,9 +681,9 @@ class MistralModel(nn.Module):
     def forward(
         self,
         inputs: relax.Expr,
-        all_seq_len_shape: relax.Expr,
         cache_len_shape: relax.Expr,
         kv_seq_len_shape: relax.Expr,
+        cache_offset_shape: relax.Expr,
         past_key_values: relax.Expr,
     ):
         if self.num_shards > 1:
@@ -674,9 +717,9 @@ class MistralModel(nn.Module):
                 hidden_states,
                 attention_mask=attention_mask,
                 past_key_value=past_key_value,
-                all_seq_len_shape=all_seq_len_shape,
                 cache_len_shape=cache_len_shape,
                 kv_seq_len_shape=kv_seq_len_shape,
+                cache_offset_shape=cache_offset_shape,
             )
             next_decoder_cache += key_value_cache
 
@@ -709,16 +752,16 @@ class MistralForCausalLM(nn.Module):
     def forward(
         self,
         inputs: relax.Expr,
-        all_seq_len_shape: relax.Expr,
         cache_len_shape: relax.Expr,
         kv_seq_len_shape: relax.Expr,
+        cache_offset_shape: relax.Expr,
         past_key_values: relax.Expr,
     ):
         hidden_states, key_value_cache = self.model(
             inputs=inputs,
-            all_seq_len_shape=all_seq_len_shape,
             cache_len_shape=cache_len_shape,
             kv_seq_len_shape=kv_seq_len_shape,
+            cache_offset_shape=cache_offset_shape,
             past_key_values=past_key_values,
         )
 
@@ -784,11 +827,13 @@ def create_encoding_func(
 
     bsz = 1
     seq_len = tvm.tir.SizeVar("n", "int64")  # number of tokens for the input
-    all_seq_len = tvm.tir.SizeVar("m", "int64")  # total_seq_len in `llm_chat.cc` (including seq_len)
     rolling_cache_len = tvm.tir.SizeVar("c", "int64")  # rolling_cache_len captures number of elements in the cache
     kv_seq_len = tvm.tir.SizeVar(
         "k", "int64"
     )  # kv_seq_len captures number of elements in cache + seq_len
+    cache_offset = tvm.tir.SizeVar(
+        "o", "int64"
+    )  # slidinf window kv cache offset
 
     hidden_size = config.hidden_size
     with bb.function(func_name):
@@ -800,9 +845,11 @@ def create_encoding_func(
             if sep_embed
             else nn.Placeholder((bsz, seq_len), dtype="int32", name="input_ids")
         )
-        all_seq_len_shape = relax.Var("all_seq_len", relax.ShapeStructInfo((all_seq_len,)))
-        cache_len_shape = relax.Var("rolling_cache_len", relax.ShapeStructInfo((rolling_cache_len,)))
+        cache_len_shape = relax.Var(
+            "rolling_cache_len", relax.ShapeStructInfo((rolling_cache_len,))
+        )
         kv_seq_len_shape = relax.Var("kv_seq_len", relax.ShapeStructInfo((kv_seq_len,)))
+        cache_offset_shape = relax.Var("cache_offset", relax.ShapeStructInfo((cache_offset,)))
         past_key_values = relax.Var(
             "kv_cache",
             relax.TupleStructInfo(
@@ -812,16 +859,16 @@ def create_encoding_func(
         with bb.dataflow():
             logits, key_value_cache = model(
                 inputs,
-                all_seq_len_shape,
                 cache_len_shape,
                 kv_seq_len_shape,
+                cache_offset_shape,
                 past_key_values=past_key_values,
             )
             params = [
                 inputs,
-                all_seq_len_shape,
                 cache_len_shape,
                 kv_seq_len_shape,
+                cache_offset_shape,
                 past_key_values,
             ] + model.parameters()
             gv = bb.emit_output((logits, relax.Tuple(key_value_cache)))
@@ -841,20 +888,24 @@ def create_decoding_func(
     func_name = "decode"
 
     bsz = 1
-    all_seq_len = tvm.tir.SizeVar("m", "int64")
     rolling_cache_len = tvm.tir.SizeVar("c", "int64")  # rolling_cache_len captures number of elements in the cache
     kv_seq_len = tvm.tir.SizeVar(
         "k", "int64"
     )  # kv_seq_len captures number of elements in cache + seq_len
+    cache_offset = tvm.tir.SizeVar(
+        "o", "int64"
+    )  # sliding window kv cache offset
 
     with bb.function(func_name):
         model = MistralForCausalLM(config, tvm.tir.SizeVar("vocab_size", "int64"))
         param_manager.register_params(model, func_name, quant_scheme, get_param_quant_kind)
 
         input_ids = nn.Placeholder((bsz, 1), dtype="int32", name="input_ids")
-        all_seq_len_shape = relax.Var("all_seq_len", relax.ShapeStructInfo((all_seq_len,)))
-        cache_len_shape = relax.Var("rolling_cache_len", relax.ShapeStructInfo((rolling_cache_len,)))
+        cache_len_shape = relax.Var(
+            "rolling_cache_len", relax.ShapeStructInfo((rolling_cache_len,))
+        )
         kv_seq_len_shape = relax.Var("kv_seq_len", relax.ShapeStructInfo((kv_seq_len,)))
+        cache_offset_shape = relax.Var("cache_offset", relax.ShapeStructInfo((cache_offset,)))
         past_key_values = relax.Var(
             "kv_cache",
             relax.TupleStructInfo(
@@ -864,16 +915,16 @@ def create_decoding_func(
         with bb.dataflow():
             logits, key_value_cache = model(
                 input_ids,
-                all_seq_len_shape,
                 cache_len_shape,
                 kv_seq_len_shape,
+                cache_offset_shape,
                 past_key_values=past_key_values,
             )
             params = [
                 input_ids,
-                all_seq_len_shape,
                 cache_len_shape,
                 kv_seq_len_shape,
+                cache_offset_shape,
                 past_key_values,
             ] + model.parameters()
             gv = bb.emit_output((logits, relax.Tuple(key_value_cache)))
@@ -933,6 +984,8 @@ def get_model(args, hf_config):
 
     if args.sliding_window != -1:
         hf_config["sliding_window"] = args.sliding_window
+        if args.num_attention_sinks > 0:
+            hf_config["num_attention_sinks"] = args.num_attention_sinks
     if args.max_seq_len != -1:
         hf_config["max_sequence_length"] = args.max_seq_len
 
@@ -944,11 +997,12 @@ def get_model(args, hf_config):
         build_model_only=args.build_model_only,
     )
 
-    assert config.sliding_window != -1
-
     # prefill chunk size same as sliding window by default
     if args.prefill_chunk_size < 1:
-        args.prefill_chunk_size = config.sliding_window
+        args.prefill_chunk_size = config.sliding_window - config.num_attention_sinks
+
+    assert config.sliding_window != -1
+    assert args.prefill_chunk_size <= config.sliding_window - config.num_attention_sinks
 
     param_manager = ParamManager()
     bb = relax.BlockBuilder()

--- a/python/mlc_chat/cli/gen_config.py
+++ b/python/mlc_chat/cli/gen_config.py
@@ -63,6 +63,12 @@ def main(argv):
         help=HELP["prefill_chunk_size"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
+        "--attention-sink-size",
+        type=int,
+        default=None,
+        help=HELP["attention_sink_size"] + ' (default: "%(default)s")',
+    )
+    parser.add_argument(
         "--tensor-parallel-shards",
         type=int,
         default=None,
@@ -85,6 +91,7 @@ def main(argv):
         context_window_size=parsed.context_window_size,
         sliding_window_size=parsed.sliding_window_size,
         prefill_chunk_size=parsed.prefill_chunk_size,
+        attention_sink_size=parsed.attention_sink_size,
         tensor_parallel_shards=parsed.tensor_parallel_shards,
         output=parsed.output,
     )

--- a/python/mlc_chat/compiler/gen_config.py
+++ b/python/mlc_chat/compiler/gen_config.py
@@ -30,6 +30,7 @@ class MLCChatConfig:  # pylint: disable=too-many-instance-attributes
     context_window_size: int
     sliding_window_size: int
     prefill_chunk_size: int
+    attention_sink_size: int
     tensor_parallel_shards: int
     # Control the behavior of the runtime
     mean_gen_len: int = None
@@ -75,6 +76,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
     context_window_size: Optional[int],
     sliding_window_size: Optional[int],
     prefill_chunk_size: Optional[int],
+    attention_sink_size: Optional[int],
     tensor_parallel_shards: Optional[int],
     output: Path,
 ):
@@ -85,6 +87,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
         context_window_size=context_window_size,
         sliding_window_size=sliding_window_size,
         prefill_chunk_size=prefill_chunk_size,
+        attention_sink_size=attention_sink_size,
         tensor_parallel_shards=tensor_parallel_shards,
     ).apply(model_config)
     mlc_chat_config = MLCChatConfig(
@@ -95,6 +98,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
         context_window_size=model_config.context_window_size,
         sliding_window_size=getattr(model_config, "sliding_window_size", -1),
         prefill_chunk_size=model_config.prefill_chunk_size,
+        attention_sink_size=getattr(model_config, "attention_sink_size", -1),
         tensor_parallel_shards=model_config.tensor_parallel_shards,
         conv_template=conv_template,
     )

--- a/python/mlc_chat/compiler/help.py
+++ b/python/mlc_chat/compiler/help.py
@@ -103,13 +103,17 @@ This flag subjects to future refactoring.
 the chunk size is the same as sliding window or max sequence length.
 This flag subjects to future refactoring.
 """.strip(),
+    "attention_sink_size": """
+(Experimental) The number of stored sinks. Only supported on Mistral yet. By default,
+the number of sinks is 4. This flag subjects to future refactoring.
+""".strip(),
     """tensor_parallel_shards""": """
 Number of shards to split the model into in tensor parallelism multi-gpu inference.
 """.strip(),
     "overrides": """
 Model configuration override. Configurations to override `mlc-chat-config.json`. Supports
-`context_window_size`, `prefill_chunk_size`, `sliding_window_size`, `max_batch_size` and
-`tensor_parallel_shards`. Meanwhile, model config could be explicitly specified via details
-knobs, e.g. --overrides "context_window_size=1024;prefill_chunk_size=128".
+`context_window_size`, `prefill_chunk_size`, `sliding_window_size`, `attention_sink_size`,
+`max_batch_size` and `tensor_parallel_shards`. Meanwhile, model config could be explicitly
+specified via details knobs, e.g. --overrides "context_window_size=1024;prefill_chunk_size=128".
 """.strip(),
 }

--- a/python/mlc_chat/compiler/model/mistral/mistral_model.py
+++ b/python/mlc_chat/compiler/model/mistral/mistral_model.py
@@ -249,9 +249,10 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         qkv_cur = self.qkv_proj(hidden_states)
         qkv_cur = op.reshape(qkv_cur, (b, s, h_q + 2 * h_kv, d))
         q, k_cur, v_cur = op.split(qkv_cur, [h_q, h_q + h_kv], axis=2)
-        q, k_cur = self.rotary_embedding(q, k_cur, rolling_cache_len)
 
         k, v = self.interleave_kv(k_cur, v_cur, kv_seq_len, rolling_cache_len, cache_offset)
+
+        q, k = self.rotary_embedding(q, k, rolling_cache_len)
 
         if h_kv != h_q:
             k = k.repeat(h_q // h_kv, axis=2)

--- a/python/mlc_chat/compiler/model/mistral/mistral_model.py
+++ b/python/mlc_chat/compiler/model/mistral/mistral_model.py
@@ -33,6 +33,7 @@ class MistralConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     head_dim: int = 0
     sliding_window_size: int = 4096
     prefill_chunk_size: int = 0
+    attention_sink_size: int = 4
     tensor_parallel_shards: int = 1
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
@@ -66,6 +67,8 @@ class MistralConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
         assert self.num_attention_heads % self.num_key_value_heads == 0
         assert self.head_dim * self.num_attention_heads == self.hidden_size
 
+        assert self.attention_sink_size >= 0
+
         if self.prefill_chunk_size == 0:
             # chunk size same as sliding window by default
             self.prefill_chunk_size = self.sliding_window_size
@@ -80,14 +83,14 @@ class MistralConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
 
 
 class RotaryEmbedding(nn.Module):
-    """Same as in Llama architecture."""
+    """Cache relative Rotary Embedding."""
 
     def __init__(self, config: MistralConfig):
         super().__init__()
         self.head_dim = config.head_dim
         self.position_embedding_base = config.position_embedding_base
 
-    def forward(self, q: Tensor, k: Tensor, offset: tir.Var):
+    def forward(self, q: Tensor, k: Tensor, q_offset: tir.Var):
         def te_op(x: te.Tensor, offset: tir.Var):
             dtype = x.dtype
 
@@ -109,8 +112,8 @@ class RotaryEmbedding(nn.Module):
 
             return te.compute(x.shape, compute, name="rotary")
 
-        q_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[q, offset])
-        k_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[k, offset])
+        q_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[q, q_offset])
+        k_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[k, 0])
         return q_embed, k_embed
 
 
@@ -143,60 +146,90 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         self.num_q_heads = config.num_attention_heads // config.tensor_parallel_shards
         self.num_kv_heads = config.num_key_value_heads // config.tensor_parallel_shards
         self.sliding_window_size = config.sliding_window_size
+        self.attention_sink_size = config.attention_sink_size
         self.qkv_proj = nn.Linear(
             in_features=config.hidden_size,
             out_features=(self.num_q_heads + 2 * self.num_kv_heads) * self.head_dim,
             bias=False,
         )
         self.o_proj = nn.Linear(self.num_q_heads * self.head_dim, config.hidden_size, bias=False)
-        self.k_cache = RollingKVCache(self.sliding_window_size, [self.num_kv_heads, self.head_dim])
-        self.v_cache = RollingKVCache(self.sliding_window_size, [self.num_kv_heads, self.head_dim])
+        self.k_cache = RollingKVCacheWithSinks(
+            self.sliding_window_size, [self.num_kv_heads, self.head_dim]
+        )
+        self.v_cache = RollingKVCacheWithSinks(
+            self.sliding_window_size, [self.num_kv_heads, self.head_dim]
+        )
 
     def interleave_kv(  # pylint: disable=too-many-arguments,too-many-locals
         self,
         k_cur: Tensor,
         v_cur: Tensor,
-        total_seq_len: tir.Var,
         kv_seq_len: tir.Var,
         rolling_cache_len: tir.Var,
+        cache_offset: tir.Var,
     ):
         """Unrotate and concatenate currunt and cached k and v"""
-        d, _, h_kv = self.head_dim, self.num_q_heads, self.num_kv_heads
-        t, kv_s, c = total_seq_len, kv_seq_len, rolling_cache_len
-        b, s, _, _ = k_cur.shape
-        cache_offset = (t - s) % self.sliding_window_size
+        h_kv, d = self.num_kv_heads, self.head_dim
+        kv_s, c, o = kv_seq_len, rolling_cache_len, cache_offset
+        b = k_cur.shape[0]
 
         k_cached = op.reshape(self.k_cache.view(c), (b, c, h_kv, d))
         v_cached = op.reshape(self.v_cache.view(c), (b, c, h_kv, d))
 
-        def _unrotate_concat(x_cur, x_cached, cache_offset, rolling_cache_len):
+        def _cache_unrotate(x_cached, rolling_cache_len, cache_offset):
             return te.compute(
                 (b, kv_s, h_kv, d),
                 lambda xb, xs, xh, xd: te.if_then_else(
-                    xs < rolling_cache_len - cache_offset,
-                    x_cached[xb, cache_offset + xs, xh, xd],
+                    xs < self.attention_sink_size,
+                    x_cached[xb, xs, xh, xd],
                     te.if_then_else(
-                        xs < rolling_cache_len,
+                        xs < rolling_cache_len - cache_offset + self.attention_sink_size,
+                        x_cached[xb, xs + cache_offset - self.attention_sink_size, xh, xd],
                         x_cached[xb, xs + cache_offset - rolling_cache_len, xh, xd],
-                        x_cur[xb, xs - rolling_cache_len, xh, xd],
                     ),
                 ),
-                name="unrotate_concat_te",
+                name="cache_unrotate_te",
             )
 
-        k = op.tensor_expr_op(
-            _unrotate_concat,
-            name_hint="te_unrotate_concat_key",
-            args=[k_cur, k_cached, cache_offset, c],
+        def _cache_cur_concat(x_cached, x_cur, rolling_cache_len):
+            return te.compute(
+                (b, kv_s, h_kv, d),
+                lambda xb, xs, xh, xd: te.if_then_else(
+                    xs < rolling_cache_len,
+                    x_cached[xb, xs, xh, xd],
+                    x_cur[xb, xs - rolling_cache_len, xh, xd],
+                ),
+                name="cache_cur_concat_te",
+            )
+
+        k_cached = op.tensor_expr_op(
+            _cache_unrotate,
+            name_hint="te_cache_unrotate_key",
+            args=[k_cached, c, o],
         )
-        v = op.tensor_expr_op(
-            _unrotate_concat,
-            name_hint="te_unrotate_concat_value",
-            args=[v_cur, v_cached, cache_offset, c],
+        k = op.tensor_expr_op(
+            _cache_cur_concat,
+            name_hint="te_cache_cur_concat_key",
+            args=[k_cached, k_cur, c],
         )
 
-        self.k_cache.override(op.squeeze(k_cur, axis=0), self.sliding_window_size)
-        self.v_cache.override(op.squeeze(v_cur, axis=0), self.sliding_window_size)
+        v_cached = op.tensor_expr_op(
+            _cache_unrotate,
+            name_hint="te_cache_unrotate_value",
+            args=[v_cached, c, o],
+        )
+        v = op.tensor_expr_op(
+            _cache_cur_concat,
+            name_hint="te_cache_cur_concat_value",
+            args=[v_cached, v_cur, c],
+        )
+
+        self.k_cache.override(
+            op.squeeze(k_cur, axis=0), self.sliding_window_size, self.attention_sink_size
+        )
+        self.v_cache.override(
+            op.squeeze(v_cur, axis=0), self.sliding_window_size, self.attention_sink_size
+        )
 
         return k, v
 
@@ -204,21 +237,21 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         self,
         hidden_states: Tensor,
         attention_mask: Tensor,
-        total_seq_len: tir.Var,  # Number of already-processed tokens plus ``seq_len``.
         rolling_cache_len: tir.Var,  # Number of elements currently in the cache.
         kv_seq_len: tir.Var,  # Equals to ``seq_len + rolling_cache_len``.
+        cache_offset: tir.Var,
     ):
         """Forward pass of MistralAttention, performing QKV."""
-        d, h_q, h_kv, t = self.head_dim, self.num_q_heads, self.num_kv_heads, total_seq_len
+        d, h_q, h_kv = self.head_dim, self.num_q_heads, self.num_kv_heads
         b, s, _ = hidden_states.shape
         assert b == 1, "Only support batch size 1 at this moment."
 
         qkv_cur = self.qkv_proj(hidden_states)
         qkv_cur = op.reshape(qkv_cur, (b, s, h_q + 2 * h_kv, d))
         q, k_cur, v_cur = op.split(qkv_cur, [h_q, h_q + h_kv], axis=2)
-        q, k_cur = self.rotary_embedding(q, k_cur, t - s)
+        q, k_cur = self.rotary_embedding(q, k_cur, rolling_cache_len)
 
-        k, v = self.interleave_kv(k_cur, v_cur, total_seq_len, kv_seq_len, rolling_cache_len)
+        k, v = self.interleave_kv(k_cur, v_cur, kv_seq_len, rolling_cache_len, cache_offset)
 
         if h_kv != h_q:
             k = k.repeat(h_q // h_kv, axis=2)
@@ -240,16 +273,16 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         return self.o_proj(output.permute_dims([0, 2, 1, 3]).reshape((b, s, h_q * d)))
 
 
-class RollingKVCache(nn.KVCache):
+class RollingKVCacheWithSinks(nn.KVCache):
     """
     Rolling buffer cache implementation.
     """
 
     cache: Optional[rx.Var]
 
-    def override(self, new_element: Tensor, max_cache_size: int) -> None:
+    def override(self, new_element: Tensor, max_cache_size: int, attention_sink_size: int) -> None:
         """
-        Override cache elements in RollingKVCache.
+        Override cache elements in RollingKVCacheWithSinks.
 
         Parameters
         ----------
@@ -258,19 +291,23 @@ class RollingKVCache(nn.KVCache):
 
         max_cache_size : int
             Max size of the cache.
+
+        attention_sink_size : int
+            Number of stored attention sinks.
         """
         if new_element.dtype != self.dtype:
             raise TypeError(
-                f'RollingKVCache has been set to use dtype "{self.dtype}", '
+                f'RollingKVCacheWithSinks has been set to use dtype "{self.dtype}", '
                 f'but got "{new_element.dtype}"'
             )
         self.cache = rx.BlockBuilder.current().emit(
             rx.Call(
-                rx.extern("vm.builtin.attention_kv_cache_window_override"),
+                rx.extern("vm.builtin.attention_kv_cache_window_override_with_sinks"),
                 args=[
                     self.cache,
                     new_element._expr,  # pylint: disable=protected-access
                     rx.PrimValue(max_cache_size),
+                    rx.PrimValue(attention_sink_size),
                 ],
                 sinfo_args=[rx.ObjectStructInfo()],
             )
@@ -293,9 +330,9 @@ class MistralDecoderLayer(nn.Module):
         self,
         hidden_states: Tensor,
         attention_mask: Tensor,
-        total_seq_len: tir.Var,
         rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
+        cache_offset: tir.Var,
     ):
         """Forward pass of a decoder layer; calculate attention, and add an residual connection."""
 
@@ -309,9 +346,9 @@ class MistralDecoderLayer(nn.Module):
         out = self.self_attn(
             self.input_layernorm(hidden_states),
             attention_mask,
-            total_seq_len,
             rolling_cache_len,
             kv_seq_len,
+            cache_offset,
         )
         hidden_states = _apply_residual(out, residual=hidden_states)
         out = self.mlp(self.post_attention_layernorm(hidden_states))
@@ -335,9 +372,9 @@ class MistralModel(nn.Module):
     def forward(  # pylint: disable=too-many-arguments
         self,
         inputs: Tensor,
-        total_seq_len: tir.Var,
         rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
+        cache_offset: tir.Var,
         attention_mask: Tensor,
     ):
         """Forward pass of the model, passing through all decoder layers."""
@@ -348,7 +385,7 @@ class MistralModel(nn.Module):
         hidden_states = self.embed_tokens(inputs)
         for layer in self.layers:
             hidden_states = layer(
-                hidden_states, attention_mask, total_seq_len, rolling_cache_len, kv_seq_len
+                hidden_states, attention_mask, rolling_cache_len, kv_seq_len, cache_offset
             )
         hidden_states = self.norm(hidden_states)
         return hidden_states
@@ -372,9 +409,9 @@ class MistralForCasualLM(nn.Module):
     def forward(  # pylint: disable=too-many-arguments
         self,
         inputs: Tensor,
-        total_seq_len: tir.Var,
         rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
+        cache_offset: tir.Var,
         attention_mask: Tensor,
     ):
         """Forward pass."""
@@ -384,7 +421,7 @@ class MistralForCasualLM(nn.Module):
             return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
 
         hidden_states = self.model(
-            inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask
+            inputs, rolling_cache_len, kv_seq_len, cache_offset, attention_mask
         )
         hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
         logits = self.lm_head(hidden_states)
@@ -395,9 +432,9 @@ class MistralForCasualLM(nn.Module):
     def prefill(
         self,
         inputs: Tensor,
-        total_seq_len: tir.Var,
         rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
+        cache_offset: tir.Var,
     ):
         """
         Prefilling the prompt.
@@ -407,14 +444,14 @@ class MistralForCasualLM(nn.Module):
         inputs: Tensor
             Input tokens, having ``seq_len`` number of tokens.
 
-        total_seq_len: tir.Var
-            Number of already-processed tokens plus ``seq_len``.
-
         rolling_cache_len: tir.Var
             Number of elements currently in the cache.
 
         kv_seq_len: tir.Var
             Equals to ``seq_len + rolling_cache_len``.
+
+        cache_offset: tir.Var
+            Next position to be overrided on the rolling kv cache.
         """
 
         def _sliding_window_attention_mask(
@@ -445,14 +482,14 @@ class MistralForCasualLM(nn.Module):
                 self.sliding_window_size,
             ],
         )
-        return self.forward(inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask)
+        return self.forward(inputs, rolling_cache_len, kv_seq_len, cache_offset, attention_mask)
 
     def decode(
         self,
         inputs: Tensor,
-        total_seq_len: tir.Var,
         rolling_cache_len: tir.Var,
         kv_seq_len: tir.Var,
+        cache_offset: tir.Var,
     ):
         """Decoding step."""
         batch_size, seq_len = inputs.shape
@@ -461,7 +498,7 @@ class MistralForCasualLM(nn.Module):
             fill_value=tir.max_value(self.dtype),
             dtype=self.dtype,
         )
-        return self.forward(inputs, total_seq_len, rolling_cache_len, kv_seq_len, attention_mask)
+        return self.forward(inputs, rolling_cache_len, kv_seq_len, cache_offset, attention_mask)
 
     def softmax_with_temperature(self, logits: Tensor, temperature: Tensor):
         """Softmax."""
@@ -473,9 +510,9 @@ class MistralForCasualLM(nn.Module):
         mod_spec = {
             "prefill": {
                 "inputs": nn.spec.Tensor([batch_size, "seq_len"], "int32"),
-                "total_seq_len": int,
                 "rolling_cache_len": int,
                 "kv_seq_len": int,
+                "cache_offset": int,
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "packed",
@@ -483,9 +520,9 @@ class MistralForCasualLM(nn.Module):
             },
             "decode": {
                 "inputs": nn.spec.Tensor([batch_size, 1], "int32"),
-                "total_seq_len": int,
                 "rolling_cache_len": int,
                 "kv_seq_len": int,
+                "cache_offset": int,
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "packed",

--- a/python/mlc_chat/compiler/model/model.py
+++ b/python/mlc_chat/compiler/model/model.py
@@ -297,6 +297,7 @@ MODEL_PRESETS: Dict[str, Any] = {
         "vocab_size": 32000,
         "sliding_window_size": 4096,
         "prefill_chunk_size": 128,
+        "attention_sink_size": 4,
     },
     "gpt2": {
         "architectures": ["GPT2LMHeadModel"],


### PR DESCRIPTION
Also added sinks support on `llm_chat.cc`. Haven't finished SLM sinks support, but it should be ready very soon (had some work to merge for quite some time on the former flow, so decided to finish on this one first).

Follow-up PRs to make attention sinks default to other models.

Note: Mistral with attention sinks can withstand long contexts with small sliding windows as low as 1024 (tested 768 and it can provide acceptable results too) and only 4 sinks. Despite maintaining good performance, one thing that I noticed is that sometimes quantized models start repeating emojis and paragraphs. However, this can be softened by slightly increasing the `repetition_penalty` (around 1.2 was enough to get much better results)

cc @tqchen 