### PR TITLE
[Docs][SLM] Update runtime tutorials

### DIFF
--- a/docs/compilation/compile_models.rst
+++ b/docs/compilation/compile_models.rst
@@ -5,9 +5,9 @@ Compile Model Libraries
 
 To run a model with MLC LLM in any platform, you need:
 
-1. Model weights converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-MLC 
+1. **Model weights** converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-MLC 
    <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-MLC/tree/main>`_.)
-2. Model library that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
+2. **Model library** that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
 
 If you are simply adding a model variant, follow :ref:`convert-weights-via-MLC` suffices.
 

--- a/docs/compilation/convert_weights.rst
+++ b/docs/compilation/convert_weights.rst
@@ -5,9 +5,9 @@ Convert Weights via MLC
 
 To run a model with MLC LLM in any platform, you need:
 
-1. Model weights converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-MLC 
+1. **Model weights** converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-MLC 
    <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-MLC/tree/main>`_.)
-2. Model library that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
+2. **Model library** that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
 
 In many cases, we only need to convert weights and reuse existing model library. 
 This page demonstrates adding a model variant with ``mlc_chat convert_weight``, which
@@ -150,30 +150,35 @@ This would result in something like `RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC
 <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC/tree/main>`_, but
 for **Instruct** instead of **Chat**.
 
-..  REPOPULATE BELOW AFTER WE UPLOADING PREBUILT WEIGHTS AND UPDATING RUNTIME
-    ---------------------------------
-    Good job, you have successfully distributed the model you compiled.
-    Next, we will talk about how we can consume the model weights in applications.
+---------------------------------
+Good job, you have successfully distributed the model you compiled.
+Next, we will talk about how we can consume the model weights in applications.
 
-    Download the Distributed Models and Run in CLI
-    ----------------------------------------------
+Download the Distributed Models and Run in Python
+-------------------------------------------------
 
-    The steps needed to run models in CLI are similar to the steps to download the prebuilt model weights and libraries.
+Running the distributed models are similar to running prebuilt model weights and libraries in :ref:`Model Prebuilts`.
 
-    .. code:: shell
+.. code:: shell
 
-        # Clone prebuilt libs so we can reuse them:
-        mkdir -p dist/prebuilt
-        git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt/lib
+    # Clone prebuilt libs so we can reuse them:
+    mkdir -p dist/
+    git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt_libs
 
-        # Or download the model library (only needed if we do not reuse the model lib):
-        cd dist/prebuilt/lib
-        wget url-to-my-model-lib
-        cd ../../..
+    # Or download the model library (only needed if we do not reuse the model lib):
+    cd dist/prebuilt_libs
+    wget url-to-my-model-lib
+    cd ../..
 
-        # Download the model weights
-        cd dist/prebuilt
-        git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo RedPajama-INCITE-Instruct-3B-v1-q4f16_1
-        cd ../..
-        # Run CLI
-        mlc_chat_cli --model RedPajama-INCITE-Instruct-3B-v1-q4f16_1
+    # Download the model weights
+    cd dist
+    git clone https://huggingface.co/my-huggingface-account/my-redpajama3b-weight-huggingface-repo RedPajama-INCITE-Instruct-3B-v1-q4f16_1-MLC
+    cd ..
+
+    # Run the model in Python; note that we reuse `-Chat` model library
+    python
+    >>> from mlc_chat import ChatModule
+    >>> cm = ChatModule(model="dist/RedPajama-INCITE-Instruct-3B-v1-q4f16_1-MLC", \
+        model_lib_path="dist/prebuilt_libs/RedPajama-INCITE-Chat-3B-v1-q4f16_1-cuda.so")  # Adjust based on backend
+    >>> cm.generate("hi")
+    'Hi! How can I assist you today?'

--- a/docs/deploy/javascript.rst
+++ b/docs/deploy/javascript.rst
@@ -61,9 +61,9 @@ we see the code snippet:
 
 Just like any other platforms, to run a model with on WebLLM, you need:
 
