### PR TITLE
[Serving] Automatically estimate KV cache capacity

### DIFF
--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -86,14 +86,16 @@ class KVCacheConfig:
         The maximum number of sequences that are allowed to processed by the KV
         cache at any time.
 
-    max_total_sequence_length : int
+    max_total_sequence_length : Optional[int]
         The maximum total number of tokens whose KV data are allowed to exist
         in the KV cache at any time.
+        Set it to None to enable automatic computation of the max total
+        sequence length.
     """
 
     page_size: int = 16
     max_num_sequence: int = 32
-    max_total_sequence_length: int = 16384
+    max_total_sequence_length: Optional[int] = None
 
     def asjson(self) -> str:
         """Return the config in string of JSON format."""

--- a/python/mlc_chat/serve/server/__main__.py
+++ b/python/mlc_chat/serve/server/__main__.py
@@ -18,7 +18,7 @@ def parse_args_and_initialize() -> argparse.Namespace:
     args.add_argument("--model-lib-path", type=str, required=True)
     args.add_argument("--device", type=str, default="auto")
     args.add_argument("--max-batch-size", type=int, default=80)
-    args.add_argument("--max-total-seq-length", type=int, default=16800)
+    args.add_argument("--max-total-seq-length", type=int)
     args.add_argument("--enable-tracing", action="store_true")
 
     args.add_argument("--host", type=str, default="127.0.0.1", help="host name")
@@ -29,7 +29,6 @@ def parse_args_and_initialize() -> argparse.Namespace:
     args.add_argument("--allowed-headers", type=json.loads, default=["*"], help="allowed headers")
 
     parsed = args.parse_args()
-    assert parsed.max_total_seq_length >= 2048
 
     # Initialize model loading info and KV cache config
     model_info = async_engine.ModelInfo(

--- a/python/mlc_chat/serve/server/popen_server.py
+++ b/python/mlc_chat/serve/server/popen_server.py
@@ -20,7 +20,7 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         device: str = "auto",
         *,
         max_batch_size: int = 80,
-        max_total_sequence_length: int = 16800,
+        max_total_sequence_length: Optional[int] = None,
         enable_tracing: bool = False,
         host: str = "127.0.0.1",
         port: int = 8000,
@@ -47,7 +47,8 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         cmd += ["--model-lib-path", self.model_lib_path]
         cmd += ["--device", self.device]
         cmd += ["--max-batch-size", str(self.max_batch_size)]
-        cmd += ["--max-total-seq-length", str(self.max_total_sequence_length)]
+        if self.max_total_sequence_length is not None:
+            cmd += ["--max-total-seq-length", str(self.max_total_sequence_length)]
         if self.enable_tracing:
             cmd += ["--enable-tracing"]
 

--- a/tests/python/serve/benchmark.py
+++ b/tests/python/serve/benchmark.py
@@ -24,14 +24,13 @@ def _parse_args():
     args.add_argument("--num-prompts", type=int, default=500)
     args.add_argument("--batch-size", type=int, default=80)
     args.add_argument("--page-size", type=int, default=16)
-    args.add_argument("--max-total-seq-length", type=int, default=16800)
+    args.add_argument("--max-total-seq-length", type=int)
     args.add_argument("--seed", type=int, default=0)
 
     parsed = args.parse_args()
     parsed.model = os.path.dirname(parsed.model_lib_path)
     assert parsed.batch_size % 16 == 0
     assert parsed.page_size == 16
-    assert parsed.max_total_seq_length >= 2048
     return parsed
 
 

--- a/tests/python/serve/evaluate_engine.py
+++ b/tests/python/serve/evaluate_engine.py
@@ -14,7 +14,7 @@ def _parse_args():
     args.add_argument("--device", type=str, default="auto")
     args.add_argument("--batch-size", type=int, default=80)
     args.add_argument("--page-size", type=int, default=16)
-    args.add_argument("--max-total-seq-length", type=int, default=16000)
+    args.add_argument("--max-total-seq-length", type=int)
     args.add_argument("--seed", type=int, default=0)
 
     parsed = args.parse_args()

--- a/tests/python/serve/server/conftest.py
+++ b/tests/python/serve/server/conftest.py
@@ -26,7 +26,6 @@ def launch_server(served_model):  # pylint: disable=redefined-outer-name
     server = PopenServer(
         model=served_model[0],
         model_lib_path=served_model[1],
-        max_total_sequence_length=5120,
         enable_tracing=True,
     )
     server.start()


### PR DESCRIPTION
This PR supports the functionality that automatically estimates the maximum KV cache capacity. This leverages the following sources:
* total GPU global memory (through TVM device API),
* model parameter memory (computed during weight conversion),
* runtime temporary memory (comptued by memory planning).

With this PR, when `max_total_sequence_length` is set to None, we will automatically estimate a KV cache capacity that can make most use of the GPU.

Alternatively, users can choose to specify total GPU global memory size via the environment variable `"MLC_GPU_SIZE_BYTES"`. If this env variable is detected, we will use this number as the GPU VRAM size.

Effects of this PR:
```
[2024-01-14 15:35:39] INFO engine.py:186: Estimated KVCacheConfig "max_total_sequence_length": 18267.
[2024-01-14 15:35:39] INFO engine.py:191: Estimated total single GPU memory usage: 23374.68 MB (Parameters: 12852.51 MB. KVCache: 9590.18 MB. Temporary buffer: 932.00 MB)
```