### PR TITLE
[Serving] Add OpenAI compatible function calling to Serving 

### DIFF
--- a/python/mlc_chat/conversation_template.py
+++ b/python/mlc_chat/conversation_template.py
@@ -40,7 +40,7 @@ class ConvTemplateRegistry:
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="llama-2",
-        system_template=f"[INST] <<SYS>>\n\n{MessagePlaceholders.system.value}\n<</SYS>>\n\n ",
+        system_template=f"[INST] <<SYS>>\n\n{MessagePlaceholders.SYSTEM.value}\n<</SYS>>\n\n ",
         system_message="You are a helpful, respectful and honest assistant.",
         roles={"user": "[INST]", "assistant": "[/INST]", "tool": "[INST]"},
         seps=[" "],
@@ -55,13 +55,17 @@ ConvTemplateRegistry.register_conv_template(
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="gorilla",
-        system_template=f"{MessagePlaceholders.system.value}",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
         system_message=(
             "A chat between a curious user and an artificial intelligence assistant. "
-            "The assistant provides helpful, detailed, and polite responses to the user's inquiries."
+            "The assistant provides helpful, detailed, and "
+            "polite responses to the user's inquiries."
         ),
         role_templates={
-            "user": f"<<question>> {MessagePlaceholders.user.value} <<function>> {MessagePlaceholders.function.value}",
+            "user": (
+                f"<<question>> {MessagePlaceholders.USER.value} <<function>> "
+                f"{MessagePlaceholders.FUNCTION.value}"
+            ),
         },
         roles={"user": "USER", "assistant": "ASSISTANT", "tool": "USER"},
         seps=["\n", "</s>"],

--- a/python/mlc_chat/conversation_template.py
+++ b/python/mlc_chat/conversation_template.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Optional
 
-from .protocol.conversation_protocol import SYSTEM_MESSAGE_PLACEHOLDER, Conversation
+from .protocol.conversation_protocol import Conversation, MessagePlaceholders
 
 
 class ConvTemplateRegistry:
@@ -40,13 +40,34 @@ class ConvTemplateRegistry:
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="llama-2",
-        system_template=f"[INST] <<SYS>>\n\n{SYSTEM_MESSAGE_PLACEHOLDER}\n<</SYS>>\n\n ",
+        system_template=f"[INST] <<SYS>>\n\n{MessagePlaceholders.system.value}\n<</SYS>>\n\n ",
         system_message="You are a helpful, respectful and honest assistant.",
-        roles=("[INST]", "[/INST]"),
+        roles={"user": "[INST]", "assistant": "[/INST]", "tool": "[INST]"},
         seps=[" "],
         role_content_sep=" ",
         role_empty_sep=" ",
         stop_str=["[INST]"],
+        stop_token_ids=[2],
+    )
+)
+
+# Gorilla
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="gorilla",
+        system_template=f"{MessagePlaceholders.system.value}",
+        system_message=(
+            "A chat between a curious user and an artificial intelligence assistant. "
+            "The assistant provides helpful, detailed, and polite responses to the user's inquiries."
+        ),
+        role_templates={
+            "user": f"<<question>> {MessagePlaceholders.user.value} <<function>> {MessagePlaceholders.function.value}",
+        },
+        roles={"user": "USER", "assistant": "ASSISTANT", "tool": "USER"},
+        seps=["\n", "</s>"],
+        role_content_sep=": ",
+        role_empty_sep=":",
+        stop_str=["</s>"],
         stop_token_ids=[2],
     )
 )

--- a/python/mlc_chat/protocol/conversation_protocol.py
+++ b/python/mlc_chat/protocol/conversation_protocol.py
@@ -1,11 +1,19 @@
 """The standard conversation protocol in MLC LLM"""
 
-from typing import List, Optional, Tuple
+from enum import Enum
+
+from typing import List, Optional, Tuple, Dict
 
 from pydantic import BaseModel, Field, field_validator
 
-# The system message placeholder in the system message prompt.
-SYSTEM_MESSAGE_PLACEHOLDER = "{system_message}"
+
+# The message placeholders in the message prompts according to roles.
+class MessagePlaceholders(Enum):
+    system = "{system_message}"
+    user = "{user_message}"
+    assistant = "{assistant_message}"
+    tool = "{tool_message}"
+    function = "{function_string}"
 
 
 class Conversation(BaseModel):
