### PR TITLE
[FT] Fallback to GroupQuantize for lm head in FasterTransformer

### DIFF
--- a/python/mlc_chat/quantization/awq_quantization.py
+++ b/python/mlc_chat/quantization/awq_quantization.py
@@ -155,9 +155,11 @@ class AWQQuantize:  # pylint: disable=too-many-instance-attributes
         float_zeros = topi.transpose(float_zeros)
         scale = topi.transpose(scale)
         return te.compute(
-            shape=[weight.shape[0], weight.shape[1] * self.num_elem_per_storage]
-            if out_shape is None
-            else out_shape,
+            shape=(
+                [weight.shape[0], weight.shape[1] * self.num_elem_per_storage]
+                if out_shape is None
+                else out_shape
+            ),
             fcompute=lambda i, j: tir.multiply(
                 tir.subtract(float_weight[i, j], float_zeros[i, j // self.group_size]),
                 scale[i, j // self.group_size],

--- a/python/mlc_chat/quantization/awq_quantization.py
+++ b/python/mlc_chat/quantization/awq_quantization.py
@@ -1,4 +1,5 @@
 """AWQ Quantization"""
+
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
@@ -8,7 +9,7 @@ from tvm.runtime import NDArray
 
 from mlc_chat.loader import QuantizeMapping
 
-from .utils import convert_uint_to_float
+from .utils import convert_uint_to_float, is_final_fc
 
 
 def _make_divisible(c, divisor):  # pylint: disable=invalid-name
@@ -116,7 +117,7 @@ class AWQQuantize:  # pylint: disable=too-many-instance-attributes
                     The new node to replace current node.
                 """
 
-                if isinstance(node, nn.Linear) and name != "lm_head":
+                if isinstance(node, nn.Linear) and not is_final_fc(name):
                     return AWQQuantizeLinear.from_linear(node, self.config)
                 return self.visit(name, node)
 

--- a/python/mlc_chat/quantization/ft_quantization.py
+++ b/python/mlc_chat/quantization/ft_quantization.py
@@ -16,6 +16,7 @@ from ..op import faster_transformer_dequantize_gemm
 from ..support import logging
 from ..support.auto_target import detect_cuda_arch_list
 from .group_quantization import GroupQuantize, GroupQuantizeEmbedding, GroupQuantizeLinear
+from .utils import is_final_fc
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
                 if isinstance(node, nn.Linear):
                     weight_name = f"{name}.weight"
                     self.quant_map.param_map[weight_name] = [f"{name}.q_weight", f"{name}.q_scale"]
-                    if name == "lm_head":
+                    if is_final_fc(name):
                         # Use GroupQuantize to avoid https://github.com/mlc-ai/mlc-llm/issues/1723
                         # If simply not quantizing lm_head leads to performance degradation
                         group_quantize = self.config.fallback_group_quantize()

--- a/python/mlc_chat/quantization/ft_quantization.py
+++ b/python/mlc_chat/quantization/ft_quantization.py
@@ -15,7 +15,11 @@ from ..loader import QuantizeMapping
 from ..op import faster_transformer_dequantize_gemm
 from ..support import logging
 from ..support.auto_target import detect_cuda_arch_list
-from .group_quantization import GroupQuantize, GroupQuantizeEmbedding, GroupQuantizeLinear
+from .group_quantization import (
+    GroupQuantize,
+    GroupQuantizeEmbedding,
+    GroupQuantizeLinear,
+)
 from .utils import is_final_fc
 
 logger = logging.getLogger(__name__)

--- a/python/mlc_chat/quantization/ft_quantization.py
+++ b/python/mlc_chat/quantization/ft_quantization.py
@@ -15,6 +15,7 @@ from ..loader import QuantizeMapping
 from ..op import faster_transformer_dequantize_gemm
 from ..support import logging
 from ..support.auto_target import detect_cuda_arch_list
+from ..support.style import bold
 from .group_quantization import (
     GroupQuantize,
     GroupQuantizeEmbedding,
@@ -133,6 +134,13 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
                         # Under any of the conditions we fall back to GroupQuantize
                         # For `is_final_fc()` see https://github.com/mlc-ai/mlc-llm/issues/1723
                         # If simply skipping lm_head quantization degrades performance
+                        logger.info(
+                            'Fallback to GroupQuantize for nn.Linear: "%s", '
+                            + "weight.shape: %s, weight.dtype: %s",
+                            bold(name),
+                            node.weight.shape,
+                            node.weight.dtype,
+                        )
                         group_quantize = self.config.fallback_group_quantize()
                         self.quant_map.map_func[weight_name] = group_quantize.quantize_weight
                         return GroupQuantizeLinear.from_linear(node, group_quantize)

--- a/python/mlc_chat/quantization/group_quantization.py
+++ b/python/mlc_chat/quantization/group_quantization.py
@@ -399,19 +399,25 @@ class GroupQuantizeLinear(nn.Module):  # pylint: disable=too-many-instance-attri
                 weight,
                 scale,
                 axis=self.config.linear_quant_axis,
-                out_shape=[
-                    tir.IntImm("int64", self.out_features)
-                    if isinstance(self.out_features, int)
-                    else weight.shape[0],  # Reuse same tir.Var for symbolic shape (after Exporter)
-                    tir.IntImm("int64", self.in_features),
-                ]
-                if self.config.linear_weight_layout == "NK"
-                else [
-                    tir.IntImm("int64", self.in_features),
-                    tir.IntImm("int64", self.out_features)
-                    if isinstance(self.out_features, int)
-                    else weight.shape[1],  # Reuse same tir.Var for symbolic shape (after Exporter)
-                ],
+                out_shape=(
+                    [
+                        (
+                            tir.IntImm("int64", self.out_features)
+                            if isinstance(self.out_features, int)
+                            else weight.shape[0]
+                        ),  # Reuse same tir.Var for symbolic shape (after Exporter)
+                        tir.IntImm("int64", self.in_features),
+                    ]
+                    if self.config.linear_weight_layout == "NK"
+                    else [
+                        tir.IntImm("int64", self.in_features),
+                        (
+                            tir.IntImm("int64", self.out_features)
+                            if isinstance(self.out_features, int)
+                            else weight.shape[1]
+                        ),  # Reuse same tir.Var for symbolic shape (after Exporter)
+                    ]
+                ),
             ),
             name_hint="dequantize",
             args=[self.q_weight, self.q_scale],
@@ -490,9 +496,11 @@ class GroupQuantizeEmbedding(nn.Module):
                 scale,
                 axis=-1,
                 out_shape=[
-                    tir.IntImm("int64", self.num)
-                    if isinstance(self.num, int)
-                    else weight.shape[0],  # Reuse same tir.Var for symbolic shape (after Exporter)
+                    (
+                        tir.IntImm("int64", self.num)
+                        if isinstance(self.num, int)
+                        else weight.shape[0]
+                    ),  # Reuse same tir.Var for symbolic shape (after Exporter)
                     tir.IntImm("int64", self.dim),
                 ],
             ),

--- a/python/mlc_chat/quantization/utils.py
+++ b/python/mlc_chat/quantization/utils.py
@@ -42,6 +42,6 @@ def convert_uint_to_float(  # pylint: disable=too-many-arguments
 
 
 def is_final_fc(name: str) -> bool:
-    """ Determines whether the parameter is the last layer based on its name."""
+    """Determines whether the parameter is the last layer based on its name."""
     # TODO: use more specious condition to determine final fc  # pylint: disable=fixme
     return name in ["head", "lm_head"]

--- a/python/mlc_chat/quantization/utils.py
+++ b/python/mlc_chat/quantization/utils.py
@@ -1,4 +1,5 @@
 """Common utilities for quantization"""
+
 from typing import List, Optional
 
 from tvm import te, tir
@@ -38,3 +39,9 @@ def convert_uint_to_float(  # pylint: disable=too-many-arguments
             tir_bin_mask,
         ).astype(model_dtype),
     )
+
+
+def is_final_fc(name: str) -> bool:
+    """ Determines whether the parameter is the last layer based on its name."""
+    # TODO: use more specious condition to determine final fc  # pylint: disable=fixme
+    return name in ["head", "lm_head"]


### PR DESCRIPTION
This PR reverts the change introduced in https://github.com/mlc-ai/mlc-llm/pull/1731 where we skip quantizing `lm_head` to avoid the dynamic vocab issue.

This led to performance degradation as pointed out in https://github.com/mlc-ai/mlc-llm/issues/1723.

Instead, we fall back to `GroupQuantizeLinear` for `lm_head`, which preserves performance and avoids the dynamic vocab size issue.

Performance change on RTX 4090

Prefill: 
throughput: **950.792 --> 973.859 tok/s**
total tokens: 7 tok

Decode:
throughput: **214.372 --> 223.491 tok/s**
total tokens: 256 tok