### PR TITLE
[ParamManager] Separate get_param_loading_functions for get/set

### DIFF
--- a/mlc_llm/utils.py
+++ b/mlc_llm/utils.py
@@ -259,13 +259,11 @@ def convert_weights(
     print(f"Automatically using target for weight quantization: {target}")
     device = tvm.device(target.kind.default_keys[0])
 
-    loaded_params: List[tvm.nd.NDArray] = []
-
-    get_item, set_item = param_mgr.get_param_loading_functions(
-        model_params,
-        loaded_params,
+    get_item = param_mgr.get_param_get_item(
         device,
+        model_params,
     )
+    set_item, loaded_params = param_mgr.get_param_set_item()
 
     get_item = wrap_tqdm_counter(
         get_item, desc="Get old param", position=0, unit="tensors", total=num_original_params


### PR DESCRIPTION
Prior to this commit, `get_param_loading_functions` generated and returned both `get_item` and `set_item`.  The code paths for these two were entirely independent, and did not depend on each other.  This commit splits it into `get_param_get_item`, which returns the `get_item` function, and `get_param_set_item`, which returns the `set_item` function.