### PR TITLE
Auto-downloading and Just-in-Time Compilation in ChatModule

### DIFF
--- a/python/mlc_chat/__init__.py
+++ b/python/mlc_chat/__init__.py
@@ -2,5 +2,11 @@
 
 MLC Chat is the app runtime of MLC LLM.
 """
-from .chat_module import ChatConfig, ChatModule, ConvConfig, GenerationConfig
+from .chat_module import (
+    ChatConfig,
+    ChatModule,
+    ConvConfig,
+    GenerationConfig,
+    JITOptions,
+)
 from .libinfo import __version__

--- a/python/mlc_chat/cli/compile.py
+++ b/python/mlc_chat/cli/compile.py
@@ -64,9 +64,9 @@ def main(argv):
     parser.add_argument(
         "--quantization",
         type=str,
-        required=False,
         choices=list(QUANTIZATION.keys()),
-        help=HELP["quantization"] + " (required, choices: %(choices)s)",
+        help=HELP["quantization"]
+        + " (default: look up mlc-chat-config.json, choices: %(choices)s)",
     )
     parser.add_argument(
         "--model-type",

--- a/python/mlc_chat/cli/delivery.py
+++ b/python/mlc_chat/cli/delivery.py
@@ -5,6 +5,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple, Union
@@ -110,7 +111,7 @@ def _run_quantization(
             logger.info("[MLC] Processing in directory: %s", output_dir)
             # Required arguments
             cmd = [
-                "python",
+                sys.executable,
                 "-m",
                 "mlc_chat",
                 "gen_config",
@@ -132,7 +133,7 @@ def _run_quantization(
             print(" ".join(cmd), file=log_file, flush=True)
             subprocess.run(cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT)
             cmd = [
-                "python",
+                sys.executable,
                 "-m",
                 "mlc_chat",
                 "convert_weight",

--- a/python/mlc_chat/interface/flags_model_config_override.py
+++ b/python/mlc_chat/interface/flags_model_config_override.py
@@ -4,8 +4,8 @@ import dataclasses
 from io import StringIO
 from typing import Any, Optional
 
-from ..support import logging
-from ..support.style import bold, red
+from mlc_chat.support import logging
+from mlc_chat.support.style import bold, red
 
 logger = logging.getLogger(__name__)
 

--- a/python/mlc_chat/support/auto_config.py
+++ b/python/mlc_chat/support/auto_config.py
@@ -135,7 +135,7 @@ def detect_model_type(model_type: str, config: Path) -> "Model":
         The model type.
     """
 
-    from mlc_chat.model import MODELS, Model  # pylint: disable=import-outside-toplevel
+    from mlc_chat.model import MODELS  # pylint: disable=import-outside-toplevel
 
     if model_type == "auto":
         with open(config, "r", encoding="utf-8") as config_file:

--- a/python/mlc_chat/support/auto_device.py
+++ b/python/mlc_chat/support/auto_device.py
@@ -30,7 +30,7 @@ def detect_device(device_hint: str) -> Optional[Device]:
         if device is None:
             logger.info("%s: No available device detected", NOT_FOUND)
             return None
-        logger.info("Using device: %s", bold(_device_to_str(device)))
+        logger.info("Using device: %s", bold(device2str(device)))
         return device
     try:
         device = tvm.device(device_hint)
@@ -41,13 +41,14 @@ def detect_device(device_hint: str) -> Optional[Device]:
     return device
 
 
-def _device_to_str(device: Device) -> str:
+def device2str(device: Device) -> str:
+    """Convert a TVM device object to string."""
     return f"{tvm.runtime.Device.MASK2STR[device.device_type]}:{device.device_id}"
 
 
 def _device_exists(device: Device) -> bool:
     device_type = tvm.runtime.Device.MASK2STR[device.device_type]
-    device_str = _device_to_str(device)
+    device_str = device2str(device)
     if device_str in _RESULT_CACHE:
         return _RESULT_CACHE[device_str]
     cmd = [

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -9,7 +9,7 @@ from tvm.ir.transform import Pass
 from tvm.target import Target
 
 from . import logging
-from .auto_device import AUTO_DETECT_DEVICES, _device_to_str, detect_device
+from .auto_device import AUTO_DETECT_DEVICES, detect_device, device2str
 from .style import bold, green, red
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ def _detect_target_gpu(hint: str) -> Tuple[Target, BuildFunc]:
         target: Optional[Target] = None
         device = detect_device(hint)
         if device is not None:
-            device_str = _device_to_str(device)
+            device_str = device2str(device)
             try:
                 target = Target.from_device(device)
             except ValueError:

--- a/python/mlc_chat/support/download.py
+++ b/python/mlc_chat/support/download.py
@@ -39,6 +39,8 @@ def get_cache_dir() -> Path:
             f"The default cache directory is not a directory: {result}. "
             "Use environment variable MLC_CACHE_DIR to specify a valid cache directory."
         )
+    (result / "model_weights").mkdir(parents=True, exist_ok=True)
+    (result / "model_lib").mkdir(parents=True, exist_ok=True)
     return result
 
 
@@ -141,7 +143,7 @@ def download_mlc_weights(  # pylint: disable=too-many-locals
     if model_url.count("/") != 1 + mlc_prefix.count("/") or not model_url.startswith(mlc_prefix):
         raise ValueError(f"Invalid model URL: {model_url}")
     user, repo = model_url[len(mlc_prefix) :].split("/")
-    git_dir = get_cache_dir() / "model_weights" / repo
+    git_dir = get_cache_dir() / "model_weights" / user / repo
     try:
         _ensure_directory_not_exist(git_dir, force_redo=force_redo)
     except ValueError:


### PR DESCRIPTION
This PR introduces support for auto-downloading quantized model from HuggingFace, and optionally JIT-compile and generate corresponding model lib if missing.

**Auto-downloading.** When creating a ChatModule, if `model` is prefixed with `HF://`, MLC will search its model cache and automatically download it from HuggingFace if missing. This way, users won't have to download the model on their own using Git LFS.

**JIT compilation.** When creating a ChatModule and `model_lib_path` is neither supplied nor found using the existing path finding protocol, MLC will generate a model lib DSO and cache it on disk.

**Caching.** Model weights are in `$MLC_CACHE_DIR/mlc_chat/model_weights` once downloaded from HuggingFace, and the model libs are cached under `$MLC_CACHE_DIR/mlc_chat/model_lib`. By default, `$MLC_CACHE_DIR` is `$HOME/.cache` on Linux/macOS and `%LOCALAPPDATA%` on windows. Right now only the very basic caching strategy is used, i.e. no eviction and no file system locks.

Example:

```python
import logging
from mlc_chat import ChatModule
from mlc_chat.callback import StreamToStdout

logging.basicConfig(
    level=logging.INFO,
    style="{",
    datefmt="%Y-%m-%d %H:%M:%S",
    format="[{asctime}] {levelname} {filename}:{lineno}: {message}",
)

cm = ChatModule("HF://junrushao/Llama-2-7b-chat-hf-q4f16_1-MLC", device="cuda")
cm.generate(
    prompt="What is the meaning of life?",
    progress_callback=StreamToStdout(callback_interval=2),
)
```