### PR TITLE
Fix Langchain support

### DIFF
--- a/python/mlc_chat/embeddings/openai.py
+++ b/python/mlc_chat/embeddings/openai.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 from langchain.embeddings import OpenAIEmbeddings  # pylint: disable=import-error
-from langchain.embeddings.openai import (  # pylint: disable=import-error
+from langchain_community.embeddings.openai import (  # pylint: disable=import-error
     async_embed_with_retry,
     embed_with_retry,
 )


### PR DESCRIPTION
`async_embed_with_retry` and _embed_with_retry_ were moved to `langchain_community.embeddings.openai`