### PR TITLE
[Serving] Set max threading concurrency for sampling manually

### DIFF
--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -402,6 +402,11 @@ class ModelImpl : public ModelObj {
 
   /*********************** Utilities  ***********************/
 
+  int EstimateHostCPURequirement() const final {
+    CHECK_NE(num_shards_, -1) << "The model has not been initialized";
+    return num_shards_ > 1 ? num_shards_ : 0;
+  }
+
   int GetMaxWindowSize() const final {
     CHECK_NE(max_window_size_, -1) << "The model has not been initialized";
     return max_window_size_;
@@ -431,6 +436,12 @@ class ModelImpl : public ModelObj {
     } else {
       LOG(FATAL) << "Key \"context_window_size\" not found.";
     }
+    if (config.count("tensor_parallel_shards")) {
+      CHECK(config["tensor_parallel_shards"].is<int64_t>());
+      this->num_shards_ = config["tensor_parallel_shards"].get<int64_t>();
+    } else {
+      LOG(FATAL) << "Key \"tensor_parallel_shards\" not found.";
+    }
     return config;
   }
 
@@ -438,6 +449,7 @@ class ModelImpl : public ModelObj {
   // Model configurations
   //----------------------------
   int max_window_size_ = -1;
+  int num_shards_ = -1;
   int max_num_sequence_ = -1;
   //----------------------------
   // TVM related states

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -123,6 +123,15 @@ class ModelObj : public Object {
 
   /*********************** Utilities  ***********************/
 
+  /*!
+   * \brief Estimate number of CPU units required to drive the model
+   * executing during TP.
+   * \note This normally equals to the number of TP shards (or 0 if
+   * the model does not use TP) and can be used to hint runtime to
+   * avoid overuse cores in other places.
+   */
+  virtual int EstimateHostCPURequirement() const = 0;
+
   /*! \brief Get the max window size of the model. */
   virtual int GetMaxWindowSize() const = 0;
 


### PR DESCRIPTION
This PR supports automatically inferring the max concurrency from the model `"num_shards"` field, so that the disco processes will not be stuck by the CPU sampler due to the overuse of threads (which roots from the TVM threading backend mechanism).