@@ -27,15 +35,20 @@ class Conversation(BaseModel):
     # The system prompt template, it optionally contains the system
     # message placeholder, and the placeholder will be replaced with
     # the system message below.
-    system_template: str = SYSTEM_MESSAGE_PLACEHOLDER
+    system_template: str = MessagePlaceholders.system.value
     # The content of the system prompt (without the template format).
     system_message: str = ""
     # The system token ids to be prepended at the beginning of tokenized
     # generated prompt.
     system_prefix_token_ids: Optional[List[int]] = None
 
-    # The conversation roles.
-    roles: Tuple[str, str]
+    # The conversation roles
+    roles: Dict[str, str]
+
+    # The roles prompt template, it optionally contains the defaults
+    # message placeholders and will be replaced by actual content
+    role_templates: Dict[str, str] = None
+
     # The conversation history messages.
     # Each message is a pair of strings, denoting "(role, content)".
     # The content can be None.
@@ -57,6 +70,22 @@ class Conversation(BaseModel):
     stop_str: List[str] = Field(default_factory=lambda: [])
     stop_token_ids: List[int] = Field(default_factory=lambda: [])
 
+    # Function call fields
+    function_string: str = ""
+    # whether using function calling or not, helps check for output message format in API call
+    use_function_calling: bool = False
+
+    def __init__(self, role_templates: Optional[Dict[str, str]] = None, **kwargs):
+        # Defaults templates which would be overridden by model specific templates
+        _role_templates: Dict[str, str] = {
+            "user": MessagePlaceholders.user.value,
+            "assistant": MessagePlaceholders.assistant.value,
+            "tool": MessagePlaceholders.tool.value,
+        }
+        if role_templates is not None:
+            _role_templates.update(role_templates)
+        super().__init__(role_templates=_role_templates, **kwargs)
+
     @field_validator("seps")
     @classmethod
     def check_message_seps(cls, seps: List[str]) -> List[str]:
@@ -70,7 +99,9 @@ class Conversation(BaseModel):
         a single prompt.
         """
         # - Get the system message.
-        system_msg = self.system_template.replace(SYSTEM_MESSAGE_PLACEHOLDER, self.system_message)
+        system_msg = self.system_template.replace(
+            MessagePlaceholders.system.value, self.system_message
+        )
 
         # - Get the message strings.
         message_list: List[str] = []
@@ -78,13 +109,24 @@ class Conversation(BaseModel):
         if len(separators) == 1:
             separators.append(separators[0])
         for role, content in self.messages:  # pylint: disable=not-an-iterable
-            if role not in self.roles:
-                raise ValueError(f'Role "{role}" is not a supported role in {self.roles}')
-            separator = separators[role == self.roles[1]]
+            if role not in self.roles.keys():
+                raise ValueError(f'Role "{role}" is not a supported role in {self.roles.keys()}')
+            separator = separators[role == "assistant"]  # check assistant role
             if content is not None:
-                message_string = role + self.role_content_sep + content + separator
+                message_string = (
+                    self.roles[role]
+                    + self.role_content_sep
+                    + self.role_templates[role].replace(MessagePlaceholders[role].value, content)
+                    + separator
+                )
             else:
-                message_string = role + self.role_empty_sep
+                message_string = self.roles[role] + self.role_empty_sep
             message_list.append(message_string)
 
-        return system_msg + separators[0] + "".join(message_list)
+        prompt = system_msg + separators[0] + "".join(message_list)
+
+        # Replace the last function string placeholder with actual function string and remove the rest
+        prompt = self.function_string.join(prompt.rsplit(MessagePlaceholders.function.value, 1))
+        prompt = prompt.replace(MessagePlaceholders.function.value, "")
+
+        return prompt

--- a/python/mlc_chat/protocol/conversation_protocol.py
+++ b/python/mlc_chat/protocol/conversation_protocol.py
@@ -1,19 +1,20 @@
 """The standard conversation protocol in MLC LLM"""
 
 from enum import Enum
-
-from typing import List, Optional, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field, field_validator
 
 
 # The message placeholders in the message prompts according to roles.
 class MessagePlaceholders(Enum):
-    system = "{system_message}"
-    user = "{user_message}"
-    assistant = "{assistant_message}"
-    tool = "{tool_message}"
-    function = "{function_string}"
+    """The message placeholders in the message prompts according to roles."""
+
+    SYSTEM = "{system_message}"
+    USER = "{user_message}"
+    ASSISTANT = "{assistant_message}"
+    TOOL = "{tool_message}"
+    FUNCTION = "{function_string}"
 
 
 class Conversation(BaseModel):
@@ -35,7 +36,7 @@ class Conversation(BaseModel):
     # The system prompt template, it optionally contains the system
     # message placeholder, and the placeholder will be replaced with
     # the system message below.
-    system_template: str = MessagePlaceholders.system.value
+    system_template: str = MessagePlaceholders.SYSTEM.value
     # The content of the system prompt (without the template format).
     system_message: str = ""
     # The system token ids to be prepended at the beginning of tokenized
@@ -47,7 +48,7 @@ class Conversation(BaseModel):
 
     # The roles prompt template, it optionally contains the defaults
     # message placeholders and will be replaced by actual content
-    role_templates: Dict[str, str] = None
+    role_templates: Dict[str, str]
 
     # The conversation history messages.
     # Each message is a pair of strings, denoting "(role, content)".
@@ -78,9 +79,9 @@ class Conversation(BaseModel):
     def __init__(self, role_templates: Optional[Dict[str, str]] = None, **kwargs):
         # Defaults templates which would be overridden by model specific templates
         _role_templates: Dict[str, str] = {
-            "user": MessagePlaceholders.user.value,
-            "assistant": MessagePlaceholders.assistant.value,
-            "tool": MessagePlaceholders.tool.value,
+            "user": MessagePlaceholders.USER.value,
+            "assistant": MessagePlaceholders.ASSISTANT.value,
+            "tool": MessagePlaceholders.TOOL.value,
         }
         if role_templates is not None:
             _role_templates.update(role_templates)
@@ -100,7 +101,7 @@ class Conversation(BaseModel):
         """
         # - Get the system message.
         system_msg = self.system_template.replace(
-            MessagePlaceholders.system.value, self.system_message
+            MessagePlaceholders.SYSTEM.value, self.system_message
         )
 
         # - Get the message strings.
