### PR TITLE
[Models] Define sharding strategy when combine_matmul=False

### DIFF
--- a/mlc_llm/relax_model/commons.py
+++ b/mlc_llm/relax_model/commons.py
@@ -66,6 +66,27 @@ def _get_shard_strategies(
         func = te.create_prim_func([a, w])
         return func
 
+    def shard_axis_0(weight: relax.TensorStructInfo):
+        (red, spatial), dtype = weight.shape, weight.dtype
+        red, spatial = int(red), int(spatial)
+        if param_shape_is_already_sharded:
+            red *= num_shards
+        a = te.placeholder((red, spatial), dtype=dtype)
+        w = topi.reshape(a, (num_shards, red // num_shards, spatial))
+        func = te.create_prim_func([a, w])
+        return func
+
+    def shard_axis_1(weight: relax.TensorStructInfo):
+        (spatial, red), dtype = weight.shape, weight.dtype
+        spatial, red = int(spatial), int(red)
+        if param_shape_is_already_sharded:
+            red *= num_shards
+        a = te.placeholder((spatial, red), dtype=dtype)
+        w = topi.reshape(a, (spatial, num_shards, red // num_shards))
+        w = topi.transpose(w, (1, 0, 2))
+        func = te.create_prim_func([a, w])
+        return func
+
     def shard_gate_up_weight_scale(weight: relax.TensorStructInfo):
         (spatial, red), dtype = weight.shape, weight.dtype
         spatial, red = int(spatial), int(red)
@@ -88,6 +109,8 @@ def _get_shard_strategies(
         "shard_mlp_k": shard_k_weight_scale,
         "shard_o_proj_k": shard_k_weight_scale,
         "shard_gate_up": shard_gate_up_weight_scale,
+        "shard_axis_0": shard_axis_0,
+        "shard_axis_1": shard_axis_1,
     }
 
 
@@ -127,6 +150,27 @@ def _get_shard_strategies_ft(
         func = te.create_prim_func([a, w])
         return func
 
+    def shard_axis_0(weight: relax.TensorStructInfo):
+        (red, spatial), dtype = weight.shape, weight.dtype
+        red, spatial = int(red), int(spatial)
+        if param_shape_is_already_sharded:
+            red *= num_shards
+        a = te.placeholder((red, spatial), dtype=dtype)
+        w = topi.reshape(a, (num_shards, red // num_shards, spatial))
+        func = te.create_prim_func([a, w])
+        return func
+
+    def shard_axis_1(weight: relax.TensorStructInfo):
+        (spatial, red), dtype = weight.shape, weight.dtype
+        spatial, red = int(spatial), int(red)
+        if param_shape_is_already_sharded:
+            red *= num_shards
+        a = te.placeholder((spatial, red), dtype=dtype)
+        w = topi.reshape(a, (spatial, num_shards, red // num_shards))
+        w = topi.transpose(w, (1, 0, 2))
+        func = te.create_prim_func([a, w])
+        return func
+
     def shard_gate_up_weight_scale(x: relax.TensorStructInfo):
         (red, spatial), dtype = x.shape, x.dtype
         red, spatial = int(red), int(spatial)
@@ -148,6 +192,8 @@ def _get_shard_strategies_ft(
         "shard_mlp_k": shard_k_weight,
         "shard_o_proj_k": shard_k_weight,
         "shard_gate_up": shard_gate_up_weight_scale,
+        "shard_axis_0": shard_axis_0,
+        "shard_axis_1": shard_axis_1,
     }
 
 

--- a/mlc_llm/relax_model/llama.py
+++ b/mlc_llm/relax_model/llama.py
@@ -189,6 +189,12 @@ class LlamaMLP(nn.Module):
             self.gate_proj = Linear(hidden_size, intermediate_size, dtype=dtype, bias=False)
             self.down_proj = Linear(intermediate_size, hidden_size, dtype=dtype, bias=False)
             self.up_proj = Linear(hidden_size, intermediate_size, dtype=dtype, bias=False)
+            self.gate_proj.weight.shard_dim = 0
+            self.gate_proj.weight.shard_strategy = "shard_axis_0"
+            self.down_proj.weight.shard_dim = 1
+            self.down_proj.weight.shard_strategy = "shard_axis_1"
+            self.up_proj.weight.shard_dim = 0
+            self.up_proj.weight.shard_strategy = "shard_axis_0"
 
     def forward(self, x):
         if self.combine_matmul:
@@ -292,6 +298,9 @@ class LlamaAttentionBase(nn.Module):
             self.q_proj.weight.shard_dim = 0
             self.k_proj.weight.shard_dim = 0
             self.v_proj.weight.shard_dim = 0
+            self.q_proj.weight.shard_strategy = "shard_axis_0"
+            self.k_proj.weight.shard_strategy = "shard_axis_0"
+            self.v_proj.weight.shard_strategy = "shard_axis_0"
 
         self.o_proj = Linear(
             self.head_dim * self.num_query_heads, self.hidden_size, dtype=dtype, bias=False


### PR DESCRIPTION
Prior to this commit, the `weight.shard_dim` and `weight.shard_strategy` fields were defined when `combine_matmul=True`, but were left undefined in some locations for `combine_matmul=False`.  This commit adds definitions for these cases.