### PR TITLE
[Android] Update build command for tvm4j_runtime_packed in Android library

### DIFF
--- a/android/library/prepare_libs.sh
+++ b/android/library/prepare_libs.sh
@@ -29,5 +29,5 @@ cmake .. \
       -DUSE_OPENCL=ON \
       -DUSE_CUSTOM_LOGGING=ON \
 
-make tvm4j_runtime_packed -j10
+cmake --build . --target tvm4j_runtime_packed --config release 
 cmake --build . --target install --config release -j


### PR DESCRIPTION
### Description of the changes
This PR updates the build command for the `tvm4j_runtime_packed` target in the Android library's build file. The previous make command has been replaced with a CMake build command to ensure a more standardized and cross-platform build process.

### Changes made
- Replaced `make tvm4j_runtime_packed -j10` with `cmake --build . --target tvm4j_runtime_packed --config release` to invoke CMake for building the `tvm4j_runtime_packed` target in release configuration.

cc @tqchen 