### PR TITLE
Provide a better error message when conversion to tokenizer.json failed

### DIFF
--- a/python/mlc_chat/interface/gen_config.py
+++ b/python/mlc_chat/interface/gen_config.py
@@ -150,7 +150,12 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
             mlc_chat_config.tokenizer_files.append("tokenizer.json")
             logger.info("Succesfully converted `tokenizer.model` to: %s", tokenizer_json_save_dest)
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.exception("%s with the exception below. Skipping", FAILED)
+            logger.warning(
+                "Convertion to `tokenizer.json` %s with the exception below. "
+                "Skipping the conversion. Tokenizer will only use `tokenizer.model`",
+                FAILED,
+                exc_info=True,
+            )
     # 3.3. If we still don't have "tokenizer.json" at this point, try looking for "*.tiktoken" files
     if (not tokenizer_json_file.exists()) and list(config.parent.glob("*.tiktoken")):
         try:


### PR DESCRIPTION
Related to https://github.com/mlc-ai/mlc-llm/issues/1727

The new error message will look like:
```
[2024-02-14 10:06:49] WARNING gen_config.py:153: Convertion to `tokenizer.json` Failed with the exception below. Skipping the conversion. Tokenizer will only use `tokenizer.model`
Traceback (most recent call last):
...
```