### PR TITLE
[CI] Model compilation test enable all quantization

### DIFF
--- a/tests/python/integration/test_model_compile.py
+++ b/tests/python/integration/test_model_compile.py
@@ -7,9 +7,9 @@ import sys
 import tempfile
 from itertools import product
 
-import mlc_chat
 import tvm
 
+import mlc_chat
 from mlc_chat.model import MODEL_PRESETS
 from mlc_chat.support.constants import MLC_TEMP_DIR
 

--- a/tests/python/integration/test_model_compile.py
+++ b/tests/python/integration/test_model_compile.py
@@ -57,13 +57,7 @@ DEVICE2SUFFIX = {
     "vulkan": "so",
 }
 MODELS = list(MODEL_PRESETS.keys())
-QUANTS = [  # TODO(@junrushao): use `list(mlc_chat.quantization.QUANTIZATION.keys())`
-    "q0f16",
-    "q0f32",
-    "q3f16_1",
-    "q4f16_1",
-    "q4f32_1",
-]
+QUANTS = list(mlc_chat.quantization.QUANTIZATION.keys())
 TENSOR_PARALLEL_SHARDS = [
     1,
 ]

--- a/tests/python/integration/test_model_compile.py
+++ b/tests/python/integration/test_model_compile.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 from itertools import product
 
+import mlc_chat
 import tvm
 
 from mlc_chat.model import MODEL_PRESETS


### PR DESCRIPTION
With apache/tvm#16429 getting merged, we can enable all quantization tests for model compilation.