### PR TITLE
[ParamManager] Preserve variable names in transform_dequantize

### DIFF
--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -172,7 +172,7 @@ def create_shard_info_func(param_manager, args, model_config) -> tvm.IRModule:
 
         shard_info_dict[param_name] = shard_info
 
-    q_params = param_manager.get_quantized_param_info("prefill").fields
+    q_params = [param.struct_info for param in param_manager.get_quantized_params("prefill")]
     for _, param in param_manager.params.items():
         if param.shard_strategy is None:
             pass
@@ -223,7 +223,7 @@ def create_shard_transformation_func(param_manager, args, model_config) -> tvm.I
             param_shape_is_already_sharded=args.build_model_only,
         )
 
-    q_params = param_manager.get_quantized_param_info("prefill").fields
+    q_params = [param.struct_info for param in param_manager.get_quantized_params("prefill")]
 
     # The order of the quantized parameters must be preserved.
     # Therefore, we need to loop over q_params and look up information


### PR DESCRIPTION
Previously, the `transform_dequantize` pass would output a function where all parameters were named `f"param_{i}"`, which could be quite difficult to read.  This commit updates `transform_dequantize` to propagate the parameter names.

If a parameter is not quantized, its name remains the same.  If a parameter is quantized and produces a single output tensor, the new name is `f"{old_name}.{new_dtype}"`.  If a parameter is quantized and produces multiple output tensors, they are named
`f"{old_name}.{new_dtype}.{i}"`.