### PR TITLE
[SLM] Streamlined Compilation Pipeline

### DIFF
--- a/python/mlc_chat/compiler/compiler_pass/attach_to_ir_module.py
+++ b/python/mlc_chat/compiler/compiler_pass/attach_to_ir_module.py
@@ -1,0 +1,34 @@
+"""A couple of passes that simply attach additional information onto the IRModule."""
+from typing import Dict
+
+import tvm
+from tvm import IRModule, relax, tir
+
+
+@tvm.transform.module_pass(opt_level=0, name="AttachVariableBounds")
+class AttachVariableBounds:  # pylint: disable=too-few-public-methods
+    """Attach variable bounds to each Relax function, which primarily helps with memory planning."""
+
+    def __init__(self, variable_bounds: Dict[str, int]):
+        self.variable_bounds = variable_bounds
+
+    def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:
+        """Entrypoint"""
+        for g_var, func in mod.functions_items():
+            if isinstance(func, relax.Function):
+                mod[g_var] = func.with_attr("tir_var_upper_bound", self.variable_bounds)
+        return mod
+
+
+@tvm.transform.module_pass(opt_level=0, name="AttachAdditionalPrimFuncs")
+class AttachAdditionalPrimFuncs:  # pylint: disable=too-few-public-methods
+    """Attach extra TIR PrimFuncs to the IRModule"""
+
+    def __init__(self, functions: Dict[str, tir.PrimFunc]):
+        self.functions = functions
+
+    def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:
+        """Entrypoint"""
+        for func_name, func in self.functions.items():
+            mod[func_name] = func.with_attr("global_symbol", func_name)
+        return mod

--- a/python/mlc_chat/compiler/compiler_pass/pipeline.py
+++ b/python/mlc_chat/compiler/compiler_pass/pipeline.py
@@ -1,12 +1,15 @@
 """The compilation pipeline for LLM applications."""
+from typing import Any, Dict
+
 import tvm
 from tvm import IRModule
 from tvm import dlight as dl
 from tvm.relax import register_pipeline  # pylint: disable=no-name-in-module
 
 from ...support import logging
+from .attach_to_ir_module import AttachAdditionalPrimFuncs, AttachVariableBounds
 from .clean_up_tir_attrs import CleanUpTIRAttrs
-from .estimate_memory_usage import EstimateMemoryUsage
+from .estimate_memory_usage import AttachMetadataWithMemoryUsage
 from .fuse_dequantize_matmul_ewise import FuseDequantizeMatmulEwise
 from .fuse_dequantize_take import FuseDequantizeTake
 from .fuse_dequantize_transpose import FuseDequantizeTranspose
@@ -31,14 +34,22 @@ class _LogProgress:  # pylint: disable=too-few-public-methods
 
 
 @register_pipeline("mlc_llm")
-def _mlc_llm_pipeline():
+def _mlc_llm_pipeline(
+    variable_bounds: Dict[str, int],
+    additional_tirs: Dict[str, tvm.tir.PrimFunc],
+    metadata: Dict[str, Any],
+    skip_gemm: bool = False,
+):
     @tvm.transform.module_pass(opt_level=0)
     def _pipeline(mod: tvm.ir.IRModule, _ctx: tvm.transform.PassContext) -> tvm.ir.IRModule:
         seq = tvm.transform.Sequential(
             [
+                # Phase 0. Add additional information for compilation
+                AttachVariableBounds(variable_bounds),
+                AttachAdditionalPrimFuncs(additional_tirs),
                 # Phase 1. Passes on high-level operator graph
                 _LogProgress("Running TVM Relax graph-level optimizations"),
-                FuseDequantizeTranspose(skip_gemm=False),
+                FuseDequantizeTranspose(skip_gemm=skip_gemm),
                 FuseTransposeMatmul(),
                 FuseSplitRotaryEmbedding(),
                 # Phase 2. Lowering to TIR, inherited TVM Relax's official "zero" pipeline
@@ -66,7 +77,18 @@ def _mlc_llm_pipeline():
                 _LogProgress("Running memory optimizations"),
                 LiftTIRGlobalBufferAlloc(),
                 tvm.tir.transform.ForceNarrowIndexToInt32(),
-                EstimateMemoryUsage(),
+                tvm.relax.transform.RewriteDataflowReshape(),
+                tvm.relax.transform.ToNonDataflow(),
+                tvm.relax.transform.RemovePurityChecking(),
+                tvm.relax.transform.CallTIRRewrite(),
+                tvm.relax.transform.StaticPlanBlockMemory(),
+                AttachMetadataWithMemoryUsage(metadata),
+                tvm.relax.transform.RewriteCUDAGraph(),
+                tvm.relax.transform.LowerAllocTensor(),
+                tvm.relax.transform.KillAfterLastUse(),
+                tvm.relax.transform.VMBuiltinLower(),
+                tvm.relax.transform.VMShapeLower(),
+                tvm.relax.transform.AttachGlobalSymbol(),
             ]
         )
         mod = seq(mod._move())  # pylint: disable=protected-access

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -121,13 +121,14 @@ def _add_system_lib_prefix(mod: IRModule, prefix: str, is_system_lib: bool) -> I
 
 
 def _build_metal_x86_64():
