### PR TITLE
[COMPACT] allow skip meta-data

### DIFF
--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -71,7 +71,11 @@ ModelMetadata ModelMetadata::FromModule(tvm::runtime::Module module) {
   std::string json_str = "";
   try {
     TypedPackedFunc<String()> pf = module.GetFunction("_metadata");
-    ICHECK(pf != nullptr) << "Unable to find `_metadata` function.";
+    if (pf == nullptr) {
+      // legacy path
+      // TODO: remove this after full SLMify
+      return ModelMetadata();
+    }
     json_str = pf();
   } catch (...) {
     return ModelMetadata();  // TODO: add a warning message about legacy usecases


### PR DESCRIPTION
In certain environment the throw may be disabled,
this patch enhances the backward compact path
so the function can work in those cases.