### PR TITLE
[KVCache] Support returning query positions

### DIFF
--- a/python/mlc_chat/nn/kv_cache.py
+++ b/python/mlc_chat/nn/kv_cache.py
@@ -144,6 +144,30 @@ class PagedKVCache(Object):  # pylint: disable=too-few-public-methods
             )
         ).reshape(b, s, num_qo_heads, d)
 
+    def get_query_positions(self, total_length: tir.PrimExpr) -> Tensor:
+        """Get the in-sequence positions of each slot in the query,
+        which are needed for applying positional embeddings in some models.
+
+        Parameters
+        ----------
+        total_length : tir.PrimExpr
+            The summed-up total sequence length of queries in
+            the batch being forwarded.
+
+        Returns
+        -------
+        q_positions : Tensor
+            The in-sequence query positions, in shape `(total_length,)`
+        """
+        return Tensor(
+            _expr=rx.BlockBuilder.current().emit(
+                rx.call_pure_packed(
+                    "vm.builtin.paged_attention_kv_cache_get_query_positions",
+                    sinfo_args=rx.TensorStructInfo((total_length,), "int32"),
+                )
+            )
+        )
+
     # pylint: enable=protected-access
 
 


### PR DESCRIPTION
This PR adds a new function to PagedKVCache in MLC to return in-sequence positions for each location in a batch of sequences that is being forwarded. This function helps apply positional embeddings for language models (e.g., GPT-2, GPT-BigCode) that do not use Rotary positional embeddings.