### PR TITLE
[Make] Add USE FLASHINFER into doc and gen cmake config

### DIFF
--- a/cmake/gen_cmake_config.py
+++ b/cmake/gen_cmake_config.py
@@ -3,15 +3,15 @@ from collections import namedtuple
 Backend = namedtuple("Backend", ["name", "cmake_config_name", "prompt_str"])
 
 if __name__ == "__main__":
-    tvm_home = ""
+    tvm_home = ""  # pylint: disable=invalid-name
 
     tvm_home = input(
         "Enter TVM_HOME in absolute path. If not specified, 3rdparty/tvm will be used by default: "
     )
     if len(tvm_home) == 0:
-        tvm_home = "3rdparty/tvm"
+        tvm_home = "3rdparty/tvm"  # pylint: disable=invalid-name
 
-    cmake_config_str = "set(TVM_HOME {})\n".format(tvm_home)
+    cmake_config_str = f"set(TVM_HOME {tvm_home})\n"
     cmake_config_str += "set(CMAKE_BUILD_TYPE RelWithDebInfo)\n"
     backends = [
         Backend("CUDA", "USE_CUDA", "Use CUDA? (y/n): "),
@@ -35,13 +35,36 @@ if __name__ == "__main__":
         while True:
             use_backend = input(backend.prompt_str)
             if use_backend in ["yes", "Y", "y"]:
-                cmake_config_str += "set({} ON)\n".format(backend.cmake_config_name)
+                cmake_config_str += f"set({backend.cmake_config_name} ON)\n"
                 break
             elif use_backend in ["no", "N", "n"]:
-                cmake_config_str += "set({} OFF)\n".format(backend.cmake_config_name)
+                cmake_config_str += f"set({backend.cmake_config_name} OFF)\n"
                 break
             else:
-                print("Invalid input: {}. Please input again.".format(use_backend))
+                print(f"Invalid input: {use_backend}. Please input again.")
+
+    # FlashInfer related
+    use_flashInfer = False  # pylint: disable=invalid-name
+    while True:
+        user_input = input("Use FlashInfer? (need CUDA w/ compute capability 80;86;89;90) (y/n): ")
+        if user_input in ["yes", "Y", "y"]:
+            cmake_config_str += "set(USE_FLASHINFER ON)\n"
+            use_flashInfer = True  # pylint: disable=invalid-name
+            break
+        elif user_input in ["no", "N", "n"]:
+            cmake_config_str += "set(USE_FLASHINFER OFF)\n"
+            break
+        else:
+            print(f"Invalid input: {use_flashInfer}. Please input again.")
+    if use_flashInfer:
+        while True:
+            user_input = input("Enter your CUDA compute capability: ")
+            if user_input in ["80", "86", "89", "90"]:
+                cmake_config_str += f"set(FLASHINFER_CUDA_ARCHITECTURES {user_input})\n"
+                cmake_config_str += f"set(CMAKE_CUDA_ARCHITECTURES {user_input})\n"
+                break
+            else:
+                print(f"Invalid input: {user_input}. FlashInfer requires 80, 86, 89, or 90.")
 
     print("\nWriting the following configuration to config.cmake...")
     print(cmake_config_str)

--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -199,6 +199,13 @@ This step is useful when you want to make modification or obtain a specific vers
     # build mlc_llm libraries
     cmake .. && cmake --build . --parallel $(nproc) && cd ..
 
+.. note::
+    If you are using CUDA and your compute capability is above 80, then it is require to build with
+    ``set(USE_FLASHINFER ON)``. Otherwise, you may run into ``Cannot find PackedFunc`` issue during
+    runtime.
+    
+    To check your CUDA compute capability, you can use ``nvidia-smi --query-gpu=compute_cap --format=csv``.
+
 **Step 3. Install via Python.** We recommend that you install ``mlc_chat`` as a Python package, giving you 
 access to ``mlc_chat.compile``, ``mlc_chat.ChatModule``, and the CLI.
 There are two ways to do so:

--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -208,6 +208,10 @@ While it is generally recommended to always use the prebuilt TVM Unity, if you r
         echo "set(USE_METAL  OFF)" >> config.cmake
         echo "set(USE_VULKAN OFF)" >> config.cmake
         echo "set(USE_OPENCL OFF)" >> config.cmake
+        # FlashInfer related, requires CUDA w/ compute capability 80;86;89;90
+        echo "set(USE_FLASHINFER OFF)" >> config.cmake
+        echo "set(FLASHINFER_CUDA_ARCHITECTURES YOUR_CUDA_COMPUTE_CAPABILITY_HERE)" >> config.cmake
+        echo "set(CMAKE_CUDA_ARCHITECTURES YOUR_CUDA_COMPUTE_CAPABILITY_HERE)" >> config.cmake
 
     .. note::
         ``HIDE_PRIVATE_SYMBOLS`` is a configuration option that enables the ``-fvisibility=hidden`` flag. This flag helps prevent potential symbol conflicts between TVM and PyTorch. These conflicts arise due to the frameworks shipping LLVMs of different versions.
@@ -217,6 +221,13 @@ While it is generally recommended to always use the prebuilt TVM Unity, if you r
         - ``Debug`` sets ``-O0 -g``
         - ``RelWithDebInfo`` sets ``-O2 -g -DNDEBUG`` (recommended)
         - ``Release`` sets ``-O3 -DNDEBUG``
+
+    .. note::
+        If you are using CUDA and your compute capability is above 80, then it is require to build with
+        ``set(USE_FLASHINFER ON)``. Otherwise, you may run into ``Cannot find PackedFunc`` issue during
+        runtime.
+        
+        To check your CUDA compute capability, you can use ``nvidia-smi --query-gpu=compute_cap --format=csv``.
 
     Once ``config.cmake`` is edited accordingly, kick off build with the commands below:
 


### PR DESCRIPTION
When using CUDA with compute capability >80, it is required to build runtime with `USE_FLASHINFER` and specifying `FLASHINFER_CUDA_ARCHITECTURES` and `CMAKE_CUDA_ARCHITECTURES`. Otherwise, users may run into issues like `Cannot find PackedFunc flashinfer.single_prefill in either Relax VM kernel library, or in TVM runtime PackedFunc registry, or in global Relax functions of the VM executable`.

This is related to issues https://github.com/mlc-ai/mlc-llm/issues/1728 and https://github.com/mlc-ai/mlc-llm/issues/1551