### PR TITLE
[ParamManager] Simplify get_param_loading_functions signature

### DIFF
--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -258,23 +258,13 @@ def convert_weights(
     target = detect_local_target()
     print(f"Automatically using target for weight quantization: {target}")
     device = tvm.device(target.kind.default_keys[0])
-    device_cpu = tvm.cpu()
 
     loaded_params: List[tvm.nd.NDArray] = []
-    loaded_idx_set: Set[int] = set()
-    loaded_torch_bins: Set[str] = set()
-    cached_relax_params: Dict[int, tvm.nd.NDArray] = {}
-    cached_torch_params: Dict[str, Any] = {}
 
     get_item, set_item = param_mgr.get_param_loading_functions(
         model_params,
         loaded_params,
-        loaded_idx_set,
-        loaded_torch_bins,
-        cached_relax_params,
-        cached_torch_params,
         device,
-        device_cpu,
     )
 
     get_item = wrap_tqdm_counter(


### PR DESCRIPTION
Prior to this commit, the `loaded_idx_set`, `loaded_torch_bins`, `cached_relax_params`, and `cached_torch_params` objects were passed by the calling scope into `ParamManager.get_param_loading_functions`. These objects are implementation details for caching purposes, and are not required by the calling scope.

This commit updates `ParamManager.get_param_loading_functions` to construct the cache object internally.  The closures `get_item` and `set_item` returned from `get_param_loading_functions` have reference to the internal cache objects.