### PR TITLE
[Config] Fix `max_batch_size` in dumped config

### DIFF
--- a/python/mlc_chat/interface/gen_config.py
+++ b/python/mlc_chat/interface/gen_config.py
@@ -33,7 +33,6 @@ class MLCChatConfig:  # pylint: disable=too-many-instance-attributes
     prefill_chunk_size: int
     attention_sink_size: int
     tensor_parallel_shards: int
-    max_batch_size: int
     # Control the behavior of the runtime
     mean_gen_len: int = None
     max_gen_len: int = None
@@ -90,6 +89,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
         sliding_window_size=sliding_window_size,
         prefill_chunk_size=prefill_chunk_size,
         attention_sink_size=attention_sink_size,
+        max_batch_size=max_batch_size,
         tensor_parallel_shards=tensor_parallel_shards,
     ).apply(model.config.from_file(config))
     mlc_chat_config = MLCChatConfig(
@@ -102,7 +102,6 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
         prefill_chunk_size=model_config.prefill_chunk_size,
         attention_sink_size=getattr(model_config, "attention_sink_size", -1),
         tensor_parallel_shards=model_config.tensor_parallel_shards,
-        max_batch_size=max_batch_size,
         conv_template=conv_template,
     )
     # Step 2. Load `generation_config.json` and `config.json` for text-generation related configs


### PR DESCRIPTION
Previously `max_batch_size` is dumped twice into `mlc_chat_config.json`: one in `model_config` field, and another one in the outmost scope.

Given `max_batch_size` is a field what we only levarage during model compilation for memory planning, we want to keep this field only in `model_config`.

This PR removes `max_batch_size` from the outmost scope and only keep it in `model_config` with the right value.