### PR TITLE
Enable FlashInfer in O2 mode

### DIFF
--- a/python/mlc_chat/cli/model_metadata.py
+++ b/python/mlc_chat/cli/model_metadata.py
@@ -46,18 +46,20 @@ def _report_memory_usage(metadata: Dict[str, Any]) -> None:
     for param in metadata["params"]:
         if all(v > 0 for v in param["shape"]):
             params_bytes += math.prod(param["shape"]) * np.dtype(param["dtype"]).itemsize
-    logger.info("%s: %.2f MB", green("Parameter size"), params_bytes / 1024 / 1024)
-
     temp_func_bytes = 0.0
     for _func_name, func_bytes in metadata["memory_usage"].items():
         temp_func_bytes = max(temp_func_bytes, func_bytes)
-    logger.info("%s: %.2f MB", green("Temporary buffer size"), temp_func_bytes / 1024 / 1024)
-
     kv_cache_bytes = metadata["kv_cache_bytes"]
-    logger.info("%s: %.2f MB", green("KVCache size"), kv_cache_bytes / 1024 / 1024)
 
     total_size = params_bytes + temp_func_bytes + kv_cache_bytes
-    logger.info("%s: %.2f MB", green("Total memory usage"), total_size / 1024 / 1024)
+    logger.info(
+        "%s: %.2f MB (Parameters: %.2f MB. KVCache: %.2f MB. Temporary buffer: %.2f MB)",
+        green("Total memory usage"),
+        total_size / 1024 / 1024,
+        params_bytes / 1024 / 1024,
+        kv_cache_bytes / 1024 / 1024,
+        temp_func_bytes / 1024 / 1024,
+    )
 
     logger.info(
         "To reduce memory usage, "

--- a/python/mlc_chat/interface/compiler_flags.py
+++ b/python/mlc_chat/interface/compiler_flags.py
@@ -157,7 +157,7 @@ OPT_FLAG_PRESET = {
         cudagraph=False,
     ),
     "O2": OptimizationFlags(
-        flashinfer=False,
+        flashinfer=True,
         cublas_gemm=True,
         cudagraph=False,
     ),

--- a/python/mlc_chat/interface/jit.py
+++ b/python/mlc_chat/interface/jit.py
@@ -34,7 +34,9 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
     quantization = mlc_chat_config.pop("quantization")
 
     def _get_optimization_flags() -> str:
-        opt = chat_config.pop("opt", "O2")
+        opt = chat_config.pop("opt", None)
+        if opt is None:
+            opt = "O2"
         return repr(OptimizationFlags.from_str(opt))
 
     def _get_overrides() -> str:

--- a/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
+++ b/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
@@ -3,13 +3,13 @@ Implementation for GPTBigCode architecture.
 TODO: add docstring
 """
 import dataclasses
-import math
 from typing import Any, Dict, Optional
 
 from tvm import te, tir
 from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import Tensor, op
 
+from mlc_chat import op as op_ext
 from mlc_chat.support import logging
 from mlc_chat.support import tensor_parallel as tp
 from mlc_chat.support.config import ConfigBase
@@ -123,26 +123,10 @@ class GPTBigCodeAttention(nn.Module):  # pylint: disable=too-many-instance-attri
 
         self.k_cache.append(op.squeeze(k, axis=0))
         self.v_cache.append(op.squeeze(v, axis=0))
-        k = op.reshape(self.k_cache.view(t), (b, t, h_kv, d))
-        v = op.reshape(self.v_cache.view(t), (b, t, h_kv, d))
-        if h_kv != h_q:
-            k = k.repeat(h_q // h_kv, axis=2)
-            v = v.repeat(h_q // h_kv, axis=2)
-        q = q.permute_dims([0, 2, 1, 3])  # [b, h, s, d]
-        k = k.permute_dims([0, 2, 1, 3])  # [b, h, t, d]
-        v = v.permute_dims([0, 2, 1, 3])  # [b, h, t, d]
-        attn_weights = op.matmul(
-            q, k.permute_dims([0, 1, 3, 2])  # [b, h, s, d] x [b, h, d, t] = [b, h, s, t]
-        ) / math.sqrt(d)
-        dtype = attn_weights.dtype
-        attn_weights = attn_weights.maximum(tir.min_value(dtype)).minimum(attention_mask)
-        if dtype == "float32":
-            attn_weights = op.softmax(attn_weights, axis=-1)
-        else:
-            attn_weights = op.softmax(attn_weights.astype("float32"), axis=-1).astype(dtype)
-        # [b, h, s, t] x [b, h, t, d] => [b, h, s, d] => [b, s, h, d]
-        output = op.matmul(attn_weights, v)
-        return self.c_proj(output.permute_dims([0, 2, 1, 3]).reshape((b, s, h_q * d)))
+        k = self.k_cache.view(t)
+        v = self.v_cache.view(t)
+        output = op_ext.attention(q, k, v, casual_mask=attention_mask)
+        return self.c_proj(output)
 
 
 class GPTBigCodeBlock(nn.Module):


### PR DESCRIPTION
This PR turns on FlashInfer in O2 mode given it has been relatively stable over the past few weeks.

This commits also brings a few misc improvements:
- Pass in scratch memory managed by RelaxVM's memory pool - this change depends on TVM's [PR #16327](https://github.com/apache/tvm/pull/16327) and FlashInfer's [PR #43](https://github.com/flashinfer-ai/flashinfer/pull/43)
- Enable FlashInfer for group size = 4, which is a setting used in Mistral models;
- Slightly shorten and clarify the log message on memory usage on model lib loading.
- Integrate FlashInfer into GPT-BigCode models.

With this PR, FlashInfer is integrated into Mistral, Llama, GPT-NeoX, GPT-BigCode, Phi. The only left out is GPT2, which has a special flag `scale_attn_by_inverse_layer_idx` which applies an elementwise normalization term `1.0 / layer_id` to attn scores before masked softmax.