### PR TITLE
[Op] Inplace RoPE supporting rotary dim

### DIFF
--- a/python/mlc_chat/op/position_embedding.py
+++ b/python/mlc_chat/op/position_embedding.py
@@ -1,6 +1,6 @@
 """Operators for positional embeddings, e.g. RoPE."""
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 from tvm import tir
 from tvm.relax.frontend.nn import Tensor, op
@@ -54,7 +54,7 @@ def llama_rope(  # pylint: disable=too-many-arguments
     num_q_heads: int,
     num_kv_heads: int,
     scale: float = 1.0,
-    rotary_dim: int = None,
+    rotary_dim: Optional[int] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Llama-style RoPE. Given a fused QKV tensor, it returns three tensors, Q, K, and V, where Q
     and K are rotated by RoPE while V remains unchanged.
@@ -80,7 +80,7 @@ def llama_rope(  # pylint: disable=too-many-arguments
     num_kv_heads : int
         The number of key/value heads. It differs from `num_q_heads` in group-query attention.
 
-    rotary_dim : int
+    rotary_dim : Optional[int]
         The number of dimensions in the embedding that RoPE is applied to. By default, the
         rotary_dim is the same as head_dim.
 
@@ -279,6 +279,7 @@ def llama_inplace_rope(
     num_kv_heads: int,
     dtype: str,
     target: Target,  # pylint: disable=unused-argument
+    rotary_dim: Optional[int] = None,
 ):
     """Return the TIR function that inplace computes Llama-style RoPE with q position offset.
 
@@ -304,9 +305,14 @@ def llama_inplace_rope(
 
     target : Target
         The target to build the model to.
+
+    rotary_dim : Optional[int]
+        The number of dimensions in the embedding that RoPE is applied to. By default, the
+        rotary_dim is the same as head_dim.
     """
     assert head_dim <= 128, "Rotary embedding currently only supports head_dim <= 128"
-    rotary_dim = head_dim
+    if rotary_dim is None:
+        rotary_dim = head_dim
 
     def _rope(
         x: T.Buffer,
@@ -360,7 +366,7 @@ def llama_inplace_rope(
                             for d1 in T.vectorized(4):
                                 s: T.int32 = s0 * 32 + s1
                                 d: T.int32 = d0 * 4 + d1
-                                if s < append_len and d < head_dim:
+                                if s < append_len and d < rotary_dim:
                                     if h < num_q_heads:
                                         q[s + instance_offset, h, d] = _rope(q, s, h, d, rope_offset, instance_offset)
                                     else:

--- a/tests/python/model/test_kv_cache.py
+++ b/tests/python/model/test_kv_cache.py
@@ -177,6 +177,7 @@ def test_nn_module_paged_kv_cache():
                 rope_mode=RopeMode.NORMAL,
                 rope_scale=1,
                 rope_theta=10000,
+                rotary_dim=128,
                 dtype="float16",
                 target=tvm.target.Target("cuda"),
             )


### PR DESCRIPTION
This PR supports the in-place rotary embedding function with the `rotary_dim` arg, so that it can apply to models like GPT-NeoX, Phi, etc..