### PR TITLE
[Serving] Stop string matching algo enhancement

### DIFF
--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -56,7 +56,8 @@ void RequestModelStateNode::RemoveAllDraftTokens() {
 
 TVM_REGISTER_OBJECT_TYPE(RequestStateNode);
 
-RequestState::RequestState(Request request, int num_models, int64_t internal_id) {
+RequestState::RequestState(Request request, int num_models, int64_t internal_id,
+                           const std::unordered_map<int32_t, std::string>& token_table) {
   ObjectPtr<RequestStateNode> n = make_object<RequestStateNode>();
   Array<RequestModelState> mstates;
   mstates.reserve(num_models);
@@ -64,6 +65,9 @@ RequestState::RequestState(Request request, int num_models, int64_t internal_id)
     mstates.push_back(RequestModelState(request, i, internal_id, request->inputs));
   }
   n->rng = RandomGenerator(request->generation_cfg->seed);
+  n->stop_str_handler = StopStrHandler(
+      !request->generation_cfg->ignore_eos ? request->generation_cfg->stop_strs : Array<String>(),
+      token_table);
   n->request = std::move(request);
   n->mstates = std::move(mstates);
   n->next_callback_token_pos = 0;
@@ -71,44 +75,73 @@ RequestState::RequestState(Request request, int num_models, int64_t internal_id)
   data_ = std::move(n);
 }
 
-Optional<String> RequestStateNode::GenerationFinished(int max_single_sequence_length) const {
+std::pair<std::vector<int32_t>, Optional<String>> RequestStateNode::GetReturnTokenIds(
+    int max_single_sequence_length) {
   // - Case 0. There is remaining draft output ==> Unfinished
   //   All draft outputs are supposed to be processed before finish.
   for (RequestModelState mstate : mstates) {
     if (!mstate->draft_output_tokens.empty()) {
-      return Optional<String>();
+      return {{}, Optional<String>()};
     }
   }
 
-  // - Decode committed tokens.
+  std::vector<int32_t> return_token_ids;
+  Optional<String> finish_reason;
   const std::vector<int32_t>& committed_tokens = mstates[0]->committed_tokens;
+  int num_committed_tokens = committed_tokens.size();
+  ICHECK_LE(this->next_callback_token_pos, num_committed_tokens);
 
-  // NOTE: the handling of stop strings are not part of engine logic,
-  //       since we don't do detokenization in engine.
-
-  // Case 1. Any of the stop tokens appears in the committed tokens ===> Finished
-  // `stop_token_ids` includes the stop tokens from conversation template and user-provided tokens.
-  // This check will be ignored when `ignore_eos` is set for the benchmarking purpopse.
-  if (!request->generation_cfg->ignore_eos &&
-      std::any_of(
-          request->generation_cfg->stop_token_ids.begin(),
-          request->generation_cfg->stop_token_ids.end(),
-          [&committed_tokens](int32_t token) { return token == committed_tokens.back(); })) {
-    mstates[0]->committed_tokens.pop_back();
-    return String("stop");
+  // Case 1. Any of the stop strings is matched.
+  ICHECK(!stop_str_handler->StopTriggered());
+  while (next_callback_token_pos < num_committed_tokens) {
+    std::vector<int32_t> delta_token_ids =
+        stop_str_handler->Put(committed_tokens[next_callback_token_pos++]);
+    return_token_ids.insert(return_token_ids.end(), delta_token_ids.begin(), delta_token_ids.end());
+    if (stop_str_handler->StopTriggered()) {
+      finish_reason = "stop";
+      break;
+    }
   }
-  // Case 2. Generation reaches the specified max generation length ==> Finished
+
+  // Case 2. Any of the stop tokens appears in the committed tokens ===> Finished
+  // `stop_token_ids` includes the stop tokens from conversation template and user-provided tokens.
+  // This check will be ignored when `ignore_eos` is set for the benchmarking purpose.
+  if (!request->generation_cfg->ignore_eos) {
+    for (int i = 0; i < static_cast<int>(return_token_ids.size()); ++i) {
+      if (std::any_of(
+              request->generation_cfg->stop_token_ids.begin(),
+              request->generation_cfg->stop_token_ids.end(),
+              [&return_token_ids, i](int32_t token) { return token == return_token_ids[i]; })) {
+        // Stop token matched. Erase all tokens after the current position.
+        finish_reason = "stop";
+        while (static_cast<int>(return_token_ids.size()) > i) {
+          return_token_ids.pop_back();
+        }
+        break;
+      }
+    }
+  }
+
+  if (finish_reason.defined()) {
+    return {return_token_ids, finish_reason};
+  }
+
+  // Case 3. Generation reaches the specified max generation length ==> Finished
   // `max_tokens` means the generation length is limited by model capacity.
   if (request->generation_cfg->max_tokens >= 0 &&
       static_cast<int>(committed_tokens.size()) >= request->generation_cfg->max_tokens) {
-    return String("length");
+    std::vector<int32_t> remaining = stop_str_handler->Finish();
+    return_token_ids.insert(return_token_ids.end(), remaining.begin(), remaining.end());
+    return {return_token_ids, String("length")};
   }
-  // Case 3. Total length of the request reaches the maximum single sequence length ==> Finished
+  // Case 4. Total length of the request reaches the maximum single sequence length ==> Finished
   if (request->input_total_length + static_cast<int>(committed_tokens.size()) >=
       max_single_sequence_length) {
-    return String("length");
+    std::vector<int32_t> remaining = stop_str_handler->Finish();
+    return_token_ids.insert(return_token_ids.end(), remaining.begin(), remaining.end());
+    return {return_token_ids, String("length")};
   }
-  return Optional<String>();
+  return {return_token_ids, Optional<String>()};
 }
 
 }  // namespace serve

--- a/cpp/tokenizers.h
+++ b/cpp/tokenizers.h
@@ -11,6 +11,8 @@
 #include <tvm/runtime/container/string.h>
 #include <tvm/runtime/object.h>
 
+#include <unordered_map>
+
 #include "base.h"
 
 namespace mlc {
@@ -28,11 +30,17 @@ class TokenizerObj : public Object {
   std::vector<int32_t> Encode(const std::string& text) const;
   /*! \brief Decode token ids into text. */
   std::string Decode(const std::vector<int32_t>& token_ids) const;
+  /*! \brief Return the token table of the tokenizer. */
+  const std::unordered_map<int32_t, std::string>& TokenTable();
 
   static constexpr const char* _type_key = "mlc.Tokenizer";
   static constexpr const bool _type_has_method_sequal_reduce = false;
   static constexpr const bool _type_has_method_shash_reduce = false;
   TVM_DECLARE_FINAL_OBJECT_INFO(TokenizerObj, Object);
+
+ private:
+  /*! \brief The cached token table. */
+  std::unordered_map<int32_t, std::string> token_table_;
 };
 
 class Tokenizer : public ObjectRef {
@@ -40,7 +48,7 @@ class Tokenizer : public ObjectRef {
   /*! \brief Create a tokenizer from a directory path on disk. */
   MLC_LLM_DLL static Tokenizer FromPath(const String& path);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Tokenizer, ObjectRef, TokenizerObj);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Tokenizer, ObjectRef, TokenizerObj);
 
  private:
   explicit Tokenizer(std::unique_ptr<tokenizers::Tokenizer> tokenizer);


### PR DESCRIPTION
This PR enhances the stop string matching algorithm.

Prior to this PR, our stop string matching works on frontend after UTF-8 decoding, and always caches a suffix string that has length not exceeding the stop string length. This algorithm is not optimal though, since it may delay the response time for a request til the first token, due to the string suffix cache.

This PR makes two changes:
1. applying KMP algorithm for linear stop string matching with minimum caching,
2. move the stop string handling from front-end back into the engine side, so that frontend only handles UTF-8.

The stop string is validated to be efficient, as tested in `tests/python/support/test_streamer.py`.

----------------------

NOTE: this PR bumps `3rdparty/tokenizers-cpp`. You may need to remove the CMakeCache.txt and build mlc-llm again. Or otherwise the incremental build may fail, since the changes in tokenizer Rust file doesn't seem to be compiled in incremental build.