### PR TITLE
Annotate TIR PrimFunc with a target to allow target-specific transform

### DIFF
--- a/python/mlc_chat/compiler_pass/pipeline.py
+++ b/python/mlc_chat/compiler_pass/pipeline.py
@@ -89,6 +89,7 @@ def _mlc_llm_pipeline(  # pylint: disable=too-many-arguments
                 AttachVariableBounds(variable_bounds),
                 AttachAdditionalPrimFuncs(additional_tirs),
                 AttachMemoryPlanAttr(),
+                tvm.tir.transform.BindTarget(tvm.target.Target.current(allow_none=False)),
                 _DebugDump("debug-phase0.py", debug_dump, show_meta=False),
                 # Phase 1. Passes on high-level operator graph
                 _LogProgress("Running TVM Relax graph-level optimizations"),


### PR DESCRIPTION
Related to: https://github.com/apache/tvm/pull/16515

Quote @MasterJH5574:
Since the Vulkan target information is required at the time of lowering, the pass BindTarget needs to apply before lowering, so that the functions have correct target information.

We need to apply the target binding in MLC pipeline