### PR TITLE
Report upper-bound memory usage based on SLM model lib

### DIFF
--- a/python/mlc_chat/cli/benchmark.py
+++ b/python/mlc_chat/cli/benchmark.py
@@ -60,8 +60,8 @@ def _load_prompt(path_or_prompt: str) -> str:
     try:
         path = Path(path_or_prompt)
         if path.is_file():
-            with path.open("r", encoding="utf-8") as f:
-                return f.read()
+            with path.open("r", encoding="utf-8") as in_file:
+                return in_file.read()
     except:  # pylint: disable=bare-except
         pass
     return path_or_prompt

--- a/python/mlc_chat/cli/model_metadata.py
+++ b/python/mlc_chat/cli/model_metadata.py
@@ -1,0 +1,100 @@
+"""A tool that inspects the metadata of a model lib."""
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+
+from mlc_chat.support import logging
+from mlc_chat.support.argparse import ArgumentParser
+from mlc_chat.support.style import green, red
+
+logging.enable_logging()
+logger = logging.getLogger(__name__)
+
+
+def _extract_metadata(model_lib: Path) -> Dict[str, Any]:
+    # pylint: disable=import-outside-toplevel
+    from tvm.runtime import device, load_module
+    from tvm.runtime.relax_vm import VirtualMachine
+
+    # pylint: enable=import-outside-toplevel
+
+    return json.loads(VirtualMachine(load_module(model_lib), device("cpu"))["_metadata"]())
+
+
+def _report_all(metadata: Dict[str, Any]) -> None:
+    # Print JSON with aesthetic values that packs each parameter into one line,
+    # while keeping the rest indented.
+    indent = 2
+    indents = " " * indent
+    params = metadata.pop("params")
+    params = indents * 2 + (",\n" + indents * 2).join(json.dumps(p) for p in params)
+    lines = json.dumps(
+        metadata,
+        sort_keys=True,
+        indent=indent,
+    ).splitlines()
+    lines.insert(1, indents + '"params": [\n' + params + "\n" + indents + "],")
+    beautified_json = "\n".join(lines)
+    print(beautified_json)
+
+
+def _report_memory_usage(metadata: Dict[str, Any]) -> None:
+    params_bytes = 0.0
+    for param in metadata["params"]:
+        if all(v > 0 for v in param["shape"]):
+            params_bytes += math.prod(param["shape"]) * np.dtype(param["dtype"]).itemsize
+    logger.info("%s: %.2f MB", green("Parameter size"), params_bytes / 1024 / 1024)
+
+    temp_func_bytes = 0.0
+    for _func_name, func_bytes in metadata["memory_usage"].items():
+        temp_func_bytes = max(temp_func_bytes, func_bytes)
+    logger.info("%s: %.2f MB", green("Temporary buffer size"), temp_func_bytes / 1024 / 1024)
+
+    kv_cache_bytes = metadata["kv_cache_bytes"]
+    logger.info("%s: %.2f MB", green("KVCache size"), kv_cache_bytes / 1024 / 1024)
+
+    total_size = params_bytes + temp_func_bytes + kv_cache_bytes
+    logger.info("%s: %.2f MB", green("Total memory usage"), total_size / 1024 / 1024)
+
+    logger.info(
+        "To reduce memory usage, "
+        "tweak `prefill_chunk_size`, `context_window_size` and `sliding_window_size`"
+    )
+
+
+def main():
+    """Entry point for the model metadata tool."""
+    parser = ArgumentParser(description="A tool that inspects the metadata of a model lib.")
+    parser.add_argument(
+        "model_lib",
+        type=Path,
+        help="""The compiled model library. In MLC LLM, an LLM is compiled to a shared or static
+        library (.so or .a), which contains GPU computation to efficiently run the LLM. MLC Chat,
+        as the runtime of MLC LLM, depends on the compiled model library to generate tokens.
+        """,
+    )
+    parser.add_argument(
+        "--memory-only",
+        action="store_true",
+        help="""If set, only inspect the metadata in memory usage and print richer analysis.
+        Otherwise, the tool will load all the metadata from the model library file but only print
+        the basic information in JSON.
+        """,
+    )
+    parsed = parser.parse_args()
+    try:
+        metadata = _extract_metadata(parsed.model_lib)
+    except:  # pylint: disable=bare-except
+        logger.exception("%s to read metadata section in legacy model lib.", red("FAILED"))
+        return
+    if parsed.memory_only:
+        _report_memory_usage(metadata)
+    else:
+        _report_all(metadata)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/mlc_chat/interface/gen_config.py
+++ b/python/mlc_chat/interface/gen_config.py
@@ -83,20 +83,19 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
 ):
     """Entrypoint of MLC Chat configuration generation."""
     # Step 1. Initialize `mlc-chat-config.json` using `config.json`