-    def build(mod: IRModule, args: "CompileArgs"):
+    def build(mod: IRModule, args: "CompileArgs", pipeline=None):
         output = args.output
         mod = _add_system_lib_prefix(mod, args.system_lib_prefix, is_system_lib=False)
         assert output.suffix == ".dylib"
         relax.build(
             mod,
             target=args.target,
+            pipeline=pipeline,
         ).export_library(
             str(output),
             fcompile=xcode.create_dylib,
@@ -145,13 +146,14 @@ def _build_iphone():
             return xcode.compile_metal(src, sdk=target.libs[0])
         return xcode.compile_metal(src)
 
-    def build(mod: IRModule, args: "CompileArgs"):
+    def build(mod: IRModule, args: "CompileArgs", pipeline=None):
         output = args.output
         mod = _add_system_lib_prefix(mod, args.system_lib_prefix, is_system_lib=True)
         assert output.suffix == ".tar"
         relax.build(
             mod,
             target=args.target,
+            pipeline=pipeline,
             system_lib=True,
         ).export_library(
             str(output),
@@ -162,13 +164,14 @@ def _build_iphone():
 
 
 def _build_android():
-    def build(mod: IRModule, args: "CompileArgs"):
+    def build(mod: IRModule, args: "CompileArgs", pipeline=None):
         output = args.output
         mod = _add_system_lib_prefix(mod, args.system_lib_prefix, is_system_lib=True)
         assert output.suffix == ".tar"
         relax.build(
             mod,
             target=args.target,
+            pipeline=pipeline,
             system_lib=True,
         ).export_library(
             str(output),
@@ -179,13 +182,14 @@ def _build_android():
 
 
 def _build_webgpu():
-    def build(mod: IRModule, args: "CompileArgs"):
+    def build(mod: IRModule, args: "CompileArgs", pipeline=None):
         output = args.output
         mod = _add_system_lib_prefix(mod, args.system_lib_prefix, is_system_lib=True)
         assert output.suffix == ".wasm"
         relax.build(
             mod,
             target=args.target,
+            pipeline=pipeline,
             system_lib=True,
         ).export_library(
             str(output),
@@ -195,7 +199,7 @@ def _build_webgpu():
 
 
 def _build_default():
-    def build(mod: IRModule, args: "CompileArgs"):
+    def build(mod: IRModule, args: "CompileArgs", pipeline=None):
         output = args.output
         if output.suffix in [".tar", ".lib"]:
             system_lib = True
@@ -208,6 +212,7 @@ def _build_default():
         relax.build(
             mod,
             target=args.target,
+            pipeline=pipeline,
             system_lib=system_lib,
         ).export_library(
             str(output),


### PR DESCRIPTION
Previously, to conform with TVM's `relax.build` API, we have to guarantee that the passes run in `mlc_llm` pipeline produce consistent IRModule for the subsequent `default_build` pipeline in `relax.build` to work on.

However, it is not usually the case and some passes will have to be rerun or have their outcome being discarded. `EstimateMemoryUsage`, as a notable example, runs half of `default_build` pipeline to lower the RelaxIR into a right stage, collects an integer representing number of bytes allocated in each Relax function, then discards the half-way lowering only to give back this func-name-to-integer dictionary. Another issue is that it makes certain IR manipulation more challenging as part of the pass infra, resulting in boilerplate logics in `compile.py` such as `_attach_metadata`.

Following https://github.com/apache/tvm/pull/16246, it's now possible to fold all IR manipulation into `mlc_llm` pipeline, and remove dependency to `default_build` as `relax.build` allows any or none passes as its `pipeline` parameter. This PR makes such refactoring happen.

WARNING: DO NOT MERGE until https://github.com/apache/tvm/pull/16246 is synced to https://github.com/mlc-ai/relax repo.