### PR TITLE
[Purity] Use `call_pure_packed` and `call_inplace_packed` where applicable

### DIFF
--- a/mlc_llm/relax_model/chatglm.py
+++ b/mlc_llm/relax_model/chatglm.py
@@ -284,16 +284,18 @@ class SelfAttention(nn.Module):
         k_cache, v_cache = past_key_value
         f_kv_cache_append = relax.extern("vm.builtin.attention_kv_cache_append")
         k_cache = nn.emit(
-            relax.Call(
+            relax.op.call_inplace_packed(
                 f_kv_cache_append,
                 args=[k_cache, squeezed_k],
+                inplace_indices=[0],
                 sinfo_args=[relax.ObjectStructInfo()],
             )
         )
         v_cache = nn.emit(
-            relax.Call(
+            relax.op.call_inplace_packed(
                 f_kv_cache_append,
                 args=[v_cache, squeezed_v],
+                inplace_indices=[0],
                 sinfo_args=[relax.ObjectStructInfo()],
             )
         )
@@ -304,14 +306,14 @@ class SelfAttention(nn.Module):
         kv_cache_shape = R.shape([kv_sl, n_groups, head_dim])
         f_kv_cache_view = relax.extern("vm.builtin.attention_kv_cache_view")
         k = nn.emit(
-            relax.Call(
+            relax.call_pure_packed(
                 f_kv_cache_view,
                 args=[k_cache, kv_cache_shape],
                 sinfo_args=[R.Tensor(kv_cache_shape, k.struct_info.dtype)],
             )
         )
         v = nn.emit(
-            relax.Call(
+            relax.call_pure_packed(
                 f_kv_cache_view,
                 args=[v_cache, kv_cache_shape],
                 sinfo_args=[R.Tensor(kv_cache_shape, v.struct_info.dtype)],
@@ -703,7 +705,7 @@ def create_kv_cache_func(bb: relax.BlockBuilder, config: ChatGLMConfig) -> None:
             for _ in range(config.num_layers * 2):
                 caches.append(
                     bb.emit(
-                        relax.Call(
+                        relax.call_pure_packed(
                             f_kv_cache_create,
                             args=[zeros, init_shape, relax.PrimValue(0)],
                             sinfo_args=[relax.ObjectStructInfo()],

--- a/mlc_llm/relax_model/gptj.py
+++ b/mlc_llm/relax_model/gptj.py
@@ -153,16 +153,18 @@ class GPTJAttention(nn.Module):
             f_kv_cache_view = relax.extern("vm.builtin.attention_kv_cache_view")
             k_cache, v_cache = past_key_value
             k_cache = nn.emit(
-                relax.Call(
+                relax.op.call_inplace_packed(
                     f_kv_cache_append,
                     args=[k_cache, squeeze(k, axis=0)],
+                    inplace_indices=[0],
                     sinfo_args=[relax.ObjectStructInfo()],
                 )
             )
             v_cache = nn.emit(
-                relax.Call(
+                relax.op.call_inplace_packed(
                     f_kv_cache_append,
                     args=[v_cache, squeeze(v, axis=0)],
+                    inplace_indices=[0],
                     sinfo_args=[relax.ObjectStructInfo()],
                 )
             )
@@ -170,14 +172,14 @@ class GPTJAttention(nn.Module):
             kv_cache_shape = R.shape([kv_seq_len, num_heads, head_size])
             kv_states_shape = R.shape([batch_size, kv_seq_len, num_heads, head_size])
             k = nn.emit(
-                relax.Call(
+                relax.call_pure_packed(
                     f_kv_cache_view,
                     args=[k_cache, kv_cache_shape],
                     sinfo_args=[R.Tensor(kv_cache_shape, k.struct_info.dtype)],
                 )
             )
             v = nn.emit(
-                relax.Call(
+                relax.call_pure_packed(
                     f_kv_cache_view,
                     args=[v_cache, kv_cache_shape],
                     sinfo_args=[R.Tensor(kv_cache_shape, v.struct_info.dtype)],

--- a/mlc_llm/relax_model/llama_batched_vllm.py
+++ b/mlc_llm/relax_model/llama_batched_vllm.py
@@ -91,15 +91,12 @@ class LlamaAttentionBatched(LlamaAttentionBase):
                 values_to_cache = nn.emit(take(values, indices_within_window, axis=0))
                 slot_mapping = nn.emit(take(slot_mapping, indices_within_window, axis=0))
 
-            # kv caches are updated inplace, but make it look like a pure operation
+            # kv caches are updated inplace, takes ownership of the arguments
             kv = nn.emit(
-                relax.op.call_pure_packed(
+                relax.op.call_inplace_packed(
                     "tvm.contrib.vllm.reshape_and_cache",
-                    keys_to_cache,
-                    values_to_cache,
-                    k_cache,
-                    v_cache,
-                    slot_mapping,
+                    args=[keys_to_cache, values_to_cache, k_cache, v_cache, slot_mapping],
+                    inplace_indices=[2, 3],
                     sinfo_args=[k_cache.struct_info, v_cache.struct_info],
                 )
             )


### PR DESCRIPTION
Currently, many MLC models use packed functions in dataflow blocks, which is not permitted. I plan to add a well-formedness check into the Relax parser to prevent that. Fortunately, `call_pure_packed` and `call_inplace_packed` can be used to avoid breaking any MLC models with this change. There are not many updates that need to be made, thankfully.

(Note: A few unrelated code changes were due to autoformatting.)