### PR TITLE
[Pass] FuseAddRMSNorm max_num_threads awareness

### DIFF
--- a/python/mlc_chat/compiler_pass/pipeline.py
+++ b/python/mlc_chat/compiler_pass/pipeline.py
@@ -96,7 +96,7 @@ def _mlc_llm_pipeline(  # pylint: disable=too-many-arguments
                 FuseFTDequantizeEpilogue(),
                 FuseDequantizeTranspose(),
                 CublasDispatch() if cublas_gemm else tvm.transform.Sequential([]),
-                FuseAddRMSNorm(),
+                FuseAddRMSNorm(target=target),
                 FuseTransposeMatmul(),
                 _DebugDump("debug-phase1.py", debug_dump, show_meta=False),
                 # Phase 2. Lowering to TIR, inherited TVM Relax's official "zero" pipeline


### PR DESCRIPTION
The current FuseAddRMSNorm would result in a workgroup of size 1024, while targets like webgpu maxes out at 256. This PR sets `TX` to `target.max_num_threads`.