### PR TITLE
[SLM] Store fp32 weight as fp16 on disk

### DIFF
--- a/python/mlc_chat/compiler/convert_weight.py
+++ b/python/mlc_chat/compiler/convert_weight.py
@@ -126,7 +126,7 @@ def _convert_args(args: ConversionArgs) -> None:  # pylint: disable=too-many-loc
             "ParamBytes": total_bytes,
             "BitsPerParam": total_bytes * 8.0 / total_params,
         },
-        encode_format="raw",
+        encode_format="f32-to-bf16",
     )
     logger.info("Saved to directory: %s", bold(str(args.output)))
 


### PR DESCRIPTION
This PR fixes the weight store of `q0f32` with fp16 on disk.