### PR TITLE
[Mixtral] Support int64 indptr

### DIFF
--- a/python/mlc_chat/quantization/group_quantization.py
+++ b/python/mlc_chat/quantization/group_quantization.py
@@ -614,6 +614,7 @@ class GroupQuantizeMixtralExperts(nn.Module):  # pylint: disable=too-many-instan
             self.q_scale,
             indptr,
             quantize_dtype=self.quantize_dtype,
+            indptr_dtype=indptr.dtype,
             group_size=self.group_size,
         )
 


### PR DESCRIPTION
This PR fixes #1752 . When using `faster_transformer`, the out_type of `indptr` is `int64`, but `dequantize_group_gemm` expects `int32`. 

An argument for `indptr_dtype` is added to the function to fix this.

Note that when using faster_transformer, the shape of `indptr` is `(num_experts,)` instead of `(num_experts + 1,)` 