### PR TITLE
[CI] Fix Metal/iOS CI regression

### DIFF
--- a/ci/task/test_model_compile.sh
+++ b/ci/task/test_model_compile.sh
@@ -5,7 +5,7 @@ set -x
 : ${WORKSPACE_CWD:=$(pwd)}
 : ${GPU:="cpu"}
 
-pip install wheels/*.whl
+pip install --force-reinstall wheels/*.whl
 
 if [[ ${GPU} == cuda* ]]; then
 	TARGET=cuda


### PR DESCRIPTION
The metal/iOS CI did not force reinstall the built mlc chat package every time, which may lead to regression caused by cache.