### PR TITLE
[Serving] Update token table type to vector

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -184,7 +184,7 @@ class EngineImpl : public Engine {
   int max_single_sequence_length_;
   Sampler sampler_;
   Tokenizer tokenizer_;
-  std::unordered_map<int32_t, std::string> token_table_;
+  std::vector<std::string> token_table_;
   // Models
   Array<Model> models_;
   // Request stream callback function

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -57,7 +57,7 @@ void RequestModelStateNode::RemoveAllDraftTokens() {
 TVM_REGISTER_OBJECT_TYPE(RequestStateNode);
 
 RequestState::RequestState(Request request, int num_models, int64_t internal_id,
-                           const std::unordered_map<int32_t, std::string>& token_table) {
+                           const std::vector<std::string>& token_table) {
   ObjectPtr<RequestStateNode> n = make_object<RequestStateNode>();
   Array<RequestModelState> mstates;
   mstates.reserve(num_models);

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -147,7 +147,7 @@ class RequestStateNode : public Object {
 class RequestState : public ObjectRef {
  public:
   explicit RequestState(Request request, int num_models, int64_t internal_id,
-                        const std::unordered_map<int32_t, std::string>& token_table);
+                        const std::vector<std::string>& token_table);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(RequestState, ObjectRef, RequestStateNode);
 };

--- a/cpp/streamer.cc
+++ b/cpp/streamer.cc
@@ -169,7 +169,7 @@ inline std::vector<int> CreatePartialMatchTable(const String& str) {
 }
 
 StopStrHandlerObj::StopStrHandlerObj(Array<String> stop_strs,
-                                     const std::unordered_map<int32_t, std::string>& token_table)
+                                     const std::vector<std::string>& token_table)
     : stop_strs_(std::move(stop_strs)), token_table_(token_table) {
   int num_stop_strs = stop_strs_.size();
   cur_match_lengths_.resize(num_stop_strs, 0);
@@ -189,9 +189,8 @@ std::vector<int32_t> StopStrHandlerObj::Put(int32_t token_id) {
 
   CHECK(!stop_triggered_) << "Cannot put new token when already stopped.";
 
-  auto it_token = token_table_.find(token_id);
-  ICHECK(it_token != token_table_.end());
-  const std::string& token = it_token->second;
+  ICHECK_LT(token_id, static_cast<int>(token_table_.size()));
+  const std::string& token = token_table_[token_id];
   pending_token_ids_.push_back(token_id);
   pending_token_lengths_.push_back(token.length());
 
@@ -257,7 +256,7 @@ std::vector<int32_t> StopStrHandlerObj::Put(int32_t token_id) {
 }
 
 StopStrHandler::StopStrHandler(Array<String> stop_strs,
-                               const std::unordered_map<int32_t, std::string>& token_table) {
+                               const std::vector<std::string>& token_table) {
   data_ = make_object<StopStrHandlerObj>(std::move(stop_strs), token_table);
 }
 

--- a/cpp/streamer.h
+++ b/cpp/streamer.h
@@ -77,8 +77,7 @@ class TextStreamer : public ObjectRef {
  */
 class StopStrHandlerObj : public Object {
  public:
-  explicit StopStrHandlerObj(Array<String> stop_strs,
-                             const std::unordered_map<int32_t, std::string>& token_table);
+  explicit StopStrHandlerObj(Array<String> stop_strs, const std::vector<std::string>& token_table);
 
   /*!
    * \brief Add new input delta token to the handler, return output
@@ -103,7 +102,7 @@ class StopStrHandlerObj : public Object {
   /*! \brief The partial match table for each stop string in the KMP algorithm. */
   std::vector<std::vector<int>> partial_match_tables_;
   /*! \brief The tokenizer token table for token id lookup. */
-  const std::unordered_map<int32_t, std::string>& token_table_;
+  const std::vector<std::string>& token_table_;
 
   /************ Global states across all stop strings. ************/
 
@@ -128,8 +127,7 @@ class StopStrHandlerObj : public Object {
  */
 class StopStrHandler : public ObjectRef {
  public:
-  explicit StopStrHandler(Array<String> stop_strs,
-                          const std::unordered_map<int32_t, std::string>& token_table);
+  explicit StopStrHandler(Array<String> stop_strs, const std::vector<std::string>& token_table);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(StopStrHandler, ObjectRef, StopStrHandlerObj);
 };

--- a/cpp/tokenizers.cc
+++ b/cpp/tokenizers.cc
@@ -82,10 +82,11 @@ Tokenizer Tokenizer::FromPath(const String& _path) {
 }
 
 /*!
- * \brief Translate a raw token (which may be a raw byte or contain lower
+ * \brief Post-process a raw token (which may be a raw byte or contain lower
  * one eights block) to the actual token.
+ * We do this in order to conform with the tokenizers' setup.
  */
-inline std::string TranslateToken(std::string token) {
+inline std::string PostProcessToken(std::string token) {
   // 1. The token represents a byte.
   if (token.length() == 6 && token.substr(0, 3) == "<0x" && token.back() == '>') {
     int byte = 0;
@@ -108,7 +109,7 @@ inline std::string TranslateToken(std::string token) {
   return token;
 }
 
-const std::unordered_map<int32_t, std::string>& TokenizerObj::TokenTable() {
+const std::vector<std::string>& TokenizerObj::TokenTable() {
   if (!token_table_.empty()) {
     return token_table_;
   }
@@ -117,7 +118,7 @@ const std::unordered_map<int32_t, std::string>& TokenizerObj::TokenTable() {
   token_table_.reserve(vocab_size);
   for (int32_t token_id = 0; token_id < vocab_size; ++token_id) {
     std::string token = tokenizer->IdToToken(token_id);
-    token_table_.emplace(token_id, TranslateToken(token));
+    token_table_.push_back(PostProcessToken(token));
   }
   return token_table_;
 }

--- a/cpp/tokenizers.h
+++ b/cpp/tokenizers.h
@@ -31,7 +31,7 @@ class TokenizerObj : public Object {
   /*! \brief Decode token ids into text. */
   std::string Decode(const std::vector<int32_t>& token_ids) const;
   /*! \brief Return the token table of the tokenizer. */
-  const std::unordered_map<int32_t, std::string>& TokenTable();
+  const std::vector<std::string>& TokenTable();
 
   static constexpr const char* _type_key = "mlc.Tokenizer";
   static constexpr const bool _type_has_method_sequal_reduce = false;
@@ -40,7 +40,7 @@ class TokenizerObj : public Object {
 
  private:
   /*! \brief The cached token table. */
-  std::unordered_map<int32_t, std::string> token_table_;
+  std::vector<std::string> token_table_;
 };
 
 class Tokenizer : public ObjectRef {

--- a/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
@@ -295,6 +295,7 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
                 prompt, generation_cfg, request_id
             ):
                 if delta_text == "":
+                    async_engine.record_event(request_id, event="skip empty delta text")
                     # Ignore empty delta text -- do not yield.
                     continue
 
@@ -309,6 +310,7 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
                     model=request.model,
                     system_fingerprint="",
                 )
+                async_engine.record_event(request_id, event=f"yield delta text {delta_text}")
                 yield f"data: {response.model_dump_json()}\n\n"
             async_engine.record_event(request_id, event="finish")
             yield "data: [DONE]\n\n"


### PR DESCRIPTION
Given the token table is continuous, there is no
need to use `std::unordered_map<int32_t, std::string>` as the token table type, and we can switch to use `std::vector`.