@@ -125,8 +126,9 @@ class Conversation(BaseModel):
 
         prompt = system_msg + separators[0] + "".join(message_list)
 
-        # Replace the last function string placeholder with actual function string and remove the rest
-        prompt = self.function_string.join(prompt.rsplit(MessagePlaceholders.function.value, 1))
-        prompt = prompt.replace(MessagePlaceholders.function.value, "")
+        # Replace the last function string placeholder with actual function string
+        prompt = self.function_string.join(prompt.rsplit(MessagePlaceholders.FUNCTION.value, 1))
+        # Replace with remaining function string placeholders with empty string
+        prompt = prompt.replace(MessagePlaceholders.FUNCTION.value, "")
 
         return prompt

--- a/python/mlc_chat/protocol/conversation_protocol.py
+++ b/python/mlc_chat/protocol/conversation_protocol.py
@@ -117,7 +117,9 @@ class Conversation(BaseModel):
                 message_string = (
                     self.roles[role]
                     + self.role_content_sep
-                    + self.role_templates[role].replace(MessagePlaceholders[role].value, content)
+                    + self.role_templates[role].replace(
+                        MessagePlaceholders[role.upper()].value, content
+                    )
                     + separator
                 )
             else:

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -165,7 +165,7 @@ class ChatCompletionRequest(BaseModel):
 
 
 class ChatCompletionResponseChoice(BaseModel):
