### PR TITLE
[Sink] Add sink size to metadata

### DIFF
--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -44,6 +44,8 @@ ModelMetadata ModelMetadata::FromJSON(const picojson::object& metadata) {
     result.sliding_window_size = json::Lookup<int64_t>(metadata, "sliding_window_size");
   if (metadata.count("sliding_window"))  // to be removed after SLM migration
     result.sliding_window_size = json::Lookup<int64_t>(metadata, "sliding_window");
+  if (metadata.count("attention_sink_size"))  // remove after sink is decoupled from model lib
+    result.attention_sink_size = json::Lookup<int64_t>(metadata, "attention_sink_size");
   result.tensor_parallel_shards = json::Lookup<int64_t>(metadata, "tensor_parallel_shards");
   {
     std::vector<ModelMetadata::Param>& params = result.params;

--- a/cpp/metadata/model.h
+++ b/cpp/metadata/model.h
@@ -44,6 +44,7 @@ struct ModelMetadata {
   int64_t prefill_chunk_size;
   int64_t sliding_window_size;
   int64_t tensor_parallel_shards;
+  int64_t attention_sink_size;
   std::vector<Param> params;
   std::unordered_map<std::string, int64_t> memory_usage;
 

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -117,6 +117,17 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
         logger.info("Running optimizations using TVM Unity")
         additional_tirs = _apply_preproc_to_params(named_params, model_config)
         variable_bounds = _get_variable_bounds(model_config)
+        metadata = {
+            "model_type": args.model.name,
+            "quantization": args.quantization.name,
+            "context_window_size": model_config.context_window_size,  # type: ignore
+            "prefill_chunk_size": model_config.prefill_chunk_size,  # type: ignore
+            "sliding_window_size": getattr(model_config, "sliding_window_size", -1),
+            "attention_sink_size": getattr(model_config, "attention_sink_size", -1),
+            "tensor_parallel_shards": model_config.tensor_parallel_shards,  # type: ignore
+        }
+        logger.info("Registering metadata: %s", metadata)
+        metadata["params"] = [_get_param_metadata(name, param) for name, param in named_params]
         args.build_func(
             mod,
             args,
@@ -125,15 +136,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
                 variable_bounds=variable_bounds,
                 additional_tirs=additional_tirs,
                 ext_mods=ext_mods,
-                metadata={
-                    "model_type": args.model.name,
-                    "quantization": args.quantization.name,
-                    "params": [_get_param_metadata(name, param) for name, param in named_params],
-                    "context_window_size": model_config.context_window_size,  # type: ignore
-                    "prefill_chunk_size": model_config.prefill_chunk_size,  # type: ignore
-                    "sliding_window_size": getattr(model_config, "sliding_window_size", -1),
-                    "tensor_parallel_shards": model_config.tensor_parallel_shards,  # type: ignore
-                },
+                metadata=metadata,
             ),
         )
     logger.info("Generated: %s", bold(str(args.output)))

--- a/python/mlc_chat/compiler/compile.py
+++ b/python/mlc_chat/compiler/compile.py
@@ -131,7 +131,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
         args.build_func(
             mod,
             args,
-            pipeline=relax.get_pipeline(
+            pipeline=relax.get_pipeline(  # type: ignore
                 "mlc_llm",
                 variable_bounds=variable_bounds,
                 additional_tirs=additional_tirs,

--- a/python/mlc_chat/compiler/model/gpt2/gpt2_loader.py
+++ b/python/mlc_chat/compiler/model/gpt2/gpt2_loader.py
@@ -29,7 +29,9 @@ def huggingface(model_config: GPT2Config, quantization: Quantization) -> ExternM
     model = GPT2LMHeadModel(model_config)
     if quantization is not None:
         model.to(quantization.model_dtype)
-    _, _named_params = model.export_tvm(spec=model.get_default_spec())
+    _, _named_params = model.export_tvm(  # pylint: disable=W0632:unbalanced-tuple-unpacking
+        spec=model.get_default_spec()
+    )
     named_parameters = dict(_named_params)
 
     mapping = ExternMapping()

--- a/python/mlc_chat/compiler/model/gpt_bigcode/gpt_bigcode_loader.py
+++ b/python/mlc_chat/compiler/model/gpt_bigcode/gpt_bigcode_loader.py
@@ -29,7 +29,9 @@ def huggingface(model_config: GPTBigCodeConfig, quantization: Quantization) -> E
     model = GPTBigCodeForCausalLM(model_config)
     if quantization is not None:
         model.to(quantization.model_dtype)
-    _, _named_params = model.export_tvm(spec=model.get_default_spec())
+    _, _named_params = model.export_tvm(  # pylint: disable=W0632:unbalanced-tuple-unpacking
+        spec=model.get_default_spec()
+    )
     named_parameters = dict(_named_params)
 
     mapping = ExternMapping()

--- a/python/mlc_chat/compiler/model/gpt_neox/gpt_neox_loader.py
+++ b/python/mlc_chat/compiler/model/gpt_neox/gpt_neox_loader.py
@@ -31,7 +31,9 @@ def huggingface(model_config: GPTNeoXConfig, quantization: Quantization) -> Exte
     model = GPTNeoXForCausalLM(model_config)
     if quantization is not None:
         model.to(quantization.model_dtype)
-    _, _named_params = model.export_tvm(spec=model.get_default_spec())
+    _, _named_params = model.export_tvm(  # pylint: disable=W0632:unbalanced-tuple-unpacking
+        spec=model.get_default_spec()
+    )
     named_parameters = dict(_named_params)
 
     mapping = ExternMapping()

--- a/python/mlc_chat/compiler/model/llama/llama_loader.py
+++ b/python/mlc_chat/compiler/model/llama/llama_loader.py
@@ -32,7 +32,9 @@ def huggingface(model_config: LlamaConfig, quantization: Quantization) -> Extern
     model = LlamaForCasualLM(model_config)
     if quantization is not None:
         model.to(quantization.model_dtype)
-    _, _named_params = model.export_tvm(spec=model.get_default_spec())
+    _, _named_params = model.export_tvm(  # pylint: disable=W0632:unbalanced-tuple-unpacking
+        spec=model.get_default_spec()
+    )
     named_parameters = dict(_named_params)
 
     mapping = ExternMapping()

--- a/python/mlc_chat/compiler/model/mistral/mistral_loader.py
+++ b/python/mlc_chat/compiler/model/mistral/mistral_loader.py
@@ -32,7 +32,9 @@ def huggingface(model_config: MistralConfig, quantization: Quantization) -> Exte
     model = MistralForCasualLM(model_config)
     if quantization is not None:
         model.to(quantization.model_dtype)
-    _, _named_params = model.export_tvm(spec=model.get_default_spec())
+    _, _named_params = model.export_tvm(  # pylint: disable=W0632:unbalanced-tuple-unpacking
+        spec=model.get_default_spec()
+    )
     named_parameters = dict(_named_params)
 
     mapping = ExternMapping()

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 from tvm import IRModule, relax
 from tvm._ffi import get_global_func, register_func
 from tvm.contrib import tar, xcode
+from tvm.ir.transform import Pass
 from tvm.target import Target
 
 from . import logging
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 HELP_MSG = """TBD"""
 FOUND = green("Found")
 NOT_FOUND = red("Not found")
-BuildFunc = Callable[[IRModule, "CompileArgs"], None]
+BuildFunc = Callable[[IRModule, "CompileArgs", Pass], None]
 
 
 def detect_target_and_host(target_hint: str, host_hint: str = "auto") -> Tuple[Target, BuildFunc]:


### PR DESCRIPTION
Add attention sink to metadata in SLM primarily for web-llm runtime. This way, we do not rely on `attention_sink` in `mlc-chat-config.json` downloaded from HF in runtime, which binds with the weight, while the `attention_sink` should really be binded with the model library (since it is built into the model's `self.attention_sink_size`). This way, we guarantee that the `attention_sink` used in runtime is the one that matches the model library's.

Did not change anything on `llm_chat.cc` so this PR doe not affect anything on any runtime platform except for web-llm.