-    model_config = model.config.from_file(config)
-    ModelConfigOverride(
+    model_config = ModelConfigOverride(
         context_window_size=context_window_size,
         sliding_window_size=sliding_window_size,
         prefill_chunk_size=prefill_chunk_size,
         attention_sink_size=attention_sink_size,
         tensor_parallel_shards=tensor_parallel_shards,
-    ).apply(model_config)
+    ).apply(model.config.from_file(config))
     mlc_chat_config = MLCChatConfig(
         model_type=model.name,
         quantization=quantization.name,
         model_config=model_config.asdict(),
         vocab_size=model_config.vocab_size,
-        context_window_size=model_config.context_window_size,
+        context_window_size=getattr(model_config, "context_window_size", -1),
         sliding_window_size=getattr(model_config, "sliding_window_size", -1),
         prefill_chunk_size=model_config.prefill_chunk_size,
         attention_sink_size=getattr(model_config, "attention_sink_size", -1),

--- a/python/mlc_chat/interface/jit.py
+++ b/python/mlc_chat/interface/jit.py
@@ -34,7 +34,7 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
     quantization = mlc_chat_config.pop("quantization")
 
     def _get_optimization_flags() -> str:
-        opt = mlc_chat_config.pop("opt", "O2")
+        opt = chat_config.pop("opt", "O2")
         return repr(OptimizationFlags.from_str(opt))
 
     def _get_overrides() -> str:
@@ -60,6 +60,11 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
         return MODELS[model_type].config.from_dict(model_config).asdict()
 
     def _run_jit(opt: str, overrides: str, device: str, dst: str):
+        def _quote(s: str) -> str:  # pylint: disable=invalid-name
+            if ";" in s:
+                return f'"{s}"'
+            return s
+
         with tempfile.TemporaryDirectory(dir=MLC_TEMP_DIR) as tmp_dir:
             dso_path = os.path.join(tmp_dir, "lib.so")
             cmd = [
@@ -78,7 +83,7 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
                 dso_path,
             ]
             logger.info("Compiling using commands below:")
-            logger.info("%s", blue(" ".join(cmd)))
+            logger.info("%s", blue(" ".join(_quote(s) for s in cmd)))
             subprocess.run(cmd, check=True)
             shutil.move(dso_path, dst)
             logger.info("Using compiled model lib: %s", bold(dst))

--- a/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
+++ b/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
@@ -50,7 +50,22 @@ class GPTBigCodeConfig(ConfigBase):  # pylint: disable=too-many-instance-attribu
                     "`context_window_size`, `max_position_embeddings` or `max_sequence_length` is "
                     "provided in `config.json`."
                 )
-        if self.prefill_chunk_size == 0:  # chunk size same as context window size by default
+        if self.prefill_chunk_size == 0:
+            logger.info(
+                "%s defaults to %s (%d)",
+                bold("prefill_chunk_size"),
+                bold("context_window_size"),
+                self.context_window_size,
+            )
+            self.prefill_chunk_size = self.context_window_size
+        elif self.prefill_chunk_size > self.context_window_size:
+            logger.info(
+                "Overriding %s from %d to %d (%s)",
+                bold("prefill_chunk_size"),
+                self.prefill_chunk_size,
+                self.context_window_size,
+                bold("context_window_size"),
+            )
             self.prefill_chunk_size = self.context_window_size
 
 

--- a/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
@@ -66,7 +66,21 @@ class GPTNeoXConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
         assert self.head_dim * self.num_attention_heads == self.hidden_size
 
         if self.prefill_chunk_size == 0:
-            # chunk size same as context window size by default
+            logger.info(
+                "%s defaults to %s (%d)",
+                bold("prefill_chunk_size"),
+                bold("context_window_size"),
+                self.context_window_size,
+            )
+            self.prefill_chunk_size = self.context_window_size
+        elif self.prefill_chunk_size > self.context_window_size:
+            logger.info(
+                "Overriding %s from %d to %d (%s)",
+                bold("prefill_chunk_size"),
+                self.prefill_chunk_size,
+                self.context_window_size,
+                bold("context_window_size"),
+            )
             self.prefill_chunk_size = self.context_window_size
 
 

--- a/python/mlc_chat/model/llama/llama_model.py
+++ b/python/mlc_chat/model/llama/llama_model.py
@@ -59,14 +59,29 @@ class LlamaConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
                     "`context_window_size`, `max_position_embeddings` or `max_sequence_length` is "
                     "provided in `config.json`."
                 )
-        if self.prefill_chunk_size == 0:  # chunk size same as context window size by default
-            self.prefill_chunk_size = self.context_window_size
         if self.num_key_value_heads == 0:
             self.num_key_value_heads = self.num_attention_heads
         if self.head_dim == 0:
             self.head_dim = self.hidden_size // self.num_attention_heads
         assert self.head_dim * self.num_attention_heads == self.hidden_size
         assert self.num_attention_heads % self.num_key_value_heads == 0
+        if self.prefill_chunk_size == 0:
+            logger.info(
+                "%s defaults to %s (%d)",
+                bold("prefill_chunk_size"),
+                bold("context_window_size"),
+                self.context_window_size,
+            )
+            self.prefill_chunk_size = self.context_window_size
+        elif self.prefill_chunk_size > self.context_window_size:
+            logger.info(
+                "Overriding %s from %d to %d (%s)",
+                bold("prefill_chunk_size"),
+                self.prefill_chunk_size,
+                self.context_window_size,
+                bold("context_window_size"),
+            )
+            self.prefill_chunk_size = self.context_window_size
 
 
 # pylint: disable=invalid-name,missing-docstring

--- a/python/mlc_chat/model/phi/phi_model.py
+++ b/python/mlc_chat/model/phi/phi_model.py
@@ -62,7 +62,9 @@ class PhiConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
                     "n_positions",
                     self.context_window_size,
                 )
-        if self.prefill_chunk_size == 0:  # chunk size same as context window size by default
+        if self.prefill_chunk_size == 0:
+            self.prefill_chunk_size = self.context_window_size
+        if self.prefill_chunk_size > self.context_window_size:
             self.prefill_chunk_size = self.context_window_size
         if self.n_head_kv == 0 or self.n_head_kv is None:
             self.n_head_kv = self.n_head


### PR DESCRIPTION
This PR introduces a command that reports the estimated upper-bound memory usage based on the metadata section of an SLM-compiled model.

Example:

```bash
>> python -m mlc_chat.cli.model_metadata /path/to/model_lib.so --memory-only
[2023-12-31 18:40:43] INFO model_metadata.py:49: Parameter size: 3885.14 MB
[2023-12-31 18:40:43] INFO model_metadata.py:58: Temporary buffer size: 7184.15 MB
[2023-12-31 18:40:43] INFO model_metadata.py:71: KVCache size when context/sliding window size is 4096: 512.00 MB
[2023-12-31 18:40:43] INFO model_metadata.py:79: Total memory usage: 11581.29 MB
[2023-12-31 18:40:43] INFO model_metadata.py:84: Tweaking `prefill_chunk_size`, `context_window_size` and `sliding_window_size` to reduce memory usage
```

Addresses both B1 and B2 in https://github.com/mlc-ai/mlc-llm/pull/1516#issuecomment-1872878113.

Another demo using Python API:

```python
from mlc_chat import ChatConfig, ChatModule, callback
from mlc_chat.support import logging

logging.enable_logging()

MODEL="HF://junrushao/NeuralHermes-2.5-Mistral-7B-q4f16_1-MLC"

cm = ChatModule(
    MODEL,
    device="cuda",
    chat_config=ChatConfig(
        sliding_window_size=4096,
        prefill_chunk_size=1024,
        opt="O2",
    ),
)
cm.generate(
    "What is the meaning of life?",
    progress_callback=callback.StreamToStdout(callback_interval=2),
)
```

```bash
>>> MLC_JIT_POLICY=REDO python main.py
```

<img width="958" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/22515877/8fcf1fb2-53b3-4768-91b4-89f90712dea8">
