### PR TITLE
[Fix] Skip FuseSplitRotaryEmbedding via attrs

### DIFF
--- a/python/mlc_chat/compiler/compiler_pass/fuse_split_rotary_embedding.py
+++ b/python/mlc_chat/compiler/compiler_pass/fuse_split_rotary_embedding.py
@@ -176,7 +176,14 @@ class FuseSplitRotaryEmbedding:  # pylint: disable=too-few-public-methods
             embedded_key = matchings[pat_embedded_key]
 
             rotary_embedding_gvar = bindings[embedded_query].args[0]
-            position_embedding_base = collect_position_embedding_base(mod[rotary_embedding_gvar])
+            rotary_embedding_func = mod[rotary_embedding_gvar]
+            if (
+                "mlc.rotary_embedding_to_all_dims" not in rotary_embedding_func.attrs
+                or not rotary_embedding_func.attrs["mlc.rotary_embedding_to_all_dims"]
+            ):
+                # manually skip split rotary fuse
+                return {}
+            position_embedding_base = collect_position_embedding_base(rotary_embedding_func)
 
             rotary_embedding_offset = bindings[embedded_query].args[-1][0]
 

--- a/python/mlc_chat/compiler/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_chat/compiler/model/gpt_neox/gpt_neox_model.py
@@ -102,8 +102,18 @@ class RotaryEmbedding(nn.Module):
 
             return te.compute(x.shape, compute, name="rotary")
 
-        q_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[q, offset])
-        k_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[k, offset])
+        q_embed = op.tensor_expr_op(
+            te_op,
+            "rotary_embedding",
+            args=[q, offset],
+            attrs={"mlc.rotary_embedding_to_all_dims": True},
+        )
+        k_embed = op.tensor_expr_op(
+            te_op,
+            "rotary_embedding",
+            args=[k, offset],
+            attrs={"mlc.rotary_embedding_to_all_dims": True},
+        )
         return q_embed, k_embed
 
 

--- a/python/mlc_chat/compiler/model/llama/llama_model.py
+++ b/python/mlc_chat/compiler/model/llama/llama_model.py
@@ -100,8 +100,18 @@ class RotaryEmbedding(nn.Module):
 
             return te.compute(x.shape, compute, name="rotary")
 
-        q_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[q, offset])
-        k_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[k, offset])
+        q_embed = op.tensor_expr_op(
+            te_op,
+            "rotary_embedding",
+            args=[q, offset],
+            attrs={"mlc.rotary_embedding_to_all_dims": True},
+        )
+        k_embed = op.tensor_expr_op(
+            te_op,
+            "rotary_embedding",
+            args=[k, offset],
+            attrs={"mlc.rotary_embedding_to_all_dims": True},
+        )
         return q_embed, k_embed
 
 

--- a/python/mlc_chat/compiler/model/mistral/mistral_model.py
+++ b/python/mlc_chat/compiler/model/mistral/mistral_model.py
@@ -112,8 +112,15 @@ class RotaryEmbedding(nn.Module):
 
             return te.compute(x.shape, compute, name="rotary")
 
-        q_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[q, q_offset])
-        k_embed = op.tensor_expr_op(te_op, "rotary_embedding", args=[k, 0])
+        q_embed = op.tensor_expr_op(
+            te_op,
+            "rotary_embedding",
+            args=[q, q_offset],
+            attrs={"mlc.rotary_embedding_to_all_dims": True},
+        )
+        k_embed = op.tensor_expr_op(
+            te_op, "rotary_embedding", args=[k, 0], attrs={"mlc.rotary_embedding_to_all_dims": True}
+        )
         return q_embed, k_embed
 
 


### PR DESCRIPTION
If the attr `"split_rotary_fuse"` of PrimFunc `rotary_embedding` is missing or `False`, we would not rewrite the bindings in `FuseSplitRotaryEmbedding` pass.