### PR TITLE
[CI] Enable ROCm & WebGPU

### DIFF
--- a/ci/jenkinsfile.groovy
+++ b/ci/jenkinsfile.groovy
@@ -17,13 +17,13 @@
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
-run_cpu = "bash ci/bash.sh mlcaidev/ci-cpu:78ce6f5 -e GPU cpu"
-run_cuda = "bash ci/bash.sh mlcaidev/ci-cu121:78ce6f5 -e GPU cuda-12.1"
-run_rocm = "bash ci/bash.sh mlcaidev/ci-rocm57:78ce6f5 -e GPU rocm-5.7"
+run_cpu = "bash ci/bash.sh mlcaidev/ci-cpu:561ceee -e GPU cpu"
+run_cuda = "bash ci/bash.sh mlcaidev/ci-cu121:561ceee -e GPU cuda-12.1"
+run_rocm = "bash ci/bash.sh mlcaidev/ci-rocm57:561ceee -e GPU rocm-5.7"
 
-pkg_cpu = "bash ci/bash.sh mlcaidev/package-rocm57:ab1296a -e GPU cpu"
-pkg_cuda = "bash ci/bash.sh mlcaidev/package-cu121:ab1296a -e GPU cuda-12.1"
-pkg_rocm = "bash ci/bash.sh mlcaidev/package-rocm57:ab1296a -e GPU rocm-5.7"
+pkg_cpu = "bash ci/bash.sh mlcaidev/package-rocm57:561ceee -e GPU cpu"
+pkg_cuda = "bash ci/bash.sh mlcaidev/package-cu121:561ceee -e GPU cuda-12.1"
+pkg_rocm = "bash ci/bash.sh mlcaidev/package-rocm57:561ceee -e GPU rocm-5.7"
 
 def per_exec_ws(folder) {
   return "workspace/exec_${env.EXECUTOR_NUMBER}/" + folder
@@ -179,7 +179,7 @@ stage('Model Compilation') {
           sh(script: "ls -alh", label: 'Show work directory')
           unpack_lib('mlc_wheel_rocm', 'wheels/*.whl')
           sh(script: "${run_rocm} conda env export --name ci-unittest", label: 'Checkout version')
-          // sh(script: "${run_rocm} conda run -n ci-unittest ./ci/task/test_model_compile.sh", label: 'Testing')
+          sh(script: "${run_rocm} conda run -n ci-unittest ./ci/task/test_model_compile.sh", label: 'Testing')
         }
       }
     },
@@ -191,6 +191,17 @@ stage('Model Compilation') {
           unpack_lib('mlc_wheel_vulkan', 'wheels/*.whl')
           sh(script: "${run_cpu} conda env export --name ci-unittest", label: 'Checkout version')
           // sh(script: "${run_cpu} conda run -n ci-unittest ./ci/task/test_model_compile.sh", label: 'Testing')
+        }
+      }
+    },
+    'WASM': {
+      node('CPU-SMALL') {
+        ws(per_exec_ws('mlc-llm-compile-wasm')) {
+          init_git(false)
+          sh(script: "ls -alh", label: 'Show work directory')
+          unpack_lib('mlc_wheel_vulkan', 'wheels/*.whl')
+          sh(script: "${run_cpu} conda env export --name ci-unittest", label: 'Checkout version')
+          sh(script: "${run_cpu} -e GPU wasm conda run -n ci-unittest ./ci/task/test_model_compile.sh", label: 'Testing')
         }
       }
     }

--- a/ci/task/test_model_compile.sh
+++ b/ci/task/test_model_compile.sh
@@ -7,6 +7,8 @@ set -x
 
 NUM_THREADS=8
 
+pip install wheels/*.whl
+
 if [[ ${GPU} == cuda* ]]; then
 	TARGET=cuda
 	pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu121
@@ -14,9 +16,14 @@ if [[ ${GPU} == cuda* ]]; then
 elif [[ ${GPU} == rocm* ]]; then
 	TARGET=rocm
 	pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm57
+elif [[ ${GPU} == wasm* ]]; then
+	TARGET=wasm
+	pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
+	export TVM_HOME=$(dirname $(python -c 'import tvm; print(tvm.__file__)'))
+	cd $TVM_HOME/web/ && make -j${NUM_THREADS} && cd -
 else
 	TARGET=vulkan
 	pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 fi
-pip install wheels/*.whl
+
 python tests/python/integration/test_model_compile.py $TARGET $NUM_THREADS

--- a/tests/python/integration/test_model_compile.py
+++ b/tests/python/integration/test_model_compile.py
@@ -50,11 +50,13 @@ DEVICE2TARGET = {
             "supports_float16": 1,
         }
     ),
+    "wasm": "webgpu",
 }
 DEVICE2SUFFIX = {
     "cuda": "so",
     "rocm": "so",
     "vulkan": "so",
+    "wasm": "wasm",
 }
 MODELS = list(MODEL_PRESETS.keys())
 QUANTS = [  # TODO(@junrushao): use `list(mlc_chat.quantization.QUANTIZATION.keys())`


### PR DESCRIPTION
This PR turns on ROCm and WebGPU in our testing pipeline.

It depends on [this commit](https://github.com/mlc-ai/relax/commit/dbb7d630774c98598766b85595a7d35bbd6ad186) that fixed compilation for GPT-NeoX, GPT-BigCode and Mixtral, which will go into effect tonight.