### PR TITLE
[Fix] Fix the global var struct info in FuseAddRMSNorm

### DIFF
--- a/python/mlc_chat/compiler_pass/fuse_add_norm.py
+++ b/python/mlc_chat/compiler_pass/fuse_add_norm.py
@@ -1,4 +1,5 @@
 """A compiler pass that fuses add + rms_norm."""
+
 import tvm
 from tvm import relax
 from tvm.relax.dpl import PatternContext, rewrite_bindings
@@ -182,7 +183,7 @@ class FuseAddRMSNorm:  # pylint: disable=too-few-public-methods
                 gvar = mod.get_global_var(func_name)
                 relax.expr._update_struct_info(  # pylint: disable=protected-access
                     gvar,
-                    relax.ObjectStructInfo(),
+                    relax.FuncStructInfo.opaque_func(ret=relax.ObjectStructInfo()),
                 )
             else:
                 gvar = mod.get_global_var(func_name)


### PR DESCRIPTION
This PR fixes the FuseAddRMSNorm pass which does not set FuncStructInfo for GlobalVar of PrimFuncs.