-    finish_reason: Optional[Literal["stop", "length", "tool_calls"]] = None
+    finish_reason: Optional[Literal["stop", "length", "tool_calls", "error"]] = None
     index: int = 0
     message: ChatCompletionMessage
 

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -2,8 +2,10 @@
 Adapted from FastChat's OpenAI protocol:
 https://github.com/lm-sys/FastChat/blob/main/fastchat/protocol/openai_api_protocol.py
 """
+
 # pylint: disable=missing-class-docstring
 import time
+import shortuuid
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field, field_validator
@@ -114,13 +116,18 @@ class ChatFunction(BaseModel):
     parameters: Dict
 
 
+class ChatTool(BaseModel):
+    type: Literal["function"]
+    function: ChatFunction
+
+
 class ChatFunctionCall(BaseModel):
     name: str
-    arguments: str
+    arguments: Union[None, Dict[str, Any]] = None
 
 
 class ChatToolCall(BaseModel):
-    id: str
+    id: str = Field(default_factory=lambda: f"call_{shortuuid.random()}")
     type: Literal["function"]
     function: ChatFunctionCall
 
@@ -151,7 +158,7 @@ class ChatCompletionRequest(BaseModel):
     stream: bool = False
     temperature: float = 1.0
     top_p: float = 1.0
-    tools: Optional[List[ChatFunction]] = None
+    tools: Optional[List[ChatTool]] = None
     tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None
     user: Optional[str] = None
     ignore_eos: bool = False
@@ -211,8 +218,6 @@ def openai_api_get_unsupported_fields(
         ("logprobs", None),
         ("n", 1),
         ("response_format", "text"),
-        ("tools", None),
-        ("tool_choice", None),
     ]
 
     unsupported_fields: List[str] = []

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -5,9 +5,9 @@ https://github.com/lm-sys/FastChat/blob/main/fastchat/protocol/openai_api_protoc
 
 # pylint: disable=missing-class-docstring
 import time
-import shortuuid
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
+import shortuuid
 from pydantic import BaseModel, Field, field_validator
 
 ################ Commons ################

--- a/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
@@ -1,7 +1,10 @@
 """OpenAI API-compatible server entrypoints in MLC LLM"""
+
 # pylint: disable=too-many-locals,too-many-return-statements,too-many-statements
 from http import HTTPStatus
-from typing import AsyncGenerator, List, Optional
+from typing import AsyncGenerator, List, Optional, Union, Dict
+import json
+import ast
 
 import fastapi
 
@@ -19,7 +22,10 @@ from ...protocol.openai_api_protocol import (
     ListResponse,
     ModelResponse,
     UsageInfo,
+    ChatToolCall,
+    ChatFunctionCall,
 )
+from ...protocol.conversation_protocol import Conversation
 from ..server import ServerContext
 from . import entrypoint_utils
 
@@ -218,6 +224,66 @@ def chat_completion_check_message_validity(
     return None
 
 
+def check_function_call_usage(request: ChatCompletionRequest, conv_template: Conversation):
+
+    # return if no tools are provided or tool_choice is set to none
+    if request.tools is None or (
+        isinstance(request.tool_choice, str) and request.tool_choice == "none"
+    ):
+        conv_template.use_function_calling = False
+        return
+
+    # select the tool based on the tool_choice if specified
+    if isinstance(request.tool_choice, dict):
+        if request.tool_choice["type"] != "function":
+            return "Only 'function' tool choice is supported"
+
+        if len(request.tool_choice["function"]) > 1:
+            return "Only one tool is supported when tool_choice is specified"
+
+        for tool in request.tools:
+            if tool.function.name == request.tool_choice["function"]["name"]:
+                conv_template.use_function_calling = True
+                conv_template.function_string = tool.function.model_dump_json()
+                return
+
+        return f"The tool_choice function {request.tool_choice['function']['name']} is not found in the tools list"
+
+    if isinstance(request.tool_choice, str) and request.tool_choice != "auto":
+        return f"Invalid tool_choice value: {request.tool_choice}"
+
+    function_list = []
+    for tool in request.tools:
+        if tool.type != "function":
+            return f"Only 'function' tool type is supported"
+        function_list.append(tool.function.model_dump())
+
+    conv_template.use_function_calling = True
+    conv_template.function_string = json.dumps(function_list)
+
+
+def convert_function_str_to_json(stringified_calls: str) -> List[Union[Dict, None]]:
+    def parse_function_call(call_str: str):
+        node = ast.parse(call_str, mode="eval")
+        call_node = node.body
+        if isinstance(call_node, ast.Call):
+            name = call_node.func.id
+            arguments = {}
+            for keyword in call_node.keywords:
+                arguments[keyword.arg] = ast.literal_eval(keyword.value)
+            return {"name": name, "arguments": arguments}
+        return None
+
+    if (
+        stringified_calls[0] == "[" and stringified_calls[-1] == "]"
+    ):  # hacky way to check if string list
+        calls = ast.literal_eval(stringified_calls)
+    else:
+        calls = [stringified_calls]
+    function_calls_json = [parse_function_call(call_str) for call_str in calls]
+    return function_calls_json
+
+
 @app.post("/v1/chat/completions")
 async def request_chat_completion(request: ChatCompletionRequest, raw_request: fastapi.Request):
     """OpenAI-compatible chat completion API.
