### PR TITLE
[Bugfix] Remove mutation of IRModule in ReorderTransformFunc

### DIFF
--- a/mlc_llm/transform/reorder_transform_func.py
+++ b/mlc_llm/transform/reorder_transform_func.py
@@ -218,8 +218,11 @@ class ReorderTransformFunc:
         }
 
     def transform_module(
-        self, mod: IRModule, ctx: tvm.transform.PassContext
+        self,
+        mod: IRModule,
+        ctx: tvm.transform.PassContext,
     ) -> IRModule:
+        mod = mod.clone()
         for gv, func in list(mod.functions.items()):
             if isinstance(func, relax.Function):
                 assert gv.name_hint.endswith("transform_params")


### PR DESCRIPTION
A pass must not mutate the `IRModule` that it receives as input. Unlike most functions exposed through the python API, the `IRModule.__setitem__` method mutates the underlying `IRModuleNode`. This can impact other users of the shared `IRModule` object, which expect mutation to be done using copy-on-write.

See https://github.com/apache/tvm/issues/11372 for more details.