### PR TITLE
[Pass] Fix estimate memory usage per latest change

### DIFF
--- a/python/mlc_chat/compiler_pass/estimate_memory_usage.py
+++ b/python/mlc_chat/compiler_pass/estimate_memory_usage.py
@@ -3,7 +3,7 @@ import json
 from typing import Any, Dict
 
 import tvm
-from tvm import relax
+from tvm import relax, tir
 from tvm.ir import IRModule, Op
 from tvm.relax.expr_functor import PyExprVisitor, visitor
 
@@ -79,5 +79,6 @@ class _MemoryEstimator(PyExprVisitor):
 
     def _storage_alloc(self, size: relax.Expr) -> None:
         assert isinstance(size, relax.ShapeExpr)
-        self.planned_mem_num += 1
-        self.planned_alloc_mem += size.values[0].value
+        if isinstance(size.values[0], tir.IntImm):
+            self.planned_mem_num += 1
+            self.planned_alloc_mem += size.values[0].value


### PR DESCRIPTION
The latest memory planning pass uses `R.memory.alloc_storage` for symbolic shape tensors, and breaks the estimation pass which assumes all `alloc_storage` are static shaped.

This PR fixes the pass to skip dynamic-shape storage allocation since these are not part of memory planning.