### PR TITLE
Fix MQA and RoPE Application

### DIFF
--- a/python/mlc_chat/compiler/extern/flashinfer.py
+++ b/python/mlc_chat/compiler/extern/flashinfer.py
@@ -90,7 +90,7 @@ class FlashInfer:
         _, s, _, _ = q.shape
         casual = 1  # True
         qkv_layout = 0  # "NHD", N for seq_len, H for num_heads, D for head_dim
-        rotary_mode = 1  # "kLlama"
+        rotary_mode = 0  # "kNone"
         allow_fp16_qk_reduction = 1  # True
         # Decoding
         if isinstance(s, int) and s == 1:


### PR DESCRIPTION
This PR fixes two issues:

It fixes multi-query attention on the fallback code path, which was broken by one of latest commits: https://github.com/mlc-ai/mlc-llm/commit/d406c175d2f9164a08450a4a3eafbda061f30393.

It also adjusts RoPE application, and the rule of thumb right now is: it is always applied immediately after QKV projection to QK, and K-cache always stores the K with RoPE applied. FlashInfer will never fuse RoPE into its attention kernel.