### PR TITLE
[Serve] Single-sequence specialization for MLC serve

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1319,7 +1319,10 @@ class LLMChat {
           IntTuple seq_ids_tuple({0});
           ShapeTuple input_len_shape = ShapeTuple({static_cast<int64_t>(input_tokens.size())});
           ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, input_len_shape);
-          ret = ft_.prefill_func_(input_data, kv_cache_, params_);
+          LOG(INFO) << "prefill";
+          LOG(INFO) << Downcast<NDArray>(input_data).Shape();
+          auto embed = ft_.embed_func_(input_data, params_);
+          ret = ft_.prefill_func_(embed, kv_cache_, params_);
           ft_.kv_cache_end_forward_func_(kv_cache_);
         } else {
           ShapeTuple cur_pos_shape = ShapeTuple({cur_pos});
@@ -1354,7 +1357,8 @@ class LLMChat {
             IntTuple seq_ids_tuple({0});
             IntTuple append_length({1});
             ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, append_length);
-            ret = ft_.decode_func_(input_data, kv_cache_, params_);
+            auto embed = ft_.embed_func_(input_data, params_);
+            ret = ft_.decode_func_(embed, kv_cache_, params_);
             ft_.kv_cache_end_forward_func_(kv_cache_);
           } else {
             ret = ft_.decode_func_(input_data, pos_shape, kv_cache_, params_);

--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1319,8 +1319,6 @@ class LLMChat {
           IntTuple seq_ids_tuple({0});
           ShapeTuple input_len_shape = ShapeTuple({static_cast<int64_t>(input_tokens.size())});
           ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, input_len_shape);
-          LOG(INFO) << "prefill";
-          LOG(INFO) << Downcast<NDArray>(input_data).Shape();
           auto embed = ft_.embed_func_(input_data, params_);
           ret = ft_.prefill_func_(embed, kv_cache_, params_);
           ft_.kv_cache_end_forward_func_(kv_cache_);

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -188,6 +188,8 @@ ObjectRef FunctionTable::LoadParams(const std::string& model_path, Device device
 
 void FunctionTable::_InitFunctions() {
   this->embed_func_ = mod_get_func("embed");
+  this->single_batch_prefill_func_ = mod_get_func("prefill");
+  this->single_batch_decode_func_ = mod_get_func("decode");
   this->prefill_func_ = mod_get_func("batch_prefill");
   this->decode_func_ = mod_get_func("batch_decode");
   this->verify_func_ = mod_get_func("batch_verify");

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -65,6 +65,8 @@ struct FunctionTable {
   ModelMetadata model_metadata_;
 
   PackedFunc embed_func_;
+  PackedFunc single_batch_prefill_func_;
+  PackedFunc single_batch_decode_func_;
   PackedFunc prefill_func_;
   PackedFunc decode_func_;
   PackedFunc verify_func_;

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -278,7 +278,7 @@ class ModelImpl : public ModelObj {
 
     // args: embeddings, kv_cache, params
     ObjectRef ret;
-    if(seq_ids.size() == 1){
+    if (seq_ids.size() == 1) {
       ret = ft_.single_batch_decode_func_(embeddings_dref_or_nd, kv_cache_, params_);
     } else {
       ret = ft_.decode_func_(embeddings_dref_or_nd, kv_cache_, params_);

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -229,8 +229,12 @@ class ModelImpl : public ModelObj {
     ObjectRef logit_pos_dref_or_nd =
         ft_.CopyToWorker0(logit_pos_nd, "logit_pos", {max_num_sequence_});
     // args: embeddings, logit_pos, kv_cache, params
-    ObjectRef ret =
-        ft_.prefill_func_(embeddings_dref_or_nd, logit_pos_dref_or_nd, kv_cache_, params_);
+    ObjectRef ret;
+    if (seq_ids.size() == 1) {
+      ret = ft_.single_batch_prefill_func_(embeddings_dref_or_nd, kv_cache_, params_);
+    } else {
+      ret = ft_.prefill_func_(embeddings_dref_or_nd, logit_pos_dref_or_nd, kv_cache_, params_);
+    }
     NDArray logits;
     if (ft_.use_disco) {
       Array<ObjectRef> result = Downcast<DRef>(ret)->DebugGetFromRemote(0);
@@ -273,7 +277,12 @@ class ModelImpl : public ModelObj {
         embeddings, "embedding_decode", {max_num_sequence_, 1, embeddings.Shape()[2]});
 
     // args: embeddings, kv_cache, params
-    ObjectRef ret = ft_.decode_func_(embeddings_dref_or_nd, kv_cache_, params_);
+    ObjectRef ret;
+    if(seq_ids.size() == 1){
+      ret = ft_.single_batch_decode_func_(embeddings_dref_or_nd, kv_cache_, params_);
+    } else {
+      ret = ft_.decode_func_(embeddings_dref_or_nd, kv_cache_, params_);
+    }
     NDArray logits;
     if (ft_.use_disco) {
       Array<ObjectRef> result = Downcast<DRef>(ret)->DebugGetFromRemote(0);

--- a/python/mlc_chat/model/llama/llama_model.py
+++ b/python/mlc_chat/model/llama/llama_model.py
@@ -352,7 +352,6 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         )
 
     def get_default_spec(self):
-        batch_size = 1
         mod_spec = {
             "embed": {
                 "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),

--- a/python/mlc_chat/model/llama/llama_model.py
+++ b/python/mlc_chat/model/llama/llama_model.py
@@ -208,12 +208,11 @@ class LlamaModel(nn.Module):
         self.norm = nn.RMSNorm(config.hidden_size, -1, config.rms_norm_eps, bias=False)
         self.tensor_parallel_shards = config.tensor_parallel_shards
 
-    def forward(self, input_ids: Tensor, paged_kv_cache: PagedKVCache):
+    def forward(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
         if self.tensor_parallel_shards > 1:
-            input_ids = op.ccl_broadcast_from_worker0(input_ids)
-        hidden_states = self.embed_tokens(input_ids)
+            input_embed = op.ccl_broadcast_from_worker0(input_embed)
         for layer_id, layer in enumerate(self.layers):
-            hidden_states = layer(hidden_states, paged_kv_cache, layer_id)
+            hidden_states = layer(input_embed, paged_kv_cache, layer_id)
         hidden_states = self.norm(hidden_states)
         return hidden_states
 
@@ -265,24 +264,24 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
     def embed(self, input_ids: Tensor):
         return self.model.embed_tokens(input_ids)
 
-    def prefill(self, input_ids: Tensor, paged_kv_cache: PagedKVCache):
+    def prefill(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
         op_ext.configure()
 
         def _index(x: te.Tensor):  # x[:-1,:]
             b, s, d = x.shape
             return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
 
-        hidden_states = self.model(input_ids, paged_kv_cache)
+        hidden_states = self.model(input_embed, paged_kv_cache)
         hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
         logits = self.lm_head(hidden_states)
         if logits.dtype != "float32":
             logits = logits.astype("float32")
         return logits, paged_kv_cache
 
-    def decode(self, input_ids: Tensor, paged_kv_cache: PagedKVCache):
+    def decode(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
         op_ext.configure()
 
-        hidden_states = self.model(input_ids, paged_kv_cache)
+        hidden_states = self.model(input_embed, paged_kv_cache)
         logits = self.lm_head(hidden_states)
         if logits.dtype != "float32":
             logits = logits.astype("float32")
@@ -362,7 +361,7 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
                 },
             },
             "prefill": {
-                "input_ids": nn.spec.Tensor([batch_size, "seq_len"], "int32"),
+                "input_embed": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
                 "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
                 "$": {
                     "param_mode": "packed",
@@ -370,7 +369,7 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
                 },
             },
             "decode": {
-                "input_ids": nn.spec.Tensor([batch_size, 1], "int32"),
+                "input_embed": nn.spec.Tensor([1, 1, self.hidden_size], self.dtype),
                 "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
                 "$": {
                     "param_mode": "packed",

--- a/python/mlc_chat/model/llama/llama_model.py
+++ b/python/mlc_chat/model/llama/llama_model.py
@@ -211,8 +211,9 @@ class LlamaModel(nn.Module):
     def forward(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
         if self.tensor_parallel_shards > 1:
             input_embed = op.ccl_broadcast_from_worker0(input_embed)
+        hidden_states = input_embed
         for layer_id, layer in enumerate(self.layers):
-            hidden_states = layer(input_embed, paged_kv_cache, layer_id)
+            hidden_states = layer(hidden_states, paged_kv_cache, layer_id)
         hidden_states = self.norm(hidden_states)
         return hidden_states
 


### PR DESCRIPTION
1. change the signature of `decode` and `prefill` to embed-in-logit-out when using paged kv cache
2. run `decode` / `prefill` instead of `batch_decode` / `batch_prefill` when batch size = 1 in mlc serve