### PR TITLE
[Rust] Add a dummy function in cpp file to force linking

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1757,7 +1757,7 @@ TVM_REGISTER_GLOBAL("mlc.random.set_seed").set_body_typed([](int seed) {
 
 // for MLC RUST API: to force the Rust compiler to link the whole translation unit
 extern "C" {
-void llm_chat_dummy_func() {}
+void LLMChatDummyLinkFunc() {}
 }
 
 }  // namespace llm

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1757,7 +1757,7 @@ TVM_REGISTER_GLOBAL("mlc.random.set_seed").set_body_typed([](int seed) {
 
 // for MLC RUST API: to force the Rust compiler to link the whole translation unit
 extern "C" {
-  void llm_chat_dummy_func() {}
+void llm_chat_dummy_func() {}
 }
 
 }  // namespace llm

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1755,5 +1755,10 @@ TVM_REGISTER_GLOBAL("mlc.random.set_seed").set_body_typed([](int seed) {
   RandomGenerator::GetInstance().SetSeed(seed);
 });
 
+// for MLC RUST API: to force the Rust compiler to link the whole translation unit
+extern "C" {
+  void llm_chat_dummy_func() {}
+}
+
 }  // namespace llm
 }  // namespace mlc

--- a/rust/src/chat_module.rs
+++ b/rust/src/chat_module.rs
@@ -8,7 +8,7 @@ use tvm_rt::{function::Function, Module};
 use super::config::*;
 
 extern "C" {
-    fn llm_chat_dummy_func();
+    fn LLMChatDummyLinkFunc();
 }
 
 #[derive(Debug)]
@@ -344,7 +344,7 @@ impl ChatModule {
         };
 
         unsafe {
-            llm_chat_dummy_func();
+            LLMChatDummyLinkFunc();
         }
 
         static GLOBAL_FUNC_NAME: &str = "mlc.llm_chat_create";

--- a/rust/src/chat_module.rs
+++ b/rust/src/chat_module.rs
@@ -7,6 +7,10 @@ use tvm_rt::{function::Function, Module};
 
 use super::config::*;
 
+extern "C" {
+    fn llm_chat_dummy_func();
+}
+
 #[derive(Debug)]
 pub enum ChatModuleError {
     /// Global function in a TVM Module is not found
@@ -338,6 +342,10 @@ impl ChatModule {
             "rocm" => 10,
             _ => panic!("{}", device_err_msg),
         };
+
+        unsafe {
+            llm_chat_dummy_func();
+        }
 
         static GLOBAL_FUNC_NAME: &str = "mlc.llm_chat_create";
         let f = Function::get(GLOBAL_FUNC_NAME).ok_or(ChatModuleError::GlobalFuncNotFound)?;


### PR DESCRIPTION
In the Rust code, we are linking to the `libmlc_llm_module.so` with the rustc **-l** flag in the [build script](https://github.com/mlc-ai/mlc-llm/blob/eddc5b146f458d331ca89d414c608b2465c0947a/rust/build.rs#L4), so that we can get the registered packed func `mlc.llm_chat_create` via the TVM Rust API `Function::get()` as in the code: https://github.com/mlc-ai/mlc-llm/blob/eddc5b146f458d331ca89d414c608b2465c0947a/rust/src/chat_module.rs#L342-L343

However, when we create another Rust crate that depends on the MLC LLM Rust crate, we have to link to the [libmlc_llm_module.so](https://github.com/mlc-ai/mlc-llm/blob/main/CMakeLists.txt#L142) in the new crate again. This happens because the rustc compiler prunes off linking to components without direct dependency, as happens here when we look up a packed function through TVM FFI by a string.

This PR fixes the issue by adding a dummy function in the llm_chat.cc file, and call the dummy function in the rust code, to force the whole translation unit to be linked. This solves the issue, so the crates that depend on the MLC Rust library no longer need to link to the shared library again.

cc: @tqchen @junrushao 