### PR TITLE
[Debug] Update instrument debugging script

### DIFF
--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -336,6 +336,21 @@ def load_params(artifact_path: str, device) -> List[tvm.nd.NDArray]:
     return plist
 
 
+def load_params_SLM(
+    model_weight_path: str, device, model_metadata: Dict[str, Any]
+) -> List[tvm.nd.NDArray]:
+    from tvm.contrib import tvmjs  # pylint: disable=import-outside-toplevel
+
+    params, meta = tvmjs.load_ndarray_cache(model_weight_path, device)
+    param_names = [param["name"] for param in model_metadata["params"]]
+    assert len(param_names) == meta["ParamSize"]
+
+    plist = []
+    for param_name in param_names:
+        plist.append(params[param_name])
+    return plist
+
+
 def copy_tokenizer(args: argparse.Namespace) -> None:
     for filename in os.listdir(args.model_path):
         if filename in [

--- a/tests/legacy-python/dump_intermediate.py
+++ b/tests/legacy-python/dump_intermediate.py
@@ -1,6 +1,8 @@
+"""Debug a model by printing out argument information before and after each function."""
+
 import argparse
+import json
 import os
-import pickle
 
 import numpy as np
 import torch
@@ -10,26 +12,69 @@ from tvm import relax
 
 from mlc_llm import utils
 
+# pylint: disable=redefined-outer-name
 
-class DumpInstrument:
+
+def _extract_metadata(model_lib):
+    # pylint: disable=import-outside-toplevel
+    from tvm.runtime import device, load_module
+    from tvm.runtime.relax_vm import VirtualMachine
+
+    # pylint: enable=import-outside-toplevel
+
+    return json.loads(VirtualMachine(load_module(model_lib), device("cpu"))["_metadata"]())
+
+
+class DumpInstrument:  # pylint: disable=too-few-public-methods
+    """Defines what to do before and after each function."""
+
     def __init__(self, verbose=True):
         self.verbose = verbose
         self.counter = 0
+        self.first_nan_occurred = False
+        self.first_inf_occurred = False
 
     def __call__(self, func, name, before_run, ret_val, *args):
-        if before_run:
+        # Determine what functions to look at
+        if before_run:  # Whether before the function is called or after
             return
+        # if self.first_nan_occurred:
+        #     return
+        # if self.first_inf_occurred:
+        #     return
         if name.startswith("vm.builtin."):
             return
         if any(not isinstance(x, tvm.nd.NDArray) for x in args):
             return
 
-        print(f"[{self.counter}][{name}]")
-        print(args[-1])
+        # Decide what to print or save about the function's arguments (where args[-1] is the
+        # buffer we write the result to)
+        func_name = (
+            f"f{self.counter}_before_{name}" if before_run else f"f{self.counter}_after_{name}"
+        )
+        print(func_name)
+
+        # Write your own behavior below. For example, we can count the number of INF/NaN in args[-1]
+        num_nans = np.sum(np.isnan(args[-1].numpy()))
+        num_infs = np.sum(np.isinf(args[-1].numpy()))
+        if num_nans > 0:
+            print(f"has NaN: {num_nans}")
+            self.first_nan_occurred = True
+        if num_infs > 0:
+            print(f"has INF: {num_infs}")
+            self.first_inf_occurred = True
+
+        # You can also save the the arguments to experiment offline
+        # if self.counter == 769:
+        #     for i, ndarray in enumerate(args):
+        #         save_name = func_name + f"_arg{i}"
+        #         np.save(f"./debug/{save_name}.npy", ndarray.numpy())
+
         self.counter += 1
 
 
-def print_as_table(sorted_list):
+def print_as_table(sorted_list):  # pylint: disable=missing-function-docstring
+    # pylint: disable=consider-using-f-string
     print(
         "Name".ljust(50)
         + "Time (ms)".ljust(12)
@@ -54,14 +99,11 @@ def print_as_table(sorted_list):
 
 
 class TestState:
+    """Embodies the virtual machine and instrument."""
+
     def __init__(self, args):
         self.primary_device = tvm.device(args.primary_device)
-        ex = tvm.runtime.load_module(
-            os.path.join(
-                args.artifact_path,
-                f"{args.model}-{args.quantization.name}-{args.primary_device}.so",
-            )
-        )
+        ex = tvm.runtime.load_module(args.model_lib_path)
         self.vm = relax.VirtualMachine(ex, self.primary_device)
         self.sess = None
         self.instrument = DumpInstrument(verbose=True)
@@ -69,19 +111,19 @@ class TestState:
 
 
 def deploy_to_pipeline(args) -> None:
+    """Main pipeline forst testing; can be modified for specific testing purposes."""
     primary_device = tvm.device(args.primary_device)
-    const_params = utils.load_params(args.artifact_path, primary_device)
+    model_metadata = _extract_metadata(args.model_lib_path)
+    const_params = utils.load_params_SLM(args.model, primary_device, model_metadata)
     state = TestState(args)
-    tokenizer = AutoTokenizer.from_pretrained(
-        os.path.join(args.artifact_path, "params"), trust_remote_code=True
-    )
+    tokenizer = AutoTokenizer.from_pretrained(os.path.join(args.model), trust_remote_code=True)
 
     print("Tokenizing...")
     inputs = tokenizer(args.prompt, return_tensors="pt").input_ids.to(torch.int32).numpy()
     first_sampled_token = tvm.nd.array(np.array([[6234]]).astype("int32"), primary_device)
     seq_len_shape = tvm.runtime.ShapeTuple([inputs.shape[1]])
     second_seq_len_shape = tvm.runtime.ShapeTuple([inputs.shape[1] + 1])
-    kv_caches = state.vm["create_kv_cache"]()
+    kv_caches = state.vm["_initialize_effect"]()
 
     print("Running inference...")
     print("======================= Starts Encoding =======================")
@@ -109,19 +151,11 @@ def deploy_to_pipeline(args) -> None:
 
 def _parse_args():
     args = argparse.ArgumentParser()
-    args.add_argument("--local-id", type=str, required=True)
-    args.add_argument("--artifact-path", type=str, default="dist")
-    args.add_argument("--primary-device", type=str, default="auto")
+    args.add_argument("--model", type=str, required=True)  # The model weight folder
+    args.add_argument("--model-lib-path", type=str, required=True)  # Path to the model library
+    args.add_argument("--primary-device", type=str, default="auto")  # Device to run on
     args.add_argument("--prompt", type=str, default="The capital of Canada is")
-    args.add_argument("--time-eval", default=False, action="store_true")
-    args.add_argument("--skip-rounds", type=int, default=0)
     parsed = args.parse_args()
-    parsed.model, parsed.quantization = parsed.local_id.rsplit("-", 1)
-    utils.argparse_postproc_common(parsed)
-
-    parsed.artifact_path = os.path.join(
-        parsed.artifact_path, f"{parsed.model}-{parsed.quantization.name}"
-    )
 
     if parsed.primary_device == "auto":
         if tvm.cuda().exist:


### PR DESCRIPTION
This PR updates `debug_intermediate.py` that uses instrumenting to debug a compiled model library, adding some comments on the script and making it SLM-model compatible.

To run:
```
python tests/legacy-python/dump_intermediate.py --model dist/phi-2-q4f16_1-MLC --model-lib-path dist/phi-2_q4f16_1-cuda.so
```

While we can use JIT to print intermediate values for debugging, as of now it only supports cpu. Some issues are platform-specific, and this script could still come in handy (e.g. helped solve https://github.com/apache/tvm/pull/16438, https://github.com/mlc-ai/mlc-llm/pull/1638).