### PR TITLE
[Andoird] Fix `model_lib` for phi-2

### DIFF
--- a/android/library/src/main/assets/app-config.json
+++ b/android/library/src/main/assets/app-config.json
@@ -20,7 +20,7 @@
     },
     {
       "model_url": "https://huggingface.co/mlc-ai/phi-2-q4f16_1-MLC",
-      "model_lib": "phi-msft_q4f16_1",
+      "model_lib": "phi_q4f16_1",
       "estimated_vram_bytes": 2036816936,
       "model_id": "phi-2-q4f16_1"
     }
@@ -28,7 +28,7 @@
   "model_lib_path_for_prepare_libs": {
     "llama_q4f16_1": "libs/Llama-2-7b-chat-hf-q4f16_1-android.tar",
     "gpt_neox_q4f16_1": "libs/RedPajama-INCITE-Chat-3B-v1-q4f16_1-android.tar",
-    "phi-msft_q4f16_1": "libs/phi-2-q4f16_1-android.tar",
+    "phi_q4f16_1": "libs/phi-2-q4f16_1-android.tar",
     "Mistral-7B-Instruct-v0.2-q4f16_1": "libs/Mistral-7B-Instruct-v0.2-q4f16_1-android.tar"
   }
 }

--- a/docs/deploy/android.rst
+++ b/docs/deploy/android.rst
@@ -14,7 +14,7 @@ The demo APK below is built for Samsung S23 with Snapdragon 8 Gen 2 chip.
 
 .. image:: https://seeklogo.com/images/D/download-android-apk-badge-logo-D074C6882B-seeklogo.com.png
   :width: 135
-  :target: https://github.com/mlc-ai/binary-mlc-llm-libs/raw/main/mlc-chat.apk
+  :target: https://github.com/mlc-ai/binary-mlc-llm-libs/releases/download/Android/mlc-chat.apk
 
 Prerequisite
 ------------


### PR DESCRIPTION
This PR fixes the `model_lib` field in `app-config.json` for phi-2 to match correctly with the `system-lib-prefix`.