### PR TITLE
[SLIM] Android AppConfig refactor

### DIFF
--- a/android/app/src/main/java/ai/mlc/mlcchat/AppViewModel.kt
+++ b/android/app/src/main/java/ai/mlc/mlcchat/AppViewModel.kt
@@ -133,7 +133,6 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
             updateAppConfig {
                 appConfig.modelList.add(ModelRecord(
                     modelUrl,
-                    modelConfig.modelPath,
                     modelConfig.modelId,
                     modelConfig.estimatedVramBytes,
                     modelConfig.modelLib)
@@ -729,7 +728,6 @@ data class AppConfig(
 
 data class ModelRecord(
     @SerializedName("model_url") val modelUrl: String,
-    @SerializedName("model_path") val modelPath: String?,
     @SerializedName("model_id") val modelId: String,
     @SerializedName("estimated_vram_bytes") val estimatedVramBytes: Long?,
     @SerializedName("model_lib") val modelLib: String
@@ -737,7 +735,6 @@ data class ModelRecord(
 
 data class ModelConfig(
     @SerializedName("model_lib") var modelLib: String,
-    @SerializedName("model_path") val modelPath: String?,
     @SerializedName("model_id") var modelId: String,
     @SerializedName("estimated_vram_bytes") var estimatedVramBytes: Long?,
     @SerializedName("tokenizer_files") val tokenizerFiles: List<String>

--- a/android/library/prepare_model_lib.py
+++ b/android/library/prepare_model_lib.py
@@ -9,7 +9,6 @@ def main():
     tar_list = []
 
     for model_lib_path in app_config["model_lib_path_for_prepare_libs"].values():
-        print(model_lib_path)
         path = os.path.join(artifact_path, model_lib_path)
         if not os.path.isfile(path):
             raise RuntimeError(f"Cannot find android library {path}")

--- a/android/library/prepare_model_lib.py
+++ b/android/library/prepare_model_lib.py
@@ -8,8 +8,9 @@ def main():
     artifact_path = os.path.abspath(os.path.join("../..", "dist"))
     tar_list = []
 
-    for model_data in app_config["model_list"]:
-        path = os.path.join(artifact_path, model_data["model_lib_path"])
+    for model_lib_path in app_config["model_lib_path_for_prepare_libs"].values():
+        print(model_lib_path)
+        path = os.path.join(artifact_path, model_lib_path)
         if not os.path.isfile(path):
             raise RuntimeError(f"Cannot find android library {path}")
         tar_list.append(path)

--- a/android/library/src/main/assets/app-config.json
+++ b/android/library/src/main/assets/app-config.json
@@ -4,29 +4,31 @@
       "model_url": "https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC/",
       "model_lib": "llama_q4f16_1",
       "estimated_vram_bytes": 4348727787,
-      "model_lib_path": "libs/Llama-2-7b-chat-hf-q4f16_1-android.tar",
       "model_id": "Llama-2-7b-chat-hf-q4f16_1"
     },
     {
       "model_url": "https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC/",
       "model_lib": "gpt_neox_q4f16_1",
       "estimated_vram_bytes": 1948348579,
-      "model_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1",
-      "model_lib_path": "libs/RedPajama-INCITE-Chat-3B-v1-q4f16_1-android.tar"
+      "model_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1"
     },
     {
       "model_url": "https://huggingface.co/mlc-ai/Mistral-7B-Instruct-v0.2-q4f16_1-MLC",
       "model_lib": "mistral_q4f16_1",
       "estimated_vram_bytes": 4275453296,
-      "model_id": "Mistral-7B-Instruct-v0.2-q4f16_1",
-      "model_lib_path": "libs/Mistral-7B-Instruct-v0.2-q4f16_1-android.tar"
+      "model_id": "Mistral-7B-Instruct-v0.2-q4f16_1"
     },
     {
       "model_url": "https://huggingface.co/mlc-ai/phi-2-q4f16_1-MLC",
       "model_lib": "phi-msft_q4f16_1",
       "estimated_vram_bytes": 2036816936,
-      "model_id": "phi-2-q4f16_1",
-      "model_lib_path": "libs/phi-2-q4f16_1-android.tar"
+      "model_id": "phi-2-q4f16_1"
     }
-  ]
+  ],
+  "model_lib_path_for_prepare_libs": {
+    "llama_q4f16_1": "libs/Llama-2-7b-chat-hf-q4f16_1-android.tar",
+    "gpt_neox_q4f16_1": "libs/RedPajama-INCITE-Chat-3B-v1-q4f16_1-android.tar",
+    "phi-msft_q4f16_1": "libs/phi-2-q4f16_1-android.tar",
+    "Mistral-7B-Instruct-v0.2-q4f16_1": "libs/Mistral-7B-Instruct-v0.2-q4f16_1-android.tar"
+  }
 }


### PR DESCRIPTION
This PR introduces the following minor refactors for Android apk

- Modify `app-config.json` to move `model_lib_path` to a. separate field 
- Remove `model_path` from `ModelRecord` class since not needed