@@ -231,6 +297,7 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
         )
     request_id = f"chatcmpl-{entrypoint_utils.random_uuid()}"
     async_engine.record_event(request_id, event="receive request")
+
     # - Check if the model supports chat conversation.
     conv_template = ServerContext.get_conv_template(request.model)
     if conv_template is None:
@@ -251,6 +318,13 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
     error_msg = chat_completion_check_message_validity(request.messages)
     if error_msg is not None:
         return entrypoint_utils.create_error_response(HTTPStatus.BAD_REQUEST, message=error_msg)
+
+    # update conv_template.use_function_calling to True if fn calling
+    # also add function list to the conv templat
+    error_msg = check_function_call_usage(request, conv_template)
+    if error_msg is not None:
+        return entrypoint_utils.create_error_response(HTTPStatus.BAD_REQUEST, message=error_msg)
+
     for message in request.messages:
         role = message.role
         content = message.content
@@ -260,8 +334,8 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
             continue
 
         assert role != "tool", "Internal error: tool role."
-        conv_template.messages.append((conv_template.roles[role == "assistant"], content))
-    conv_template.messages.append((conv_template.roles[1], None))
+        conv_template.messages.append((role, content))
+    conv_template.messages.append(("assistant", None))
 
     # - Get the prompt from template, and encode to token ids.
     # - Check prompt length
@@ -298,6 +372,9 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
                     async_engine.record_event(request_id, event="skip empty delta text")
                     # Ignore empty delta text -- do not yield.
                     continue
