### PR TITLE
[SLM] Support Quantization `q4f16_0` and `q3f16_0`

### DIFF
--- a/python/mlc_chat/interface/compile.py
+++ b/python/mlc_chat/interface/compile.py
@@ -137,6 +137,14 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
             and model_config.tensor_parallel_shards > 1
         ):
             raise NotImplementedError
+        if (
+            args.quantization.linear_weight_layout == "KN"
+            and hasattr(model_config, "tensor_parallel_shards")
+            and model_config.tensor_parallel_shards > 1
+        ):
+            raise NotImplementedError(
+                "KN layout (q3f16_0 and q4f16_0) is not supported for tensor parallelism"
+            )
         model, _ = args.model.quantize[args.quantization.kind](model_config, args.quantization)
         kv_cache_bytes = _find_kv_cache_bytes(model, model_config)
         # Step 2. Exporting the model to TVM Unity

--- a/python/mlc_chat/op/attention.py
+++ b/python/mlc_chat/op/attention.py
@@ -101,7 +101,8 @@ def attention(  # pylint: disable=invalid-name,too-many-locals,too-many-statemen
             if not WARN_FLASHINFER_GROUP_SIZE:
                 WARN_FLASHINFER_GROUP_SIZE = True
                 logger.warning(
-                    "FlashInfer only supports group size in [1, 4, 8], but got %d",
+                    "FlashInfer only supports group size in [1, 4, 8], but got %d. Skip and "
+                    "fallback to default implementation.",
                     group_size,
                 )
             return _fallback()
@@ -110,7 +111,8 @@ def attention(  # pylint: disable=invalid-name,too-many-locals,too-many-statemen
             if not WARN_FLASHINFER_HEAD_DIM:
                 WARN_FLASHINFER_HEAD_DIM = True
                 logger.warning(
-                    "FlashInfer only head_dim in [128], but got %d",
+                    "FlashInfer only supports head_dim in [128], but got %d. Skip and fallback to "
+                    "default implementation.",
                     d,
                 )
             return _fallback()

--- a/python/mlc_chat/quantization/awq_quantization.py
+++ b/python/mlc_chat/quantization/awq_quantization.py
@@ -138,7 +138,7 @@ class AWQQuantize:  # pylint: disable=too-many-instance-attributes
             self.num_elem_per_storage,
             self.storage_dtype,
             self.model_dtype,
-            [weight.shape[0], weight.shape[1] * self.num_elem_per_storage],
+            out_shape=[weight.shape[0], weight.shape[1] * self.num_elem_per_storage],
             ft_reorder=True,
         )
         float_zeros = convert_uint_to_float(
@@ -147,7 +147,7 @@ class AWQQuantize:  # pylint: disable=too-many-instance-attributes
             self.num_elem_per_storage,
             self.storage_dtype,
             self.model_dtype,
-            [zeros.shape[0], zeros.shape[1] * self.num_elem_per_storage],
+            out_shape=[zeros.shape[0], zeros.shape[1] * self.num_elem_per_storage],
             ft_reorder=True,
         )
         float_weight = topi.transpose(float_weight)

--- a/python/mlc_chat/quantization/ft_quantization.py
+++ b/python/mlc_chat/quantization/ft_quantization.py
@@ -1,6 +1,6 @@
 """The FasterTransformer quantization config"""
 from dataclasses import dataclass
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Literal, Optional, Tuple
 
 import tvm
 from tvm import DataType, DataTypeCode, IRModule
@@ -25,9 +25,9 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
 
     name: str
     kind: str
-    quantize_dtype: str  # "int4", "int8"
-    storage_dtype: str  # "int8"
-    model_dtype: str  # "float16"
+    quantize_dtype: Literal["int4", "int8"]
+    storage_dtype: Literal["int8"]
+    model_dtype: Literal["float16"]
     group_size: Optional[int] = None
 
     num_elem_per_storage: int = 0
@@ -49,6 +49,7 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
             quantize_dtype=self.quantize_dtype,
             storage_dtype="uint32",
             model_dtype=self.model_dtype,
+            linear_weight_layout="NK",
         )
 
     def __post_init__(self):

--- a/python/mlc_chat/quantization/quantization.py
+++ b/python/mlc_chat/quantization/quantization.py
@@ -36,6 +36,15 @@ QUANTIZATION: Dict[str, Quantization] = {
         kind="no-quant",
         model_dtype="float32",
     ),
+    "q3f16_0": GroupQuantize(
+        name="q3f16_0",
+        kind="group-quant",
+        group_size=40,
+        quantize_dtype="int3",
+        storage_dtype="uint32",
+        model_dtype="float16",
+        linear_weight_layout="KN",
+    ),
     "q3f16_1": GroupQuantize(
         name="q3f16_1",
         kind="group-quant",
@@ -43,6 +52,16 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_dtype="int3",
         storage_dtype="uint32",
         model_dtype="float16",
+        linear_weight_layout="NK",
+    ),
+    "q4f16_0": GroupQuantize(
+        name="q4f16_0",
+        kind="group-quant",
+        group_size=32,
+        quantize_dtype="int4",
+        storage_dtype="uint32",
+        model_dtype="float16",
+        linear_weight_layout="KN",
     ),
     "q4f16_1": GroupQuantize(
         name="q4f16_1",
@@ -51,6 +70,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_dtype="int4",
         storage_dtype="uint32",
         model_dtype="float16",
+        linear_weight_layout="NK",
     ),
     "q4f32_1": GroupQuantize(
         name="q4f32_1",
@@ -59,6 +79,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_dtype="int4",
         storage_dtype="uint32",
         model_dtype="float32",
+        linear_weight_layout="NK",
     ),
     "q4f16_autoawq": AWQQuantize(
         name="q4f16_autoawq",


### PR DESCRIPTION
As `q4f16_0` is useful at Adreno and potentially benefits Hexagon backends, this PR adds support for `q4f16_0` and `q3f16_0` quantization back to SLM.

Note that the current flow does not support Mixtral.

Confirmed `q3f16_0`, `q4f16_0`, and `q4f16_1` work well on a single Cuda device. I suppose it would work on other platforms as it's backend-independent. But would be great if you could help confirm if it works with disco

cc @junrushao @LeshengJin 