### PR TITLE
[Serving] Switching to SLM model definition flow

### DIFF
--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -14,6 +14,8 @@
 
 #include <string>
 
+#include "../metadata/model.h"
+
 namespace mlc {
 namespace llm {
 namespace serve {
@@ -55,6 +57,8 @@ struct FunctionTable {
 
   TypedPackedFunc<PackedFunc(const std::string&)> mod_get_func;
   TypedPackedFunc<PackedFunc(const std::string&)> get_global_func;
+
+  ModelMetadata model_metadata_;
 
   PackedFunc embed_func_;
   PackedFunc prefill_func_;

--- a/python/mlc_chat/serve/engine.py
+++ b/python/mlc_chat/serve/engine.py
@@ -35,15 +35,14 @@ class ModelInfo:
         It can be "auto", "device_name" (e.g., "cuda") or
         "device_name:device_id" (e.g., "cuda:1").
 
-    model_lib_path : Optional[str]
-        The compiled library of the model.
-        When specified, it is a path to the model library,
-        e.g., "dist/prebuilt/lib/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+    model_lib_path : str
+        The path to the compiled library of the model.
+        E.g., "dist/prebuilt/lib/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
     """
 
     model: str
+    model_lib_path: str
     device: Device = "auto"  # type: ignore
-    model_lib_path: Optional[str] = None
 
     def __post_init__(self):
         if isinstance(self.device, str):

--- a/python/mlc_chat/serve/server/popen_server.py
+++ b/python/mlc_chat/serve/server/popen_server.py
@@ -16,9 +16,9 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
         model: str,
+        model_lib_path: str,
         device: str = "auto",
         *,
-        model_lib_path: str = "",
         max_batch_size: int = 80,
         max_total_sequence_length: int = 16800,
         enable_tracing: bool = False,
@@ -28,8 +28,8 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         """Please check out `python/mlc_chat/serve/server/__main__.py`
         for the server arguments."""
         self.model = model
-        self.device = device
         self.model_lib_path = model_lib_path
+        self.device = device
         self.max_batch_size = max_batch_size
         self.max_total_sequence_length = max_total_sequence_length
         self.enable_tracing = enable_tracing
@@ -44,8 +44,8 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         cmd = [sys.executable]
         cmd += ["-m", "mlc_chat.serve.server"]
         cmd += ["--model", self.model]
-        cmd += ["--device", self.device]
         cmd += ["--model-lib-path", self.model_lib_path]
+        cmd += ["--device", self.device]
         cmd += ["--max-batch-size", str(self.max_batch_size)]
         cmd += ["--max-total-seq-length", str(self.max_total_sequence_length)]
         if self.enable_tracing:

--- a/tests/python/serve/evaluate_engine.py
+++ b/tests/python/serve/evaluate_engine.py
@@ -1,5 +1,6 @@
 # pylint: disable=line-too-long,missing-docstring
 import argparse
+import os
 import random
 from typing import List, Tuple
 
@@ -9,7 +10,7 @@ from mlc_chat.serve.engine import ModelInfo
 
 def _parse_args():
     args = argparse.ArgumentParser()
-    args.add_argument("--model-id", type=str, default="Llama-2-7b-chat-hf-q0f16")
+    args.add_argument("--model-lib-path", type=str)
     args.add_argument("--device", type=str, default="auto")
     args.add_argument("--batch-size", type=int, default=80)
     args.add_argument("--page-size", type=int, default=16)
@@ -17,6 +18,7 @@ def _parse_args():
     args.add_argument("--seed", type=int, default=0)
 
     parsed = args.parse_args()
+    parsed.model = os.path.dirname(parsed.model_lib_path)
     assert parsed.batch_size % 16 == 0
     assert parsed.page_size == 16
     assert parsed.max_total_seq_length >= 2048
@@ -42,7 +44,7 @@ def benchmark(args: argparse.Namespace):
     random.seed(args.seed)
 
     # Initialize model loading info and KV cache config
-    model = ModelInfo(args.model_id, args.device)
+    model = ModelInfo(args.model, args.model_lib_path, args.device)
     kv_cache_config = KVCacheConfig(
         page_size=args.page_size,
         max_num_sequence=args.batch_size,

--- a/tests/python/serve/server/conftest.py
+++ b/tests/python/serve/server/conftest.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 import os
+from typing import Tuple
 
 import pytest
 
@@ -7,21 +8,24 @@ from mlc_chat.serve import PopenServer
 
 
 @pytest.fixture(scope="session")
-def served_model() -> str:
-    model = os.environ.get("MLC_SERVE_MODEL")
-    if model is None:
+def served_model() -> Tuple[str, str]:
+    model_lib_path = os.environ.get("MLC_SERVE_MODEL_LIB")
+    if model_lib_path is None:
         raise ValueError(
-            'Environment variable "MLC_SERVE_MODEL" not found. '
-            "Please set it to model compiled by MLC LLM (e.g., Llama-2-7b-chat-hf-q0f16)."
+            'Environment variable "MLC_SERVE_MODEL_LIB" not found. '
+            "Please set it to model lib compiled by MLC LLM "
+            "(e.g., `dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so`)."
         )
-    return model
+    model = os.path.dirname(model_lib_path)
+    return model, model_lib_path
 
 
 @pytest.fixture(scope="session")
 def launch_server(served_model):  # pylint: disable=redefined-outer-name
     """A pytest session-level fixture which launches the server in a subprocess."""
     server = PopenServer(
-        served_model,
+        model=served_model[0],
+        model_lib_path=served_model[1],
         max_total_sequence_length=5120,
         enable_tracing=True,
     )

--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -22,7 +22,10 @@ prompts = [
 
 async def test_engine_generate():
     # Initialize model loading info and KV cache config
-    model = ModelInfo("Llama-2-7b-chat-hf-q4f16_1")
+    model = ModelInfo(
+        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
+        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
+    )
     kv_cache_config = KVCacheConfig(page_size=16)
     # Create engine
     async_engine = AsyncThreadedEngine(model, kv_cache_config)

--- a/tests/python/serve/test_serve_engine.py
+++ b/tests/python/serve/test_serve_engine.py
@@ -68,7 +68,10 @@ def test_engine_basic():
     """
 
     # Initialize model loading info and KV cache config
-    model = ModelInfo("Llama-2-7b-chat-hf-q4f16_1")
+    model = ModelInfo(
+        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
+        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
+    )
     kv_cache_config = KVCacheConfig(page_size=16)
 
     # Hyperparameters for tests (you can try different combinations).
@@ -125,7 +128,10 @@ def test_engine_continuous_batching_1():
     """
 
     # Initialize model loading info and KV cache config
-    model = ModelInfo("Llama-2-7b-chat-hf-q4f16_1")
+    model = ModelInfo(
+        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
+        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
+    )
     kv_cache_config = KVCacheConfig(page_size=16)
 
     # Hyperparameters for tests (you can try different combinations)
@@ -200,7 +206,10 @@ def test_engine_continuous_batching_2():
     """
 
     # Initialize model loading info and KV cache config
-    model = ModelInfo("Llama-2-7b-chat-hf-q4f16_1")
+    model = ModelInfo(
+        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
+        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
+    )
     kv_cache_config = KVCacheConfig(page_size=16)
 
     # Hyperparameters for tests (you can try different combinations)
@@ -276,7 +285,10 @@ def test_engine_continuous_batching_3():
     """
 
     # Initialize model loading info and KV cache config
-    model = ModelInfo("Llama-2-7b-chat-hf-q4f16_1")
+    model = ModelInfo(
+        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
+        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
+    )
     kv_cache_config = KVCacheConfig(page_size=16)
 
     # Hyperparameters for tests (you can try different combinations)
@@ -352,7 +364,10 @@ def test_engine_continuous_batching_3():
 
 def test_engine_generate():
     # Initialize model loading info and KV cache config
-    model = ModelInfo("Llama-2-7b-chat-hf-q4f16_1")
+    model = ModelInfo(
+        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
+        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
+    )
     kv_cache_config = KVCacheConfig(page_size=16)
     # Create engine
     engine = Engine(model, kv_cache_config)


### PR DESCRIPTION
PR #1520 introduces batched llama to SLM. This PR
updates the serving codebase and fully switch the model definition to SLM flow. Most changes in this PR are trivial.

Note that with this PR merged in, the previous batching model definition flow becomes outdated and no longer usable.