### PR TITLE
[Fix] Skip lm_head quantization for q4f16_ft

### DIFF
--- a/python/mlc_chat/quantization/ft_quantization.py
+++ b/python/mlc_chat/quantization/ft_quantization.py
@@ -1,4 +1,5 @@
 """The FasterTransformer quantization config"""
+
 from dataclasses import dataclass
 from typing import Any, Callable, List, Literal, Optional, Tuple
 
@@ -116,7 +117,9 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
                 ret_node: Any
                     The new node to replace current node.
                 """
-                if isinstance(node, nn.Linear):
+                if isinstance(node, nn.Linear) and node.out_features != "vocab_size":
+                    # This skips lm_head in llama; otherwise the quantized shape would be an op
+                    # See https://github.com/mlc-ai/mlc-llm/issues/1723
                     weight_name = f"{name}.weight"
                     self.quant_map.param_map[weight_name] = [f"{name}.q_weight", f"{name}.q_scale"]
                     self.quant_map.map_func[weight_name] = self.config.quantize_weight


### PR DESCRIPTION
This PR fixes the issue brought up in https://github.com/mlc-ai/mlc-llm/issues/1723.

The issue is due to how the `lm_head` of Llama has `out_features` defined as a `tir.Var("vocab_size")`. However, in the FT quantization scheme, the linear layer would be quatnzied to shape `(in_features, tir.ceildiv(out_features, config.num_elem_per_storage)),`. This causes the shape of the parameter to be a FloorDiv operation rather than just a `tir.Var`. Later it would lead to issue during shape-lowering:

```
tvm-unity/src/relax/backend/vm/vm_shape_lower.cc", line 305
InternalError: Check failed: (it != slot_map_.end()) is false: Var vocab_sizeis not defined in the function but is referenced by (vocab_size + T.int64(2) - T.int64(1)) // T.int64(2)
```

Instead, we skip quantizing `lm_head` here.

