### PR TITLE
[SLM] Phi-1/Phi-1.5 new model type support

### DIFF
--- a/python/mlc_chat/model/model.py
+++ b/python/mlc_chat/model/model.py
@@ -152,4 +152,17 @@ MODELS: Dict[str, Model] = {
             "group-quant": phi_quantization.group_quant,
         },
     ),
+    "phi": Model(
+        name="phi",
+        model=phi_model.PhiForCausalLM,
+        config=phi_model.Phi1Config,
+        source={
+            "huggingface-torch": phi_loader.phi1_huggingface,
+            "huggingface-safetensor": phi_loader.phi1_huggingface,
+        },
+        quantize={
+            "no-quant": phi_quantization.no_quant,
+            "group-quant": phi_quantization.group_quant,
+        },
+    ),
 }

--- a/python/mlc_chat/model/phi/phi_loader.py
+++ b/python/mlc_chat/model/phi/phi_loader.py
@@ -70,7 +70,7 @@ def huggingface(model_config: PhiConfig, quantization: Quantization) -> ExternMa
         _add("lm_head.linear.bias", f"{prefix}.linear.bias")
 
     elif model_config.model_type == "phi-msft":
-        _add("transformer.embd.weight", "transformer.wte.weight")
+        _add("transformer.embd.weight", "transformer.embd.wte.weight")
         for mlc_name, _ in named_parameters.items():
             if mlc_name not in mapping.param_map:
                 _add(mlc_name, mlc_name)

