### PR TITLE
[VRAM] Report memory usage in mlc_chat compile

### DIFF
--- a/python/mlc_chat/cli/model_metadata.py
+++ b/python/mlc_chat/cli/model_metadata.py
@@ -1,6 +1,7 @@
 """A tool that inspects the metadata of a model lib."""
 import json
 import math
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
@@ -8,6 +9,7 @@ import numpy as np
 
 from mlc_chat.support import logging
 from mlc_chat.support.argparse import ArgumentParser
+from mlc_chat.support.config import ConfigBase
 from mlc_chat.support.style import green, red
 
 logging.enable_logging()
@@ -41,7 +43,9 @@ def _report_all(metadata: Dict[str, Any]) -> None:
     print(beautified_json)
 
 
-def _read_dynamic_shape(shape: List[Union[int, str]], config: Dict) -> List[int]:
+def _read_dynamic_shape(shape: List[Union[int, str]], config: Union[Dict, ConfigBase]) -> List[int]:
+    if isinstance(config, ConfigBase):
+        config = asdict(config)
     param_shape = []
     for s in shape:
         if isinstance(s, int):
@@ -57,9 +61,10 @@ def _read_dynamic_shape(shape: List[Union[int, str]], config: Dict) -> List[int]
                 raise AttributeError
             if not s in config:
                 logger.error(
-                    "%s to retrieve concrete %s for dynamic shape from `mlc-chat-config`.",
+                    "%s to retrieve concrete %s for dynamic shape from %s.",
                     red("FAILED"),
                     red(s),
+                    config,
                 )
                 raise KeyError
             param_shape.append(config[s])
@@ -84,7 +89,7 @@ def _compute_memory_usage(metadata: Dict[str, Any], config: Dict):
     return params_bytes, temp_func_bytes, kv_cache_bytes
 
 
-def _report_memory_usage(metadata: Dict[str, Any], config: Dict) -> None:
+def _report_memory_usage(metadata: Dict[str, Any], config: Union[Dict, ConfigBase]) -> None:
     params_bytes, temp_func_bytes, kv_cache_bytes = _compute_memory_usage(metadata, config)
     total_size = params_bytes + temp_func_bytes + kv_cache_bytes
     logger.info(

--- a/python/mlc_chat/cli/model_metadata.py
+++ b/python/mlc_chat/cli/model_metadata.py
@@ -71,7 +71,7 @@ def _read_dynamic_shape(shape: List[Union[int, str]], config: Union[Dict, Config
     return param_shape
 
 
-def _compute_memory_usage(metadata: Dict[str, Any], config: Dict):
+def _compute_memory_usage(metadata: Dict[str, Any], config: Union[Dict, ConfigBase]):
     params_bytes = 0.0
     for param in metadata["params"]:
         if all(isinstance(v, int) for v in param["shape"]):

--- a/python/mlc_chat/interface/compile.py
+++ b/python/mlc_chat/interface/compile.py
@@ -13,6 +13,7 @@ from tvm.target import Target
 
 from mlc_chat import compiler_pass as _
 from mlc_chat import op as op_ext
+from mlc_chat.cli.model_metadata import _report_memory_usage
 from mlc_chat.model import Model
 from mlc_chat.quantization import Quantization
 from mlc_chat.support import logging
@@ -185,6 +186,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
                 debug_dump=args.debug_dump,
             ),
         )
+        _report_memory_usage(metadata=metadata, config=model_config)
     logger.info("Generated: %s", bold(str(args.output)))
 
 

--- a/python/mlc_chat/support/config.py
+++ b/python/mlc_chat/support/config.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 ConfigClass = TypeVar("ConfigClass", bound="ConfigBase")
 
 
+@dataclasses.dataclass
 class ConfigBase:
     """Base class for configurations, providing a common interface for loading configs from a
     JSON file or a dict. It requires the subclasses to be dataclasses, and has an `kwargs` field


### PR DESCRIPTION
For devices like iOS, Android, and WebGPU, the compiled model library cannot reuse the `model_metadata` script but need a script on their own device ([e.g. for webllm](https://github.com/mlc-ai/web-llm/tree/main/utils/vram_requirements)).

We print out the VRAM requirements in this PR during `mlc_chat compile`. 