### PR TITLE
Introduce MLC_JIT_POLICY and Dissolve JITOptions into ChatConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(
 
 set(MLC_LLM_COMPILE_DEFS ${MLC_LLM_COMPILE_DEFS} DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
 set(MLC_LLM_COMPILE_DEFS ${MLC_LLM_COMPILE_DEFS} __STDC_FORMAT_MACROS=1)
+set(MLC_LLM_COMPILE_DEFS ${MLC_LLM_COMPILE_DEFS} PICOJSON_USE_INT64)
 
 target_include_directories(mlc_llm_objs PRIVATE ${MLC_LLM_INCLUDES})
 target_compile_definitions(mlc_llm_objs PRIVATE ${MLC_LLM_COMPILE_DEFS})

--- a/cpp/cli_main.cc
+++ b/cpp/cli_main.cc
@@ -6,9 +6,6 @@
 // NOTE we only interact with the module through tvm runtime
 // so there is no need to depend on a header interface
 // the same set of operations can be implemented in other languages
-#define PICOJSON_USE_INT64
-#define __STDC_FORMAT_MACROS
-
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/registry.h>

--- a/cpp/conversation.h
+++ b/cpp/conversation.h
@@ -3,8 +3,6 @@
  * \file conversation.h
  * \brief Header of conversation template in MLC-LLM.
  */
-#define PICOJSON_USE_INT64
-#define __STDC_FORMAT_MACROS
 #include <picojson.h>
 #include <tvm/runtime/module.h>
 

--- a/cpp/image_embed.cc
+++ b/cpp/image_embed.cc
@@ -3,9 +3,6 @@
  * \file image_embed.cc
  * \brief Implementation of image embedding module in support of multimodality in LLM.
  */
-#define PICOJSON_USE_INT64
-#define __STDC_FORMAT_MACROS
-
 #include "image_embed.h"
 
 #include <picojson.h>

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -3,9 +3,6 @@
  * \file llm_chat.cc
  * \brief Implementation of llm chat.
  */
-#define PICOJSON_USE_INT64
-#define __STDC_FORMAT_MACROS
-
 #include "llm_chat.h"
 
 #include <picojson.h>

--- a/cpp/metadata/json_parser.h
+++ b/cpp/metadata/json_parser.h
@@ -5,9 +5,6 @@
 #ifndef MLC_LLM_CPP_JSON_PARSER_H_
 #define MLC_LLM_CPP_JSON_PARSER_H_
 
-#define PICOJSON_USE_INT64
-#define __STDC_FORMAT_MACROS
-
 #include <picojson.h>
 #include <tvm/runtime/container/shape_tuple.h>
 #include <tvm/runtime/data_type.h>

--- a/python/mlc_chat/__init__.py
+++ b/python/mlc_chat/__init__.py
@@ -2,11 +2,5 @@
 
 MLC Chat is the app runtime of MLC LLM.
 """
-from .chat_module import (
-    ChatConfig,
-    ChatModule,
-    ConvConfig,
-    GenerationConfig,
-    JITOptions,
-)
+from .chat_module import ChatConfig, ChatModule, ConvConfig, GenerationConfig
 from .libinfo import __version__

--- a/python/mlc_chat/base.py
+++ b/python/mlc_chat/base.py
@@ -8,6 +8,8 @@ import tvm._ffi.base
 
 from . import libinfo
 
+SKIP_LOADING_MLCLLM_SO = os.environ.get("SKIP_LOADING_MLCLLM_SO", "0")
+
 
 def _load_mlc_llm_lib():
     """Load MLC LLM lib"""
@@ -22,5 +24,5 @@ def _load_mlc_llm_lib():
 
 
 # only load once here
-if os.environ.get("SKIP_LOADING_MLCLLM_SO", "0") == "0":
+if SKIP_LOADING_MLCLLM_SO == "0":
     _LIB, _LIB_PATH = _load_mlc_llm_lib()

--- a/python/mlc_chat/cli/delivery.py
+++ b/python/mlc_chat/cli/delivery.py
@@ -2,7 +2,6 @@
 import argparse
 import dataclasses
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -15,12 +14,13 @@ from huggingface_hub.utils import HfHubHTTPError  # pylint: disable=import-error
 
 from mlc_chat.support import logging
 from mlc_chat.support.argparse import ArgumentParser
+from mlc_chat.support.constants import MLC_TEMP_DIR
 from mlc_chat.support.download import git_clone
 from mlc_chat.support.style import bold, green, red
 
 logging.enable_logging()
 logger = logging.getLogger(__name__)
-MLC_TEMP_DIR = os.getenv("MLC_TEMP_DIR", None)
+
 GEN_CONFIG_OPTIONAL_ARGS = [
     "context_window_size",
     "sliding_window_size",

--- a/python/mlc_chat/help.py
+++ b/python/mlc_chat/help.py
@@ -47,7 +47,7 @@ Optimization flags. MLC LLM maintains a predefined set of optimization flags,
 denoted as O0, O1, O2, O3, where O0 means no optimization, O2 means majority of them,
 and O3 represents extreme optimization that could potentially break the system.
 Meanwhile, optimization flags could be explicitly specified via details knobs, e.g.
---opt="cutlass_attn=1;cutlass_norm=0;cublas_gemm=0;cudagraph=0".
+--opt="cublas_gemm=1;cudagraph=0".
 """.strip(),
     "system_lib_prefix": """
 Adding a prefix to all symbols exported. Similar to "objcopy --prefix-symbols".

--- a/python/mlc_chat/interface/compile.py
+++ b/python/mlc_chat/interface/compile.py
@@ -13,82 +13,13 @@ from mlc_chat import compiler_pass as _
 from mlc_chat import op as op_ext
 from mlc_chat.model import Model
 from mlc_chat.quantization import Quantization
-from mlc_chat.support import argparse, logging
+from mlc_chat.support import logging
 from mlc_chat.support.config import ConfigBase
 from mlc_chat.support.style import bold
 
-from .flags_model_config_override import ModelConfigOverride
+from .compiler_flags import ModelConfigOverride, OptimizationFlags
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass
-class OptimizationFlags:
-    """Optimization flags"""
-
-    flashinfer: bool = False
-    cublas_gemm: bool = False
-    cudagraph: bool = False
-
-    def __repr__(self) -> str:
-        out = StringIO()
-        print(f"flashinfer={int(self.flashinfer)}", file=out, end="")
-        print(f";cublas_gemm={int(self.cublas_gemm)}", file=out, end="")
-        print(f";cudagraph={int(self.cudagraph)}", file=out, end="")
-        return out.getvalue().rstrip()
-
-    @staticmethod
-    def from_str(source: str) -> "OptimizationFlags":
-        """Parse optimization flags from a string."""
-
-        if source in OPT_FLAG_PRESET:
-            return OPT_FLAG_PRESET[source]
-
-        def boolean(value: str) -> bool:
-            if value == "0":
-                return False
-            if value == "1":
-                return True
-            raise ValueError(f"Invalid boolean value: {value}")
-
-        parser = argparse.ArgumentParser(description="optimization flags")
-        parser.add_argument("--flashinfer", type=boolean, default=True)
-        parser.add_argument("--cublas_gemm", type=boolean, default=False)
-        parser.add_argument("--cudagraph", type=boolean, default=False)
-        results = parser.parse_args([f"--{i}" for i in source.split(";") if i])
-        return OptimizationFlags(
-            flashinfer=results.flashinfer,
-            cublas_gemm=results.cublas_gemm,
-            cudagraph=results.cudagraph,
-        )
-
-    def update(self, target: Target, quantization: Quantization) -> None:
-        """Update optimization flags based on additional information."""
-
-        def _flashinfer(target) -> bool:
-            from mlc_chat.support.auto_target import (  # pylint: disable=import-outside-toplevel
-                detect_cuda_arch_list,
-            )
-
-            if not self.flashinfer:
-                return False
-            if target.kind.name != "cuda":
-                return False
-            arch_list = detect_cuda_arch_list(target)
-            for arch in arch_list:
-                if arch < 80:
-                    logger.warning("flashinfer is not supported on CUDA arch < 80")
-                    return False
-            return True
-
-        def _cublas_gemm(target, quantization) -> bool:
-            """correct cublas_gemm flag"""
-            if not (target.kind.name == "cuda" and quantization.name in ["q0f16", "q0f32"]):
-                return False
-            return self.cublas_gemm
-
-        self.flashinfer = _flashinfer(target)
-        self.cublas_gemm = _cublas_gemm(target, quantization)
 
 
 @dataclasses.dataclass
@@ -248,27 +179,3 @@ def compile(  # pylint: disable=too-many-arguments,redefined-builtin
     )
     args.display()
     _compile(args, model_config)
-
-
-OPT_FLAG_PRESET = {
-    "O0": OptimizationFlags(
-        flashinfer=False,
-        cublas_gemm=False,
-        cudagraph=False,
-    ),
-    "O1": OptimizationFlags(
-        flashinfer=False,
-        cublas_gemm=True,
-        cudagraph=False,
-    ),
-    "O2": OptimizationFlags(
-        flashinfer=False,
-        cublas_gemm=True,
-        cudagraph=False,
-    ),
-    "O3": OptimizationFlags(
-        flashinfer=True,
-        cublas_gemm=True,
-        cudagraph=True,
-    ),
-}

--- a/python/mlc_chat/interface/compiler_flags.py
+++ b/python/mlc_chat/interface/compiler_flags.py
@@ -1,13 +1,81 @@
 """Flags for overriding model config."""
-import argparse
 import dataclasses
 from io import StringIO
 from typing import Any, Optional
 
-from mlc_chat.support import logging
+from mlc_chat.support import argparse, logging
 from mlc_chat.support.style import bold, red
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class OptimizationFlags:
+    """Optimization flags"""
+
+    flashinfer: bool = False
+    cublas_gemm: bool = False
+    cudagraph: bool = False
+
+    def __repr__(self) -> str:
+        out = StringIO()
+        print(f"flashinfer={int(self.flashinfer)}", file=out, end="")
+        print(f";cublas_gemm={int(self.cublas_gemm)}", file=out, end="")
+        print(f";cudagraph={int(self.cudagraph)}", file=out, end="")
+        return out.getvalue().rstrip()
+
+    @staticmethod
+    def from_str(source: str) -> "OptimizationFlags":
+        """Parse optimization flags from a string."""
+
+        if source in OPT_FLAG_PRESET:
+            return OPT_FLAG_PRESET[source]
+
+        def boolean(value: str) -> bool:
+            if value == "0":
+                return False
+            if value == "1":
+                return True
+            raise ValueError(f"Invalid boolean value: {value}")
+
+        parser = argparse.ArgumentParser(description="optimization flags")
+        parser.add_argument("--flashinfer", type=boolean, default=True)
+        parser.add_argument("--cublas_gemm", type=boolean, default=False)
+        parser.add_argument("--cudagraph", type=boolean, default=False)
+        results = parser.parse_args([f"--{i}" for i in source.split(";") if i])
+        return OptimizationFlags(
+            flashinfer=results.flashinfer,
+            cublas_gemm=results.cublas_gemm,
+            cudagraph=results.cudagraph,
+        )
+
+    def update(self, target, quantization) -> None:
+        """Update optimization flags based on additional information."""
+
+        def _flashinfer(target) -> bool:
+            from mlc_chat.support.auto_target import (  # pylint: disable=import-outside-toplevel
+                detect_cuda_arch_list,
+            )
+
+            if not self.flashinfer:
+                return False
+            if target.kind.name != "cuda":
+                return False
+            arch_list = detect_cuda_arch_list(target)
+            for arch in arch_list:
+                if arch < 80:
+                    logger.warning("flashinfer is not supported on CUDA arch < 80")
+                    return False
+            return True
+
+        def _cublas_gemm(target, quantization) -> bool:
+            """correct cublas_gemm flag"""
+            if not (target.kind.name == "cuda" and quantization.name in ["q0f16", "q0f32"]):
+                return False
+            return self.cublas_gemm
+
+        self.flashinfer = _flashinfer(target)
+        self.cublas_gemm = _cublas_gemm(target, quantization)
 
 
 @dataclasses.dataclass
@@ -123,3 +191,27 @@ def _model_config_override(model_config, field: str, value: Any) -> None:
             bold(type(model_config).__name__),
             bold(field),
         )
+
+
+OPT_FLAG_PRESET = {
+    "O0": OptimizationFlags(
+        flashinfer=False,
+        cublas_gemm=False,
+        cudagraph=False,
+    ),
+    "O1": OptimizationFlags(
+        flashinfer=False,
+        cublas_gemm=True,
+        cudagraph=False,
+    ),
+    "O2": OptimizationFlags(
+        flashinfer=False,
+        cublas_gemm=True,
+        cudagraph=False,
+    ),
+    "O3": OptimizationFlags(
+        flashinfer=True,
+        cublas_gemm=True,
+        cudagraph=True,
+    ),
+}

--- a/python/mlc_chat/interface/gen_config.py
+++ b/python/mlc_chat/interface/gen_config.py
@@ -10,7 +10,7 @@ from mlc_chat.quantization import Quantization
 from mlc_chat.support import logging
 from mlc_chat.support.style import bold, green, red
 
-from .flags_model_config_override import ModelConfigOverride
+from .compiler_flags import ModelConfigOverride
 
 logger = logging.getLogger(__name__)
 

--- a/python/mlc_chat/interface/jit.py
+++ b/python/mlc_chat/interface/jit.py
@@ -1,0 +1,115 @@
+"""Just-in-time compilation of MLC-Chat models."""
+import dataclasses
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+from tvm.runtime import Device
+
+from mlc_chat.model import MODELS
+from mlc_chat.support import logging
+from mlc_chat.support.auto_device import device2str
+from mlc_chat.support.constants import MLC_CACHE_DIR, MLC_JIT_POLICY, MLC_TEMP_DIR
+from mlc_chat.support.style import blue, bold
+
+from .compiler_flags import ModelConfigOverride, OptimizationFlags
+
+logger = logging.getLogger(__name__)
+
+
+def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
+    """Just-in-time compile a MLC-Chat model."""
+    if MLC_JIT_POLICY == "OFF":
+        raise RuntimeError("JIT is disabled by MLC_JIT_POLICY=OFF")
+
+    with open(model_path / "mlc-chat-config.json", "r", encoding="utf-8") as in_file:
+        mlc_chat_config = json.load(in_file)
+    model_type = mlc_chat_config.pop("model_type")
+    quantization = mlc_chat_config.pop("quantization")
+
+    def _get_optimization_flags() -> str:
+        opt = mlc_chat_config.pop("opt", "O2")
+        return repr(OptimizationFlags.from_str(opt))
+
+    def _get_overrides() -> str:
+        forbid_list = ["context_window_size", "sliding_window_size", "attention_sink_size"]
+        result = []
+        for field in dataclasses.fields(ModelConfigOverride):
+            value = chat_config.get(field.name, None)
+            if value is not None:
+                if field.name in forbid_list and value == -1:
+                    continue
+                result.append(f"{field.name}={value}")
+        if not result:
+            result = ["tensor_parallel_shards=1"]
+        return ";".join(result)
+
+    def _get_model_config() -> Dict[str, Any]:
+        model_config = mlc_chat_config.pop("model_config")
+        model_config.update(mlc_chat_config)
+        for field in dataclasses.fields(ModelConfigOverride):
+            value = chat_config.get(field.name, None)
+            if value is not None:
+                model_config[field.name] = value
+        return MODELS[model_type].config.from_dict(model_config).asdict()
+
+    def _run_jit(opt: str, overrides: str, device: str, dst: str):
+        with tempfile.TemporaryDirectory(dir=MLC_TEMP_DIR) as tmp_dir:
+            dso_path = os.path.join(tmp_dir, "lib.so")
+            cmd = [
+                sys.executable,
+                "-m",
+                "mlc_chat",
+                "compile",
+                str(model_path),
+                "--opt",
+                opt,
+                "--overrides",
+                overrides,
+                "--device",
+                device,
+                "--output",
+                dso_path,
+            ]
+            logger.info("Compiling using commands below:")
+            logger.info("%s", blue(" ".join(cmd)))
+            subprocess.run(cmd, check=True)
+            shutil.move(dso_path, dst)
+            logger.info("Using compiled model lib: %s", bold(dst))
+
+    hash_key = {
+        "model_config": _get_model_config(),
+        "overrides": _get_overrides(),
+        "opt": _get_optimization_flags(),
+        "device": device2str(device),
+        "model_type": model_type,
+        "quantization": quantization,
+    }
+    hash_value = hashlib.md5(
+        json.dumps(
+            hash_key,
+            sort_keys=True,
+            indent=2,
+        ).encode("utf-8")
+    ).hexdigest()
+    dst = MLC_CACHE_DIR / "model_lib" / f"{hash_value}.so"
+    if dst.is_file() and MLC_JIT_POLICY in ["ON", "READONLY"]:
+        logger.info("Using cached model lib: %s", bold(str(dst)))
+        return dst
+    if MLC_JIT_POLICY == "READONLY":
+        raise RuntimeError(
+            "No cached model lib found, and JIT is disabled by MLC_JIT_POLICY=READONLY"
+        )
+    _run_jit(
+        opt=hash_key["opt"],
+        overrides=hash_key["overrides"],
+        device=hash_key["device"],
+        dst=str(dst),
+    )
+    return dst

--- a/python/mlc_chat/libinfo.py
+++ b/python/mlc_chat/libinfo.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 __version__ = "0.1.dev0"
+MLC_LIBRARY_PATH = os.environ.get("MLC_LIBRARY_PATH", None)
 
 
 def get_env_paths(env_var, splitter):
@@ -22,20 +23,16 @@ def get_dll_directories():
         os.path.join(source_dir, "build"),
         os.path.join(source_dir, "build", "Release"),
     ]
-
-    if "MLC_LIBRARY_PATH" in os.environ:
-        dll_path.append(os.environ["MLC_LIBRARY_PATH"])
-
+    if MLC_LIBRARY_PATH:
+        dll_path.append(MLC_LIBRARY_PATH)
     if "CONDA_PREFIX" in os.environ:
         dll_path.append(os.path.join(os.environ["CONDA_PREFIX"], "lib"))
-
     if sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         dll_path.extend(get_env_paths("LD_LIBRARY_PATH", ":"))
     elif sys.platform.startswith("darwin"):
         dll_path.extend(get_env_paths("DYLD_LIBRARY_PATH", ":"))
     elif sys.platform.startswith("win32"):
         dll_path.extend(get_env_paths("PATH", ";"))
-
     return [os.path.abspath(p) for p in dll_path if os.path.isdir(p)]
 
 

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -1,5 +1,4 @@
 """Helper functioms for target auto-detection."""
-import os
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 from tvm import IRModule, relax
@@ -10,6 +9,7 @@ from tvm.target import Target
 
 from . import logging
 from .auto_device import AUTO_DETECT_DEVICES, detect_device, device2str
+from .constants import MLC_MULTI_ARCH
 from .style import bold, green, red
 
 if TYPE_CHECKING:
@@ -227,9 +227,8 @@ def _build_default():
 def detect_cuda_arch_list(target: Target) -> List[int]:
     """Detect the CUDA architecture list from the target."""
     assert target.kind.name == "cuda", f"Expect target to be CUDA, but got {target}"
-    env_multi_arch = os.environ.get("MLC_MULTI_ARCH", None)
-    if env_multi_arch is not None:
-        multi_arch = [int(x.strip()) for x in env_multi_arch.split(",")]
+    if MLC_MULTI_ARCH is not None:
+        multi_arch = [int(x.strip()) for x in MLC_MULTI_ARCH.split(",")]
     else:
         assert target.arch.startswith("sm_")
         multi_arch = [int(target.arch[3:])]
@@ -238,8 +237,7 @@ def detect_cuda_arch_list(target: Target) -> List[int]:
 
 
 def _register_cuda_hook(target: Target):
-    env_multi_arch = os.environ.get("MLC_MULTI_ARCH", None)
-    if env_multi_arch is None:
+    if MLC_MULTI_ARCH is None:
         default_arch = target.attrs.get("arch", None)
         logger.info("Generating code for CUDA architecture: %s", bold(default_arch))
         logger.info(
@@ -249,8 +247,8 @@ def _register_cuda_hook(target: Target):
         )
         multi_arch = None
     else:
-        logger.info("%s %s: %s", FOUND, bold("MLC_MULTI_ARCH"), env_multi_arch)
-        multi_arch = [int(x.strip()) for x in env_multi_arch.split(",")]
+        logger.info("%s %s: %s", FOUND, bold("MLC_MULTI_ARCH"), MLC_MULTI_ARCH)
+        multi_arch = [int(x.strip()) for x in MLC_MULTI_ARCH.split(",")]
         logger.info("Generating code for CUDA architecture: %s", multi_arch)
 
     @register_func("tvm_callback_cuda_compile", override=True)

--- a/python/mlc_chat/support/constants.py
+++ b/python/mlc_chat/support/constants.py
@@ -1,0 +1,44 @@
+"""Environment variables used by the MLC LLM."""
+import os
+import sys
+from pathlib import Path
+
+
+def _check():
+    if MLC_JIT_POLICY not in ["ON", "OFF", "REDO", "READONLY"]:
+        raise ValueError(
+            'Invalid MLC_JIT_POLICY. It has to be one of "ON", "OFF", "REDO", "READONLY"'
+            f"but got {MLC_JIT_POLICY}."
+        )
+
+
+def _get_cache_dir() -> Path:
+    if "MLC_CACHE_DIR" in os.environ:
+        result = Path(os.environ["MLC_CACHE_DIR"])
+    elif sys.platform == "win32":
+        result = Path(os.environ["LOCALAPPDATA"])
+        result = result / "mlc_chat"
+    elif os.getenv("XDG_CACHE_HOME", None) is not None:
+        result = Path(os.getenv("XDG_CACHE_HOME"))
+        result = result / "mlc_chat"
+    else:
+        result = Path(os.path.expanduser("~/.cache"))
+        result = result / "mlc_chat"
+    result.mkdir(parents=True, exist_ok=True)
+    if not result.is_dir():
+        raise ValueError(
+            f"The default cache directory is not a directory: {result}. "
+            "Use environment variable MLC_CACHE_DIR to specify a valid cache directory."
+        )
+    (result / "model_weights").mkdir(parents=True, exist_ok=True)
+    (result / "model_lib").mkdir(parents=True, exist_ok=True)
+    return result
+
+
+MLC_TEMP_DIR = os.getenv("MLC_TEMP_DIR", None)
+MLC_MULTI_ARCH = os.environ.get("MLC_MULTI_ARCH", None)
+MLC_CACHE_DIR: Path = _get_cache_dir()
+MLC_JIT_POLICY = os.environ.get("MLC_JIT_POLICY", "ON")
+
+
+_check()


### PR DESCRIPTION
This PR introduces an environment variable `MLC_JIT_POLICY` as a follow-up item to PR [#1508](https://github.com/mlc-ai/mlc-llm/pull/1508#issuecomment-1871611605). It allows to enable/disable the JIT behavior by:
- `OFF`: never JIT, and will throw an error if `model_lib` is missing;
- `ON` (default): JIT whenever the model lib is missing and there's a cache miss;
- `REDO`: whenever the model lib is missing, always do JIT compilation even if cache hits;
- `READONLY`: never do JIT compilation but look up the JIT cache whenever the model lib is missing.

It also dissolves the newly-introduced `JITOption` into `ChatConfig` so that it can be used more seamlessly with exactly the existing APIs. By doing so, users can simply specify `context_window_size`, `prefill_chunk_size` to control the VRAM used in each model without having to recompile the model lib themselves.

Example: If one focuses on developing compiler/runtime rather than quantization, we could simply run

```bash
MLC_JIT_POLICY=REDO python main.py
```

to test if the compiler/runtime work smoothly together, where `main.py` is:

```python
from mlc_chat import ChatConfig, ChatModule, callback
from mlc_chat.support import logging

logging.enable_logging()
MODEL="HF://junrushao/Llama-2-7b-chat-hf-q4f16_1-MLC",

cm = ChatModule(
    MODEL,
    device="cuda",
    chat_config=ChatConfig(
        context_window_size=1024,
        prefill_chunk_size=1024,
    ),
)
cm.generate(
    "What is the meaning of life?",
    progress_callback=callback.StreamToStdout(callback_interval=2),
)
```