### PR TITLE
[Bug] Fix Llama2 System Prompt 

### DIFF
--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -97,7 +97,7 @@ Conversation Llama2() {
   Conversation conv;
   conv.name = "llama-2";
   conv.system =
-      ("[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n ");
+      ("[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n ");
   conv.roles = {"[INST]", "[/INST]"};
   conv.messages = {};
   conv.offset = 0;

--- a/python/mlc_chat/conversation_template.py
+++ b/python/mlc_chat/conversation_template.py
@@ -40,7 +40,7 @@ class ConvTemplateRegistry:
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="llama-2",
-        system_template=f"[INST] <<SYS>>\n\n{SYSTEM_MESSAGE_PLACEHOLDER}\n<</SYS>>\n\n ",
+        system_template=f"[INST] <<SYS>>\n{SYSTEM_MESSAGE_PLACEHOLDER}\n<</SYS>>\n\n ",
         system_message="You are a helpful, respectful and honest assistant.",
         roles=("[INST]", "[/INST]"),
         seps=[" "],


### PR DESCRIPTION
Remove the extra `\n` from the llama-2 system prompt to match with [Meta implementation](https://github.com/facebookresearch/llama/blob/ef351e9cd9496c579bf9f2bb036ef11bdc5ca3d2/llama/generation.py#L320-L353)

cc @MasterJH5574 