### PR TITLE
Fix undefined reference to std::filesystem::xx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set_target_properties(mlc_llm_static PROPERTIES OUTPUT_NAME mlc_llm)
 
 target_link_libraries(mlc_llm PUBLIC tvm_runtime)
 target_link_libraries(mlc_llm PRIVATE tokenizers_cpp)
+target_link_libraries(mlc_llm PUBLIC -lstdc++fs)
 
 find_library(FLASH_ATTN_LIBRARY flash_attn)
 


### PR DESCRIPTION
When building mlc-llm from source using clang 17(=>gcc 8) and CUDA 12.0
```
set(CMAKE_BUILD_TYPE RelWithDebInfo)
set(USE_CUDA ON)
set(USE_CUTLASS OFF)
set(USE_CUBLAS OFF)
set(USE_ROCM OFF)
set(USE_VULKAN OFF)
set(USE_METAL OFF)
set(USE_OPENCL OFF)
```
I met following errors like 
```
undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
```
This PR is to fix link error about std::filesystem