### PR TITLE
Support TinyLlama in SLM flow

### DIFF
--- a/python/mlc_chat/interface/jit.py
+++ b/python/mlc_chat/interface/jit.py
@@ -3,6 +3,7 @@ import dataclasses
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -62,11 +63,6 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
         return MODELS[model_type].config.from_dict(model_config).asdict()
 
     def _run_jit(opt: str, overrides: str, device: str, dst: str):
-        def _quote(s: str) -> str:  # pylint: disable=invalid-name
-            if ";" in s:
-                return f'"{s}"'
-            return s
-
         with tempfile.TemporaryDirectory(dir=MLC_TEMP_DIR) as tmp_dir:
             dso_path = os.path.join(tmp_dir, "lib.so")
             cmd = [
@@ -85,7 +81,7 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
                 dso_path,
             ]
             logger.info("Compiling using commands below:")
-            logger.info("%s", blue(" ".join(_quote(s) for s in cmd)))
+            logger.info("%s", blue(shlex.join(cmd)))
             subprocess.run(cmd, check=True)
             shutil.move(dso_path, dst)
             logger.info("Using compiled model lib: %s", bold(dst))

--- a/python/mlc_chat/loader/utils.py
+++ b/python/mlc_chat/loader/utils.py
@@ -55,7 +55,12 @@ def load_safetensor_shard(path: Path) -> Iterator[Tuple[str, np.ndarray]]:
     """Load and yield SafeTensor format parameters."""
     import safetensors  # pylint: disable=import-outside-toplevel,import-error
 
-    with safetensors.safe_open(path, framework="numpy", device="cpu") as in_file:
+    with safetensors.safe_open(path, framework="pt", device="cpu") as in_file:
         for name in in_file.keys():
             param = in_file.get_tensor(name)
+            param = param.detach().cpu()
+            dtype = str(param.dtype)
+            if dtype == "torch.bfloat16":
+                param = param.float()
+            param = param.numpy()
             yield name, param

--- a/python/mlc_chat/op/attention.py
+++ b/python/mlc_chat/op/attention.py
@@ -12,6 +12,10 @@ from . import extern as _extern
 logger = logging.getLogger(__name__)
 
 
+WARN_FLASHINFER_GROUP_SIZE = False
+WARN_FLASHINFER_HEAD_DIM = False
+
+
 def attention(  # pylint: disable=invalid-name,too-many-locals
     q: nn.Tensor,
     k: nn.Tensor,
@@ -89,10 +93,22 @@ def attention(  # pylint: disable=invalid-name,too-many-locals
         and v.dtype == "float16"
     ):
         if group_size not in [1, 4, 8]:
-            logger.warning(
-                "FlashInfer only supports group size in [1, 4, 8], but got %d",
-                group_size,
-            )
+            global WARN_FLASHINFER_GROUP_SIZE  # pylint: disable=global-statement
+            if not WARN_FLASHINFER_GROUP_SIZE:
+                WARN_FLASHINFER_GROUP_SIZE = True
+                logger.warning(
+                    "FlashInfer only supports group size in [1, 4, 8], but got %d",
+                    group_size,
+                )
+            return _fallback()
+        if d not in [128]:
+            global WARN_FLASHINFER_HEAD_DIM  # pylint: disable=global-statement
+            if not WARN_FLASHINFER_HEAD_DIM:
+                WARN_FLASHINFER_HEAD_DIM = True
+                logger.warning(
+                    "FlashInfer only head_dim in [128], but got %d",
+                    d,
+                )
             return _fallback()
         rope_theta = 0.0
         rope_scale = 1.0


### PR DESCRIPTION
This PR includes two minor fixes to support TinyLlama:

- Fix BF16 loading via SafeTensor - it was broken because numpy does not support bf16, which leads to an exception in safetensor internally.
- FlashInfer doesn't support `head_dim == 64`, which we skipped in this PR.

After this PR, the following snippet runs TinyLlama pretty conveniently:

```python
from mlc_chat import ChatConfig, ChatModule, callback
from mlc_chat.support import logging

logging.enable_logging()

MODEL = "HF://junrushao/TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC"

def main():
    cm = ChatModule(
        MODEL,
        device="metal",
        chat_config=ChatConfig(context_window_size=1024),
    )
    cm.generate(
        "What is the meaning of life?",
        progress_callback=callback.StreamToStdout(callback_interval=2),
    )

if __name__ == "__main__":
    main()
```