### PR TITLE
[Serving] Kill child processes in PopenServer

### DIFF
--- a/python/mlc_chat/serve/async_engine.py
+++ b/python/mlc_chat/serve/async_engine.py
@@ -31,7 +31,9 @@ class AsyncRequestStream:
     #   delta output text, the number of delta tokens, the optional
     #   finish reason respectively,
     # - or an exception.
-    _queue: asyncio.Queue[Union[Tuple[str, int, Optional[str]], Exception]]
+    _queue: asyncio.Queue[  # pylint: disable=unsubscriptable-object
+        Union[Tuple[str, int, Optional[str]], Exception]
+    ]
     # The finish flag.
     _finished: bool
 

--- a/python/mlc_chat/serve/server/popen_server.py
+++ b/python/mlc_chat/serve/server/popen_server.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+import psutil
 import requests
 
 
@@ -86,6 +87,22 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         """Terminate the server subprocess."""
         if self._proc is None:
             return
+
+        # Kill all the child processes.
+        def kill_child_processes():
+            try:
+                parent = psutil.Process(self._proc.pid)
+                children = parent.children(recursive=True)
+            except psutil.NoSuchProcess:
+                return
+
+            for process in children:
+                try:
+                    process.kill()
+                except psutil.NoSuchProcess:
+                    pass
+
+        kill_child_processes()
 
         # Kill the process.
         try:


### PR DESCRIPTION
This PR adds the logic of killing child processes prior to killing the main process in PopenServer, so that when running models in tensor parallelism, the GPU memory held by processes other than the main process can get released after terminating the server.