### PR TITLE
[Transform] Add check for function.attrs

### DIFF
--- a/mlc_llm/transform/transpose_matmul.py
+++ b/mlc_llm/transform/transpose_matmul.py
@@ -46,11 +46,7 @@ class TransposeMatmulCodeGenerator(relax.PyExprMutator):
                 b_shape.append(1)
 
             is_a_larger = len(a_shape) > len(b_shape)
-            offset = (
-                len(a_shape) - len(b_shape)
-                if is_a_larger
-                else len(b_shape) - len(a_shape)
-            )
+            offset = len(a_shape) - len(b_shape) if is_a_larger else len(b_shape) - len(a_shape)
 
             a_relax = relax.Var("a", relax.TensorStructInfo(a.shape))
             bT_shape = list(b.shape)
@@ -72,9 +68,7 @@ class TransposeMatmulCodeGenerator(relax.PyExprMutator):
                             a_indices.append(idx_spatial[i])
                         else:
                             b_indices.append(idx_spatial[i])
-                    for i in range(
-                        offset, len(output_shape) - (2 - a_prepended - b_appended)
-                    ):
+                    for i in range(offset, len(output_shape) - (2 - a_prepended - b_appended)):
                         a_dim = a_shape[i if is_a_larger else i - offset]
                         b_dim = b_shape[i if not is_a_larger else i - offset]
                         dim_equal = a_dim == b_dim
@@ -110,7 +104,8 @@ class TransposeMatmulCodeGenerator(relax.PyExprMutator):
         if isinstance(call.op, relax.GlobalVar):
             function = self.builder_.get()[call.op]
             if (
-                "Composite" in function.attrs
+                function.attrs
+                and "Composite" in function.attrs
                 and function.attrs["Composite"] == "transpose_matmul_fuse"
             ):
                 out_dtype = function.ret_struct_info.dtype
@@ -126,9 +121,7 @@ class TransposeMatmulCodeGenerator(relax.PyExprMutator):
 
 @tvm.transform.module_pass(opt_level=0, name="FuseTransposeMatmul")
 class FuseTransposeMatmul:
-    def transform_module(
-        self, mod: IRModule, ctx: tvm.transform.PassContext
-    ) -> IRModule:
+    def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
         mod = relax.transform.FuseOpsByPattern(
             [("transpose_matmul_fuse", *TransposeMatmulCodeGenerator.pattern())]
         )(mod)


### PR DESCRIPTION
A relax function may have `None` for `function.attrs`.  If this occurs, checking `"Composite" in function.attrs` would raise an error.