### PR TITLE
[Disco] Dynamic-shape parameter loading in TP

### DIFF
--- a/cpp/metadata/model.h
+++ b/cpp/metadata/model.h
@@ -12,7 +12,7 @@
 
 #include <unordered_map>
 
-// Forward decalre picojson's value, object and array
+// Forward declare picojson's value, object and array
 namespace picojson {
 class value;
 using object = std::unordered_map<std::string, value>;
@@ -28,14 +28,14 @@ struct ModelMetadata {
       tvm::runtime::String func_name;
       tvm::runtime::ShapeTuple out_shape;
       tvm::runtime::DataType out_dtype;
-      static Preproc FromJSON(const picojson::object& js);
+      static Preproc FromJSON(const picojson::object& js, const picojson::object& model_config);
     };
 
     tvm::runtime::String name;
     tvm::runtime::ShapeTuple shape;
     tvm::runtime::DataType dtype;
     std::vector<Preproc> preprocs;
-    static Param FromJSON(const picojson::object& param_obj);
+    static Param FromJSON(const picojson::object& param_obj, const picojson::object& model_config);
   };
 
   std::string model_type;
@@ -48,8 +48,10 @@ struct ModelMetadata {
   std::vector<Param> params;
   std::unordered_map<std::string, int64_t> memory_usage;
 
-  static ModelMetadata FromJSON(const picojson::object& json_str);
-  static ModelMetadata FromModule(tvm::runtime::Module module);
+  static ModelMetadata FromJSON(const picojson::object& json_str,
+                                const picojson::object& model_config);
+  static ModelMetadata FromModule(tvm::runtime::Module module,
+                                  const picojson::object& model_config);
 };
 
 }  // namespace llm

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -2,8 +2,6 @@
  *  Copyright (c) 2023 by Contributors
  * \file serve/config.cc
  */
-#define PICOJSON_USE_INT64
-
 #include "config.h"
 
 #include <picojson.h>

--- a/cpp/serve/event_trace_recorder.cc
+++ b/cpp/serve/event_trace_recorder.cc
@@ -2,8 +2,6 @@
  *  Copyright (c) 2023 by Contributors
  * \file serve/event_trace_recorder.cc
  */
-#define PICOJSON_USE_INT64
-
 #include "event_trace_recorder.h"
 
 #include <picojson.h>

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -7,6 +7,7 @@
 #ifndef MLC_LLM_SERVE_FUNCTION_TABLE_H_
 #define MLC_LLM_SERVE_FUNCTION_TABLE_H_
 
+#include <picojson.h>
 #include <tvm/runtime/disco/session.h>
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/ndarray.h>
@@ -40,7 +41,7 @@ using namespace tvm::runtime;
 struct FunctionTable {
   static PackedFunc SessionFuncAsPackedFunc(Session sess, DRef sess_func, String name);
 
-  void Init(TVMArgValue reload_lib, Device device, int num_shards);
+  void Init(TVMArgValue reload_lib, Device device, picojson::object model_config);
 
   ObjectRef LoadParams(const std::string& model_path, Device device);
 
@@ -56,6 +57,7 @@ struct FunctionTable {
   DRef disco_mod{nullptr};
   Map<String, DRef> disco_buffers;
   tvm::runtime::Module local_vm{nullptr};
+  picojson::object model_config;
 
   TypedPackedFunc<PackedFunc(const std::string&)> mod_get_func;
   TypedPackedFunc<PackedFunc(const std::string&)> get_global_func;

--- a/cpp/serve/sampler.cc
+++ b/cpp/serve/sampler.cc
@@ -3,8 +3,6 @@
  * \file serve/sampler.cc
  * \brief The implementation for runtime module of sampler functions.
  */
-#define __STDC_FORMAT_MACROS
-
 #include "sampler.h"
 
 #include <tvm/runtime/ndarray.h>

--- a/python/mlc_chat/chat_module.py
+++ b/python/mlc_chat/chat_module.py
@@ -635,13 +635,15 @@ def _convert_generation_config_to_json_str(generation_config: Optional[Generatio
     return json.dumps(asdict(generation_config))
 
 
-def _inspect_model_lib_metadata_memory_usage(model_lib_path):
+def _inspect_model_lib_metadata_memory_usage(model_lib_path, config_file_path):
     cmd = [
         sys.executable,
         "-m",
         "mlc_chat.cli.model_metadata",
         model_lib_path,
         "--memory-only",
+        "--mlc-chat-config",
+        config_file_path,
     ]
     subprocess.run(cmd, check=False)
 
@@ -769,7 +771,7 @@ class ChatModule:  # pylint: disable=too-many-instance-attributes
                     device=self.device,
                 )
             )
-        _inspect_model_lib_metadata_memory_usage(self.model_lib_path)
+        _inspect_model_lib_metadata_memory_usage(self.model_lib_path, self.config_file_path)
 
         # 5. Call reload
         user_chat_config_json_str = _convert_chat_config_to_json_str(

--- a/python/mlc_chat/serve/engine.py
+++ b/python/mlc_chat/serve/engine.py
@@ -186,7 +186,7 @@ def _estimate_max_total_sequence_length(  # pylint: disable=too-many-locals
             )
 
     max_total_sequence_length = int(
-        (int(gpu_size_bytes) * 0.98 - params_bytes * 1.04 - temp_func_bytes) / kv_bytes_per_token
+        (int(gpu_size_bytes) * 0.97 - params_bytes * 1.04 - temp_func_bytes) / kv_bytes_per_token
     )
     assert max_total_sequence_length > 0, (
         "Cannot estimate KV cache capacity. "
@@ -194,7 +194,7 @@ def _estimate_max_total_sequence_length(  # pylint: disable=too-many-locals
     )
 
     total_size = (
-        params_bytes * 1.04 + temp_func_bytes + kv_bytes_per_token * max_total_sequence_length
+        params_bytes * 1.05 + temp_func_bytes + kv_bytes_per_token * max_total_sequence_length
     )
     logger.info(
         "%s: %d.",


### PR DESCRIPTION
This PR fixes the issue introduced due to the dynamic-shape parameter support.

The way is to introduce a temporary data structure called `SymShapeTuple` in model metadata reading. The `SymShapeTuple` instance may contain `-1` in some of its dimensions, and have a corresponding symbolic name on such dimensions. The symbolic shape tuple will be instantiated to `ShapeTuple` with the concrete shape in model config.