-1. Model weights converted to MLC format (e.g. `Llama-2-7b-hf-q4f32_1-MLC 
+1. **Model weights** converted to MLC format (e.g. `Llama-2-7b-hf-q4f32_1-MLC 
    <https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f32_1-MLC/tree/main>`_.): downloaded through ``model_url``
-2. Model library that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__): downloaded through ``model_lib_url``.
+2. **Model library** that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__): downloaded through ``model_lib_url``.
 
 Verify Installation for Adding Models
 -------------------------------------

--- a/docs/deploy/python.rst
+++ b/docs/deploy/python.rst
@@ -8,15 +8,27 @@ Python API
    :depth: 2
 
 We expose Python API for the MLC-Chat for easy integration into other Python projects.
-We also provide a web demo based on `gradio <https://gradio.app/>`_ as an example of using Python API to interact with MLC-Chat.
 
-Python API
-----------
+The Python API is a part of the MLC-Chat package, which we have prepared pre-built pip wheels via
+the :doc:`installation page <../install/mlc_llm>`.
 
-The Python API is a part of the MLC-Chat package, which we have prepared pre-built pip wheels via the :doc:`installation page <../install/mlc_llm>`.
+Instead of following this page, you could also checkout the following tutorials in
+Python notebook (all runnable in Colab):
+
+- `Getting Started with MLC-LLM <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_chat_module_getting_started.ipynb>`_:
+  how to quickly download prebuilt models and chat with it
+- `Raw Text Generation with MLC-LLM <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_raw_text_generation.ipynb>`_:
+  how to perform raw text generation with MLC-LLM in Python
+
+.. These notebooks are not up-to-date with SLM yet
+.. - `Compiling Llama-2 with MLC-LLM <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_compile_llama2_with_mlc_llm.ipynb>`_:
+..   how to use Python APIs to compile models with the MLC-LLM workflow
+.. - `Extensions to More Model Variants <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_extensions_to_more_model_variants.ipynb>`_:
+..   how to use Python APIs to compile and chat with any model variant you'd like
+
 
 Verify Installation
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 .. code:: bash
 
@@ -24,85 +36,46 @@ Verify Installation
 
 You are expected to see the information about the :class:`mlc_chat.ChatModule` class.
 
-If the prebuilt is unavailable on your platform, or you would like to build a runtime
-that supports other GPU runtime than the prebuilt version, please refer to :ref:`mlcchat_build_from_source`.
+If the command above results in error, follow :ref:`install-mlc-packages` (either install the prebuilt pip wheels
+or :ref:`mlcchat_build_from_source`).
 
-Get Started
-^^^^^^^^^^^
-After confirming that the package ``mlc_chat`` is installed, we can follow the steps
-below to chat with an MLC-compiled model in Python.
+Run MLC Models w/ Python
+------------------------
 
-First, let us make sure that the MLC-compiled ``model`` we want to chat with already exists.
+To run a model with MLC LLM in any platform/runtime, you need:
 
-.. note::
-   ``model`` has the format ``f"{model_name}-{quantize_mode}"``. For instance, if
-   you used ``q4f16_1`` as the ``quantize_mode`` to compile ``Llama-2-7b-chat-hf``, you 
-   would have ``model`` being ``Llama-2-7b-chat-hf-q4f16_1``.
+1. **Model weights** converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-MLC 
+   <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-MLC/tree/main>`_.)
+2. **Model library** that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
 
-If you do not have the MLC-compiled ``model`` ready:
+There are two ways to obtain the model weights and libraries:
 
-- Checkout :ref:`Try out MLC Chat<get_started>` to download prebuilt models for simplicity, or
-- Checkout :ref:`Compile Models via MLC<compile-model-libraries>` to compile models with ``mlc_llm`` (another package) yourself
+1. Compile your own model weights and libraries following :doc:`the model compilation page </compilation/compile_models>`.
+2. Use off-the-shelf `prebuilt models weights <https://huggingface.co/mlc-ai>`__ and
+   `prebuilt model libraries <https://github.com/mlc-ai/binary-mlc-llm-libs>`__ (see :ref:`Model Prebuilts` for details).
 
-.. tabs ::
+We use off-the-shelf prebuilt models in this page. However, same steps apply if you want to run
+the models you compiled yourself.
 
-   .. tab :: Check prebuilt models
+**Step 1: Download prebuilt model weights and libraries**
 
-      If you downloaded prebuilt models from MLC LLM, by default:
+Skip this step if you have already obtained the model weights and libraries.
 
-      - Model lib should be placed at ``./dist/prebuilt/lib/$(model)-$(arch).$(suffix)``.
-      - Model weights and chat config are located under ``./dist/prebuilt/mlc-chat-$(model)/``.
+.. code:: shell
 
-      .. note::
-         Please make sure that you have the same directory structure as above, because Python API
-         relies on it to automatically search for model lib and weights. If you would like to directly
-         provide a full model lib path to override the auto-search, you can specify ``ChatModule.model_lib_path``
+  # Download pre-conveted weights
+  git lfs install && mkdir dist/
+  git clone https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC \
+                                     dist/Llama-2-7b-chat-hf-q4f16_1-MLC
 
-      .. collapse:: Example
+  # Download pre-compiled model library
+  git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt_libs
 
-         .. code:: shell
 
-            >>> ls -l ./dist/prebuilt/lib
-            Llama-2-7b-chat-hf-q4f16_1-metal.so  # Format: $(model)-$(arch).$(suffix)
-            Llama-2-7b-chat-hf-q4f16_1-vulkan.so
-            ...
-            >>> ls -l ./dist/prebuilt/mlc-chat-Llama-2-7b-chat-hf-q4f16_1  # Format: ./dist/prebuilt/mlc-chat-$(model)/
-            # chat config:
-            mlc-chat-config.json
-            # model weights:
-            ndarray-cache.json
-            params_shard_*.bin
-            ...
+**Step 2: Run the model in Python**
 
-   .. tab :: Check compiled models
-
-      If you have compiled models using MLC LLM, by default:
-
-      - Model libraries should be placed at ``./dist/$(model)/$(model)-$(arch).$(suffix)``.
-      - Model weights and chat config are located under ``./dist/$(model)/params/``.
-
-      .. note::
-         Please make sure that you have the same directory structure as above, because Python API
-         relies on it to automatically search for model lib and weights. If you would like to directly
-         provide a full model lib path to override the auto-search, you can specify ``ChatModule.model_lib_path``
-
-      .. collapse:: Example
-
-         .. code:: shell
-
-            >>> ls -l ./dist/Llama-2-7b-chat-hf-q4f16_1/ # Format: ./dist/$(model)/
-            Llama-2-7b-chat-hf-q4f16_1-metal.so  # Format: $(model)-$(arch).$(suffix)
-            ...
-            >>> ls -l ./dist/Llama-2-7b-chat-hf-q4f16_1/params  # Format: ``./dist/$(model)/params/``
-            # chat config:
-            mlc-chat-config.json
-            # model weights:
-            ndarray-cache.json
-            params_shard_*.bin
-            ...
-
-After making sure that the files exist, use the conda environment you used
-to install ``mlc_chat``, from the ``mlc-llm`` directory, you can create a Python
+Use the conda environment you used to install ``mlc_chat``.
+From the ``mlc-llm`` directory, you can create a Python
 file ``sample_mlc_chat.py`` and paste the following lines:
 
 .. code:: python
@@ -110,14 +83,24 @@ file ``sample_mlc_chat.py`` and paste the following lines:
    from mlc_chat import ChatModule
    from mlc_chat.callback import StreamToStdout
 
-   # From the mlc-llm directory, run
-   # $ python sample_mlc_chat.py
-
    # Create a ChatModule instance
-   cm = ChatModule(model="Llama-2-7b-chat-hf-q4f16_1")
-   # You can change to other models that you downloaded, for example,
-   # cm = ChatModule(model="Llama-2-13b-chat-hf-q4f16_1")  # Llama2 13b model
+   cm = ChatModule(
+      model="dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
+      model_lib_path="dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+      # Vulkan on Linux: Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+      # Metal on macOS: Llama-2-7b-chat-hf-q4f16_1-metal.so
+      # Other platforms: Llama-2-7b-chat-hf-q4f16_1-{backend}.{suffix}
+   )
 
+   # You can change to other models that you downloaded
+   # Model variants of the same architecture can reuse the same model library
+   # Here WizardMath reuses Mistral's model library
+   # cm = ChatModule(
+   #     model="dist/Mistral-7B-Instruct-v0.2-q4f16_1-MLC",  # or "dist/WizardMath-7B-V1.1-q4f16_1-MLC"
+   #     model_lib_path="dist/prebuilt_libs/Mistral-7B-Instruct-v0.2/Mistral-7B-Instruct-v0.2-q4f16_1-cuda.so"
+   # )
+
+   # Generate a response for a given prompt
    output = cm.generate(
       prompt="What is the meaning of life?",
       progress_callback=StreamToStdout(callback_interval=2),
@@ -134,13 +117,13 @@ file ``sample_mlc_chat.py`` and paste the following lines:
    # Reset the chat module by
    # cm.reset_chat()
 
+
 Now run the Python file to start the chat
 
 .. code:: bash
 
    python sample_mlc_chat.py
 
-You can also checkout the :doc:`/prebuilt_models` page to run other models.
 
 .. collapse:: See output
 
@@ -168,28 +151,19 @@ You can also checkout the :doc:`/prebuilt_models` page to run other models.
 
 |
 
-.. note:: 
-   You could also specify the address of ``model`` and ``model_lib_path`` explicitly. If
-   you only specify ``model`` as ``model_name`` and ``quantize_mode``, we will
-   do a search for you. See more in the documentation of :meth:`mlc_chat.ChatModule.__init__`.
+**Running other models**
 
-Tutorial with Python Notebooks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Checkout the :doc:`/prebuilt_models` page to run other pre-compiled models.
 
-Now that you have tried out how to chat with the model in Python, we would
-recommend you to checkout the following tutorials in Python notebook (all runnable in Colab):
+For models other than the prebuilt ones we provided:
 
-- `Getting Started with MLC-LLM <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_chat_module_getting_started.ipynb>`_:
-  how to quickly download prebuilt models and chat with it
-- `Compiling Llama-2 with MLC-LLM <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_compile_llama2_with_mlc_llm.ipynb>`_:
-  how to use Python APIs to compile models with the MLC-LLM workflow
-- `Extensions to More Model Variants <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_extensions_to_more_model_variants.ipynb>`_:
-  how to use Python APIs to compile and chat with any model variant you'd like
-- `Raw Text Generation with MLC-LLM <https://github.com/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_raw_text_generation.ipynb>`_:
-  how to perform raw text generation with MLC-LLM in Python
+1. If the model is a variant to an existing model library (e.g. ``WizardMathV1.1`` and ``OpenHermes`` are variants of ``Mistral`` as
+   shown in the code snippet), follow :ref:`convert-weights-via-MLC` to convert the weights and reuse existing model libraries.
+2. Otherwise, follow :ref:`compile-model-libraries` to compile both the model library and weights.
+
 
 Configure MLCChat in Python
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 If you have checked out :ref:`Configure MLCChat in JSON<configure-mlc-chat-json>`, you would know
 that you could configure MLCChat through various fields such as ``temperature``. We provide the
 option of overriding any field you'd like in Python, so that you do not need to manually edit
@@ -214,7 +188,14 @@ We provide an example below.
    chat_config = ChatConfig(max_gen_len=256, conv_config=conv_config)
 
    # Using the `chat_config` we created, instantiate a `ChatModule`
-   cm = mlc_chat.ChatModule('Llama-2-7b-chat-hf-q4f16_1', chat_config=chat_config)
+   cm = ChatModule(
+      chat_config=chat_config,
+      model="dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
+      model_lib_path="dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+      # Vulkan on Linux: Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+      # Metal on macOS: Llama-2-7b-chat-hf-q4f16_1-metal.so
+      # Other platforms: Llama-2-7b-chat-hf-q4f16_1-{backend}.{suffix}
+   )
 
    output = cm.generate(
       prompt="What is one plus one?",
@@ -259,7 +240,7 @@ We provide an example below.
    :ref:`Configure MLCChat in JSON<configure-mlc-chat-json>`.
 
 Raw Text Generation in Python
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------
 
 Raw text generation allows the user to have more flexibility over his prompts, 
 without being forced to create a new conversational template, making prompt customization easier.
@@ -282,8 +263,14 @@ We provide an example below.
    chat_config = ChatConfig(conv_config=conv_config, conv_template="LM")
 
    # Using the `chat_config` we created, instantiate a `ChatModule`
-   cm = ChatModule('Llama-2-7b-chat-hf-q4f16_1', chat_config=chat_config)
-
+   cm = ChatModule(
+      chat_config=chat_config,
+      model="dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
+      model_lib_path="dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+      # Vulkan on Linux: Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+      # Metal on macOS: Llama-2-7b-chat-hf-q4f16_1-metal.so
+      # Other platforms: Llama-2-7b-chat-hf-q4f16_1-{backend}.{suffix}
+   )
    # To make the model follow conversations a chat structure should be provided
    # This allows users to build their own prompts without building a new template
    system_prompt = "<<SYS>>\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n"
@@ -309,7 +296,7 @@ We provide an example below.
    unless explicitly given inside the prompt.
 
 Stream Iterator in Python
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
 
 Stream Iterator gives users an option to stream generated text to the function that the API is called from,
 instead of streaming to stdout, which could be a necessity when building services on top of MLC Chat.
@@ -322,7 +309,13 @@ We provide an example below.
    from mlc_chat.callback import StreamIterator
 
    # Create a ChatModule instance
-   cm = ChatModule(model="Llama-2-7b-chat-hf-q4f16_1")
+   cm = ChatModule(
+      model="dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
+      model_lib_path="dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+      # Vulkan on Linux: Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+      # Metal on macOS: Llama-2-7b-chat-hf-q4f16_1-metal.so
+      # Other platforms: Llama-2-7b-chat-hf-q4f16_1-{backend}.{suffix}
+   )
 
    # Stream to an Iterator
    from threading import Thread
@@ -365,30 +358,3 @@ The :class:`mlc_chat.ChatModule` class provides the following methods:
 
 .. autoclass:: GenerationConfig
    :members:
-
-Gradio Frontend (Deprecated)
-----------------------------
-
-The gradio frontend provides a web interface for the MLC-Chat model, which allows users to interact with the model in a more user-friendly way and switch between different models to compare performance.
-To use gradio frontend, you need to install gradio first:
-
-.. code-block:: bash
-
-   pip install gradio
-
-Then you can run the following code to start the interface:
-
-.. code:: bash
-
-   python -m mlc_chat.gradio --artifact-path ARTIFACT_PATH [--device DEVICE] [--port PORT_NUMBER] [--share]
-
---artifact-path        Please provide a path containing all the model folders you wish to use. The default value is ``dist``.
---device               The description of the device to run on. User should provide a string in the form of 'device_name:device_id' or 'device_name', where 'device_name' is one of 'cuda', 'metal', 'vulkan', 'rocm', 'opencl', 'auto' (automatically detect the local device), and 'device_id' is the device id to run on. If no 'device_id' is provided, it will be set to 0. The default value is ``auto``.
---port                 The port number to run gradio. The default value is ``7860``.   
---share                Whether to create a publicly shareable link for the interface.
-
-After setting it up properly, you are expected to see the following interface in your browser:
-
-.. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/gradio-interface.png
-   :width: 100%
-   :align: center

--- a/docs/get_started/project_overview.rst
+++ b/docs/get_started/project_overview.rst
@@ -24,22 +24,20 @@ The MLC-LLM project consists of three distinct submodules: model definition, mod
 Terminologies
 -------------
 
-It is helpful for us to familiarize the basic terminologies used in the MLC chat applications.
-
-- **model weights**: The model weight is a folder that contains the quantized neural network weights
-  of the language models as well as the tokenizer configurations.
+It is helpful for us to familiarize the basic terminologies used in the MLC chat applications. Below are the
+three things you need to run a model with MLC.
 
 - **model lib**: The model library refers to the executable libraries that enable
-  the execution of a specific model architecture.   On Linux, these libraries have the suffix
-  ``.so``, on macOS, the suffix is ``.dylib``, and on Windows, the library file ends with ``.dll``.
-  On web browser, the library suffix is ``.wasm``
+  the execution of a specific model architecture. On Linux and M-chip macOS, these libraries have the suffix
+  ``.so``; on intel macOS, the suffix is ``.dylib``; on Windows, the library file ends with ``.dll``;
+  on web browser, the library suffix is ``.wasm``. (see `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
+
+- **model weights**: The model weight is a folder that contains the quantized neural network weights
+  of the language models as well as the tokenizer configurations. (e.g. `Llama-2-7b-chat-hf-q4f16_1-MLC <https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC>`__)
 
 - **chat config**: The chat configuration includes settings that allow customization of parameters such as temperature and system prompt.
-  The default chat config usually resides in the same directory as model weights.
-  A chat config also contains the following two meta-data fields that are used in multi-model support settings.
-
-  - ``local_id``, which uniquely identifies the model within an app, and
-  - ``model_lib``, which specifies which model library to use.
+  The default chat config usually resides in the same directory as model weights. (e.g. see ``Llama-2-7b-chat-hf-q4f16_1``'s
+  `mlc-chat-config.json <https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC/blob/main/mlc-chat-config.json>`__)
 
 Model Preparation
 -----------------
@@ -49,7 +47,7 @@ There are several ways to prepare the model weights and model lib.
 
 - :ref:`Model Prebuilts` contains models that can be directly used.
 - You can also :doc:`run model compilation </compilation/compile_models>` for model weight variants for given supported architectures.
-- Finally, we can enhance the overall model definition flow to incorporate new model architectures.
+- Finally, you can incorporate a new model architecture/inference logic following :doc:`Define New Models </compilation/define_new_models>`.
 
 A default chat config usually comes with the model weight directory. You can further customize
 the system prompt, temperature, and other options by modifying the JSON file.
@@ -63,14 +61,13 @@ Runtime Flow Overview
 Once the model weights, model library, and chat configuration are prepared, an MLC chat runtime can consume them as an engine to drive a chat application.
 The diagram below shows a typical workflow for a MLC chat application.
 
-.. image:: https://raw.githubusercontent.com/mlc-ai/web-data/de9a5e5b424f36119bd464ddf5a3ddb4c58cc85e/images/mlc-llm/tutorials/mlc-llm-flow.svg
+.. image:: https://raw.githubusercontent.com/mlc-ai/web-data/a05d4598bae6eb5a3133652d5cc0323ced3b0e17/images/mlc-llm/tutorials/mlc-llm-flow-slm.svg
   :width: 90%
   :align: center
 
 On the right side of the figure, you can see pseudo-code illustrating the structure of an MLC chat API during the execution of a chat app.
-Typically, there is a ``ChatModule`` that manages the model. The chat app includes a reload function that takes a ``local_id``
-as well as an optional chat configuration override, which allows for overriding settings such as the system prompt and temperature.
-The runtime utilizes the ``local_id`` and ``model_lib`` to locate the model weights and libraries.
+Typically, there is a ``ChatModule`` that manages the model. We instantiate the chat app with two files: the model weights (which include an ``mlc-chat-config.json``)
+and the model library. We also have an optional chat configuration, which allows for overriding settings such as the system prompt and temperature.
 
 All MLC runtimes, including iOS, Web, CLI, and others, use these three elements.
 All the runtime can read the same model weight folder. The packaging of the model libraries may vary depending on the runtime.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,19 +20,19 @@ It is recommended to have at least 6GB free VRAM to run it.
     **Install MLC Chat Python**. :doc:`MLC LLM <install/mlc_llm>` is available via pip.
     It is always recommended to install it in an isolated conda virtual environment.
 
-    **Download pre-quantized weights**. The comamnds below download the int4-quantized Llama2-7B from HuggingFace:
+    **Download pre-quantized weights**. The commands below download the int4-quantized Llama2-7B from HuggingFace:
 
     .. code:: bash
 
-      git lfs install && mkdir -p dist/prebuilt
-      git clone https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1 \
-                                dist/prebuilt/mlc-chat-Llama-2-7b-chat-hf-q4f16_1
+      git lfs install && mkdir dist/
+      git clone https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC \
+                                        dist/Llama-2-7b-chat-hf-q4f16_1-MLC
 
     **Download pre-compiled model library**. The pre-compiled model library is available as below:
 
     .. code:: bash
 
-      git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt/lib
+      git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt_libs
 
     **Run in Python.** The following Python script showcases the Python API of MLC LLM and its stream capability:
 
@@ -41,7 +41,13 @@ It is recommended to have at least 6GB free VRAM to run it.
       from mlc_chat import ChatModule
       from mlc_chat.callback import StreamToStdout
 
-      cm = ChatModule(model="Llama-2-7b-chat-hf-q4f16_1")
+      cm = ChatModule(
+          model="dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
+          model_lib_path="dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+          # Vulkan on Linux: Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+          # Metal on macOS: Llama-2-7b-chat-hf-q4f16_1-metal.so
+          # Other platforms: Llama-2-7b-chat-hf-q4f16_1-{backend}.{suffix}
+      )
       cm.generate(prompt="What is the meaning of life?", progress_callback=StreamToStdout(callback_interval=2))
 
     **Colab walkthrough.**  A Jupyter notebook on `Colab <https://colab.research.google.com/github/mlc-ai/notebooks/blob/main/mlc-llm/tutorial_chat_module_getting_started.ipynb>`_
@@ -70,21 +76,23 @@ It is recommended to have at least 6GB free VRAM to run it.
 
     .. code:: bash
 
-      git lfs install && mkdir -p dist/prebuilt
-      git clone https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1 \
-                                dist/prebuilt/mlc-chat-Llama-2-7b-chat-hf-q4f16_1
+      git lfs install && mkdir dist/
+      git clone https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC \
+                                        dist/Llama-2-7b-chat-hf-q4f16_1-MLC
 
     **Download pre-compiled model library**. The pre-compiled model library is available as below:
 
     .. code:: bash
 
-      git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt/lib
+      git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt_libs
 
     **Run in command line**.
 
     .. code:: bash
 
-      mlc_chat_cli --model Llama-2-7b-chat-hf-q4f16_1
+      mlc_chat_cli --model dist/Llama-2-7b-chat-hf-q4f16_1-MLC \
+                   --model-lib-path dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+                   # Metal on macOS: dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-metal.so
 
     .. figure:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/Llama2-macOS.gif
       :width: 500

--- a/docs/prebuilt_models.rst
+++ b/docs/prebuilt_models.rst
@@ -16,18 +16,13 @@ MLC-LLM is a universal solution for deploying different language models. Any mod
 (a general representation for Neural Networks and can be imported from models written in PyTorch) can be recognized by MLC-LLM and thus deployed to different backends with the 
 help of :doc:`TVM Unity </install/tvm>`.
 
-There are two ways to run a model on MLC-LLM:
+There are two ways to run a model on MLC-LLM (this page focuses on the second one):
 
 1. Compile your own models following :doc:`the model compilation page </compilation/compile_models>`.
 2. Use off-the-shelf prebuilts models following this current page.
 
-This page focuses on the second option.
-
-..
-  This page focuses on the second option:
-
-  - Documenting :ref:`how to use prebuilts <using-model-prebuilts>` for various platforms, and
-  - Tracking what current :ref:`prebuilt models we provide <supported-model-architectures>`.
+.. This page focuses on the second option, documenting :ref:`how to use prebuilts <using-model-prebuilts>`
+.. for various platforms, and tracking what current :ref:`prebuilt models we provide <supported-model-architectures>`.
 
 In order to run a specific model on MLC-LLM, you need:
 
@@ -37,220 +32,218 @@ See the full list of all precompiled model libraries `here <https://github.com/m
 **2. Compiled weights:** a folder containing multiple files that store the compiled and quantized weights of a model
 (e.g. https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC).  See the full list of all precompiled weights `here <https://huggingface.co/mlc-ai>`__.
 
-.. 
-  .. _using-model-prebuilts:
+.. POPULATE BELOW AFTER IOS AND ANDROID RUNTIME DOCUMENTATION ARE SLM-IFIED
+.. .. _using-model-prebuilts:
 
-  Using Prebuilt Models for Different Platforms
-  ---------------------------------------------
+.. Using Prebuilt Models for Different Platforms
+.. ---------------------------------------------
 
-  We quickly go over how to use prebuilt models for each platform. You can find detailed instruction on each platform's corresponding page.
+.. We quickly go over how to use prebuilt models for each platform. You can find detailed instruction on each platform's corresponding page.
 
-  .. _using-prebuilt-models-cli:
+.. _using-prebuilt-models-cli:
 
+.. Prebuilt Models on CLI / Python
+.. ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Prebuilt Models on CLI / Python
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. For more, please see :doc:`the CLI page </deploy/cli>`, and the :doc:`the Python page </deploy/python>`.
 
-  For more, please see :doc:`the CLI page </deploy/cli>`, and the :doc:`the Python page </deploy/python>`.
+.. .. collapse:: Click to show details
 
-  .. collapse:: Click to show details
+..   First create the conda environment if you have not done so.
 
-    First create the conda environment if you have not done so.
+..     .. code:: shell
 
-      .. code:: shell
+..       conda create -n mlc-chat-venv -c mlc-ai -c conda-forge mlc-chat-cli-nightly
+..       conda activate mlc-chat-venv
+..       conda install git git-lfs
+..       git lfs install
 
-        conda create -n mlc-chat-venv -c mlc-ai -c conda-forge mlc-chat-cli-nightly
-        conda activate mlc-chat-venv
-        conda install git git-lfs
-        git lfs install
+..   Download the prebuilt model libraries from github.
 
-    Download the prebuilt model libraries from github.
+..     .. code:: shell
 
-      .. code:: shell
-
-        mkdir -p dist/prebuilt
-        git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt/lib
-
-    Download the prebuilt model weights from hugging face for the model variant you want.
-
-      .. code:: shell
-
-        # Say we want to run rwkv-raven-7b-q8f16_0
-        cd dist/prebuilt
-        git clone https://huggingface.co/mlc-ai/mlc-chat-rwkv-raven-7b-q8f16_0
-        cd ../..
-
-        # The format being:
-        # cd dist/prebuilt
-        # git clone https://huggingface.co/mlc-ai/mlc-chat-[model-code]
-        # cd ../..
-        # mlc_chat_cli --model [model-code]
-
-    Run the model with CLI:
-
-      .. code:: shell
-
-        # For CLI
-        mlc_chat_cli --model rwkv-raven-7b-q8f16_0
-
-    To run the model with Python API, see :doc:`the Python page </deploy/python>` (all other downloading steps are the same as CLI).
+..       mkdir dist/
+..       git clone https://github.com/mlc-ai/binary-mlc-llm-libs.git dist/prebuilt_libs
 
 
-  .. for a blank line
+..   Download the prebuilt model weights from hugging face for the model variant you want.
 
-  |
+..     .. code:: shell
 
-  .. _using-prebuilt-models-ios:
+..       # Say we want to run Llama-2-7b-chat-hf-q4f16_1-MLC
+..       git lfs install
+..       git clone https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC \
+..                                         dist/Llama-2-7b-chat-hf-q4f16_1-MLC
 
-  Prebuilt Models on iOS
-  ^^^^^^^^^^^^^^^^^^^^^^
+..   Run the model with CLI:
 
-  For more, please see :doc:`the iOS page </deploy/ios>`.
+..     .. code:: shell
 
-  .. collapse:: Click to show details
+..       mlc_chat_cli --model dist/Llama-2-7b-chat-hf-q4f16_1-MLC \
+..                   --model-lib-path dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+..                   # CUDA on Linux: dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-cuda.so
+..                   # Metal on macOS: dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-metal.so
+..                   # Same rule applies for other platforms
 
-    The `iOS app <https://apps.apple.com/us/app/mlc-chat/id6448482937>`_ has builtin RedPajama-3B and Llama-2-7b support. 
 
-    All prebuilt models with an entry in ``iOS`` in the :ref:`model library table <model-library-tables>` are supported by iOS. Namely, we have:
+..   To run the model with Python API, see :doc:`the Python page </deploy/python>` (all other downloading steps are the same as CLI).
 
-    .. list-table:: Prebuilt model libraries integrated in the iOS app
-      :widths: 15 15 15
-      :header-rows: 1
 
-      * - Model library name
-        - Model Family
-        - Quantization Mode
-      * - `Llama-2-7b-chat-hf-q3f16_1`
-        - LLaMA
-        - * Weight storage data type: int3
-          * Running data type: float16
-          * Symmetric quantization
-      * - `vicuna-v1-7b-q3f16_0`
-        - LLaMA
-        - * Weight storage data type: int3
-          * Running data type: float16
-          * Symmetric quantization
-      * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
-        - GPT-NeoX
-        - * Weight storage data type: int4
-          * Running data type: float16
-          * Symmetric quantization
+.. .. for a blank line
 
-    As for prebuilt model weights, the ones we have integrated into app are listed below:
+.. |
 
-    .. list-table:: Tested prebuilt model weights for iOS
-      :widths: 15 15 15 15
-      :header-rows: 1
+.. .. _using-prebuilt-models-ios:
 
-      * - Model code
-        - Model Series
-        - Quantization Mode
-        - Hugging Face repo
-      * - `Llama-2-7b-q3f16_1`
-        - `Llama <https://ai.meta.com/llama/>`__
-        - * Weight storage data type: int3
-          * Running data type: float16
-          * Symmetric quantization
-        - `link <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1>`__
-      * - `vicuna-v1-7b-q3f16_0`
-        - `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
-        - * Weight storage data type: int3
-          * Running data type: float16
-          * Symmetric quantization
-        - `link <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
-      * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
-        - `RedPajama <https://www.together.xyz/blog/redpajama>`__
-        - * Weight storage data type: int4
-          * Running data type: float16
-          * Symmetric quantization
-        - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
-    
-    To run a model variant you compiled on your own, you can directly reuse the above
-    integrated prebuilt model libraries, as long as the model shares the
-    architecture and is compiled with the same quantization mode.
-    For example, if you compile `OpenLLaMA-7B <https://github.com/openlm-research/open_llama>`_
-    with quantization mode ``q3f16_0``, then you can run the compiled OpenLLaMA model on iPhone
-    without rebuilding the iOS app by reusing the `vicuna-v1-7b-q3f16_0` model library.
-    Then you can upload the compiled weights to hugging face so that you can download
-    the weights in the app as shown below (for more on uploading to hugging face,
-    please check :ref:`distribute-compiled-models`).
-    
-    To add a model to the iOS app, follow the steps below:
+.. Prebuilt Models on iOS
+.. ^^^^^^^^^^^^^^^^^^^^^^
 
-    .. tabs::
+.. For more, please see :doc:`the iOS page </deploy/ios>`.
 
-        .. tab:: Step 1
+.. .. collapse:: Click to show details
 
-            Open "MLCChat" app, click "Add model variant".
+..   The `iOS app <https://apps.apple.com/us/app/mlc-chat/id6448482937>`_ has builtin RedPajama-3B and Llama-2-7b support. 
 
-            .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-1.png
-                :align: center
-                :width: 30%
+..   All prebuilt models with an entry in ``iOS`` in the :ref:`model library table <model-library-tables>` are supported by iOS. Namely, we have:
 
-        .. tab:: Step 2
+..   .. list-table:: Prebuilt model libraries integrated in the iOS app
+..     :widths: 15 15 15
+..     :header-rows: 1
 
-            Paste the repository URL of the model built on your own, and click "Add".
+..     * - Model library name
+..       - Model Family
+..       - Quantization Mode
+..     * - `Llama-2-7b-chat-hf-q3f16_1`
+..       - LLaMA
+..       - * Weight storage data type: int3
+..         * Running data type: float16
+..         * Symmetric quantization
+..     * - `vicuna-v1-7b-q3f16_0`
+..       - LLaMA
+..       - * Weight storage data type: int3
+..         * Running data type: float16
+..         * Symmetric quantization
+..     * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
+..       - GPT-NeoX
+..       - * Weight storage data type: int4
+..         * Running data type: float16
+..         * Symmetric quantization
 
-            You can refer to the link in the image as an example.
+..   As for prebuilt model weights, the ones we have integrated into app are listed below:
 
-            .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-2.png
-                :align: center
-                :width: 30%
+..   .. list-table:: Tested prebuilt model weights for iOS
+..     :widths: 15 15 15 15
+..     :header-rows: 1
 
-        .. tab:: Step 3
+..     * - Model code
+..       - Model Series
+..       - Quantization Mode
+..       - Hugging Face repo
+..     * - `Llama-2-7b-q3f16_1`
+..       - `Llama <https://ai.meta.com/llama/>`__
+..       - * Weight storage data type: int3
+..         * Running data type: float16
+..         * Symmetric quantization
+..       - `link <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q3f16_1>`__
+..     * - `vicuna-v1-7b-q3f16_0`
+..       - `Vicuna <https://lmsys.org/blog/2023-03-30-vicuna/>`__
+..       - * Weight storage data type: int3
+..         * Running data type: float16
+..         * Symmetric quantization
+..       - `link <https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q3f16_0>`__
+..     * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
+..       - `RedPajama <https://www.together.xyz/blog/redpajama>`__
+..       - * Weight storage data type: int4
+..         * Running data type: float16
+..         * Symmetric quantization
+..       - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
+  
+..   To run a model variant you compiled on your own, you can directly reuse the above
+..   integrated prebuilt model libraries, as long as the model shares the
+..   architecture and is compiled with the same quantization mode.
+..   For example, if you compile `OpenLLaMA-7B <https://github.com/openlm-research/open_llama>`_
+..   with quantization mode ``q3f16_0``, then you can run the compiled OpenLLaMA model on iPhone
+..   without rebuilding the iOS app by reusing the `vicuna-v1-7b-q3f16_0` model library.
+..   Then you can upload the compiled weights to hugging face so that you can download
+..   the weights in the app as shown below (for more on uploading to hugging face,
+..   please check :ref:`distribute-compiled-models`).
+  
+..   To add a model to the iOS app, follow the steps below:
 
-            After adding the model, you can download your model from the URL by clicking the download button.
+..   .. tabs::
 
-            .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-3.png
-                :align: center
-                :width: 30%
+..       .. tab:: Step 1
 
-        .. tab:: Step 4
+..           Open "MLCChat" app, click "Add model variant".
 
-            When the download is finished, click into the model and enjoy.
+..           .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-1.png
+..               :align: center
+..               :width: 30%
 
-            .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-4.png
-                :align: center
-                :width: 30%
+..       .. tab:: Step 2
 
-  .. for a blank line
+..           Paste the repository URL of the model built on your own, and click "Add".
 
-  |
+..           You can refer to the link in the image as an example.
 
-  .. _prebuilt-models-android:
+..           .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-2.png
+..               :align: center
+..               :width: 30%
 
-  Prebuilt Models on Android
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+..       .. tab:: Step 3
 
-  For more, please see :doc:`the Android page </deploy/android>`.
+..           After adding the model, you can download your model from the URL by clicking the download button.
 
-  .. collapse:: Click to show details
+..           .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-3.png
+..               :align: center
+..               :width: 30%
 
-    The apk for demo Android app includes the following models. To add more, check out the Android page.
+..       .. tab:: Step 4
 
-    .. list-table:: Prebuilt Models for Android
-      :widths: 15 15 15 15
-      :header-rows: 1
+..           When the download is finished, click into the model and enjoy.
 
-      * - Model code
-        - Model Series
-        - Quantization Mode
-        - Hugging Face repo
-      * - `Llama-2-7b-q4f16_1`
-        - `Llama <https://ai.meta.com/llama/>`__
-        - * Weight storage data type: int4
-          * Running data type: float16
-          * Symmetric quantization
-        - `link <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1>`__
-      * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
-        - `RedPajama <https://www.together.xyz/blog/redpajama>`__
-        - * Weight storage data type: int4
-          * Running data type: float16
-          * Symmetric quantization
-        - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
-  .. for a blank line
+..           .. image:: https://raw.githubusercontent.com/mlc-ai/web-data/main/images/mlc-llm/tutorials/iPhone-custom-4.png
+..               :align: center
+..               :width: 30%
 
-  |
+.. .. for a blank line
+
+.. |
+
+.. .. _prebuilt-models-android:
+
+.. Prebuilt Models on Android
+.. ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. For more, please see :doc:`the Android page </deploy/android>`.
+
+.. .. collapse:: Click to show details
+
+..   The apk for demo Android app includes the following models. To add more, check out the Android page.
+
+..   .. list-table:: Prebuilt Models for Android
+..     :widths: 15 15 15 15
+..     :header-rows: 1
+
+..     * - Model code
+..       - Model Series
+..       - Quantization Mode
+..       - Hugging Face repo
+..     * - `Llama-2-7b-q4f16_1`
+..       - `Llama <https://ai.meta.com/llama/>`__
+..       - * Weight storage data type: int4
+..         * Running data type: float16
+..         * Symmetric quantization
+..       - `link <https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1>`__
+..     * - `RedPajama-INCITE-Chat-3B-v1-q4f16_1`
+..       - `RedPajama <https://www.together.xyz/blog/redpajama>`__
+..       - * Weight storage data type: int4
+..         * Running data type: float16
+..         * Symmetric quantization
+..       - `link <https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1>`__
+.. .. for a blank line
+
+.. |
 
 .. _supported-model-architectures:
 

--- a/examples/python/sample_mlc_chat.py
+++ b/examples/python/sample_mlc_chat.py
@@ -5,9 +5,21 @@ from mlc_chat.callback import StreamToStdout
 # $ python examples/python/sample_mlc_chat.py
 
 # Create a ChatModule instance
-cm = ChatModule(model="Llama-2-7b-chat-hf-q4f16_1")
-# You can change to other models that you downloaded, for example,
-# cm = ChatModule(model="Llama-2-13b-chat-hf-q4f16_1")  # Llama2 13b model
+cm = ChatModule(
+    model="dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
+    model_lib_path="dist/prebuilt_libs/Llama-2-7b-chat-hf/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+    # Vulkan on Linux: Llama-2-7b-chat-hf-q4f16_1-vulkan.so
+    # Metal on macOS: Llama-2-7b-chat-hf-q4f16_1-metal.so
+    # Other platforms: Llama-2-7b-chat-hf-q4f16_1-{backend}.{suffix}
+)
+
+# You can change to other models that you downloaded
+# Model variants of the same architecture can reuse the same model library
+# Here WizardMath reuses Mistral's model library
+# cm = ChatModule(
+#     model="dist/Mistral-7B-Instruct-v0.2-q4f16_1-MLC",  # or "dist/WizardMath-7B-V1.1-q4f16_1-MLC"
+#     model_lib_path="dist/prebuilt_libs/Mistral-7B-Instruct-v0.2/Mistral-7B-Instruct-v0.2-q4f16_1-cuda.so"
+# )
 
 # Generate a response for a given prompt
 output = cm.generate(


### PR DESCRIPTION
This PR updates the runtime portion of the documentation to reflect changes in SLM, as per https://github.com/mlc-ai/mlc-llm/issues/1420.

- We specify the full model path and model lib path in Python/CLI runtime (S5).
- Update project overview to remove `local_id` and `model_lib` fields from `mlc-chat-config.json` ([redrew figure](https://github.com/mlc-ai/web-data/blob/main/images/mlc-llm/tutorials/mlc-llm-flow-slm.svg) to highlight model weights and model lib) (S6)