### PR TITLE
[Serving] Fix AsyncThreadedEngine for Metal

### DIFF
--- a/cpp/serve/async_threaded_engine.h
+++ b/cpp/serve/async_threaded_engine.h
@@ -30,9 +30,6 @@ class AsyncThreadedEngine {
  public:
   virtual ~AsyncThreadedEngine() = default;
 
-  /*! \brief Create an AsyncThreadedEngine with the given background engine. */
-  static std::unique_ptr<AsyncThreadedEngine> Create(std::unique_ptr<Engine> engine);
-
   /*! \brief Starts the background request processing loop. */
   virtual void RunBackgroundLoop() = 0;
 


### PR DESCRIPTION
This PR fixes a threading issue when using AsyncThreadedEngine on Metal. This issue does not exist for CUDA.

Prior to this PR, the engine is constructed on one threaded and is driven by the other thread. After this PR, both the construction and the engine drive is on the same thread, which does not raise issue in the current Metal runtime.