### PR TITLE
[Fix][Python] `__init__.py` under `nn` subpackage

### DIFF
--- a/python/mlc_chat/nn/__init__.py
+++ b/python/mlc_chat/nn/__init__.py
@@ -1,0 +1,2 @@
+"""Neural network components for LLM."""
+from .kv_cache import FlashInferPagedKVCache, PagedKVCache


### PR DESCRIPTION
This is a quick fix to #1547. Sorry for missing the init file in the nn subpackage.