### PR TITLE
[KVCache] Support mode "None" for Rotary Embedding

### DIFF
--- a/python/mlc_chat/nn/kv_cache.py
+++ b/python/mlc_chat/nn/kv_cache.py
@@ -21,12 +21,14 @@ from mlc_chat.op.position_embedding import (
 
 class RopeMode(enum.IntEnum):
     """The RoPE mode of the Paged KV cache.
+    If it is none, the KV cache will not apply RoPE to q and k.
     If it is normal, RoPE will be applied to k before adding k to cache.
     Otherwise, RoPE will be applied to q/k in attention kernel on-the-fly.
     """
 
-    NORMAL = 0
-    INLINE = 1
+    NONE = 0
+    NORMAL = 1
+    INLINE = 2
 
 
 class PagedKVCache(Object):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
This PR supports a "None" Rotary Embedding mode in PagedKVCache. When the mode is None, the rotary embedding will not be applied to when computing attention.