+
+                if conv_template.use_function_calling:
+                    finish_reason = "tool_calls"
 
                 response = ChatCompletionStreamResponse(
                     id=request_id,
@@ -341,12 +418,43 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
     assert finish_reason is not None
 
     async_engine.record_event(request_id, event="finish")
+
+    if conv_template.use_function_calling:
+        try:
+            fn_json_list = convert_function_str_to_json(output_text)
+        except Exception as e:
+            return entrypoint_utils.create_error_response(
+                HTTPStatus.BAD_GATEWAY, message="Got an invalid function call output from model"
+            )
+        tool_calls = [
+            ChatToolCall(
+                type="function",
+                function=ChatFunctionCall(
+                    name=fn_json_obj["name"], arguments=fn_json_obj["arguments"]
+                ),
+            )
+            for fn_json_obj in fn_json_list
+            if fn_json_obj is not None
+        ]
+        if len(tool_calls) == 0:
+            return entrypoint_utils.create_error_response(
+                HTTPStatus.BAD_GATEWAY, message="Got an invalid function call output from model"
+            )
+
+        finish_reason = "tool_calls"
+
+    message = (
+        ChatCompletionMessage(role="assistant", content=output_text)
+        if not conv_template.use_function_calling
+        else ChatCompletionMessage(role="assistant", content=None, tool_calls=tool_calls)
+    )
+
     return ChatCompletionResponse(
         id=request_id,
         choices=[
             ChatCompletionResponseChoice(
                 finish_reason=finish_reason,
-                message=ChatCompletionMessage(role="assistant", content=output_text),
+                message=message,
             )
         ],
         model=request.model,

--- a/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_chat/serve/entrypoints/openai_entrypoints.py
@@ -272,12 +272,13 @@ def check_function_call_usage(
 
 
 def convert_function_str_to_json(stringified_calls: str) -> List[Union[Dict, None]]:
-    """Convert a (possibly list) of function call string to a list of json objects."""
+    """Convert a (possibly list) of function call string to a list of json objects.
+    Return None for invalid function call string."""
 
     def parse_function_call(call_str: str):
         node = ast.parse(call_str, mode="eval")
         call_node = node.body
-        if isinstance(call_node, ast.Call):
+        if isinstance(call_node, ast.Call) and isinstance(call_node.func, ast.Name):
             name = call_node.func.id
             arguments = {}
             for keyword in call_node.keywords:

--- a/python/mlc_chat/serve/server/server_context.py
+++ b/python/mlc_chat/serve/server/server_context.py
@@ -1,4 +1,5 @@
 """Server context that shared by multiple entrypoint files."""
+
 from typing import Dict, List, Optional
 
 from ...conversation_template import ConvTemplateRegistry

--- a/tests/python/serve/server/test_server.py
+++ b/tests/python/serve/server/test_server.py
@@ -17,6 +17,7 @@ two steps:
 - start another shell session, run this file
   MLC_SERVE_MODEL_LIB="YOUR_MODEL_LIB" python tests/python/serve/server/test_server.py
 """
+
 # pylint: disable=missing-function-docstring,too-many-arguments,too-many-locals,too-many-branches
 import json
 import os

--- a/tests/python/serve/server/test_server_function_call.py
+++ b/tests/python/serve/server/test_server_function_call.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long
 """
 Test script for function call in chat completion. To run this script, use the following command:
 MLC_SERVE_MODEL_LIB=dist/gorilla-openfunctions-v1-q4f16_1_MLC/gorilla-openfunctions-v1-q4f16_1-cuda.so 
@@ -23,10 +24,6 @@ def check_openai_nonstream_response(
     num_choices: int,
     finish_reason: str,
     completion_tokens: Optional[int] = None,
-    echo_prompt: Optional[str] = None,
-    suffix: Optional[str] = None,
-    stop: Optional[List[str]] = None,
-    require_substr: Optional[List[str]] = None,
 ):
     print(response)
     assert response["model"] == model
@@ -48,6 +45,7 @@ def check_openai_nonstream_response(
     assert isinstance(usage, dict)
     assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
     assert usage["prompt_tokens"] > 0
+
     if completion_tokens is not None:
         assert usage["completion_tokens"] == completion_tokens
 
@@ -59,7 +57,6 @@ def check_openai_stream_response(
     object_str: str,
     num_choices: int,
     finish_reason: str,
-    completion_tokens: Optional[int] = None,
     echo_prompt: Optional[str] = None,
     suffix: Optional[str] = None,
     stop: Optional[List[str]] = None,

--- a/tests/python/serve/server/test_server_function_call.py
+++ b/tests/python/serve/server/test_server_function_call.py
@@ -1,0 +1,208 @@
+"""
+Test script for function call in chat completion. To run this script, use the following command:
+MLC_SERVE_MODEL_LIB=dist/gorilla-openfunctions-v1-q4f16_1_MLC/gorilla-openfunctions-v1-q4f16_1-cuda.so 
+MLC_SERVE_MODEL_LIB=${MLC_SERVE_MODEL_LIB} python -m pytest -x tests/python/serve/server/test_server_function_call.py
+"""
+
+# pylint: disable=missing-function-docstring,too-many-arguments,too-many-locals,too-many-branches
+import json
+import os
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+import requests
+
+OPENAI_V1_CHAT_COMPLETION_URL = "http://127.0.0.1:8000/v1/chat/completions"
+
+
+def check_openai_nonstream_response(
+    response: Dict,
+    *,
+    model: str,
+    object_str: str,
+    num_choices: int,
+    finish_reason: str,
+    completion_tokens: Optional[int] = None,
+    echo_prompt: Optional[str] = None,
+    suffix: Optional[str] = None,
+    stop: Optional[List[str]] = None,
+    require_substr: Optional[List[str]] = None,
+):
+    print(response)
+    assert response["model"] == model
+    assert response["object"] == object_str
+
+    choices = response["choices"]
+    assert isinstance(choices, list)
+    assert len(choices) == num_choices
+    for idx, choice in enumerate(choices):
+        assert choice["index"] == idx
+        assert choice["finish_reason"] == finish_reason
+
+        # text: str
+        message = choice["message"]
+        assert message["role"] == "assistant"
+        assert isinstance(message["tool_calls"], list)
+
+    usage = response["usage"]
+    assert isinstance(usage, dict)
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+    assert usage["prompt_tokens"] > 0
+    if completion_tokens is not None:
+        assert usage["completion_tokens"] == completion_tokens
+
+
+def check_openai_stream_response(
+    responses: List[Dict],
+    *,
+    model: str,
+    object_str: str,
+    num_choices: int,
+    finish_reason: str,
+    completion_tokens: Optional[int] = None,
+    echo_prompt: Optional[str] = None,
+    suffix: Optional[str] = None,
+    stop: Optional[List[str]] = None,
+    require_substr: Optional[List[str]] = None,
+):
+    assert len(responses) > 0
+
+    finished = [False for _ in range(num_choices)]
+    outputs = ["" for _ in range(num_choices)]
+    for response in responses:
+        assert response["model"] == model
+        assert response["object"] == object_str
+
+        choices = response["choices"]
+        assert isinstance(choices, list)
+        assert len(choices) == num_choices
+        for idx, choice in enumerate(choices):
+            assert choice["index"] == idx
+
+            delta = choice["delta"]
+            assert delta["role"] == "assistant"
+            assert isinstance(delta["content"], str)
+            outputs[idx] += delta["content"]
+
+            if finished[idx]:
+                assert choice["finish_reason"] == finish_reason
+            elif choice["finish_reason"] is not None:
+                assert choice["finish_reason"] == finish_reason
+                finished[idx] = True
+
+    for output in outputs:
+        if echo_prompt is not None:
+            assert output.startswith(echo_prompt)
+        if suffix is not None:
+            assert output.endswith(suffix)
+        if stop is not None:
+            for stop_str in stop:
+                assert stop_str not in output
+        if require_substr is not None:
+            for substr in require_substr:
+                assert substr in output
+
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+
+CHAT_COMPLETION_MESSAGES = [
+    # messages #0
+    [
+        {
+            "role": "user",
+            "content": "What is the current weather in Pittsburgh, PA?",
+        }
+    ],
+    # messages #1
+    [
+        {
+            "role": "user",
+            "content": "What is the current weather in Pittsburgh, PA and Tokyo, JP?",
+        }
+    ],
+    # messages #2
+    [
+        {
+            "role": "user",
+            "content": "What is the current weather in Pittsburgh, PA in fahrenheit?",
+        }
+    ],
+]
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("messages", CHAT_COMPLETION_MESSAGES)
+def test_openai_v1_chat_completion_function_call(
+    served_model: Tuple[str, str],
+    launch_server,  # pylint: disable=unused-argument
+    stream: bool,
+    messages: List[Dict[str, str]],
+):
+    # `served_model` and `launch_server` are pytest fixtures
+    # defined in conftest.py.
+
+    payload = {
+        "model": served_model[0],
+        "messages": messages,
+        "stream": stream,
+        "tools": tools,
+    }
+
+    response = requests.post(OPENAI_V1_CHAT_COMPLETION_URL, json=payload, timeout=60)
+    if not stream:
+        check_openai_nonstream_response(
+            response.json(),
+            model=served_model[0],
+            object_str="chat.completion",
+            num_choices=1,
+            finish_reason="tool_calls",
+        )
+    else:
+        responses = []
+        for chunk in response.iter_lines(chunk_size=512):
+            if not chunk or chunk == b"data: [DONE]":
+                continue
+            responses.append(json.loads(chunk.decode("utf-8")[6:]))
+        check_openai_stream_response(
+            responses,
+            model=served_model[0],
+            object_str="chat.completion.chunk",
+            num_choices=1,
+            finish_reason="tool_calls",
+        )
+
+
+if __name__ == "__main__":
+    model_lib_path = os.environ.get("MLC_SERVE_MODEL_LIB")
+    if model_lib_path is None:
+        raise ValueError(
+            'Environment variable "MLC_SERVE_MODEL_LIB" not found. '
+            "Please set it to model lib compiled by MLC LLM "
+            "(e.g., `./dist/gorilla-openfunctions-v1-q4f16_1_MLC/gorilla-openfunctions-v1-q4f16_1-cuda.so`) "
+            "which supports function calls."
+        )
+    MODEL = (os.path.dirname(model_lib_path), model_lib_path)
+
+    for msg in CHAT_COMPLETION_MESSAGES:
+        test_openai_v1_chat_completion_function_call(MODEL, None, stream=False, messages=msg)
+        test_openai_v1_chat_completion_function_call(MODEL, None, stream=True, messages=msg)


### PR DESCRIPTION
This PR adds OpenAI compatible function calling functionality in serving.

**Summary of Changes**

- The `openai_entrypoints` module has been updated to handle function calls.
- New roles and message placeholders have been created for user, assistant, and functions.
- The `as_prompt` function has been modified to support the creation of prompts that include function calls.
- The `openai_api_protocol` has been expanded to include a new ChatToolCall class.

**Additional Note**
When `stream = True`, the output from function calls is currently returned in the `content` field, rather than the `tool_calls` field, which is used for non-streaming output.

The changes were collaboratively worked on with @shreygupta2809!

cc @tqchen 