### PR TITLE
Add Mistral and Phi to model table

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ use off-the-shelf. Visit [Prebuilt Models](https://llm.mlc.ai/docs/prebuilt_mode
       <td>StableLM</td>
       <td></td>
     </tr>
+    <tr>
+      <td>Mistral</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Phi</td>
+      <td></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
I was looking into running a good embedding model locally. The popular [embedding model leaderboard](https://huggingface.co/spaces/mteb/leaderboard) currently (2024-01-07) shows [`e5-mistral-7b-instruct`](https://huggingface.co/intfloat/e5-mistral-7b-instruct) as top entry. I checked mlc-llm's README and it didn't seem to support the Mistral architecture. Only when checking the docs that turned out to be wrong.

=> As many people might be quick to leave when not finding Mistral on the README, I propose to include this info on the README directly, instead of only in the docs.

To have a smaller README, maybe some of the other listed models can be removed, which might be less popular?

It might also be worth adding one row with `...` or `... (see docs)` with a link, to the docs, which might make clearer that people should check the link and it's easier/quicker to see than reading the text paragraph above the table.
If you want, I can adjust this PR accordingly.