--- a/python/mlc_chat/model/phi/phi_loader.py
+++ b/python/mlc_chat/model/phi/phi_loader.py
@@ -4,10 +4,12 @@ PyTorch, HuggingFace safetensors.
 """
 import functools
 
+import numpy as np
+
 from mlc_chat.loader import ExternMapping
 from mlc_chat.quantization import Quantization
 
-from .phi_model import PhiConfig, PhiForCausalLM
+from .phi_model import Phi1Config, PhiConfig, PhiForCausalLM
 
 
 def huggingface(model_config: PhiConfig, quantization: Quantization) -> ExternMapping:
@@ -72,4 +74,89 @@ def huggingface(model_config: PhiConfig, quantization: Quantization) -> ExternMa
         for mlc_name, _ in named_parameters.items():
             if mlc_name not in mapping.param_map:
                 _add(mlc_name, mlc_name)
+    return mapping
+
+
+def phi1_huggingface(model_config: Phi1Config, quantization: Quantization) -> ExternMapping:
+    """Returns a parameter mapping that maps from the names of MLC LLM parameters to
+    the names of Phi-1/Phi-1.5 HuggingFace PyTorch parameters.
+
+    Parameters
+    ----------
+    model_config : PhiConfig
+        The configuration of the Phi model.
+
+    quantization : Quantization
+        The quantization configuration.
+
+    Returns
+    -------
+    param_map : ExternMapping
+        The parameter mapping from MLC to HuggingFace PyTorch.
+    """
+    model = PhiForCausalLM(model_config)
+    if quantization is not None:
+        model.to(quantization.model_dtype)
+    _, _named_params = model.export_tvm(  # pylint: disable=W0632:unbalanced-tuple-unpacking
+        spec=model.get_default_spec()
+    )
+    named_parameters = dict(_named_params)
+
+    mapping = ExternMapping()
+
+    def _add(mlc_name, hf_name):
+        mapping.add_mapping(
+            mlc_name,
+            [hf_name],
+            functools.partial(
+                lambda x, dtype: x.astype(dtype),
+                dtype=named_parameters[mlc_name].dtype,
+            ),
+        )
+
+    def _concat_add(mlc_name, hf_names):
+        mapping.add_mapping(
+            mlc_name,
+            hf_names,
+            functools.partial(
+                lambda q, k, v, dtype: np.concatenate([q, k, v], axis=0).astype(dtype),
+                dtype=named_parameters[mlc_name].dtype,
+            ),
+        )
+
+    _add("lm_head.linear.weight", "lm_head.weight")
+    _add("lm_head.linear.bias", "lm_head.bias")
+    _add("lm_head.ln.weight", "model.final_layernorm.weight")
+    _add("lm_head.ln.bias", "model.final_layernorm.bias")
+    _add("transformer.embd.weight", "model.embed_tokens.weight")
+
+    prefix = "transformer.h"
+    hf_prefix = "model.layers"
+    for i in range(model_config.num_hidden_layers):
+        _add(f"{prefix}.{i}.ln.weight", f"{hf_prefix}.{i}.input_layernorm.weight")
+        _add(f"{prefix}.{i}.ln.bias", f"{hf_prefix}.{i}.input_layernorm.bias")
+        _concat_add(
+            f"{prefix}.{i}.mixer.Wqkv.weight",
+            [
+                f"{hf_prefix}.{i}.self_attn.q_proj.weight",
+                f"{hf_prefix}.{i}.self_attn.k_proj.weight",
+                f"{hf_prefix}.{i}.self_attn.v_proj.weight",
+            ],
+        )
+        _concat_add(
+            f"{prefix}.{i}.mixer.Wqkv.bias",
+            [
+                f"{hf_prefix}.{i}.self_attn.q_proj.bias",
+                f"{hf_prefix}.{i}.self_attn.k_proj.bias",
+                f"{hf_prefix}.{i}.self_attn.v_proj.bias",
+            ],
+        )
+        _add(f"{prefix}.{i}.mixer.out_proj.weight", f"{hf_prefix}.{i}.self_attn.dense.weight")
+        _add(f"{prefix}.{i}.mixer.out_proj.bias", f"{hf_prefix}.{i}.self_attn.dense.bias")
+        _add(f"{prefix}.{i}.mlp.fc1.weight", f"{hf_prefix}.{i}.mlp.fc1.weight")
+        _add(f"{prefix}.{i}.mlp.fc1.bias", f"{hf_prefix}.{i}.mlp.fc1.bias")
+        _add(f"{prefix}.{i}.mlp.fc2.weight", f"{hf_prefix}.{i}.mlp.fc2.weight")
+        _add(f"{prefix}.{i}.mlp.fc2.bias", f"{hf_prefix}.{i}.mlp.fc2.bias")
+        mapping.add_unused(f"{hf_prefix}.{i}.mixer.rotary_emb.inv_freq")
+
     return mapping

--- a/python/mlc_chat/model/phi/phi_model.py
+++ b/python/mlc_chat/model/phi/phi_model.py
@@ -18,8 +18,64 @@ logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
+class Phi1Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
+    """Configuration of the Phi-1/Phi-1.5 model."""
+
+    vocab_size: int = 51200
+    hidden_size: int = 2048
+    intermediate_size: int = 8192
+    num_hidden_layers: int = 24
+    num_attention_heads: int = 32
+    layer_norm_eps: float = 1e-5
+    position_embedding_base: float = 0
+    partial_rotary_factor: float = 0.5
+    num_key_value_heads: int = 0
+    context_window_size: int = 0
+    prefill_chunk_size: int = 0
+    head_dim: int = 0
+    tensor_parallel_shards: int = 1
+    kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.position_embedding_base == 0:
+            if "rope_theta" in self.kwargs:
+                self.position_embedding_base = self.kwargs.pop("rope_theta")
+            else:
+                self.position_embedding_base = 10000
+        if self.context_window_size == 0:
+            for name in ["max_position_embeddings", "max_sequence_length"]:
+                if name in self.kwargs:
+                    self.context_window_size = self.kwargs.pop(name)
+                    logger.info(
+                        "%s not found in config.json. Falling back to %s (%d)",
+                        bold("context_window_size"),
+                        bold(name),
+                        self.context_window_size,
+                    )
+                    break
+            else:
+                raise ValueError(
+                    "Unable to determine the maxmimum sequence length, because none of "
+                    "`context_window_size`, `max_position_embeddings` or `max_sequence_length` is "
+                    "provided in `config.json`."
+                )
+        if self.prefill_chunk_size == 0:
+            self.prefill_chunk_size = self.context_window_size
+        if self.prefill_chunk_size > self.context_window_size:
+            self.prefill_chunk_size = self.context_window_size
+        if self.num_key_value_heads == 0 or self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+        if self.intermediate_size == 0 or self.intermediate_size is None:
+            self.intermediate_size = 4 * self.hidden_size
+        if self.head_dim == 0:
+            self.head_dim = self.hidden_size // self.num_attention_heads
+        assert self.head_dim * self.num_attention_heads == self.hidden_size
+        assert self.num_attention_heads % self.num_key_value_heads == 0
+
+
+@dataclasses.dataclass
 class PhiConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
-    """Configuration of the Phi model."""
+    """Configuration of the Phi-2 model."""
 
     model_type: str  # "phi", "phi-msft", "mixformer-sequential"
     vocab_size: int = 51200
@@ -75,6 +131,28 @@ class PhiConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
             self.head_dim = self.n_embd // self.n_head
         assert self.head_dim * self.n_head == self.n_embd
         assert self.n_head % self.n_head_kv == 0
+
+    @staticmethod
+    def from_phi1(config: Phi1Config) -> "PhiConfig":
+        "Build PhiConig from a Phi1Config."
+        return PhiConfig(
+            model_type="phi",
+            vocab_size=config.vocab_size,
+            n_positions=config.context_window_size,
+            n_embd=config.hidden_size,
+            n_layer=config.num_hidden_layers,
+            n_inner=config.intermediate_size,
+            n_head=config.num_attention_heads,
+            rotary_dim=int(config.partial_rotary_factor * config.head_dim),
+            position_embedding_base=config.position_embedding_base,
+            layer_norm_epsilon=config.layer_norm_eps,
+            context_window_size=config.context_window_size,
+            prefill_chunk_size=config.prefill_chunk_size,
+            n_head_kv=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            tensor_parallel_shards=config.tensor_parallel_shards,
+            kwargs=config.kwargs,
+        )
 
 
 # pylint: disable=invalid-name,missing-docstring
@@ -198,6 +276,9 @@ class PhiModel(nn.Module):
 class PhiForCausalLM(nn.Module):
     def __init__(self, config: PhiConfig) -> None:
         super().__init__()
+
+        if isinstance(config, Phi1Config):
+            config = PhiConfig.from_phi1(config)
 
         self.transformer = PhiModel(config)
         self.lm_head = PhiCausalLMHead(config)

--- a/python/mlc_chat/model/phi/phi_model.py
+++ b/python/mlc_chat/model/phi/phi_model.py
@@ -3,7 +3,7 @@ Implementation for Phi architecture.
 TODO: add docstring
 """
 import dataclasses
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from tvm import te, tir
 from tvm.relax.frontend import nn
@@ -27,7 +27,7 @@ class Phi1Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     num_hidden_layers: int = 24
     num_attention_heads: int = 32
     layer_norm_eps: float = 1e-5
-    position_embedding_base: float = 0
+    position_embedding_base: int = 0
     partial_rotary_factor: float = 0.5
     num_key_value_heads: int = 0
     context_window_size: int = 0
@@ -274,7 +274,7 @@ class PhiModel(nn.Module):
 
 
 class PhiForCausalLM(nn.Module):
-    def __init__(self, config: PhiConfig) -> None:
+    def __init__(self, config: Union[PhiConfig, Phi1Config]) -> None:
         super().__init__()
 
         if isinstance(config, Phi1Config):

--- a/python/mlc_chat/support/auto_config.py
+++ b/python/mlc_chat/support/auto_config.py
@@ -148,7 +148,7 @@ def detect_model_type(model_type: str, config: Path) -> "Model":
                 f"Please explicitly specify `--model-type` instead."
             )
         model_type = cfg["model_type"] if "model_type" in cfg else cfg["model_config"]["model_type"]
-    if model_type in ["mixformer-sequential", "phi"]:
+    if model_type in ["mixformer-sequential"]:
         model_type = "phi-msft"
     logger.info("%s model type: %s. Use `--model-type` to override.", FOUND, bold(model_type))
     if model_type not in MODELS:


### PR DESCRIPTION
Add support for the latest Phi-1 and Phi-1.5.

Introduce model_type `phi`, which is model type of the latest Phi-1 and Phi-1.5

Discussion: https://github.com/mlc-ai/mlc-llm/issues/1567

cc: @federicoparra @junrushao 