### PR TITLE
[Serving][Grammar] BNF grammar simplifier and matcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,11 @@ else ()
   target_link_libraries(mlc_llm PUBLIC -Wl,--no-as-needed ${FLASH_ATTN_LIBRARY})
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(mlc_llm PRIVATE "TVM_LOG_DEBUG")
+    target_compile_definitions(mlc_llm_objs PRIVATE "TVM_LOG_DEBUG")
+    target_compile_definitions(mlc_llm_static PRIVATE "TVM_LOG_DEBUG")
+endif()
 
 if (BUILD_CPP_TEST)
   message(STATUS "Building cpp unittests")

--- a/cpp/serve/grammar/grammar.cc
+++ b/cpp/serve/grammar/grammar.cc
@@ -5,11 +5,120 @@
 
 #include "grammar.h"
 
+#include "grammar_parser.h"
+#include "grammar_serializer.h"
+#include "grammar_simplifier.h"
+
 namespace mlc {
 namespace llm {
 namespace serve {
 
 TVM_REGISTER_OBJECT_TYPE(BNFGrammarNode);
+
+std::ostream& operator<<(std::ostream& os, const BNFGrammar& grammar) {
+  os << BNFGrammarPrinter(grammar).ToString();
+  return os;
+}
+
+BNFGrammar BNFGrammar::FromEBNFString(const String& ebnf_string, bool normalize, bool simplify) {
+  auto grammar = EBNFParser::Parse(ebnf_string);
+  if (normalize) {
+    grammar = NestedRuleUnwrapper(grammar).Apply();
+  }
+  return grammar;
+}
+
+TVM_REGISTER_GLOBAL("mlc.serve.BNFGrammarFromEBNFString")
+    .set_body_typed([](String ebnf_string, bool normalize, bool simplify) {
+      return BNFGrammar::FromEBNFString(ebnf_string, normalize, simplify);
+    });
+
+BNFGrammar BNFGrammar::FromJSON(const String& json_string) {
+  return BNFJSONParser::Parse(json_string);
+}
+
+TVM_REGISTER_GLOBAL("mlc.serve.BNFGrammarFromJSON").set_body_typed([](String json_string) {
+  return BNFGrammar::FromJSON(json_string);
+});
+
+const std::string kJSONGrammarString = R"(
+main ::= (
+    "{" ws members_or_embrace ws |
+    "[" ws elements_or_embrace ws
+)
+value ::= (
+    "{" ws members_or_embrace |
+    "[" ws elements_or_embrace |
+    "\"" characters "\"" |
+    [0-9] fraction exponent |
+    [1-9] digits fraction exponent |
+    "-" [0-9] fraction exponent |
+    "-" [1-9] digits fraction exponent |
+    "true" |
+    "false" |
+    "null"
+)
+members_or_embrace ::= (
+    "\"" characters "\"" ws ":" ws value members_rest ws "}" |
+    "}"
+)
+members ::= "\"" characters "\"" ws ":" ws value members_rest
+members_rest ::= (
+    "" |
+    "," ws "\"" characters "\"" ws ":" ws value members_rest |
+    " " ws "," ws "\"" characters "\"" ws ":" ws value members_rest |
+    "\n" ws "," ws "\"" characters "\"" ws ":" ws value members_rest |
+    "\t" ws "," ws "\"" characters "\"" ws ":" ws value members_rest
+)
+elements_or_embrace ::= (
+    "{" ws members_or_embrace elements_rest ws "]" |
+    "[" ws elements_or_embrace elements_rest ws "]" |
+    "\"" characters "\"" elements_rest ws "]" |
+    [0-9] fraction exponent elements_rest ws "]" |
+    [1-9] digits fraction exponent elements_rest ws "]" |
+    "-" [0-9] fraction exponent elements_rest ws "]" |
+    "-" [1-9] digits fraction exponent elements_rest ws "]" |
+    "true" elements_rest ws "]" |
+    "false" elements_rest ws "]" |
+    "null" elements_rest ws "]" |
+    "]"
+)
+elements ::= (
+    "{" ws members_or_embrace elements_rest |
+    "[" ws elements_or_embrace elements_rest |
+    "\"" characters "\"" elements_rest |
+    [0-9] fraction exponent elements_rest |
+    [1-9] digits fraction exponent elements_rest |
+    "-" [0-9] fraction exponent elements_rest |
+    "-" [1-9] digits fraction exponent elements_rest |
+    "true" elements_rest |
+    "false" elements_rest |
+    "null" elements_rest
+)
+elements_rest ::= (
+    "" |
+    "," ws elements |
+    " " ws "," ws elements |
+    "\n" ws "," ws elements |
+    "\t" ws "," ws elements
+)
+characters ::= "" | [^"\\] characters | "\\" escape characters
+escape ::= "\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+digits ::= [0-9] | [0-9] digits
+fraction ::= "" | "." digits
+exponent ::= "" |  "e" sign digits | "E" sign digits
+sign ::= "" | "+" | "-"
+ws ::= [ \n\t]*
+)";
+
+BNFGrammar BNFGrammar::GetGrammarOfJSON() {
+  static const BNFGrammar grammar = BNFGrammar::FromEBNFString(kJSONGrammarString, true, false);
+  return grammar;
+}
+
+TVM_REGISTER_GLOBAL("mlc.serve.BNFGrammarGetGrammarOfJSON").set_body_typed([]() {
+  return BNFGrammar::GetGrammarOfJSON();
+});
 
 }  // namespace serve
 }  // namespace llm

--- a/cpp/serve/grammar/grammar.h
+++ b/cpp/serve/grammar/grammar.h
@@ -23,32 +23,48 @@ using namespace tvm::runtime;
 /*!
  * \brief This class stores the abstract syntax tree (AST) of the Backus-Naur Form (BNF) grammar.
  * The BNF definition here is standard BNF, and the characters are represented using regex-style
- * character ranges (e.g. [a-z], [^a-z]).
+ * character classes (e.g. [a-z], [^a-z]).
  *
- * \details The BNF grammar consists of a set of rules. Each rule has a name and a definition, and
- * represents a production rule. Each rule has a rule_id for reference.
+ * \details
+ * ### Rules
+ * The BNF grammar AST consists of a set of rules. Each rule contains a name and a definition, and
+ * corresponds to a production in the grammar. The definition of a rule is a RuleExpr. Each rule
+ * has a rule_id for reference.
  *
- * The definition of a rule is a RuleExpr. Ruleexpr can be the definition of a rule or part of the
- * definition of a rule.
+ * ### RuleExprs
+ * RuleExpr is the definition of a rule or part of the definition of a rule. It can contain
+ * elements, empty string, reference to other RuleExprs, or reference to other rules. Each RuleExpr
+ * corresponds to an rule_expr_id for reference.
  *
  * For example, in the following rule: rule ::= ("a" "b") | "c"
  * ("a" "b"), "c", ("a" "b") | "c" are all RuleExprs.
  *
+ * #### Types of RuleExprs
  * Every RuleExpr is represented by a type as well as a variable-length array containing its data.
- * There are several types for RuleExpr:
- * - Character range: a range of characters (each character is a unicode codepoint),
- *   e.g. [a-z], [ac-z]
- * - Negative character range: all characters that are not in the range, e.g. [^a-z], [^ac-z]
+ * RuleExpr has several types:
+ * - Character class: a range of characters (each character is a unicode codepoint), e.g. [a-z],
+ *   [ac-z].
+ *   A single character is represented by a character class with the same lower and upper bound.
+ *   A string is represented by a sequence of character classes.
+ * - Negated character class: all characters that are not in the range, e.g. [^a-z], [^ac-z]
  * - EmptyStr: an empty string, i.e. ""
  * - Rule reference: a reference to another rule
  * - Sequence: a sequence of rule_exprs, e.g. ("a" "b"). These rule_exprs are concatenated together.
  * - Choices: a choice of rule_exprs, e.g. ("a" "b") | "c". Each rule_expr can be matched.
+ * - Character class star: special support for a repetition of a character class. e.g. [a-z]*
  *
- * For the format of the data, see BNFGrammarNode::DataKind. Each RuleExpr corresponds to an
- * rule_expr_id for reference.
+ * #### Storage of RuleExprs
+ * Each type of RuleExpr has a different data format. For the format of each type of RuleExpr, see
+ * docs in BNFGrammarNode::RuleExprType.
  *
  * We store all RuleExprs in csr_matrix style. That is, they are stored consecutively in one vector
  * (data vector) and the starting position of each RuleExpr is recorded in the indptr vector.
+ *
+ * \remark The character class star RuleExpr is for the special support for elements like [a-z]*
+ * in the grammar. We add it to make the matching more efficient, as we can avoid recursion into
+ * rules when matching a sequence of characters. It should be used like:
+ * rule1 ::= ((element1 element2 rule2 ...) | ...)
+ * rule2 ::= character_class_star_rule_expr(id_of_a_character_class_rule_expr)
  */
 class BNFGrammarNode : public Object {
  public:
@@ -56,22 +72,25 @@ class BNFGrammarNode : public Object {
   struct Rule {
     /*! \brief The name of the rule. */
     std::string name;
-    /*! \brief The RuleExpr id of the definition of the rule. */
-    int32_t rule_expr_id;
+    /*! \brief The RuleExpr id of the body of the rule. */
+    int32_t body_expr_id;
   };
 
   /*! \brief Get the number of rules. */
   size_t NumRules() const { return rules_.size(); }
   /*! \brief Get the rule with the given id. */
-  const Rule& GetRule(int32_t rule_id) const { return rules_[rule_id]; }
+  const Rule& GetRule(int32_t rule_id) const {
+    DCHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(rules_.size()))
+        << "rule_id " << rule_id << " is out of bound";
+    return rules_[rule_id];
+  }
 
-  /*! \brief The data kind of the content of rule_exprs. */
-  enum class DataKind : int32_t {
+  /*! \brief The type of the rule expr. */
+  enum class RuleExprType : int32_t {
     // data format: [lower0, upper0, lower1, upper1, ...]
-    // to represent a single character, just add the same lower and upper bound.
-    kCharacterRange,
+    kCharacterClass,
     // data format: [lower0, upper0, lower1, upper1, ...]
-    kNegCharacterRange,
+    kNegCharacterClass,
     // data format: []
     kEmptyStr,
     // data format: [rule_id]
@@ -80,37 +99,41 @@ class BNFGrammarNode : public Object {
     kSequence,
     // data format: [rule_expr_id0, rule_expr_id1, ...]
     kChoices,
+    // data format: [rule_expr_id]
+    kStarQuantifier,
   };
 
   /*! \brief The object representing a rule expr. */
   struct RuleExpr {
-    /*! \brief The data kind. */
-    DataKind kind;
+    /*! \brief The type of the rule expr. */
+    RuleExprType type;
     /*! \brief The data of the RuleExpr. A variable-length array. */
     const int32_t* data;
     /*! \brief The length of the data array. */
-    size_t data_len;
+    int32_t data_len;
 
+    const int32_t size() const { return data_len; }
     /*! \brief Get the i-th element of the data array. */
-    const int32_t& operator[](int i) const { return data[i]; }
+    const int32_t& operator[](int i) const {
+      DCHECK(i >= 0 && i < static_cast<int32_t>(data_len)) << "Index " << i << " is out of bound";
+      return data[i];
+    }
+    const int32_t* begin() const { return data; }
+    const int32_t* end() const { return data + data_len; }
   };
 
   /*! \brief Get the number of rule_exprs. */
   size_t NumRuleExprs() const { return rule_expr_indptr_.size(); }
   /*! \brief Get the rule_expr with the given id. */
   RuleExpr GetRuleExpr(int32_t rule_expr_id) const {
+    DCHECK(rule_expr_id >= 0 && rule_expr_id < static_cast<int32_t>(rule_expr_indptr_.size()))
+        << "rule_expr_id " << rule_expr_id << " is out of bound";
     int start_index = rule_expr_indptr_[rule_expr_id];
-    DataKind kind = static_cast<DataKind>(rule_expr_data_[start_index]);
-    ++start_index;
-    int end_index;
-    if (rule_expr_id == static_cast<int32_t>(rule_expr_indptr_.size()) - 1) {
-      end_index = rule_expr_data_.size();
-    } else {
-      end_index = rule_expr_indptr_[rule_expr_id + 1];
-    }
-    ICHECK_GE(end_index, start_index);
-    return {kind, rule_expr_data_.data() + start_index,
-            static_cast<size_t>(end_index - start_index)};
+    auto start_ptr = rule_expr_data_.data() + start_index;
+    auto type = static_cast<RuleExprType>(start_ptr[0]);
+    auto data_ptr = start_ptr + 2;
+    auto data_len = start_ptr[1];
+    return {type, data_ptr, data_len};
   }
 
   static constexpr const char* _type_key = "mlc.serve.BNFGrammar";
@@ -134,7 +157,41 @@ class BNFGrammarNode : public Object {
 
 class BNFGrammar : public ObjectRef {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(BNFGrammar, ObjectRef, BNFGrammarNode);
+  /*!
+   * \brief Construct a BNF grammar with a EBNF-formatted string. Will parse the string and
+   * transform it into BNF AST.
+   * \param ebnf_string The EBNF-formatted string.
+   * \param normalize Whether to normalize the grammar. Default: true. Only set to false for the
+   * purpose of testing.
+   *
+   * \note In The normalized form of a BNF grammar, every rule is in the form:
+   * `rule_name ::= ("" | (element1_1 element1_2 ...) | (element2_1 element2_2 ...) | ...)`.
+   *
+   * I.e. a list of choices, each choice is a sequence of elements. Elements can be a character
+   * class or a rule reference. And if the rule can be empty, the first choice will be an empty
+   * string.
+   * \param simplify Whether to simplify the grammar to make matching more efficient. Default: true.
+   * Not implemented yet.
+   */
+  static BNFGrammar FromEBNFString(const String& ebnf_string, bool normalize = true,
+                                   bool simplify = true);
+
+  /*!
+   * \brief Construct a BNF grammar from the dumped JSON string.
+   * \param json_string The JSON-formatted string. This string should have the same format as
+   * the result of BNFGrammarJSONSerializer::ToString.
+   */
+  static BNFGrammar FromJSON(const String& json_string);
+
+  /*！
+   * \brief Get the grammar of standard JSON format. We have built-in support for JSON.
+   */
+  static BNFGrammar GetGrammarOfJSON();
+
+  /*! \brief Print a BNF grammar. */
+  friend std::ostream& operator<<(std::ostream& os, const BNFGrammar& grammar);
+
+  TVM_DEFINE_OBJECT_REF_METHODS(BNFGrammar, ObjectRef, BNFGrammarNode);
 };
 
 }  // namespace serve

--- a/cpp/serve/grammar/grammar_builder.h
+++ b/cpp/serve/grammar/grammar_builder.h
@@ -24,7 +24,7 @@ using namespace tvm::runtime;
 class BNFGrammarBuilder {
  public:
   using Rule = BNFGrammarNode::Rule;
-  using DataKind = BNFGrammarNode::DataKind;
+  using RuleExprType = BNFGrammarNode::RuleExprType;
   using RuleExpr = BNFGrammarNode::RuleExpr;
 
   /*! \brief Default constructor. Creates a new grammar object. */
@@ -36,82 +36,91 @@ class BNFGrammarBuilder {
    * \param grammar The existing grammar.
    */
   explicit BNFGrammarBuilder(const BNFGrammar& grammar)
-      : grammar_(make_object<BNFGrammarNode>(*grammar.get())) {}
+      : grammar_(make_object<BNFGrammarNode>(*grammar.get())) {
+    // for (size_t i = 0; i < grammar_->rules_.size(); ++i) {
+    //   rule_name_to_id_[grammar_->rules_[i].name] = i;
+    // }
+  }
 
-  /*! \brief Finalize the grammar building and return the built grammar. */
-  BNFGrammar Finalize() { return BNFGrammar(grammar_); }
+  /*! \brief Get the result grammar. */
+  BNFGrammar Get() { return BNFGrammar(grammar_); }
 
   /****************** RuleExpr handling ******************/
 
-  /*! \brief Insert a rule_expr and return the rule_expr id. */
-  int32_t InsertRuleExpr(const RuleExpr& rule_expr) {
+  /*! \brief Add a rule_expr and return the rule_expr id. */
+  int32_t AddRuleExpr(const RuleExpr& rule_expr) {
     grammar_->rule_expr_indptr_.push_back(grammar_->rule_expr_data_.size());
-    grammar_->rule_expr_data_.push_back(static_cast<int32_t>(rule_expr.kind));
+    grammar_->rule_expr_data_.push_back(static_cast<int32_t>(rule_expr.type));
+    grammar_->rule_expr_data_.push_back(rule_expr.data_len);
     grammar_->rule_expr_data_.insert(grammar_->rule_expr_data_.end(), rule_expr.data,
                                      rule_expr.data + rule_expr.data_len);
     return static_cast<int32_t>(grammar_->rule_expr_indptr_.size()) - 1;
   }
 
   /*!
-   * \brief One element of a character range, containing a lower and a upper bound. Both bounds are
+   * \brief One element of a character class, containing a lower and a upper bound. Both bounds are
    * inclusive.
    */
-  struct CharacterRangeElement {
+  struct CharacterClassElement {
     int32_t lower;
     int32_t upper;
   };
 
-  /*! \brief Insert a RuleExpr for character range.*/
-  int32_t InsertCharacterRange(const std::vector<CharacterRangeElement>& elements) {
+  /*!
+   * \brief Add a RuleExpr for character class.
+   * \param elements A vector of CharacterClassElement, each containing a lower and a upper bound.
+   * \param is_neg_range Whether the character class is negated.
+   */
+  int32_t AddCharacterClass(const std::vector<CharacterClassElement>& elements,
+                            bool is_neg_range = false) {
     std::vector<int32_t> data;
     for (const auto& range : elements) {
       data.push_back(range.lower);
       data.push_back(range.upper);
     }
-    return InsertRuleExpr({DataKind::kCharacterRange, data.data(), data.size()});
+    auto type = is_neg_range ? RuleExprType::kNegCharacterClass : RuleExprType::kCharacterClass;
+    return AddRuleExpr({type, data.data(), static_cast<int32_t>(data.size())});
   }
 
-  /*! \brief Insert a RuleExpr for character range negation.*/
-  int32_t InsertNegCharacterRange(const std::vector<CharacterRangeElement>& elements) {
-    std::vector<int32_t> data;
-    for (const auto& range : elements) {
-      data.push_back(range.lower);
-      data.push_back(range.upper);
-    }
-    return InsertRuleExpr({DataKind::kNegCharacterRange, data.data(), data.size()});
-  }
+  /*! \brief Add a RuleExpr for empty string.*/
+  int32_t AddEmptyStr() { return AddRuleExpr({RuleExprType::kEmptyStr, nullptr, 0}); }
 
-  /*! \brief Insert a RuleExpr for empty string.*/
-  int32_t InsertEmptyStr() { return InsertRuleExpr({DataKind::kEmptyStr, nullptr, 0}); }
-
-  /*! \brief Insert a RuleExpr for rule reference.*/
-  int32_t InsertRuleRef(int32_t rule_id) {
+  /*! \brief Add a RuleExpr for rule reference.*/
+  int32_t AddRuleRef(int32_t rule_id) {
     std::vector<int32_t> data;
     data.push_back(rule_id);
-    return InsertRuleExpr({DataKind::kRuleRef, data.data(), data.size()});
+    return AddRuleExpr({RuleExprType::kRuleRef, data.data(), static_cast<int32_t>(data.size())});
   }
 
-  /*! \brief Insert a RuleExpr for RuleExpr sequence.*/
-  int32_t InsertSequence(const std::vector<int32_t>& elements) {
+  /*! \brief Add a RuleExpr for RuleExpr sequence.*/
+  int32_t AddSequence(const std::vector<int32_t>& elements) {
     std::vector<int32_t> data;
     data.insert(data.end(), elements.begin(), elements.end());
-    return InsertRuleExpr({DataKind::kSequence, data.data(), data.size()});
+    return AddRuleExpr({RuleExprType::kSequence, data.data(), static_cast<int32_t>(data.size())});
   }
 
-  /*! \brief Insert a RuleExpr for RuleExpr choices.*/
-  int32_t InsertChoices(const std::vector<int32_t>& choices) {
+  /*! \brief Add a RuleExpr for RuleExpr choices.*/
+  int32_t AddChoices(const std::vector<int32_t>& choices) {
     std::vector<int32_t> data;
     data.insert(data.end(), choices.begin(), choices.end());
-    return InsertRuleExpr({DataKind::kChoices, data.data(), data.size()});
+    return AddRuleExpr({RuleExprType::kChoices, data.data(), static_cast<int32_t>(data.size())});
   }
 
+  int32_t AddStarQuantifier(int32_t element) {
+    std::vector<int32_t> data;
+    data.push_back(element);
+    return AddRuleExpr(
+        {RuleExprType::kStarQuantifier, data.data(), static_cast<int32_t>(data.size())});
+  }
+
+  size_t NumRuleExprs() const { return grammar_->NumRuleExprs(); }
   /*! \brief Get the rule_expr with the given id. */
   RuleExpr GetRuleExpr(int32_t rule_expr_id) { return grammar_->GetRuleExpr(rule_expr_id); }
 
   /****************** Rule handling ******************/
 
-  /*! \brief Insert a rule and return the rule id. */
-  int32_t InsertRule(const Rule& rule) {
+  /*! \brief Add a rule and return the rule id. */
+  int32_t AddRule(const Rule& rule) {
     int32_t id = grammar_->rules_.size();
     auto rules = grammar_->rules_;
     grammar_->rules_.push_back(rule);
@@ -120,33 +129,45 @@ class BNFGrammarBuilder {
     return id;
   }
 
+  int32_t AddRule(const std::string& name, int32_t body_expr_id) {
+    return AddRule({name, body_expr_id});
+  }
+
+  int32_t AddRuleWithHint(const std::string& name_hint, int32_t body_expr_id) {
+    return AddRule({GetNewRuleName(name_hint), body_expr_id});
+  }
+
+  size_t NumRules() const { return grammar_->NumRules(); }
+
   /*! \brief Get the rule with the given id. */
   const Rule& GetRule(int32_t rule_id) const { return grammar_->rules_[rule_id]; }
 
   /*!
-   * \brief Insert an rule without body, and return the rule id. The rule body should be set later
+   * \brief Add an rule without body, and return the rule id. The rule body should be set later
    * with BNFGrammarBuilder::UpdateRuleBody. This method is useful for cases where the rule id is
    * required to build the rule body.
    * \sa BNFGrammarBuilder::UpdateRuleBody
    */
-  int32_t InsertEmptyRule(const std::string& name) { return InsertRule({name, -1}); }
+  int32_t AddEmptyRule(const std::string& name) { return AddRule({name, -1}); }
 
   /*!
    * \brief Update the rule body of the given rule, specified by rule id. Can be used to set the
-   * rule body of a rule inserted by BNFGrammarBuilder::InsertEmptyRule.
+   * rule body of a rule inserted by BNFGrammarBuilder::AddEmptyRule.
    */
-  void UpdateRuleBody(int32_t rule_id, int32_t rule_expr_id) {
-    grammar_->rules_[rule_id].rule_expr_id = rule_expr_id;
+  void UpdateRuleBody(int32_t rule_id, int32_t body_expr_id) {
+    CHECK(rule_id < static_cast<int32_t>(grammar_->rules_.size()))
+        << "Rule id " << rule_id << " is out of range.";
+    grammar_->rules_[rule_id].body_expr_id = body_expr_id;
   }
 
   /*!
    * \brief Update the rule body of the given rule, specified by rule name. Can be used to set the
-   * rule body of a rule inserted by BNFGrammarBuilder::InsertEmptyRule.
+   * rule body of a rule inserted by BNFGrammarBuilder::AddEmptyRule.
    */
-  void UpdateRuleBody(std::string rule_name, int32_t rule_expr_id) {
+  void UpdateRuleBody(std::string rule_name, int32_t body_expr_id) {
     int32_t rule_id = GetRuleId(rule_name);
     CHECK(rule_id != -1) << "Rule " << rule_name << " is not found.";
-    UpdateRuleBody(rule_id, rule_expr_id);
+    UpdateRuleBody(rule_id, body_expr_id);
   }
 
   /*!

--- a/cpp/serve/grammar/grammar_parser.h
+++ b/cpp/serve/grammar/grammar_parser.h
@@ -20,7 +20,7 @@ using namespace tvm::runtime;
 
 /*!
  * \brief This class parses a BNF/EBNF grammar string into an BNF abstract syntax tree (AST).
- * \details This function accepts the EBNF notation from the W3C XML Specification
+ * \details This function accepts the EBNF notation defined in the W3C XML Specification
  * (https://www.w3.org/TR/xml/#sec-notation), which is a popular standard, with the following
  * changes:
  * - Using # as comment mark instead of /**\/

--- a/cpp/serve/grammar/grammar_serializer.h
+++ b/cpp/serve/grammar/grammar_serializer.h
@@ -38,7 +38,8 @@ class BNFGrammarSerializer {
  */
 class BNFGrammarPrinter : public BNFGrammarSerializer {
  private:
-  using DataKind = BNFGrammarNode::DataKind;
+  using Rule = BNFGrammarNode::Rule;
+  using RuleExprType = BNFGrammarNode::RuleExprType;
   using RuleExpr = BNFGrammarNode::RuleExpr;
 
  public:
@@ -51,24 +52,28 @@ class BNFGrammarPrinter : public BNFGrammarSerializer {
   /*! \brief Print the complete grammar. */
   String ToString() final;
 
-  /*! \brief Print a rule_expr corresponding to the given id. */
+  /*! \brief Print a rule. */
+  std::string PrintRule(const Rule& rule);
+  /*! \brief Print a rule corresponding to the given id. */
+  std::string PrintRule(int32_t rule_id);
+  /*! \brief Print a RuleExpr. */
+  std::string PrintRuleExpr(const RuleExpr& rule_expr);
+  /*! \brief Print a RuleExpr corresponding to the given id. */
   std::string PrintRuleExpr(int32_t rule_expr_id);
 
-  /*! \brief Print rule_exprs for character range. */
-  std::string PrintCharacterRange(const RuleExpr& rule_expr);
-  /*! \brief Print rule_exprs for empty string. */
-  std::string PrintEmptyStr(const RuleExpr& rule_expr);
-  /*! \brief Print rule_exprs for rule reference. */
-  std::string PrintRuleRef(const RuleExpr& rule_expr);
-  /*! \brief Print rule_exprs for rule_expr sequence. */
-  std::string PrintSequence(const RuleExpr& rule_expr);
-  /*! \brief Print rule_exprs for rule_expr choices. */
-  std::string PrintChoices(const RuleExpr& rule_expr);
-
  private:
-  // Only print parentheses when necessary (i.e. when this rule_expr contains multiple elements
-  // and is nested within another multi-element rule_expr)
-  bool require_parentheses_ = false;
+  /*! \brief Print a RuleExpr for character class. */
+  std::string PrintCharacterClass(const RuleExpr& rule_expr);
+  /*! \brief Print a RuleExpr for empty string. */
+  std::string PrintEmptyStr(const RuleExpr& rule_expr);
+  /*! \brief Print a RuleExpr for rule reference. */
+  std::string PrintRuleRef(const RuleExpr& rule_expr);
+  /*! \brief Print a RuleExpr for rule_expr sequence. */
+  std::string PrintSequence(const RuleExpr& rule_expr);
+  /*! \brief Print a RuleExpr for rule_expr choices. */
+  std::string PrintChoices(const RuleExpr& rule_expr);
+  /*! \brief Print a RuleExpr for star quantifier. */
+  std::string PrintStarQuantifier(const RuleExpr& rule_expr);
 };
 
 /*!

--- a/cpp/serve/grammar/grammar_simplifier.cc
+++ b/cpp/serve/grammar/grammar_simplifier.cc
@@ -1,0 +1,219 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/grammar/grammar_simplifier.cc
+ */
+
+#include "grammar_simplifier.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*!
+ * \brief Eliminates single-element sequence or choice nodes in the grammar.
+ * \example The sequence `(a)` or the choice `(a)` will be replaced by `a` in a rule.
+ * \example The rule `A ::= ((b) (((d))))` will be replaced by `A ::= (b d)`.
+ */
+class SingleElementSequenceOrChoiceEliminator : public BNFGrammarMutator<int32_t, BNFGrammar> {
+ public:
+  using BNFGrammarMutator::Apply;
+  using BNFGrammarMutator::BNFGrammarMutator;
+
+ private:
+  int32_t VisitSequence(const RuleExpr& rule_expr) {
+    std::vector<int32_t> sequence_ids;
+    for (int32_t i : rule_expr) {
+      sequence_ids.push_back(VisitExpr(grammar_->GetRuleExpr(i)));
+    }
+    if (sequence_ids.size() == 1) {
+      return sequence_ids[0];
+    } else {
+      return builder_.AddSequence(sequence_ids);
+    }
+  }
+
+  int32_t VisitChoices(const RuleExpr& rule_expr) {
+    std::vector<int32_t> choice_ids;
+    for (int32_t i : rule_expr) {
+      choice_ids.push_back(VisitExpr(grammar_->GetRuleExpr(i)));
+    }
+    if (choice_ids.size() == 1) {
+      return choice_ids[0];
+    } else {
+      return builder_.AddChoices(choice_ids);
+    }
+  }
+};
+
+class NestedRuleUnwrapperImpl : public BNFGrammarMutator<int32_t, BNFGrammar> {
+ public:
+  using BNFGrammarMutator::BNFGrammarMutator;
+
+  BNFGrammar Apply() final {
+    grammar_ = SingleElementSequenceOrChoiceEliminator(grammar_).Apply();
+    for (int i = 0; i < static_cast<int>(grammar_->NumRules()); ++i) {
+      builder_.AddEmptyRule(grammar_->GetRule(i).name);
+    }
+    for (int i = 0; i < static_cast<int>(grammar_->NumRules()); ++i) {
+      auto rule = grammar_->GetRule(i);
+      auto rule_expr = grammar_->GetRuleExpr(rule.body_expr_id);
+      cur_rule_name_ = rule.name;
+      auto new_body_expr_id = VisitRuleBody(rule_expr);
+      builder_.UpdateRuleBody(i, new_body_expr_id);
+    }
+    return builder_.Get();
+  }
+
+ private:
+  /*! \brief Visit a RuleExpr as the rule body. */
+  int32_t VisitRuleBody(const RuleExpr& rule_expr) {
+    switch (rule_expr.type) {
+      case RuleExprType::kSequence:
+        return builder_.AddChoices({builder_.AddSequence(VisitSequence_(rule_expr))});
+      case RuleExprType::kChoices:
+        return builder_.AddChoices(VisitChoices_(rule_expr));
+      case RuleExprType::kEmptyStr:
+        return builder_.AddChoices({builder_.AddEmptyStr()});
+      case RuleExprType::kCharacterClass:
+      case RuleExprType::kNegCharacterClass:
+      case RuleExprType::kRuleRef:
+        return builder_.AddChoices({builder_.AddSequence({builder_.AddRuleExpr(rule_expr)})});
+      case RuleExprType::kStarQuantifier:
+        return builder_.AddStarQuantifier(VisitExpr(grammar_->GetRuleExpr(rule_expr[0])));
+      default:
+        LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(rule_expr.type);
+    }
+  }
+
+  /*!
+   * \brief Visit a RuleExpr containing choices.
+   * \returns A list of new choice RuleExpr ids.
+   */
+  std::vector<int32_t> VisitChoices_(const RuleExpr& rule_expr) {
+    std::vector<int32_t> new_choice_ids;
+    bool found_empty = false;
+    for (auto i : rule_expr) {
+      auto choice_expr = grammar_->GetRuleExpr(i);
+      switch (choice_expr.type) {
+        case RuleExprType::kSequence:
+          VisitSequenceInChoices(choice_expr, &new_choice_ids, &found_empty);
+          break;
+        case RuleExprType::kChoices:
+          VisitChoicesInChoices(choice_expr, &new_choice_ids, &found_empty);
+          break;
+        case RuleExprType::kEmptyStr:
+          found_empty = true;
+          break;
+        case RuleExprType::kCharacterClass:
+        case RuleExprType::kNegCharacterClass:
+        case RuleExprType::kRuleRef:
+          VisitElementInChoices(choice_expr, &new_choice_ids);
+          break;
+        default:
+          LOG(FATAL) << "Unexpected choice type: " << static_cast<int>(choice_expr.type);
+      }
+    }
+    if (found_empty) {
+      new_choice_ids.insert(new_choice_ids.begin(), builder_.AddEmptyStr());
+    }
+    ICHECK_GE(new_choice_ids.size(), 1);
+    return new_choice_ids;
+  }
+
+  /*! \brief Visit a sequence RuleExpr that is one of a list of choices. */
+  void VisitSequenceInChoices(const RuleExpr& rule_expr, std::vector<int32_t>* new_choice_ids,
+                              bool* found_empty) {
+    auto sub_sequence_ids = VisitSequence_(rule_expr);
+    if (sub_sequence_ids.size() == 0) {
+      *found_empty = true;
+    } else {
+      new_choice_ids->push_back(builder_.AddSequence(sub_sequence_ids));
+    }
+  }
+
+  /*! \brief Visit a choice RuleExpr that is one of a list of choices. */
+  void VisitChoicesInChoices(const RuleExpr& rule_expr, std::vector<int32_t>* new_choice_ids,
+                             bool* found_empty) {
+    auto sub_choice_ids = VisitChoices_(rule_expr);
+    bool contains_empty = builder_.GetRuleExpr(sub_choice_ids[0]).type == RuleExprType::kEmptyStr;
+    if (contains_empty) {
+      *found_empty = true;
+      new_choice_ids->insert(new_choice_ids->end(), sub_choice_ids.begin() + 1,
+                             sub_choice_ids.end());
+    } else {
+      new_choice_ids->insert(new_choice_ids->end(), sub_choice_ids.begin(), sub_choice_ids.end());
+    }
+  }
+
+  /*! \brief Visit an atom element RuleExpr that is one of a list of choices. */
+  void VisitElementInChoices(const RuleExpr& rule_expr, std::vector<int32_t>* new_choice_ids) {
+    auto sub_expr_id = builder_.AddRuleExpr(rule_expr);
+    new_choice_ids->push_back(builder_.AddSequence({sub_expr_id}));
+  }
+
+  /*!
+   * \brief Visit a RuleExpr containing a sequence.
+   * \returns A list of new sequence RuleExpr ids.
+   */
+  std::vector<int32_t> VisitSequence_(const RuleExpr& rule_expr) {
+    std::vector<int32_t> new_sequence_ids;
+    for (auto i : rule_expr) {
+      auto seq_expr = grammar_->GetRuleExpr(i);
+      switch (seq_expr.type) {
+        case RuleExprType::kSequence:
+          VisitSequenceInSequence(seq_expr, &new_sequence_ids);
+          break;
+        case RuleExprType::kChoices:
+          VisitChoiceInSequence(seq_expr, &new_sequence_ids);
+          break;
+        case RuleExprType::kEmptyStr:
+          break;
+        case RuleExprType::kCharacterClass:
+        case RuleExprType::kNegCharacterClass:
+        case RuleExprType::kRuleRef:
+          VisitElementInSequence(seq_expr, &new_sequence_ids);
+          break;
+        default:
+          LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(seq_expr.type);
+      }
+    }
+    return new_sequence_ids;
+  }
+
+  /*! \brief Visit a sequence RuleExpr that is one element in another sequence. */
+  void VisitSequenceInSequence(const RuleExpr& rule_expr, std::vector<int32_t>* new_sequence_ids) {
+    auto sub_sequence_ids = VisitSequence_(rule_expr);
+    new_sequence_ids->insert(new_sequence_ids->end(), sub_sequence_ids.begin(),
+                             sub_sequence_ids.end());
+  }
+
+  /*! \brief Visit a choice RuleExpr that is one element in a sequence. */
+  void VisitChoiceInSequence(const RuleExpr& rule_expr, std::vector<int32_t>* new_sequence_ids) {
+    auto sub_choice_ids = VisitChoices_(rule_expr);
+    if (sub_choice_ids.size() == 1) {
+      auto choice_element_expr = builder_.GetRuleExpr(sub_choice_ids[0]);
+      if (choice_element_expr.type != RuleExprType::kEmptyStr) {
+        new_sequence_ids->insert(new_sequence_ids->end(), choice_element_expr.begin(),
+                                 choice_element_expr.end());
+      }
+    } else {
+      auto new_choice_id = builder_.AddChoices(sub_choice_ids);
+      auto new_choice_rule_id = builder_.AddRuleWithHint(cur_rule_name_ + "_choice", new_choice_id);
+      new_sequence_ids->push_back(builder_.AddRuleRef(new_choice_rule_id));
+    }
+  }
+
+  /*! \brief Visit an atom element RuleExpr that is in a sequence. */
+  void VisitElementInSequence(const RuleExpr& rule_expr, std::vector<int32_t>* new_sequence_ids) {
+    new_sequence_ids->push_back(builder_.AddRuleExpr(rule_expr));
+  }
+
+  /*! \brief The name of the current rule being visited. */
+  std::string cur_rule_name_;
+};
+
+BNFGrammar NestedRuleUnwrapper::Apply() { return NestedRuleUnwrapperImpl(grammar_).Apply(); }
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/grammar/grammar_simplifier.h
+++ b/cpp/serve/grammar/grammar_simplifier.h
@@ -1,0 +1,184 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/grammar/grammar_serializer.h
+ * \brief The header for printing the AST of a BNF grammar.
+ */
+
+#ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_SIMPLIFIER_H_
+#define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_SIMPLIFIER_H_
+
+#include <queue>
+#include <string>
+
+#include "grammar.h"
+#include "grammar_builder.h"
+#include "grammar_serializer.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*!
+ * \brief Base class for visitors and mutators of the BNF grammar.
+ * \tparam T The type of the return value of visitor functions. Typical values:
+ * - int32_t: the id of the new rule_expr
+ * - void: no return value
+ * \tparam ReturnType The type of the return value of the transform function Apply(). Typical values
+ * are void (for visitor) and BNFGrammar (for mutator).
+ */
+template <typename T = int32_t, typename ReturnType = BNFGrammar>
+class BNFGrammarMutator {
+ public:
+  /*!
+   * \brief Constructor.
+   * \param grammar The grammar to visit or mutate.
+   */
+  explicit BNFGrammarMutator(const BNFGrammar& grammar) : grammar_(grammar) {}
+
+  /*!
+   * \brief Apply the transformation to the grammar, or visit the grammar.
+   * \return The transformed grammar, or the visiting result, or void.
+   * \note Should be called only once after the mutator is constructed.
+   */
+  virtual ReturnType Apply() {
+    if constexpr (std::is_same<T, int32_t>::value && std::is_same<ReturnType, BNFGrammar>::value) {
+      for (int i = 0; i < static_cast<int>(grammar_->NumRules()); ++i) {
+        auto rule = grammar_->GetRule(i);
+        auto rule_expr = grammar_->GetRuleExpr(rule.body_expr_id);
+        auto new_body_expr_id = VisitExpr(rule_expr);
+        builder_.AddRule(rule.name, new_body_expr_id);
+      }
+      return builder_.Get();
+    } else if constexpr (!std::is_same<ReturnType, void>::value) {
+      return ReturnType();
+    }
+  }
+
+ protected:
+  using Rule = BNFGrammarNode::Rule;
+  using RuleExpr = BNFGrammarNode::RuleExpr;
+  using RuleExprType = BNFGrammarNode::RuleExprType;
+
+  /*! \brief Visit a RuleExpr. Dispatch to the corresponding Visit function. */
+  virtual T VisitExpr(const RuleExpr& rule_expr) {
+    switch (rule_expr.type) {
+      case RuleExprType::kSequence:
+        return VisitSequence(rule_expr);
+      case RuleExprType::kChoices:
+        return VisitChoices(rule_expr);
+      case RuleExprType::kEmptyStr:
+        return VisitEmptyStr(rule_expr);
+      case RuleExprType::kCharacterClass:
+      case RuleExprType::kNegCharacterClass:
+        return VisitCharacterClass(rule_expr);
+      case RuleExprType::kRuleRef:
+        return VisitRuleRef(rule_expr);
+      case RuleExprType::kStarQuantifier:
+        return VisitStarQuantifier(rule_expr);
+      default:
+        LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(rule_expr.type);
+    }
+  }
+
+  /*! \brief Visit a sequence RuleExpr. */
+  virtual T VisitSequence(const RuleExpr& rule_expr) {
+    if constexpr (std::is_same<T, void>::value) {
+      for (auto i : rule_expr) {
+        VisitExpr(grammar_->GetRuleExpr(i));
+      }
+    } else if constexpr (std::is_same<T, int32_t>::value) {
+      std::vector<T> sequence_ids;
+      for (int32_t i : rule_expr) {
+        sequence_ids.push_back(VisitExpr(grammar_->GetRuleExpr(i)));
+      }
+      return builder_.AddSequence(sequence_ids);
+    } else {
+      return T();
+    }
+  }
+
+  /*! \brief Visit a choices RuleExpr. */
+  virtual T VisitChoices(const RuleExpr& rule_expr) {
+    if constexpr (std::is_same<T, void>::value) {
+      for (auto i : rule_expr) {
+        VisitExpr(grammar_->GetRuleExpr(i));
+      }
+    } else if constexpr (std::is_same<T, int32_t>::value) {
+      std::vector<int32_t> choice_ids;
+      for (int32_t i : rule_expr) {
+        choice_ids.push_back(VisitExpr(grammar_->GetRuleExpr(i)));
+      }
+      return builder_.AddChoices(choice_ids);
+    } else {
+      return T();
+    }
+  }
+
+  /*! \brief Visit an element RuleExpr, including empty string, character class, and rule ref. */
+  virtual T VisitElement(const RuleExpr& rule_expr) {
+    if constexpr (std::is_same<T, void>::value) {
+      return;
+    } else if constexpr (std::is_same<T, int32_t>::value) {
+      return builder_.AddRuleExpr(rule_expr);
+    } else {
+      return T();
+    }
+  }
+
+  /*! \brief Visit an empty string RuleExpr. */
+  virtual T VisitEmptyStr(const RuleExpr& rule_expr) { return VisitElement(rule_expr); }
+
+  /*! \brief Visit a character class RuleExpr. */
+  virtual T VisitCharacterClass(const RuleExpr& rule_expr) { return VisitElement(rule_expr); }
+
+  /*! \brief Visit a rule reference RuleExpr. */
+  virtual T VisitRuleRef(const RuleExpr& rule_expr) { return VisitElement(rule_expr); }
+
+  /*! \brief Visit a star quantifier RuleExpr. */
+  virtual T VisitStarQuantifier(const RuleExpr& rule_expr) {
+    if constexpr (std::is_same<T, void>::value) {
+      VisitExpr(grammar_->GetRuleExpr(rule_expr[0]));
+    } else if constexpr (std::is_same<T, int32_t>::value) {
+      return builder_.AddStarQuantifier(VisitExpr(grammar_->GetRuleExpr(rule_expr[0])));
+    } else {
+      return T();
+    }
+  }
+
+  /*! \brief The grammar to visit or mutate. */
+  BNFGrammar grammar_;
+  /*!
+   * \brief The builder to build the new grammar. It is empty when the mutator is constructed, and
+   * can be used to build a new grammar in subclasses.
+   */
+  BNFGrammarBuilder builder_;
+};
+
+/*!
+ * \brief Unwrap the rules containing nested expressions. After unwrapping, each rule will be in
+ * the form: `rule_name ::= ("" | (element1_1 element1_2 ...) | (element2_1 element2_2 ...) | ...)`.
+ *
+ * I.e. a list of choices, each choice is a sequence of elements. Elements can be a character class
+ * or a rule reference. And if the rule can be empty, the first choice will be an empty string.
+ *
+ * \example The rule `A ::= ((a) (((b)) (c)) "")` will be replaced by `A ::= ((a b c))`. One choice
+ * containing a sequence of three elements. The empty string is removed.
+ * \example The rule `A ::= (a | (b | (c | "")))` will be replaced by
+ * `A ::= ("" | (a) | (b) | (c))`. The first choice is an empty string, and each of the other three
+ * choices is a sequence containing a single element.
+ * \example The rule `A ::= (a | (b (c | d)))` will be replaced by
+ * `A ::= ((a) | (b B)), B ::= ((c) | (d))`. A new rule B is created to represent the nested
+ * choices.
+ */
+class NestedRuleUnwrapper : public BNFGrammarMutator<int32_t, BNFGrammar> {
+ public:
+  using BNFGrammarMutator::BNFGrammarMutator;
+
+  BNFGrammar Apply() final;
+};
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_GRAMMAR_GRAMMAR_SIMPLIFIER_H_

--- a/cpp/serve/grammar/grammar_simplifier.h
+++ b/cpp/serve/grammar/grammar_simplifier.h
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2023 by Contributors
- * \file serve/grammar/grammar_serializer.h
- * \brief The header for printing the AST of a BNF grammar.
+ * \file serve/grammar/grammar_simplifier.h
+ * \brief The header for the simplification of the BNF AST.
  */
 
 #ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_SIMPLIFIER_H_

--- a/cpp/serve/grammar/grammar_state_matcher.cc
+++ b/cpp/serve/grammar/grammar_state_matcher.cc
@@ -1,0 +1,520 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/grammar/grammar_state_matcher.cc
+ */
+// #ifndef TVM_LOG_DEBUG
+// #define TVM_LOG_DEBUG 1
+// #endif
+#include "grammar_state_matcher.h"
+
+#include <chrono>
+#include <queue>
+
+#include "../../tokenizers.h"
+#include "grammar.h"
+#include "grammar_serializer.h"
+#include "grammar_state_matcher_base.h"
+#include "grammar_state_matcher_preproc.h"
+#include "grammar_state_matcher_state.h"
+#include "support.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*
+ * Note on the matching algorithm
+ *
+ * Given a context-free grammar, we match the characters in a string one by one.
+ *
+ * We adopt a non-deterministic pushdown automata (NPDA) in matching. To be specific, we maintain
+ * several stacks, each of which represents a possible path in the NPDA, and update the stacks
+ * during matching.
+ *
+ * ## Stack Structure (see grammar_state_matcher_state.h)
+ * The element of every stack is a RulePosition object, referring a position in the grammar. If a
+ * RulePosition is a RuleRef element (referring to another rule), the next element of the stack will
+ * be a position in this rule. If a RulePosition is a CharacterClass element, it will be the last
+ * in the stack, meaning *the next* character to match.
+ *
+ * ## Matching Process (see grammar_state_matcher_base.h)
+ * When accepting a new character and it is accepted by a stack, the last element of the stack will
+ * be advanced to the next position in the grammar. If it gets to the end of the rule, several
+ * elements at the end may be popped out, and the last element of the stack will be advanced.
+ *
+ * One stack may split since there may be multiple possible next positions. In this case, similar
+ * stacks with different top elements will be added. When ome stack cannot accept the new character,
+ * it will be removed from the stacks.
+ *
+ * ## Storage of Stacks (see grammar_state_matcher_state.h)
+ * Note these stacks form a tree structure as when splitting, the new stacks share the same prefix.
+ * We store all RulePositions as a tree, where every path from tree root to a node represents a
+ * stack. To represent stack tops, we attach additional pointers pointing the stack top nodes.
+ * Also, We maintain a history of the stack top pointers, so we can rollback to the previous state.
+ *
+ * All tree nodes are maintained by a buffer, and utilize reference counting to recycle. If a node
+ * is neither pointed by a stack top pointer, not pointed by some child nodes, it will be freed.
+ *
+ * ## Example
+ * ### Grammar
+ * main ::= [a] R
+ * R ::= [b] S [c] | [b] [c] T
+ * S ::= "" | [c] [d]
+ * T ::= [e]
+ *
+ * ### Previous step
+ * Previous accepted string: ab
+ * Previous stack tree:
+ * A------
+ * |  \   \
+ * B   D<  E<
+ * |
+ * C<
+ *
+ * A: (rule main, choice 0, element 1)
+ * B: (rule R, choice 0, element 1)
+ * C: (rule S, choice 1, element 0)
+ * D: (rule R, choice 0, element 2)
+ * E: (rule R, choice 1, element 1)
+ * < means the stack top pointers in the previous step.
+ * The stacks in the previous step is: (A, B, C), (A, D), (A, E)
+ *
+ * ### Current step
+ * Current accepted string: abc
+ * Current stack tree:
+ * A-----------------      G<<
+ * |     \     \     \
+ * B---   D<    E<    H
+ * |   \              |
+ * C<   F<<           I<<
+ *
+ * F: (rule S, choice 1, element 1)
+ * G: (rule main, choice 0, element 2) (means the matching process has finished, and will be deleted
+ * when next char comes)
+ * H: (rule R, choice 1, element 2)
+ * I: (rule T, choice 0, element 0)
+ * << means the stack top pointers in the current step.
+ * The stacks in the current step is: (A, B, F), (A, H, I), (G,)
+ *
+ * ## Preprocess (see grammar_state_matcher_preproc.h)
+ * We will store all information about tokens that needed in matching in a GrammarStateInitContext
+ * object. Tokens are sorted by codepoint, allowing us to reuse the repeated prefixes between
+ * different tokens.
+ *
+ * For a given position in a rule, if we only consider this rule and its sub-rules during matching,
+ * without considering its parent rules (in actual matching, we also need to consider its parent
+ * rules), we can already determine that some tokens are acceptable while others are definitely
+ * rejected. Therefore, for a position in a rule, we can divide the token set into three categories:
+ * - accepted_indices: If a token is accepted by this rule
+ * - rejected_indices: If a token is rejected by this rule
+ * - uncertain_indices: Whether it can be accepted depends on the information from the parent
+ * level during actual matching. To be specific, If this token has a prefix that has not been
+ * rejected and has reached the end of this rule, then it is possible for it to be further accepted
+ * by the parent rule.
+ *
+ * During actual matching, we will directly accept or reject the tokens in accepted_indices and
+ * rejected_indices, and only consider the tokens in uncertain_indices. That speeds up the matching
+ * process.
+ */
+
+using namespace tvm::runtime;
+
+TVM_REGISTER_OBJECT_TYPE(GrammarStateMatcherNode);
+
+/* \brief The concrete implementation of GrammarStateMatcherNode. */
+class GrammarStateMatcherNodeImpl : public GrammarStateMatcherNode, public GrammarStateMatcherBase {
+ private:
+  using RuleExpr = BNFGrammarNode::RuleExpr;
+  using RuleExprType = BNFGrammarNode::RuleExprType;
+
+ public:
+  GrammarStateMatcherNodeImpl(std::shared_ptr<GrammarStateInitContext> init_ctx,
+                              int max_rollback_steps = 0)
+      : GrammarStateMatcherBase(init_ctx->grammar),
+        init_ctx_(init_ctx),
+        max_rollback_steps_(max_rollback_steps) {}
+
+  bool AcceptToken(int32_t token_id) final;
+
+  void FindNextTokenBitmask(DLTensor* next_token_bitmask) final;
+
+  void Rollback(int num_tokens) final;
+
+  int MaxRollbackSteps() final { return max_rollback_steps_; }
+
+  void ResetState() final {
+    stack_tops_history_.Reset();
+    token_size_history_.clear();
+    InitStackState();
+  }
+
+ private:
+  /*!
+   * \brief If is_uncertain_saved is true, find the next token in uncertain_indices. Otherwise,
+   * find the next token that is set to true in uncertain_tokens_bitset.
+   * \param iterator_uncertain The helper iterator to iterate over uncertain_indices or
+   * uncertain_tokens_bitset.
+   * \returns The index of the next token, or -1 if no more token.
+   */
+  int GetNextUncertainToken(bool is_uncertain_saved, int* iterator_uncertain,
+                            const std::vector<int>& uncertain_indices,
+                            const std::vector<bool>& uncertain_tokens_bitset);
+
+  /*! \brief Set the acceptable next token in next_token_bitmask. */
+  void SetTokenBitmask(DLTensor* next_token_bitmask, std::vector<int32_t>& accepted_indices,
+                       std::vector<int32_t>& rejected_indices, bool can_reach_end);
+
+  friend IntTuple FindNextRejectedTokens(GrammarStateMatcher matcher);
+
+  std::shared_ptr<GrammarStateInitContext> init_ctx_;
+  int max_rollback_steps_;
+  std::deque<int> token_size_history_;
+
+  // Temporary data for FindNextTokenBitmask. They are stored here to avoid repeated allocation.
+  std::vector<int32_t> tmp_accepted_indices_;
+  std::vector<int32_t> tmp_rejected_indices_;
+  std::vector<int32_t> tmp_accepted_indices_delta_;
+  std::vector<int32_t> tmp_rejected_indices_delta_;
+  std::vector<bool> tmp_uncertain_tokens_bitset_;
+};
+
+bool GrammarStateMatcherNodeImpl::AcceptToken(int32_t token_id) {
+  CHECK(init_ctx_->codepoint_tokens_lookup.count(token_id) > 0);
+  const auto& token = init_ctx_->codepoint_tokens_lookup[token_id].token;
+  for (auto codepoint : token) {
+    if (!AcceptCodepoint(codepoint, false)) {
+      return false;
+    }
+  }
+  token_size_history_.push_back(token.size());
+  if (token_size_history_.size() > max_rollback_steps_) {
+    DiscardEarliestCodepoints(token_size_history_.front());
+    token_size_history_.pop_front();
+  }
+  return true;
+}
+
+void GrammarStateMatcherNodeImpl::FindNextTokenBitmask(DLTensor* next_token_bitmask) {
+  const auto& tokens_sorted_by_codepoint = init_ctx_->tokens_sorted_by_codepoint;
+  const auto& catagorized_tokens_for_grammar = init_ctx_->catagorized_tokens_for_grammar;
+  const auto& latest_stack_tops = stack_tops_history_.GetLatest();
+
+  // We check all the stacks one by one, and find the accepted token set or the rejected token set
+  // for each stack. We will try to find the small one of the two sets.
+  // The final accepted token set is the union of the accepted token sets of all stacks.
+  // The final rejected token set is the intersection of the rejected token sets of all stacks.
+
+  // Note these indices store the indices in tokens_sorted_by_codepoint, instead of the token ids.
+  tmp_accepted_indices_.clear();
+  // {-1} means the universal set, i.e. all tokens initially
+  tmp_rejected_indices_.assign({-1});
+
+  for (auto top : latest_stack_tops) {
+    // Step 1. Find the current catagorized_tokens
+    auto cur_rule_position = tree_[top];
+    auto current_sequence = grammar_->GetRuleExpr(cur_rule_position.sequence_id);
+    if (cur_rule_position.parent_id == RulePosition::kNoParent &&
+        cur_rule_position.element_id == current_sequence.size()) {
+      continue;
+    }
+
+    const auto& catagorized_tokens = catagorized_tokens_for_grammar.at(
+        {cur_rule_position.sequence_id, cur_rule_position.element_id});
+
+    // For each stack, we will check every uncertain token and put them into the accepted or
+    // rejected list.
+    // If the accepted tokens are saved, it means it is likely to be smaller than the rejected
+    // tokens, so we will just find the accepted tokens, and vice versa.
+    bool is_find_accept_mode =
+        catagorized_tokens.not_saved_index != CatagorizedTokens::NotSavedIndex::kAccepted;
+
+    // If uncertain tokens are saved, we will iterate over the uncertain tokens.
+    // Otherwise, we will iterate over all_tokens - accepted_tokens - rejected_tokens.
+    bool is_uncertain_saved =
+        catagorized_tokens.not_saved_index != CatagorizedTokens::NotSavedIndex::kUncertain;
+
+    // Step 2. Update the accepted tokens in accepted_indices_delta, or the rejected tokens in
+    // rejected_indices_delta.
+
+    // Examine only the current one stack
+    stack_tops_history_.PushHistory({tree_.NewNode(cur_rule_position)});
+
+    const std::vector<TCodepoint>* prev_token = nullptr;
+    int prev_matched_size = 0;
+
+    tmp_accepted_indices_delta_.clear();
+    tmp_rejected_indices_delta_.clear();
+
+    if (!is_uncertain_saved) {
+      // unc_tokens = all_tokens - accepted_tokens - rejected_tokens
+      tmp_uncertain_tokens_bitset_.assign(tokens_sorted_by_codepoint.size(), true);
+      for (auto idx : catagorized_tokens.accepted_indices) {
+        tmp_uncertain_tokens_bitset_[idx] = false;
+      }
+      for (auto idx : catagorized_tokens.rejected_indices) {
+        tmp_uncertain_tokens_bitset_[idx] = false;
+      }
+    }
+
+    int iterator_uncertain = -1;
+
+    while (true) {
+      // Step 2.1. Find the current token.
+      auto idx =
+          GetNextUncertainToken(is_uncertain_saved, &iterator_uncertain,
+                                catagorized_tokens.uncertain_indices, tmp_uncertain_tokens_bitset_);
+      if (idx == -1) {
+        break;
+      }
+      const auto& cur_token = tokens_sorted_by_codepoint[idx].token;
+
+      // Step 2.2. Find the longest common prefix with the accepted part of the previous token.
+      // We can reuse the previous matched size to avoid unnecessary matching.
+      int prev_useful_size = 0;
+      if (prev_token) {
+        prev_useful_size = std::min(prev_matched_size, static_cast<int>(cur_token.size()));
+        for (int j = 0; j < prev_useful_size; ++j) {
+          if (cur_token[j] != (*prev_token)[j]) {
+            prev_useful_size = j;
+            break;
+          }
+        }
+        RollbackCodepoints(prev_matched_size - prev_useful_size);
+      }
+
+      // Step 2.3. Find if the current token is accepted or rejected.
+      bool accepted = true;
+      prev_matched_size = prev_useful_size;
+
+      for (int j = prev_useful_size; j < cur_token.size(); ++j) {
+        if (!AcceptCodepoint(cur_token[j], false)) {
+          accepted = false;
+          break;
+        }
+        prev_matched_size = j + 1;
+      }
+
+      // Step 2.4. Push the result to the delta list.
+      if (accepted && is_find_accept_mode) {
+        tmp_accepted_indices_delta_.push_back(idx);
+      } else if (!accepted && !is_find_accept_mode) {
+        tmp_rejected_indices_delta_.push_back(idx);
+      }
+
+      prev_token = &cur_token;
+    }
+
+    RollbackCodepoints(prev_matched_size + 1);
+
+    // Step 3. Update the accepted_indices and rejected_indices
+    if (is_find_accept_mode) {
+      // accepted_indices += catagorized_tokens.accepted_indices + accepted_indices_delta
+      IntsetUnion(&tmp_accepted_indices_delta_, catagorized_tokens.accepted_indices);
+      IntsetUnion(&tmp_accepted_indices_, tmp_accepted_indices_delta_);
+    } else {
+      // rejected_indices = Intersect(
+      //     rejected_indices,
+      //     catagorized_tokens.rejected_indices + rejected_indices_delta)
+      IntsetUnion(&tmp_rejected_indices_delta_, catagorized_tokens.rejected_indices);
+      IntsetIntersection(&tmp_rejected_indices_, tmp_rejected_indices_delta_);
+    }
+  }
+
+  // Finally update the rejected_ids bitset
+  bool can_reach_end = CanReachEnd();
+  SetTokenBitmask(next_token_bitmask, tmp_accepted_indices_, tmp_rejected_indices_, can_reach_end);
+}
+
+void GrammarStateMatcherNodeImpl::Rollback(int num_tokens) {
+  CHECK(num_tokens <= token_size_history_.size());
+  while (num_tokens > 0) {
+    int steps = token_size_history_.back();
+    RollbackCodepoints(steps);
+    token_size_history_.pop_back();
+    --num_tokens;
+  }
+}
+
+void GrammarStateMatcherNodeImpl::SetTokenBitmask(DLTensor* next_token_bitmask,
+                                                  std::vector<int32_t>& accepted_indices,
+                                                  std::vector<int32_t>& rejected_indices,
+                                                  bool can_reach_end) {
+  // accepted_ids = Union(accepted_indices, all_tokens - rejected_indices)
+  // rejected_ids = Intersect(all_tokens - accepted_indices, rejected_indices)
+  DCHECK(next_token_bitmask->dtype.code == kDLUInt && next_token_bitmask->dtype.bits == 32 &&
+         next_token_bitmask->data && next_token_bitmask->ndim == 1 && next_token_bitmask->shape);
+
+  BitsetManager next_token_bitset(reinterpret_cast<uint32_t*>(next_token_bitmask->data),
+                                  next_token_bitmask->shape[0]);
+
+  if (rejected_indices.size() == 1 && rejected_indices[0] == -1) {
+    // If rejected_indices is the universal set, the final accepted token set is just
+    // accepted_indices
+    next_token_bitset.Reset(init_ctx_->vocab_size, false);
+    for (int idx : accepted_indices) {
+      next_token_bitset.Set(init_ctx_->tokens_sorted_by_codepoint[idx].id, true);
+    }
+
+    if (can_reach_end) {
+      // add end tokens
+      for (int idx : init_ctx_->stop_token_ids) {
+        next_token_bitset.Set(idx, true);
+      }
+    }
+  } else {
+    // Otherwise, the final rejected token set is (rejected_indices \ accepted_indices)
+    next_token_bitset.Reset(init_ctx_->vocab_size, true);
+
+    auto it_acc = accepted_indices.begin();
+    for (auto i : rejected_indices) {
+      while (it_acc != accepted_indices.end() && *it_acc < i) {
+        ++it_acc;
+      }
+      if (it_acc == accepted_indices.end() || *it_acc != i) {
+        next_token_bitset.Set(init_ctx_->tokens_sorted_by_codepoint[i].id, false);
+      }
+    }
+
+    for (int idx : init_ctx_->special_token_ids) {
+      next_token_bitset.Set(idx, false);
+    }
+    if (!can_reach_end) {
+      for (int idx : init_ctx_->stop_token_ids) {
+        next_token_bitset.Set(idx, false);
+      }
+    }
+  }
+}
+
+int GrammarStateMatcherNodeImpl::GetNextUncertainToken(
+    bool is_uncertain_saved, int* iterator_uncertain, const std::vector<int>& uncertain_indices,
+    const std::vector<bool>& uncertain_tokens_bitset) {
+  if (is_uncertain_saved) {
+    ++*iterator_uncertain;
+    if (*iterator_uncertain == uncertain_indices.size()) {
+      return -1;
+    }
+    return uncertain_indices[*iterator_uncertain];
+  } else {
+    ++*iterator_uncertain;
+    while (*iterator_uncertain < uncertain_tokens_bitset.size() &&
+           !uncertain_tokens_bitset[*iterator_uncertain]) {
+      ++*iterator_uncertain;
+    }
+    if (*iterator_uncertain == uncertain_tokens_bitset.size()) {
+      return -1;
+    }
+    return *iterator_uncertain;
+  }
+}
+
+GrammarStateMatcher::GrammarStateMatcher(std::shared_ptr<GrammarStateInitContext> init_ctx,
+                                         int max_rollback_steps)
+    : ObjectRef(make_object<GrammarStateMatcherNodeImpl>(init_ctx, max_rollback_steps)) {}
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFromTokenizer")
+    .set_body_typed([](BNFGrammar grammar, Optional<Tokenizer> tokenizer, int max_rollback_steps) {
+      auto init_ctx = CreateInitContext(
+          grammar, tokenizer ? tokenizer.value()->TokenTable() : std::vector<std::string>());
+      return GrammarStateMatcher(init_ctx, max_rollback_steps);
+    });
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFromTokenTable")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      BNFGrammar grammar = args[0];
+      std::vector<std::string> token_table;
+      for (int i = 1; i < args.size() - 1; ++i) {
+        token_table.push_back(args[i]);
+      }
+      int max_rollback_steps = args[args.size() - 1];
+      auto init_ctx = CreateInitContext(grammar, token_table);
+      *rv = GrammarStateMatcher(init_ctx, max_rollback_steps);
+    });
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherDebugAcceptCodepoint")
+    .set_body_typed([](GrammarStateMatcher matcher, int32_t codepoint) {
+      auto mutable_node =
+          const_cast<GrammarStateMatcherNodeImpl*>(matcher.as<GrammarStateMatcherNodeImpl>());
+      return mutable_node->AcceptCodepoint(codepoint);
+    });
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherAcceptToken")
+    .set_body_typed([](GrammarStateMatcher matcher, int32_t token_id) {
+      return matcher->AcceptToken(token_id);
+    });
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherRollback")
+    .set_body_typed([](GrammarStateMatcher matcher, int num_tokens) {
+      matcher->Rollback(num_tokens);
+    });
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherMaxRollbackSteps")
+    .set_body_typed([](GrammarStateMatcher matcher) { return matcher->MaxRollbackSteps(); });
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherResetState")
+    .set_body_typed([](GrammarStateMatcher matcher) { matcher->ResetState(); });
+
+/*! \brief Check if a matcher can accept the complete string, and then reach the end of the
+ * grammar. For test purpose. */
+bool MatchCompleteString(GrammarStateMatcher matcher, String str) {
+  auto mutable_node =
+      const_cast<GrammarStateMatcherNodeImpl*>(matcher.as<GrammarStateMatcherNodeImpl>());
+  auto codepoints = Utf8StringToCodepoints(str.c_str());
+  int accepted_cnt = 0;
+  for (auto codepoint : codepoints) {
+    if (!mutable_node->AcceptCodepoint(codepoint, false)) {
+      mutable_node->RollbackCodepoints(accepted_cnt);
+      return false;
+    }
+    ++accepted_cnt;
+  }
+  return mutable_node->CanReachEnd();
+}
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherDebugMatchCompleteString")
+    .set_body_typed([](GrammarStateMatcher matcher, String str) {
+      return MatchCompleteString(matcher, str);
+    });
+
+/*!
+ * \brief Find the ids of the rejected tokens for the next step.
+ * \returns A tuple of rejected token ids.
+ */
+IntTuple FindNextRejectedTokens(GrammarStateMatcher matcher) {
+  auto init_ctx = matcher.as<GrammarStateMatcherNodeImpl>()->init_ctx_;
+  auto vocab_size = init_ctx->vocab_size;
+  auto bitset_size = BitsetManager::GetBitsetSize(vocab_size);
+  auto ndarray = NDArray::Empty(ShapeTuple{static_cast<long>(bitset_size)},
+                                DLDataType{kDLUInt, 32, 1}, DLDevice{kDLCPU, 0});
+  auto dltensor_manager = ndarray.ToDLPack();
+  auto dltensor = ndarray.ToDLPack()->dl_tensor;
+
+  auto start = std::chrono::high_resolution_clock::now();
+  matcher->FindNextTokenBitmask(&dltensor);
+  auto end = std::chrono::high_resolution_clock::now();
+  std::cout << "FindNextTokenBitmask takes "
+            << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "us";
+
+  auto bitset = BitsetManager(reinterpret_cast<uint32_t*>(dltensor.data), bitset_size);
+  std::vector<long> rejected_ids;
+  for (int i = 0; i < vocab_size; i++) {
+    if (bitset[i] == 0) {
+      rejected_ids.push_back(i);
+    }
+  }
+
+  std::cout << ", found accepted: " << vocab_size - rejected_ids.size()
+            << ", rejected: " << rejected_ids.size() << std::endl;
+
+  dltensor_manager->deleter(dltensor_manager);
+
+  auto ret = IntTuple(rejected_ids);
+  return ret;
+}
+
+TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFindNextRejectedTokens")
+    .set_body_typed(FindNextRejectedTokens);
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/grammar/grammar_state_matcher.cc
+++ b/cpp/serve/grammar/grammar_state_matcher.cc
@@ -493,7 +493,7 @@ IntTuple FindNextRejectedTokens(GrammarStateMatcher matcher) {
             << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << "us";
 
   auto bitset = BitsetManager(reinterpret_cast<uint32_t*>(dltensor.data), bitset_size);
-  std::vector<long> rejected_ids;
+  std::vector<int64_t> rejected_ids;
   for (int i = 0; i < vocab_size; i++) {
     if (bitset[i] == 0) {
       rejected_ids.push_back(i);

--- a/cpp/serve/grammar/grammar_state_matcher.cc
+++ b/cpp/serve/grammar/grammar_state_matcher.cc
@@ -2,9 +2,6 @@
  *  Copyright (c) 2023 by Contributors
  * \file serve/grammar/grammar_state_matcher.cc
  */
-// #ifndef TVM_LOG_DEBUG
-// #define TVM_LOG_DEBUG 1
-// #endif
 #include "grammar_state_matcher.h"
 
 #include <chrono>

--- a/cpp/serve/grammar/grammar_state_matcher.h
+++ b/cpp/serve/grammar/grammar_state_matcher.h
@@ -1,12 +1,12 @@
 /*!
  *  Copyright (c) 2023 by Contributors
  * \file serve/grammar/grammar_state_matcher.h
- * \brief The header for the support of matching characters to a BNF grammar. This is the core
+ * \brief The header for the support of matching tokens to BNF grammar. This is the core
  * logic of the grammar-guided generation.
  */
 
-#ifndef MLC_LLM_SERVE_GRAMMAR_grammar_state_matcher_H_
-#define MLC_LLM_SERVE_GRAMMAR_grammar_state_matcher_H_
+#ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_H_
+#define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_H_
 
 #include <tvm/runtime/object.h>
 #include <tvm/runtime/registry.h>
@@ -122,4 +122,4 @@ class GrammarStateMatcher : public ObjectRef {
 }  // namespace llm
 }  // namespace mlc
 
-#endif  // MLC_LLM_SERVE_GRAMMAR_grammar_state_matcher_H_
+#endif  // MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_H_

--- a/cpp/serve/grammar/grammar_state_matcher.h
+++ b/cpp/serve/grammar/grammar_state_matcher.h
@@ -1,0 +1,125 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/grammar/grammar_state_matcher.h
+ * \brief The header for the support of matching characters to a BNF grammar. This is the core
+ * logic of the grammar-guided generation.
+ */
+
+#ifndef MLC_LLM_SERVE_GRAMMAR_grammar_state_matcher_H_
+#define MLC_LLM_SERVE_GRAMMAR_grammar_state_matcher_H_
+
+#include <tvm/runtime/object.h>
+#include <tvm/runtime/registry.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "../../support/encoding.h"
+#include "grammar.h"
+#include "support.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/*!
+ * \brief A stateful matcher to match tokens to the specified BNF grammar. This class is the core
+ * logic of the grammar-guided generation.
+ *
+ * \details This class implements the non-deterministic pushdown automaton (NPDA) matching algorithm
+ * to match characters to a BNF grammar. It keep track of the current state of the matching process
+ * by maintaining several stacks internally as possible paths in the NPDA. It also supports
+ * backtracking.
+ *
+ * It is particularly capable of finding the set of tokens that are acceptable for the next step
+ * and storing them in a bitmask. This aids in grammar-guided generation.
+ *
+ * \example
+ * \code
+ * Tokenizer tokenizer = ...;
+ * auto init_ctx = GrammarStateMatcher::CreateInitContext(grammar, tokenizer->TokenTable());
+ * GrammarStateMatcher matcher(init_ctx, 10);
+ * matcher->AcceptToken(67);
+ *
+ * // Construct a DLTensor with shape (tokenizer.GetVocabSize() + 31) / 32, and dtype uint32.
+ * DLTensor next_token_bitmask = ...;
+ * matcher->FindNextTokenBitmask(&next_token_bitmask);
+ *
+ * // Rollback is supported
+ * matcher->Rollback(1);
+ * \endcode
+ */
+class GrammarStateMatcherNode : public Object {
+ public:
+  /*!
+   * \brief Accept one token and update the state of the matcher.
+   * \param token_id The id of the token to accept.
+   * \return Whether the token is accepted.
+   */
+  virtual bool AcceptToken(int32_t token_id) = 0;
+
+  /*!
+   * \brief Find the set of tokens that are acceptable for the next step and store them in a
+   * bitmask.
+   * \param next_token_bitmask The bitmask to store the result. The bitmask must be pre-allocated,
+   * and its shape needs to be (ceil(vocab_size, 32),), with a dtype of uint32.
+   */
+  virtual void FindNextTokenBitmask(DLTensor* next_token_bitmask) = 0;
+
+  /*!
+   * \brief Rollback the matcher to a previous state.
+   * \param num_tokens The number of tokens to rollback. It cannot exceed the current number of
+   * steps, nor can it exceed the specified maximum number of rollback steps.
+   */
+  virtual void Rollback(int num_tokens) = 0;
+
+  /*! \brief Get the maximum number of rollback steps allowed. */
+  virtual int MaxRollbackSteps() = 0;
+
+  /*! \brief Reset the matcher to the initial state. */
+  virtual void ResetState() = 0;
+
+  static constexpr const char* _type_key = "mlc.serve.GrammarStateMatcher";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(GrammarStateMatcherNode, Object);
+};
+
+/*!
+ * \brief The init context of a GrammarStateMatcher. It contains the preprocessing results of the
+ * grammar and tokenizer.
+ */
+class GrammarStateInitContext;
+
+class GrammarStateMatcher : public ObjectRef {
+ public:
+  /*!
+   * \brief Construct a GrammarStateMatcher from the preprocessing result of type
+   * GrammarStateInitContext.
+   * \param init_ctx The init context. It is obtained through
+   * CreateInitContext as a result of preprocessing the grammar and tokenizer.
+   */
+  GrammarStateMatcher(std::shared_ptr<GrammarStateInitContext> init_ctx,
+                      int max_rollback_steps = 0);
+
+  /*!
+   * \brief Specify a grammar and token_table to return their preprocessing results. These results
+   * are used to construct a GrammarStateMatcher. They can be stored elsewhere for quick
+   * construction of GrammarStateMatcher.
+   * \param grammar The grammar that the matcher follows.
+   * \param token_table The tokens that the matcher requires for matching.
+   */
+  static std::shared_ptr<GrammarStateInitContext> CreateInitContext(
+      const BNFGrammar& grammar, const std::vector<std::string>& token_table);
+
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(GrammarStateMatcher, ObjectRef, GrammarStateMatcherNode);
+};
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_GRAMMAR_grammar_state_matcher_H_

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -1,6 +1,7 @@
 /*!
  *  Copyright (c) 2023 by Contributors
- * \file serve/grammar/grammar_state_matcher.cc
+ * \file serve/grammar/grammar_state_matcher_base.h
+ * \brief The base class of GrammarStateMatcher. It implements a character-based matching automata.
  */
 #ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_
 #define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -1,0 +1,235 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/grammar/grammar_state_matcher.cc
+ */
+#ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_
+#define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_
+
+#include <vector>
+
+#include "../../tokenizers.h"
+#include "grammar.h"
+#include "grammar_state_matcher_state.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/*! \brief The base class of GrammarStateMatcher. It implements a character-based matching
+ * automata, and supports accepting a character, rolling back by character, etc.
+ */
+class GrammarStateMatcherBase {
+ protected:
+  using RuleExpr = BNFGrammarNode::RuleExpr;
+  using RuleExprType = BNFGrammarNode::RuleExprType;
+
+ public:
+  /*!
+   * \brief Construct a GrammarStateMatcherBase with the given grammar and initial rule position.
+   * \param grammar The grammar to match.
+   * \param init_rule_position The initial rule position. If not specified, the main rule will be
+   * used.
+   */
+  GrammarStateMatcherBase(const BNFGrammar& grammar, RulePosition init_rule_position = {})
+      : grammar_(grammar), tree_(grammar), stack_tops_history_(&tree_) {
+    InitStackState(init_rule_position);
+  }
+
+  /*! \brief Accept one codepoint. */
+  bool AcceptCodepoint(TCodepoint codepoint, bool verbose = false);
+
+  /*! \brief Check if the end of the main rule is reached. If so, the stop token can be accepted. */
+  bool CanReachEnd() const;
+
+  /*! \brief Rollback the matcher to a previous state. */
+  void RollbackCodepoints(int rollback_codepoint_cnt);
+
+  /*! \brief Discard the earliest history. */
+  void DiscardEarliestCodepoints(int discard_codepoint_cnt);
+
+  /*! \brief Print the stack state. */
+  std::string PrintStackState(int steps_behind_latest = 0) const;
+
+ protected:
+  // Init the stack state according to the given rule position.
+  // If init_rule_position is {}, init the stack with the main rule.
+  void InitStackState(RulePosition init_rule_position = {});
+
+  // Update the old stack top to the next position, and push the new stack tops to new_stack_tops.
+  void UpdateNewStackTops(int32_t old_node_id, std::vector<int32_t>* new_stack_tops);
+
+  BNFGrammar grammar_;
+  RulePositionTree tree_;
+  StackTopsHistory stack_tops_history_;
+
+  // Temporary data for AcceptCodepoint.
+  std::vector<int32_t> tmp_new_stack_tops_;
+};
+
+/*! \brief Check the codepoint is contained in the character class. */
+inline bool CharacterClassContains(const BNFGrammarNode::RuleExpr& rule_expr,
+                                   TCodepoint codepoint) {
+  DCHECK(rule_expr.type == BNFGrammarNode::RuleExprType::kCharacterClass ||
+         rule_expr.type == BNFGrammarNode::RuleExprType::kNegCharacterClass);
+  for (int i = 0; i < rule_expr.size(); i += 2) {
+    if (rule_expr.data[i] <= codepoint && codepoint <= rule_expr.data[i + 1]) {
+      return rule_expr.type == BNFGrammarNode::RuleExprType::kCharacterClass;
+    }
+  }
+  return rule_expr.type == BNFGrammarNode::RuleExprType::kNegCharacterClass;
+}
+
+inline bool GrammarStateMatcherBase::AcceptCodepoint(TCodepoint codepoint, bool verbose) {
+  if (verbose) {
+    std::cout << "Stack before accepting: " << PrintStackState() << std::endl;
+  }
+  tmp_new_stack_tops_.clear();
+
+  const auto& prev_stack_tops = stack_tops_history_.GetLatest();
+  for (auto old_top : prev_stack_tops) {
+    const auto& rule_position = tree_[old_top];
+    auto current_sequence = grammar_->GetRuleExpr(rule_position.sequence_id);
+    if (rule_position.parent_id == RulePosition::kNoParent &&
+        rule_position.element_id == current_sequence.size()) {
+      // This RulePosition means previous elements has matched the complete rule.
+      // But we are still need to accept a new character, so this stack will become invalid.
+      continue;
+    }
+    auto current_char_class = grammar_->GetRuleExpr(current_sequence[rule_position.element_id]);
+    // Special support for star quantifiers of character classes.
+    if (current_char_class.type == RuleExprType::kRuleRef) {
+      DCHECK(rule_position.char_class_id != -1);
+      current_char_class = grammar_->GetRuleExpr(rule_position.char_class_id);
+    }
+    DCHECK(current_char_class.type == RuleExprType::kCharacterClass ||
+           current_char_class.type == RuleExprType::kNegCharacterClass);
+    auto ok = CharacterClassContains(current_char_class, codepoint);
+    if (!ok) {
+      continue;
+    }
+    UpdateNewStackTops(old_top, &tmp_new_stack_tops_);
+  }
+  if (tmp_new_stack_tops_.empty()) {
+    if (verbose) {
+      std::cout << "Codepoint: " << codepoint << " \"" << CodepointToPrintable(codepoint)
+                << "\" Rejected" << std::endl;
+    }
+    return false;
+  }
+  stack_tops_history_.PushHistory(tmp_new_stack_tops_);
+  if (verbose) {
+    std::cout << "Codepoint: " << codepoint << " \"" << CodepointToPrintable(codepoint)
+              << "\" Accepted" << std::endl;
+    std::cout << "Stack after accepting: " << PrintStackState() << std::endl;
+  }
+  return true;
+}
+
+inline bool GrammarStateMatcherBase::CanReachEnd() const {
+  const auto& last_stack_tops = stack_tops_history_.GetLatest();
+  return std::any_of(last_stack_tops.begin(), last_stack_tops.end(),
+                     [&](int32_t id) { return tree_.IsEndPosition(tree_[id]); });
+}
+
+inline void GrammarStateMatcherBase::RollbackCodepoints(int rollback_codepoint_cnt) {
+  stack_tops_history_.Rollback(rollback_codepoint_cnt);
+}
+
+inline void GrammarStateMatcherBase::DiscardEarliestCodepoints(int discard_codepoint_cnt) {
+  stack_tops_history_.DiscardEarliest(discard_codepoint_cnt);
+}
+
+inline std::string GrammarStateMatcherBase::PrintStackState(int steps_behind_latest) const {
+  return stack_tops_history_.PrintHistory(steps_behind_latest);
+}
+
+inline void GrammarStateMatcherBase::InitStackState(RulePosition init_rule_position) {
+  if (init_rule_position == kInvalidRulePosition) {
+    // Initialize the stack with the main rule.
+    auto main_rule = grammar_->GetRule(0);
+    auto main_rule_expr = grammar_->GetRuleExpr(main_rule.body_expr_id);
+    std::vector<int32_t> new_stack_tops;
+    for (auto i : main_rule_expr) {
+      DCHECK(grammar_->GetRuleExpr(i).type == RuleExprType::kSequence ||
+             grammar_->GetRuleExpr(i).type == RuleExprType::kEmptyStr);
+      new_stack_tops.push_back(tree_.NewNode(RulePosition(0, i, 0, RulePosition::kNoParent)));
+    }
+    stack_tops_history_.PushHistory(new_stack_tops);
+  } else {
+    stack_tops_history_.PushHistory({tree_.NewNode(init_rule_position)});
+  }
+}
+
+inline void GrammarStateMatcherBase::UpdateNewStackTops(int32_t old_node_id,
+                                                        std::vector<int32_t>* new_stack_tops) {
+  const auto& old_rule_position = tree_[old_node_id];
+  // For char_class*, the old rule position itself is also the next position
+  if (old_rule_position.char_class_id != -1) {
+    new_stack_tops->push_back(tree_.NewNode(old_rule_position));
+  }
+
+  auto cur_rule_position = tree_.GetNextPosition(tree_[old_node_id]);
+
+  // Continuously iterate to the next position (if reachs the end of the current rule, go to the
+  // next position of the parent rule). Push it into new_stack_tops. If this position can not
+  // be empty, exit the loop.
+  // Positions that can be empty: reference to a rule that can be empty, or a star quantifier
+  // rule.
+  for (; !tree_.IsEndPosition(cur_rule_position);
+       cur_rule_position = tree_.GetNextPosition(cur_rule_position)) {
+    auto sequence = grammar_->GetRuleExpr(cur_rule_position.sequence_id);
+    auto element = grammar_->GetRuleExpr(sequence[cur_rule_position.element_id]);
+    if (element.type == RuleExprType::kCharacterClass ||
+        element.type == RuleExprType::kNegCharacterClass) {
+      // Character class: cannot be empty. Break the loop.
+      new_stack_tops->push_back(tree_.NewNode(cur_rule_position));
+      break;
+    } else {
+      // RuleRef
+      DCHECK(element.type == RuleExprType::kRuleRef);
+      auto new_rule_id = element[0];
+      auto new_rule = grammar_->GetRule(new_rule_id);
+      auto new_rule_expr = grammar_->GetRuleExpr(new_rule.body_expr_id);
+      if (new_rule_expr.type == RuleExprType::kStarQuantifier) {
+        cur_rule_position.char_class_id = new_rule_expr[0];
+        new_stack_tops->push_back(tree_.NewNode(cur_rule_position));
+      } else {
+        DCHECK(new_rule_expr.type == RuleExprType::kChoices);
+
+        bool contain_empty = false;
+
+        // For rule containing choices, expand the rule and push all positions into new_stack_tops
+        for (auto j : new_rule_expr) {
+          auto sequence = grammar_->GetRuleExpr(j);
+          if (sequence.type == RuleExprType::kEmptyStr) {
+            contain_empty = true;
+            continue;
+          }
+          DCHECK(sequence.type == RuleExprType::kSequence);
+          DCHECK(grammar_->GetRuleExpr(sequence[0]).type == RuleExprType::kCharacterClass ||
+                 grammar_->GetRuleExpr(sequence[0]).type == RuleExprType::kNegCharacterClass);
+          // Note: rule_position is not inserted to the tree yet, so it need to be inserted first
+          auto parent_id = tree_.NewNode(cur_rule_position);
+          new_stack_tops->push_back(tree_.NewNode(RulePosition(new_rule_id, j, 0, parent_id)));
+        }
+
+        if (!contain_empty) {
+          break;
+        }
+      }
+    }
+  }
+
+  // Reaches the end of the main rule. Insert a special node to indicate the end.
+  if (tree_.IsEndPosition(cur_rule_position)) {
+    new_stack_tops->push_back(tree_.NewNode(cur_rule_position));
+  }
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_

--- a/cpp/serve/grammar/grammar_state_matcher_preproc.h
+++ b/cpp/serve/grammar/grammar_state_matcher_preproc.h
@@ -1,0 +1,314 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/grammar/grammar_state_matcher.cc
+ */
+#ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_PREPROC_H_
+#define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_PREPROC_H_
+
+#include <vector>
+
+#include "../../support/encoding.h"
+#include "grammar.h"
+#include "grammar_state_matcher_base.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/*! \brief A token and its id. */
+struct TokenAndId {
+  std::vector<TCodepoint> token;
+  int32_t id;
+  /*! \brief Compare tokens by their unicode codepoint sequence. */
+  bool operator<(const TokenAndId& other) const;
+};
+
+/*!
+ * \brief Preprocessed information, for a given specific rule and position, divides the token set
+ * into three categories: accepted, rejected, and uncertain.
+ * \note Since the union of these three sets is the whole token set, we only need to store the
+ * smaller two sets. The unsaved set is specified by not_saved_index.
+ * \note These indices are the indices of tokens_sorted_by_codepoint in the GrammarStateInitContext
+ * object, instead of the token ids. That helps the matching process.
+ */
+struct CatagorizedTokens {
+  std::vector<int32_t> accepted_indices;
+  std::vector<int32_t> rejected_indices;
+  std::vector<int32_t> uncertain_indices;
+  enum class NotSavedIndex { kAccepted = 0, kRejected = 1, kUncertain = 2 };
+  NotSavedIndex not_saved_index;
+
+  CatagorizedTokens() = default;
+
+  CatagorizedTokens(std::vector<int32_t>&& accepted_indices,
+                    std::vector<int32_t>&& rejected_indices,
+                    std::vector<int32_t>&& uncertain_indices);
+};
+
+/*!
+ * \brief All information that we need to match tokens in the tokenizer to the specified grammar.
+ * It is the result of preprocessing.
+ * \sa mlc::llm::serve::GrammarStateMatcher
+ */
+class GrammarStateInitContext {
+ public:
+  BNFGrammar grammar;
+  /*! \brief The vocabulary size of the tokenizer. */
+  size_t vocab_size;
+  /*! \brief The sorted token and its id. Tokens are sorted to reuse the common prefix during
+   * matching. */
+  std::vector<TokenAndId> tokens_sorted_by_codepoint;
+  /*! \brief The mapping from token id to token represented by codepoints. */
+  std::unordered_map<int32_t, TokenAndId> codepoint_tokens_lookup;
+  /*! \brief The stop tokens. They can be accepted iff GramamrMatcher can reach the end of the
+   * grammar. */
+  std::vector<int32_t> stop_token_ids;
+  /*! \brief The special tokens. Currently we will ignore these tokens during grammar-guided
+   * matching. */
+  std::vector<int32_t> special_token_ids;
+
+  /*! \brief A sequence id and its position. */
+  struct SequenceIdAndPosition {
+    int32_t sequence_id;
+    int32_t element_id;
+    bool operator==(const SequenceIdAndPosition& other) const {
+      return sequence_id == other.sequence_id && element_id == other.element_id;
+    }
+  };
+
+  /*! \brief Hash function for SequenceIdAndPosition. */
+  struct SequenceIdAndPositionHash {
+    std::size_t operator()(const SequenceIdAndPosition& k) const {
+      return std::hash<int32_t>()(k.sequence_id) ^ (std::hash<int32_t>()(k.element_id) << 1);
+    }
+  };
+
+  /*! \brief Mapping from sequence id and its position to the catagorized tokens. */
+  std::unordered_map<SequenceIdAndPosition, CatagorizedTokens, SequenceIdAndPositionHash>
+      catagorized_tokens_for_grammar;
+};
+
+/* \brief The concrete implementation of GrammarStateMatcherNode. */
+class GrammarStateMatcherForInitContext : public GrammarStateMatcherBase {
+ public:
+  GrammarStateMatcherForInitContext(const BNFGrammar& grammar, RulePosition init_rule_position)
+      : GrammarStateMatcherBase(grammar, init_rule_position) {}
+
+  CatagorizedTokens GetCatagorizedTokens(const std::vector<TokenAndId>& tokens_sorted_by_codepoint,
+                                         bool is_main_rule);
+
+ private:
+  using RuleExpr = BNFGrammarNode::RuleExpr;
+  using RuleExprType = BNFGrammarNode::RuleExprType;
+
+  // Temporary data for GetCatagorizedTokens.
+  std::vector<int32_t> tmp_accepted_indices_;
+  std::vector<int32_t> tmp_rejected_indices_;
+  std::vector<int32_t> tmp_uncertain_indices_;
+  std::vector<bool> tmp_can_see_end_stack_;
+};
+
+inline bool TokenAndId::operator<(const TokenAndId& other) const {
+  for (size_t i = 0; i < token.size(); ++i) {
+    if (i >= other.token.size()) {
+      return false;
+    }
+    if (token[i] < other.token[i]) {
+      return true;
+    } else if (token[i] > other.token[i]) {
+      return false;
+    }
+  }
+  return token.size() < other.token.size();
+}
+
+inline CatagorizedTokens::CatagorizedTokens(std::vector<int32_t>&& accepted_indices,
+                                            std::vector<int32_t>&& rejected_indices,
+                                            std::vector<int32_t>&& uncertain_indices) {
+  auto size_acc = accepted_indices.size();
+  auto size_rej = rejected_indices.size();
+  auto size_unc = uncertain_indices.size();
+  not_saved_index =
+      (size_acc >= size_rej && size_acc >= size_unc)
+          ? NotSavedIndex::kAccepted
+          : (size_rej >= size_unc ? NotSavedIndex::kRejected : NotSavedIndex::kUncertain);
+
+  if (not_saved_index != NotSavedIndex::kAccepted) {
+    this->accepted_indices = std::move(accepted_indices);
+  }
+  if (not_saved_index != NotSavedIndex::kRejected) {
+    this->rejected_indices = std::move(rejected_indices);
+  }
+  if (not_saved_index != NotSavedIndex::kUncertain) {
+    this->uncertain_indices = std::move(uncertain_indices);
+  }
+}
+
+inline CatagorizedTokens GrammarStateMatcherForInitContext::GetCatagorizedTokens(
+    const std::vector<TokenAndId>& tokens_sorted_by_codepoint, bool is_main_rule) {
+  // Support the current stack contains only one stack with one RulePosition.
+  // Iterate over all tokens. Split them into three categories:
+  // - accepted_indices: If a token is accepted by current rule
+  // - rejected_indices: If a token is rejected by current rule
+  // - uncertain_indices: If a prefix of a token is accepted by current rule and comes to the end
+  // of the rule.
+
+  // Note many tokens may contain the same prefix, so we will avoid unnecessary matching
+
+  tmp_accepted_indices_.clear();
+  tmp_rejected_indices_.clear();
+  tmp_uncertain_indices_.clear();
+  // For every character in the current token, stores whether it is possible to reach the end of
+  // the rule when matching until this character. Useful for rollback.
+  tmp_can_see_end_stack_.assign({CanReachEnd()});
+
+  int prev_matched_size = 0;
+  for (int i = 0; i < static_cast<int>(tokens_sorted_by_codepoint.size()); ++i) {
+    const auto& token = tokens_sorted_by_codepoint[i].token;
+    const auto* prev_token = i > 0 ? &tokens_sorted_by_codepoint[i - 1].token : nullptr;
+
+    // Find the longest common prefix with the accepted part of the previous token.
+    auto prev_useful_size = 0;
+    if (prev_token) {
+      prev_useful_size = std::min(prev_matched_size, static_cast<int>(token.size()));
+      for (int j = 0; j < prev_useful_size; ++j) {
+        if (token[j] != (*prev_token)[j]) {
+          prev_useful_size = j;
+          break;
+        }
+      }
+      RollbackCodepoints(prev_matched_size - prev_useful_size);
+      tmp_can_see_end_stack_.erase(
+          tmp_can_see_end_stack_.end() - (prev_matched_size - prev_useful_size),
+          tmp_can_see_end_stack_.end());
+    }
+
+    // Find if the current token is accepted or rejected or uncertain.
+    bool accepted = true;
+    bool can_see_end = tmp_can_see_end_stack_.back();
+    prev_matched_size = prev_useful_size;
+    for (int j = prev_useful_size; j < token.size(); ++j) {
+      if (!AcceptCodepoint(token[j], false)) {
+        accepted = false;
+        break;
+      }
+      if (CanReachEnd()) {
+        can_see_end = true;
+      }
+      tmp_can_see_end_stack_.push_back(can_see_end);
+      prev_matched_size = j + 1;
+    }
+    if (accepted) {
+      tmp_accepted_indices_.push_back(i);
+    } else if (can_see_end && !is_main_rule) {
+      // If the current rule is the main rule, there will be no uncertain indices since we will
+      // never consider its parent rule. Unaccepted tokens are just rejected.
+      tmp_uncertain_indices_.push_back(i);
+    } else {
+      tmp_rejected_indices_.push_back(i);
+    }
+  }
+  RollbackCodepoints(prev_matched_size);
+  return CatagorizedTokens(std::move(tmp_accepted_indices_), std::move(tmp_rejected_indices_),
+                           std::move(tmp_uncertain_indices_));
+}
+
+inline std::string ReplaceUnderscoreWithSpace(const std::string& str,
+                                              const std::string& kSpecialUnderscore) {
+  std::string res;
+  size_t pos = 0;
+  while (pos < str.size()) {
+    size_t found = str.find(kSpecialUnderscore, pos);
+    if (found == std::string::npos) {
+      res += str.substr(pos);
+      break;
+    }
+    res += str.substr(pos, found - pos) + " ";
+    pos = found + kSpecialUnderscore.size();
+  }
+  return res;
+}
+
+inline std::shared_ptr<GrammarStateInitContext> CreateInitContext(
+    const BNFGrammar& grammar, const std::vector<std::string>& token_table) {
+  using RuleExprType = BNFGrammarNode::RuleExprType;
+  auto ptr = std::make_shared<GrammarStateInitContext>();
+
+  ptr->grammar = grammar;
+  ptr->vocab_size = token_table.size();
+
+  if (ptr->vocab_size == 0) {
+    return ptr;
+  }
+
+  for (int i = 0; i < token_table.size(); ++i) {
+    auto token = token_table[i];
+    if (token == "<unk>" || token == "<pad>" || token == "<s>") {
+      ptr->special_token_ids.push_back(i);
+    } else if (token == "</s>") {
+      ptr->stop_token_ids.push_back(i);
+    } else if (token.size() == 1 &&
+               (static_cast<unsigned char>(token[0]) >= 128 || token[0] == 0)) {
+      // Currently we consider all tokens with one character that >= 128 as special tokens.
+      ptr->special_token_ids.push_back(i);
+    } else {
+      // First replace the special underscore with space.
+      auto codepoints = Utf8StringToCodepoints(token.c_str());
+      DCHECK(!codepoints.empty() &&
+             codepoints[0] != static_cast<TCodepoint>(CharHandlingError::kInvalidUtf8))
+          << "Invalid token: " << token;
+      ptr->tokens_sorted_by_codepoint.push_back({codepoints, i});
+      ptr->codepoint_tokens_lookup[i] = {codepoints, i};
+    }
+  }
+  std::sort(ptr->tokens_sorted_by_codepoint.begin(), ptr->tokens_sorted_by_codepoint.end());
+
+  // Find the corresponding catagorized tokens for:
+  // 1. All character elements in the grammar
+  // 2. All RuleRef elements that refers to a rule of a StarQuantifier of a character class
+  for (int i = 0; i < static_cast<int>(grammar->NumRules()); ++i) {
+    auto rule = grammar->GetRule(i);
+    auto rule_expr = grammar->GetRuleExpr(rule.body_expr_id);
+    // Skip StarQuantifier since we just handle it at the reference element during matching.
+    if (rule_expr.type == RuleExprType::kStarQuantifier) {
+      continue;
+    }
+    DCHECK(rule_expr.type == RuleExprType::kChoices);
+    for (auto sequence_id : rule_expr) {
+      auto sequence_expr = grammar->GetRuleExpr(sequence_id);
+      if (sequence_expr.type == RuleExprType::kEmptyStr) {
+        continue;
+      }
+      DCHECK(sequence_expr.type == RuleExprType::kSequence);
+      for (int element_id = 0; element_id < sequence_expr.size(); ++element_id) {
+        auto element_expr = grammar->GetRuleExpr(sequence_expr[element_id]);
+        auto cur_rule_position = RulePosition{i, sequence_id, element_id};
+        if (element_expr.type == RuleExprType::kRuleRef) {
+          auto ref_rule = grammar->GetRule(element_expr[0]);
+          auto ref_rule_expr = grammar->GetRuleExpr(ref_rule.body_expr_id);
+          if (ref_rule_expr.type == RuleExprType::kChoices) {
+            continue;
+          } else {
+            // Reference to a StarQuantifier of a character class.
+            cur_rule_position.char_class_id = ref_rule_expr[0];
+          }
+        }
+
+        auto grammar_state_matcher = GrammarStateMatcherForInitContext(grammar, cur_rule_position);
+        auto cur_catagorized_tokens_for_grammar =
+            grammar_state_matcher.GetCatagorizedTokens(ptr->tokens_sorted_by_codepoint, i == 0);
+        ptr->catagorized_tokens_for_grammar[{sequence_id, element_id}] =
+            cur_catagorized_tokens_for_grammar;
+      }
+    }
+  }
+  return ptr;
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // TVM_LLVM_COMPILE_ENGINE_CPP_SERVE_GRAMMAR_STATE_MATCHER_PREPROC_H_

--- a/cpp/serve/grammar/grammar_state_matcher_preproc.h
+++ b/cpp/serve/grammar/grammar_state_matcher_preproc.h
@@ -1,6 +1,7 @@
 /*!
  *  Copyright (c) 2023 by Contributors
- * \file serve/grammar/grammar_state_matcher.cc
+ * \file serve/grammar/grammar_state_matcher_preproc.h
+ * \brief The header for the preprocessing of the grammar state matcher.
  */
 #ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_PREPROC_H_
 #define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_PREPROC_H_

--- a/cpp/serve/grammar/grammar_state_matcher_state.h
+++ b/cpp/serve/grammar/grammar_state_matcher_state.h
@@ -1,0 +1,441 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/grammar/grammar_state_matcher.cc
+ */
+#ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_STATE_H_
+#define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_STATE_H_
+
+#include <queue>
+#include <vector>
+
+#include "grammar.h"
+#include "grammar_serializer.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/*! \brief Specifies a position in a rule. */
+struct RulePosition {
+  /*! \brief The rule's id. */
+  int32_t rule_id = -1;
+  /*! \brief Which choice in this rule is selected. */
+  int32_t sequence_id = -1;
+  /*! \brief Which element of the choice sequence is being visited. */
+  int32_t element_id = -1;
+  /*!
+   * \brief If the element refers to another rule, and another rule is a star quantifier of
+   * a character class, this field will be set to the id of the character class.
+   * This is part of the special support of star quantifiers of character classes.
+   */
+  int32_t char_class_id = -1;
+  /*! \brief The id of the parent node in the RulePositionTree. */
+  int32_t parent_id = -1;
+  /*! \brief The reference count of this RulePosition. If reduces to zero, the node will be
+   * removed from the RulePositionBuffer. */
+  int reference_count = 0;
+
+  /*! \brief A parent_id value of kNoParent means this RulePosition is the root of the tree. */
+  static constexpr int32_t kNoParent = -1;
+
+  constexpr RulePosition() = default;
+  constexpr RulePosition(int32_t rule_id, int32_t sequence_id, int32_t element_id,
+                         int32_t parent_id = kNoParent, int32_t char_class_id = -1)
+      : rule_id(rule_id),
+        sequence_id(sequence_id),
+        element_id(element_id),
+        char_class_id(char_class_id),
+        parent_id(parent_id) {}
+
+  bool operator==(const RulePosition& other) const {
+    return rule_id == other.rule_id && sequence_id == other.sequence_id &&
+           element_id == other.element_id && char_class_id == other.char_class_id &&
+           parent_id == other.parent_id;
+  }
+
+  bool operator!=(const RulePosition& other) const { return !(*this == other); }
+};
+
+/*! \brief A special value for invalid RulePosition. */
+inline constexpr RulePosition kInvalidRulePosition(-1, -1, -1, -1, -1);
+
+/*! \brief A buffer to manage all RulePositions. */
+class RulePositionBuffer {
+ public:
+  /*!
+   * \brief Allocate a new RulePosition. with given initial value.
+   * \returns The id of the allocated node.
+   */
+  int32_t Allocate(RulePosition rule_position) {
+    int32_t id;
+    if (free_nodes_.empty()) {
+      buffer_.emplace_back();
+      id = buffer_.size() - 1;
+    } else {
+      id = free_nodes_.back();
+      DCHECK(buffer_[id] == kInvalidRulePosition);
+      free_nodes_.pop_back();
+    }
+    rule_position.reference_count = 0;
+    buffer_[id] = rule_position;
+    return id;
+  }
+
+  /*! \brief Free the RulePosition with the given id. */
+  void Free(int32_t id) {
+    DCHECK(buffer_[id] != kInvalidRulePosition);
+    buffer_[id] = kInvalidRulePosition;
+    free_nodes_.push_back(id);
+  }
+
+  /*! \brief Get the capacity of the buffer. */
+  size_t Capacity() const { return buffer_.size(); }
+
+  /*! \brief Get the number of allocated nodes. */
+  size_t Size() const {
+    DCHECK(buffer_.size() >= free_nodes_.size());
+    return buffer_.size() - free_nodes_.size();
+  }
+
+  /*! \brief Get the RulePosition with the given id. */
+  RulePosition& operator[](int32_t id) { return buffer_[id]; }
+  const RulePosition& operator[](int32_t id) const { return buffer_[id]; }
+
+  void Reset() {
+    buffer_.clear();
+    free_nodes_.clear();
+  }
+
+  friend class RulePositionTree;
+
+ private:
+  /*! \brief The buffer to store all RulePositions. */
+  std::vector<RulePosition> buffer_;
+  /*! \brief A stack to store all free node ids. */
+  std::vector<int32_t> free_nodes_;
+};
+
+/*!
+ * \brief A tree structure to store all stacks. Every stack contains several RulePositions, and
+ * is represented as a path from the root to a leaf node.
+ */
+class RulePositionTree {
+ public:
+  /*! \brief Construct a RulePositionTree associated with the given grammar. */
+  RulePositionTree(const BNFGrammar& grammar) : grammar_(grammar) {}
+
+  /*!
+   * \brief Create a new node with the given RulePosition. The reference count of the new node
+   * is zero.
+   *
+   * \note Later, this node should either be pointed by some child rule, or become a stack top
+   * node (so it will be pointed to by an attached pointer) to be maintained in the
+   * reference-counting based memory management.
+   */
+  int32_t NewNode(const RulePosition& rule_position) {
+    auto id = node_buffer_.Allocate(rule_position);
+    if (rule_position.parent_id != RulePosition::kNoParent) {
+      DCHECK(rule_position.parent_id < static_cast<int32_t>(node_buffer_.Capacity()) &&
+             node_buffer_[rule_position.parent_id] != kInvalidRulePosition);
+      node_buffer_[rule_position.parent_id].reference_count++;
+    }
+    return id;
+  }
+
+  /*!
+   * \brief Update a node in the stack to the next position. Next position means either the next
+   * element in the current rule, or if the current element is the last element in the rule, the
+   * next element in the parent rule. If the current node is the last element in the main rule, it
+   * is at the end position.
+   */
+  RulePosition GetNextPosition(RulePosition rule_position) const;
+
+  bool IsEndPosition(const RulePosition& rule_position) const;
+
+  /*! \brief Attach an additional reference to the node with the given id. */
+  void AttachRefTo(int32_t id) {
+    DCHECK(id != RulePosition::kNoParent);
+    node_buffer_[id].reference_count++;
+  }
+
+  /*! \brief Remove a reference to the node with the given id. If the reference count becomes zero,
+   * free the node and recursively all its ancestors with zero reference count. */
+  void RemoveRefTo(int32_t id) {
+    DCHECK(id != RulePosition::kNoParent);
+    auto cur_node = id;
+    while (cur_node != RulePosition::kNoParent) {
+      node_buffer_[cur_node].reference_count--;
+      if (node_buffer_[cur_node].reference_count != 0) {
+        break;
+      }
+      auto next_node = node_buffer_[cur_node].parent_id;
+      node_buffer_.Free(cur_node);
+      cur_node = next_node;
+    }
+  }
+
+  /*! \brief Get the RulePosition with the given id. */
+  const RulePosition& operator[](int32_t id) const {
+    DCHECK(id != RulePosition::kNoParent);
+    return node_buffer_[id];
+  }
+
+  /*! \brief Print the node with the given id to a string. */
+  std::string PrintNode(int32_t id) const;
+
+  /*! \brief Print the stack with the given top id to a string. */
+  std::string PrintStackByTopId(int32_t top_id) const;
+
+  /*!
+   * \brief Check the well-formedness of the tree and the associated buffer. For debug purpose.
+   * \details This function checks the following properties:
+   * 1. Every node is pointed directly or indirectly by a outside pointer.
+   * 2. Every node's reference count is consistent with the actual reference count.
+   * 3. All ids and positions are valid.
+   * 4. If a node in the buffer is free, it should be equal to kInvalidRulePosition.
+   */
+  void CheckWellFormed(const std::vector<int32_t>& outside_pointers) const;
+
+  /*! \brief Reset the tree and the associated buffer. */
+  void Reset() { node_buffer_.Reset(); }
+
+ private:
+  /*! \brief The grammar associated with this RulePositionTree. */
+  BNFGrammar grammar_;
+  /*! \brief The buffer to store all RulePositions. */
+  RulePositionBuffer node_buffer_;
+};
+
+/*!
+ * \brief A class to maintain the stack tops and its history to support rollback.
+ * \details This class helps to maintain nodes by automatically maintaining the attached references.
+ * If a node is not existing in any stack in the history record, it will be freed.
+ *
+ * It can store up to the previous max_rollback_steps + 1 steps of history, and thus supports
+ * rolling back up to max_rollback_steps steps.
+ */
+class StackTopsHistory {
+ public:
+  /*!
+   * \param tree The RulePositionTree to be associated with. Possibly modify the tree by attaching
+   * and removing references to the stack top nodes.
+   * \param max_rollback_steps The maximum number of rollback steps to be supported.
+   */
+  StackTopsHistory(RulePositionTree* tree) : tree_(tree) {}
+
+  /*!
+   * \brief Push a new history record consisting a list of stack tops. These nodes will be recorded
+   * as existing in a stack (by attaching a reference to them).
+   * \param stack_tops The stack tops to be pushed.
+   * \param drop_old Whether to drop the oldest history record if the history size exceeds the
+   * limit. If the history is dropped, node that do not exist in any stack any more will be freed.
+   */
+  void PushHistory(const std::vector<int32_t>& stack_tops) {
+    stack_tops_history_.push_back(stack_tops);
+    for (auto id : stack_tops) {
+      tree_->AttachRefTo(id);
+    }
+  }
+
+  /*! \brief Roll back to several previous steps. Possibly frees node that do not exist in any stack
+   * any more. */
+  void Rollback(int rollback_steps) {
+    DCHECK(rollback_steps < stack_tops_history_.size())
+        << "The number of requested rollback steps is greater than or equal to the current "
+           "history "
+        << "size: " << rollback_steps << " vs " << stack_tops_history_.size() << ".";
+    while (rollback_steps--) {
+      PopLatest();
+    }
+  }
+
+  /*! \brief Discard the earliest several steps. Possibly frees node that do not exist in any stack
+   * any more. */
+  void DiscardEarliest(int discard_steps) {
+    DCHECK(discard_steps < stack_tops_history_.size())
+        << "The number of requested discard steps is greater than or equal to the current "
+           "history "
+        << "size: " << discard_steps << " vs " << stack_tops_history_.size() << ".";
+    while (discard_steps--) {
+      PopEarliest();
+    }
+  }
+
+  /*! \brief Get the latest stack tops. */
+  const std::vector<int32_t>& GetLatest() const { return stack_tops_history_.back(); }
+
+  /*!
+   * \brief Print one history record.
+   * \param history_position_to_latest The number of steps behind the latest record. 0 means the
+   * latest record.
+   */
+  std::string PrintHistory(int history_position_to_latest = 0) const;
+
+  /*! \brief Get the number of history records. */
+  int Size() const { return stack_tops_history_.size(); }
+
+  /*! \brief Check the well-formedness of the tree and the associated buffer. */
+  void CheckWellFormed() const;
+
+  /*! \brief Reset the history and the associated node tree. */
+  void Reset() {
+    stack_tops_history_.clear();
+    tree_->Reset();
+  }
+
+ private:
+  /*! \brief Pop the oldest history record. Possibly frees node that do not exist in any stack any
+   * more. */
+  void PopEarliest() {
+    const auto& old_stack_tops = stack_tops_history_.front();
+    for (auto id : old_stack_tops) {
+      tree_->RemoveRefTo(id);
+    }
+    stack_tops_history_.pop_front();
+  }
+
+  /*! \brief Pop the latest history record. Possibly frees node that do not exist in any stack any
+   * more. */
+  void PopLatest() {
+    const auto& new_stack_tops = stack_tops_history_.back();
+    for (auto id : new_stack_tops) {
+      tree_->RemoveRefTo(id);
+    }
+    stack_tops_history_.pop_back();
+  }
+
+  /*! \brief Modifiable pointer to the RulePositionTree. */
+  RulePositionTree* tree_;
+  /*! \brief The history of stack tops. */
+  std::deque<std::vector<int32_t>> stack_tops_history_;
+};
+
+/*! \brief See GetNextPosition. */
+inline bool RulePositionTree::IsEndPosition(const RulePosition& rule_position) const {
+  return rule_position.parent_id == RulePosition::kNoParent &&
+         grammar_->GetRuleExpr(rule_position.sequence_id).size() == rule_position.element_id;
+}
+
+/*!
+ * \brief Update a node in the stack to the next position. Next position means either the next
+ * element in the current rule, or if the current element is the last element in the rule, the
+ * next element in the parent rule. If the current node is the last element in the main rule, it
+ * is at the end position.
+ */
+inline RulePosition RulePositionTree::GetNextPosition(RulePosition rule_position) const {
+  if (IsEndPosition(rule_position)) {
+    return kInvalidRulePosition;
+  }
+  rule_position = RulePosition(rule_position.rule_id, rule_position.sequence_id,
+                               rule_position.element_id + 1, rule_position.parent_id);
+  while (rule_position.parent_id != RulePosition::kNoParent &&
+         grammar_->GetRuleExpr(rule_position.sequence_id).size() == rule_position.element_id) {
+    auto parent_rule_position = node_buffer_[rule_position.parent_id];
+    rule_position =
+        RulePosition(parent_rule_position.rule_id, parent_rule_position.sequence_id,
+                     parent_rule_position.element_id + 1, parent_rule_position.parent_id);
+  }
+  return rule_position;
+}
+
+inline std::string RulePositionTree::PrintNode(int32_t id) const {
+  std::stringstream ss;
+  const auto& rule_position = node_buffer_[id];
+  ss << "id: " << id;
+  ss << ", rule " << rule_position.rule_id << ": " << grammar_->GetRule(rule_position.rule_id).name;
+  ss << ", sequence " << rule_position.sequence_id << ": "
+     << BNFGrammarPrinter(grammar_).PrintRuleExpr(rule_position.sequence_id);
+  ss << ", element id: " << rule_position.element_id << ", parent id: " << rule_position.parent_id
+     << ", ref count: " << rule_position.reference_count;
+  return ss.str();
+}
+
+inline std::string RulePositionTree::PrintStackByTopId(int32_t top_id) const {
+  std::stringstream ss;
+  std::vector<int32_t> stack;
+  for (auto cur_id = top_id; cur_id != RulePosition::kNoParent;
+       cur_id = node_buffer_[cur_id].parent_id) {
+    stack.push_back(cur_id);
+  }
+  ss << "{\n";
+  for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
+    ss << PrintNode(*it) << "\n";
+  }
+  ss << "}";
+  return ss.str();
+}
+
+inline void RulePositionTree::CheckWellFormed(const std::vector<int32_t>& outside_pointers) const {
+  const auto& buffer = node_buffer_.buffer_;
+  std::unordered_set<int32_t> free_nodes_set(node_buffer_.free_nodes_.begin(),
+                                             node_buffer_.free_nodes_.end());
+  int buffer_size = static_cast<int>(buffer.size());
+  std::vector<int> new_reference_counter(buffer_size, 0);
+  std::vector<bool> visited(buffer_size, false);
+  std::queue<int> visit_queue;
+  for (auto id : outside_pointers) {
+    CHECK(id >= 0 && id < buffer_size);
+    CHECK(buffer[id] != kInvalidRulePosition);
+    new_reference_counter[id]++;
+    if (visited[id] == false) {
+      visited[id] = true;
+      visit_queue.push(id);
+    }
+  }
+  while (!visit_queue.empty()) {
+    auto cur_id = visit_queue.front();
+    visit_queue.pop();
+    const auto& rule_position = buffer[cur_id];
+    if (rule_position.parent_id != RulePosition::kNoParent) {
+      CHECK(rule_position.parent_id >= 0 && rule_position.parent_id < buffer_size);
+      CHECK(buffer[rule_position.parent_id] != kInvalidRulePosition);
+      new_reference_counter[rule_position.parent_id]++;
+      if (visited[rule_position.parent_id] == false) {
+        visited[rule_position.parent_id] = true;
+        visit_queue.push(rule_position.parent_id);
+      }
+    }
+  }
+
+  for (int i = 0; i < static_cast<int32_t>(buffer.size()); ++i) {
+    if (free_nodes_set.count(i)) {
+      CHECK(buffer[i] == kInvalidRulePosition);
+      CHECK(visited[i] == false);
+    } else {
+      CHECK(visited[i] == true);
+      CHECK(buffer[i] != kInvalidRulePosition);
+      CHECK(new_reference_counter[i] == buffer[i].reference_count)
+          << "Reference counters unmatch for node #" << i << ": Updated "
+          << new_reference_counter[i] << ", Original " << buffer[i].reference_count;
+    }
+  }
+}
+
+inline std::string StackTopsHistory::PrintHistory(int history_position_to_latest) const {
+  const auto& latest_tops =
+      stack_tops_history_[stack_tops_history_.size() - 1 - history_position_to_latest];
+  std::stringstream ss;
+  ss << "Stacks tops size: " << latest_tops.size() << std::endl;
+  int cnt = 0;
+  for (auto id : latest_tops) {
+    ss << "Stack #" << cnt << ": " << tree_->PrintStackByTopId(id) << "\n";
+    ++cnt;
+  }
+  return ss.str();
+}
+
+inline void StackTopsHistory::CheckWellFormed() const {
+  std::vector<int32_t> outside_pointers;
+  for (const auto& stack_tops : stack_tops_history_) {
+    outside_pointers.insert(outside_pointers.end(), stack_tops.begin(), stack_tops.end());
+  }
+  tree_->CheckWellFormed(outside_pointers);
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_STATE_H_

--- a/cpp/serve/grammar/grammar_state_matcher_state.h
+++ b/cpp/serve/grammar/grammar_state_matcher_state.h
@@ -1,6 +1,7 @@
 /*!
  *  Copyright (c) 2023 by Contributors
- * \file serve/grammar/grammar_state_matcher.cc
+ * \file serve/grammar/grammar_state_matcher_state.h
+ * \brief The header for the definition of the state used in the grammar state matcher.
  */
 #ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_STATE_H_
 #define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_STATE_MATCHER_STATE_H_

--- a/cpp/serve/grammar/support.h
+++ b/cpp/serve/grammar/support.h
@@ -1,0 +1,123 @@
+/*!
+ * Copyright (c) 2023 by Contributors
+ * \file dynamic_bitset.h
+ * \brief The header for the dynamic bitset container.
+ */
+#ifndef MLC_LLM_SERVE_GRAMMAR_SUPPORT_H_
+#define MLC_LLM_SERVE_GRAMMAR_SUPPORT_H_
+
+#include <tvm/runtime/logging.h>
+
+#include <cstdint>
+#include <cstring>
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*! \brief Manages a segment of externally provided memory and use it as a bitset. */
+class BitsetManager {
+ public:
+  BitsetManager(uint32_t* data, int buffer_size) : data_(data), buffer_size_(buffer_size) {}
+
+  static int GetBitsetSize(int size) { return (size + 31) / 32; }
+
+  bool operator[](int index) const {
+    DCHECK(index >= 0 && index / 32 < buffer_size_);
+    return (data_[index / 32] >> (index % 32)) & 1;
+  }
+
+  void Set(int index, bool value) {
+    DCHECK(index >= 0 && index / 32 < buffer_size_);
+    if (value) {
+      data_[index / 32] |= 1 << (index % 32);
+    } else {
+      data_[index / 32] &= ~(1 << (index % 32));
+    }
+  }
+
+  void Reset(int size, bool value) {
+    DCHECK(buffer_size_ >= GetBitsetSize(size));
+    std::memset(data_, value ? 0xFF : 0, GetBitsetSize(size) * sizeof(uint32_t));
+  }
+
+ private:
+  uint32_t* const data_;
+  const int buffer_size_;
+};
+
+/*!
+ * \brief Let lhs be the union of lhs and rhs. Suppose that both sets are sorted.
+ * \note No additional vectors are allocated, and the time complexity is O(n)
+ */
+void IntsetUnion(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
+  int original_lhs_size = lhs->size();
+  int rhs_size = rhs.size();
+
+  lhs->resize(original_lhs_size + rhs_size);
+
+  auto it_lhs = lhs->rbegin() + rhs_size;
+  auto it_rhs = rhs.rbegin();
+  auto it_result = lhs->rbegin();
+
+  while (it_lhs != lhs->rend() && it_rhs != rhs.rend()) {
+    if (*it_lhs > *it_rhs) {
+      *it_result = *it_lhs;
+      ++it_lhs;
+    } else if (*it_lhs < *it_rhs) {
+      *it_result = *it_rhs;
+      ++it_rhs;
+    } else {
+      *it_result = *it_lhs;
+      ++it_lhs;
+      ++it_rhs;
+    }
+    ++it_result;
+  }
+
+  while (it_rhs != rhs.rend()) {
+    *it_result = *it_rhs;
+    ++it_result;
+    ++it_rhs;
+  }
+
+  auto last = std::unique(lhs->begin(), lhs->end());
+  lhs->erase(last, lhs->end());
+}
+
+/*!
+ * \brief Let lhs be the intersection of lhs and rhs. Suppose that both sets are sorted.
+ * \note No additional vector is allocated, and the time complexity is O(n).
+ * \note Support the case where lhs is the universal set by setting lhs to {-1}. The result will be
+ * rhs then.
+ */
+void IntsetIntersection(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
+  if (lhs->size() == 1 && (*lhs)[0] == -1) {
+    *lhs = rhs;
+    return;
+  }
+
+  auto it_lhs = lhs->begin();
+  auto it_rhs = rhs.begin();
+  auto it_result = lhs->begin();
+
+  while (it_lhs != lhs->end() && it_rhs != rhs.end()) {
+    if (*it_lhs < *it_rhs) {
+      ++it_lhs;
+    } else if (*it_lhs > *it_rhs) {
+      ++it_rhs;
+    } else {
+      *it_result = *it_lhs;
+      ++it_lhs;
+      ++it_rhs;
+      ++it_result;
+    }
+  }
+  lhs->erase(it_result, lhs->end());
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SERVE_GRAMMAR_SUPPORT_H_

--- a/cpp/serve/grammar/support.h
+++ b/cpp/serve/grammar/support.h
@@ -1,7 +1,7 @@
 /*!
  * Copyright (c) 2023 by Contributors
- * \file dynamic_bitset.h
- * \brief The header for the dynamic bitset container.
+ * \file serve/grammar/support.h
+ * \brief The header for utilities used in grammar-guided generation.
  */
 #ifndef MLC_LLM_SERVE_GRAMMAR_SUPPORT_H_
 #define MLC_LLM_SERVE_GRAMMAR_SUPPORT_H_

--- a/cpp/support/encoding.cc
+++ b/cpp/support/encoding.cc
@@ -10,7 +10,6 @@
 
 namespace mlc {
 namespace llm {
-namespace serve {
 
 std::string CodepointToUtf8(TCodepoint codepoint) {
   ICHECK(codepoint <= 0x10FFFF) << "Invalid codepoint: " << codepoint;
@@ -35,6 +34,33 @@ std::string CodepointToUtf8(TCodepoint codepoint) {
     utf8 += static_cast<char>(0x80 | (codepoint & 0x3F));
   }
   return utf8;
+}
+
+std::string CodepointToPrintable(
+    TCodepoint codepoint, const std::unordered_map<TCodepoint, std::string>& custom_escape_map) {
+  static const std::unordered_map<TCodepoint, std::string> kCodepointToEscape = {
+      {'\'', "\\\'"}, {'\"', "\\\""}, {'\?', "\\\?"}, {'\\', "\\\\"}, {'\a', "\\a"},
+      {'\b', "\\b"},  {'\f', "\\f"},  {'\n', "\\n"},  {'\r', "\\r"},  {'\t', "\\t"},
+      {'\v', "\\v"},  {'\0', "\\0"},  {'\x1B', "\\e"}};
+
+  if (auto it = custom_escape_map.find(codepoint); it != custom_escape_map.end()) {
+    return it->second;
+  }
+
+  if (auto it = kCodepointToEscape.find(codepoint); it != kCodepointToEscape.end()) {
+    return it->second;
+  }
+
+  if (codepoint >= 0x20 && codepoint <= 0x7E) {
+    return std::string({static_cast<char>(codepoint)});
+  }
+
+  // convert codepoint to hex
+  int width = codepoint <= 0xFFFF ? 4 : 8;
+  std::stringstream ss;
+  ss << std::setfill('0') << std::setw(width) << std::hex << codepoint;
+  auto hex = ss.str();
+  return codepoint <= 0xFFFF ? "\\u" + hex : "\\U" + hex;
 }
 
 std::pair<TCodepoint, int> Utf8ToCodepoint(const char* utf8) {
@@ -77,31 +103,17 @@ std::pair<TCodepoint, int> Utf8ToCodepoint(const char* utf8) {
   return {res, bytes};
 }
 
-std::string CodepointToPrintable(
-    TCodepoint codepoint, const std::unordered_map<TCodepoint, std::string>& custom_escape_map) {
-  static const std::unordered_map<TCodepoint, std::string> kCodepointToEscape = {
-      {'\'', "\\\'"}, {'\"', "\\\""}, {'\?', "\\\?"}, {'\\', "\\\\"}, {'\a', "\\a"},
-      {'\b', "\\b"},  {'\f', "\\f"},  {'\n', "\\n"},  {'\r', "\\r"},  {'\t', "\\t"},
-      {'\v', "\\v"},  {'\0', "\\0"},  {'\x1B', "\\e"}};
-
-  if (auto it = custom_escape_map.find(codepoint); it != custom_escape_map.end()) {
-    return it->second;
+std::vector<TCodepoint> Utf8StringToCodepoints(const char* utf8) {
+  std::vector<TCodepoint> codepoints;
+  while (*utf8 != 0) {
+    auto [codepoint, bytes] = Utf8ToCodepoint(utf8);
+    if (codepoint == static_cast<TCodepoint>(CharHandlingError::kInvalidUtf8)) {
+      return {codepoint};
+    }
+    codepoints.push_back(codepoint);
+    utf8 += bytes;
   }
-
-  if (auto it = kCodepointToEscape.find(codepoint); it != kCodepointToEscape.end()) {
-    return it->second;
-  }
-
-  if (codepoint >= 0x20 && codepoint <= 0x7E) {
-    return std::string({static_cast<char>(codepoint)});
-  }
-
-  // convert codepoint to hex
-  int width = codepoint <= 0xFFFF ? 4 : 8;
-  std::stringstream ss;
-  ss << std::setfill('0') << std::setw(width) << std::hex << codepoint;
-  auto hex = ss.str();
-  return codepoint <= 0xFFFF ? "\\u" + hex : "\\U" + hex;
+  return codepoints;
 }
 
 int HexCharToInt(char c) {
@@ -168,6 +180,5 @@ std::pair<TCodepoint, int> Utf8OrEscapeToCodepoint(
   }
 }
 
-}  // namespace serve
 }  // namespace llm
 }  // namespace mlc

--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -8,10 +8,10 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace mlc {
 namespace llm {
-namespace serve {
 
 /*! \brief Represents a unicode codepoint. */
 using TCodepoint = int32_t;
@@ -42,9 +42,9 @@ std::string CodepointToPrintable(
  */
 enum class CharHandlingError : TCodepoint {
   /*! \brief The UTF-8 string is invalid. */
-  kInvalidUtf8 = -1,
+  kInvalidUtf8 = -10,
   /*! \brief The escape sequence is invalid. */
-  kInvalidEscape = -2,
+  kInvalidEscape = -11,
 };
 
 /*!
@@ -54,6 +54,8 @@ enum class CharHandlingError : TCodepoint {
  * function returns (CharHandlingError::kInvalidUtf8, 0).
  */
 std::pair<TCodepoint, int> Utf8ToCodepoint(const char* utf8);
+
+std::vector<TCodepoint> Utf8StringToCodepoints(const char* utf8);
 
 /*!
  * \brief Convert a UTF-8 string or an escape sequence to a codepoint. By default the function
@@ -69,7 +71,6 @@ std::pair<TCodepoint, int> Utf8ToCodepoint(const char* utf8);
 std::pair<TCodepoint, int> Utf8OrEscapeToCodepoint(
     const char* utf8, const std::unordered_map<std::string, TCodepoint>& custom_escape_map = {});
 
-}  // namespace serve
 }  // namespace llm
 }  // namespace mlc
 

--- a/cpp/tokenizers.cc
+++ b/cpp/tokenizers.cc
@@ -34,6 +34,16 @@ std::string TokenizerObj::Decode(const std::vector<int32_t>& token_ids) const {
   return tokenizer->Decode(token_ids);
 }
 
+size_t TokenizerObj::GetVocabSize() const { return tokenizer->GetVocabSize(); }
+
+std::string TokenizerObj::IdToToken(int32_t token_id) const {
+  return tokenizer->IdToToken(token_id);
+}
+
+int32_t TokenizerObj::TokenToId(const std::string& token) const {
+  return tokenizer->TokenToId(token);
+}
+
 Tokenizer Tokenizer::FromPath(const String& _path) {
   std::filesystem::path path(_path.operator std::string());
   std::filesystem::path sentencepiece;

--- a/cpp/tokenizers.h
+++ b/cpp/tokenizers.h
@@ -33,6 +33,22 @@ class TokenizerObj : public Object {
   /*! \brief Return the token table of the tokenizer. */
   const std::vector<std::string>& TokenTable();
 
+  /*!
+   * \brief Returns the vocabulary size. Special tokens are considered.
+   */
+  size_t GetVocabSize() const;
+
+  /*!
+   * \brief Convert the given id to its corresponding token if it exists. If not, return an
+   * empty string.
+   */
+  std::string IdToToken(int32_t token_id) const;
+
+  /*!
+   * \brief Convert the given token to its corresponding id if it exists. If not, return -1.
+   */
+  int32_t TokenToId(const std::string& token) const;
+
   static constexpr const char* _type_key = "mlc.Tokenizer";
   static constexpr const bool _type_has_method_sequal_reduce = false;
   static constexpr const bool _type_has_method_shash_reduce = false;

--- a/python/mlc_chat/serve/__init__.py
+++ b/python/mlc_chat/serve/__init__.py
@@ -5,6 +5,6 @@ from .async_engine import AsyncThreadedEngine
 from .config import EngineMode, GenerationConfig, KVCacheConfig
 from .data import Data, TextData, TokenData
 from .engine import Engine
-from .grammar import BNFGrammar
+from .grammar import BNFGrammar, GrammarStateMatcher
 from .request import Request, RequestStreamOutput
 from .server import PopenServer

--- a/python/mlc_chat/serve/grammar.py
+++ b/python/mlc_chat/serve/grammar.py
@@ -23,7 +23,7 @@ class BNFGrammar(Object):
         r"""Parse a BNF grammar from a string in BNF/EBNF format.
 
         This method accepts the EBNF notation from the W3C XML Specification
-        (https://www.w3.org/TR/xml/#sec-notatPion), which is a popular standard, with the following
+        (https://www.w3.org/TR/xml/#sec-notation), which is a popular standard, with the following
         changes:
         - Using # as comment mark instead of /**/
         - Using C-style unicode escape sequence \u01AB, \U000001AB, \xAB instead of #x0123

--- a/python/mlc_chat/serve/grammar.py
+++ b/python/mlc_chat/serve/grammar.py
@@ -1,7 +1,10 @@
 """Classes handling the grammar guided generation of MLC LLM serving"""
+from typing import List, Union
+
 import tvm._ffi
 from tvm.runtime import Object
 
+from ..tokenizer import Tokenizer
 from . import _ffi_api
 
 
@@ -14,11 +17,13 @@ class BNFGrammar(Object):
     """
 
     @staticmethod
-    def from_ebnf_string(ebnf_string: str) -> "BNFGrammar":
+    def from_ebnf_string(
+        ebnf_string: str, normalize: bool = True, simplify: bool = True
+    ) -> "BNFGrammar":
         r"""Parse a BNF grammar from a string in BNF/EBNF format.
 
         This method accepts the EBNF notation from the W3C XML Specification
-        (https://www.w3.org/TR/xml/#sec-notation), which is a popular standard, with the following
+        (https://www.w3.org/TR/xml/#sec-notatPion), which is a popular standard, with the following
         changes:
         - Using # as comment mark instead of /**/
         - Using C-style unicode escape sequence \u01AB, \U000001AB, \xAB instead of #x0123
@@ -31,13 +36,28 @@ class BNFGrammar(Object):
         ebnf_string : str
             The grammar string.
 
+        normalize : bool
+            Whether to normalize the grammar. Default: true. Only set to false for the purpose of
+            testing.
+
+            In The normalized form of a BNF grammar, every rule is in the form:
+            `rule_name ::= ("" | (element1_1 element1_2 ...) | (element2_1 element2_2 ...) | ...)`.
+
+            I.e. a list of choices, each choice is a sequence of elements. Elements can be a
+            character class or a rule reference. And if the rule can be empty, the first choice
+            will be an empty string.
+
+        simplify : bool
+            Whether to simplify the grammar to make matching more efficient. Default: true. Not
+            implemented yet.
+
         Returns
         -------
         grammar : BNFGrammar
             The parsed BNF grammar.
         """
         return _ffi_api.BNFGrammarFromEBNFString(  # type: ignore  # pylint: disable=no-member
-            ebnf_string
+            ebnf_string, normalize, simplify
         )
 
     def to_string(self) -> str:
@@ -49,6 +69,9 @@ class BNFGrammar(Object):
             The BNF grammar string.
         """
         return str(_ffi_api.BNFGrammarToString(self))  # type: ignore  # pylint: disable=no-member
+
+    def __str__(self) -> str:
+        return self.to_string()
 
     @staticmethod
     def from_json(json_string: str) -> "BNFGrammar":
@@ -82,3 +105,138 @@ class BNFGrammar(Object):
         return str(
             _ffi_api.BNFGrammarToJSON(self, prettify)  # type: ignore  # pylint: disable=no-member
         )
+
+    @staticmethod
+    def get_grammar_of_json() -> "BNFGrammar":
+        """Get the grammar of standard JSON.
+
+        Returns
+        -------
+        grammar : BNFGrammar
+            The JSON grammar.
+        """
+        return _ffi_api.BNFGrammarGetGrammarOfJSON()  # type: ignore  # pylint: disable=no-member
+
+
+@tvm._ffi.register_object("mlc.serve.GrammarStateMatcher")  # pylint: disable=protected-access
+class GrammarStateMatcher(Object):
+    """A stateful matcher to match tokens to the specified BNF grammar. This class is the core logic
+    of the grammar-guided generation.
+
+    This class implements the non-deterministic pushdown automaton (NPDA) matching algorithm to
+    match characters to a BNF grammar. It keep track of the current state of the matching process by
+    maintaining several stacks internally as possible paths in the NPDA. It also supports
+    backtracking.
+
+    It is particularly capable of finding the set of tokens that are acceptable for the next step
+    and storing them in a bitmask. This aids in grammar-guided generation.
+
+    Parameters
+    ----------
+    grammar : BNFGrammar
+        The BNF grammar to match.
+
+    tokenizer : Union[None, Tokenizer, List[str]]
+        The tokenizer to use, or the list of tokens.
+
+        (For debug purpose) If None, the matcher will use an empty token set, and can only accept
+        and match characters. Default: None.
+
+    max_rollback_steps : int
+        The maximum number of steps to rollback when backtracking. Default: 0.
+    """
+
+    def __init__(
+        self,
+        grammar: BNFGrammar,
+        tokenizer: Union[None, Tokenizer, List[str]] = None,
+        max_rollback_steps: int = 0,
+    ):
+        if isinstance(tokenizer, list):
+            self.__init_handle_by_constructor__(
+                _ffi_api.GrammarStateMatcherFromTokenTable,  # type: ignore  # pylint: disable=no-member
+                grammar,
+                *tokenizer,
+                max_rollback_steps,
+            )
+        else:
+            self.__init_handle_by_constructor__(
+                _ffi_api.GrammarStateMatcherFromTokenizer,  # type: ignore  # pylint: disable=no-member
+                grammar,
+                tokenizer,
+                max_rollback_steps,
+            )
+
+    def accept_token(self, token_id: int) -> bool:
+        """Accept one token and update the state of the matcher.
+
+        Parameters
+        ----------
+        token_id : int
+            The id of the token to accept.
+
+        Returns
+        -------
+        accepted : bool
+            Whether the token is accepted.
+        """
+        return _ffi_api.GrammarStateMatcherAcceptToken(self, token_id)  # type: ignore  # pylint: disable=no-member
+
+    def find_next_rejected_tokens(self) -> List[int]:
+        """Find the ids of the rejected tokens for the next step.
+
+        Returns
+        -------
+        rejected_token_ids : List[int]
+            A list of rejected token ids.
+        """
+
+        return _ffi_api.GrammarStateMatcherFindNextRejectedTokens(self)  # type: ignore  # pylint: disable=no-member
+
+    def rollback(self, num_tokens: int) -> None:
+        """Rollback the matcher to a previous state.
+
+        Parameters
+        ----------
+        num_tokens : int
+            The number of tokens to rollback. It cannot exceed the current number of steps, nor can
+            it exceed the specified maximum number of rollback steps.
+        """
+        _ffi_api.GrammarStateMatcherRollback(self, num_tokens)  # type: ignore  # pylint: disable=no-member
+
+    def max_rollback_steps(self) -> int:
+        """Get the maximum number of rollback steps allowed.
+
+        Returns
+        -------
+        max_rollback_steps : int
+            The maximum number of rollback steps.
+        """
+        return _ffi_api.GrammarStateMatcherMaxRollbackSteps(self)  # type: ignore  # pylint: disable=no-member
+
+    def reset_state(self) -> None:
+        """Reset the matcher to the initial state."""
+        _ffi_api.GrammarStateMatcherResetState(self)  # type: ignore  # pylint: disable=no-member
+
+    def debug_accept_char(self, codepoint: int) -> bool:
+        """Accept one unicode codepoint to the current state.
+
+        Parameters
+        ----------
+        codepoint : int
+            The unicode codepoint of the character to be accepted.
+        """
+        return _ffi_api.GrammarStateMatcherDebugAcceptCodepoint(  # type: ignore  # pylint: disable=no-member
+            self, codepoint
+        )
+
+    def debug_match_complete_string(self, string: str) -> bool:
+        """Check if a matcher can accept the complete string, and then reach the end of the
+        grammar.
+
+        Parameters
+        ----------
+        string : str
+            The string to be matched.
+        """
+        return _ffi_api.GrammarStateMatcherDebugMatchCompleteString(self, string)  # type: ignore  # pylint: disable=no-member

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-module-docstring,unused-import
+import pytest
+import tvm.testing
+
+pytest_plugins = ["tvm.testing.plugin"]

--- a/tests/python/serve/test_grammar_state_matcher.py
+++ b/tests/python/serve/test_grammar_state_matcher.py
@@ -1,0 +1,389 @@
+# pylint: disable=missing-module-docstring,missing-function-docstring
+# pylint: disable=redefined-outer-name,unbalanced-tuple-unpacking
+from typing import List
+
+import pytest
+import tvm
+import tvm.testing
+
+from mlc_chat.serve import BNFGrammar, GrammarStateMatcher
+from mlc_chat.tokenizer import Tokenizer
+
+
+@pytest.fixture(scope="function")
+def json_grammar():
+    return BNFGrammar.get_grammar_of_json()
+
+
+(json_input_accepted,) = tvm.testing.parameters(
+    ('{"name": "John"}',),
+    ('{ "name" : "John" } \n',),
+    ("{}",),
+    ("[]",),
+    ('{"name": "Alice", "age": 30, "city": "New York"}',),
+    ('{"name": "Mike", "hobbies": ["reading", "cycling", "hiking"]}',),
+    ('{"name": "Emma", "address": {"street": "Maple Street", "city": "Boston"}}',),
+    ('[{"name": "David"}, {"name": "Sophia"}]',),
+    (
+        '{"name": "William", "age": null, "married": true, "children": ["Liam", "Olivia"],'
+        ' "hasPets": false}',
+    ),
+    (
+        '{"name": "Olivia", "contact": {"email": "olivia@example.com", "address": '
+        '{"city": "Chicago", "zipcode": "60601"}}}',
+    ),
+    (
+        '{"name": "Liam", "skills": ["Java", "Python"], "experience": '
+        '[{"company": "CompanyA", "years": 5}, {"company": "CompanyB", "years": 3}]}',
+    ),
+    (
+        '{"person": {"name": "Ethan", "age": 40}, "education": {"degree": "Masters", '
+        '"university": "XYZ University"}, "work": [{"company": "ABC Corp", "position": '
+        '"Manager"}, {"company": "DEF Corp", "position": "Senior Manager"}]}',
+    ),
+    (
+        '{"name": "Charlotte", "details": {"personal": {"age": 35, "hobbies": ["gardening", '
+        '"painting"]}, "professional": {"occupation": "Engineer", "skills": '
+        '["CAD", "Project Management"], "projects": [{"name": "Project A", '
+        '"status": "Completed"}, {"name": "Project B", "status": "In Progress"}]}}}',
+    ),
+)
+
+
+def test_json_accept(json_grammar: BNFGrammar, json_input_accepted: str):
+    assert GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_accepted)
+
+
+# test_json_accept(json_grammar(), '{"name": "John"}')
+# exit()
+
+(json_input_refused,) = tvm.testing.parameters(
+    (r'{ name: "John" }',),
+    (r'{ "name": "John", "age": 30, }',),  # x
+    (r'{ "name": "John", "address": { "street": "123 Main St", "city": "New York" }',),
+    (r'{ "name": "John", "age": 30, "hobbies": ["reading", "traveling",], }',),  # x
+    (r'{ "name": "John", "age": 30.5.7 }',),
+    (r'{ "name": "John, "age": 30, "hobbies": ["reading", "traveling"] }',),
+    (
+        r'{ "name": "John", "age": 30, "hobbies": ["reading", { "type": "outdoor", "list": '
+        r'["hiking", "swimming",]}] }',  #
+    ),
+    (r'{ "name": "John", "age": 30, "status": "\P\J" }',),
+    (
+        r'{ "name": "John", "age": 30, "hobbies": ["reading", "traveling"], "address": '
+        r'{ "street": "123 Main St", "city": "New York", "coordinates": { "latitude": 40.7128, '
+        r'"longitude": -74.0060 }}}, "work": { "company": "Acme", "position": "developer" }}',
+    ),
+)
+
+
+def test_json_refuse(json_grammar: BNFGrammar, json_input_refused):
+    assert not GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_refused)
+
+
+(json_input_pressure,) = tvm.testing.parameters(
+    # Extra long string: 1k chars
+    (
+        '["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent '
+        "libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum "
+        "imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper "
+        "porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu "
+        "ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula "
+        "in libero. Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. "
+        "In scelerisque sem at dolor. Maecenas mattis. Sed convallis tristique sem. Proin ut "
+        "ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, "
+        "luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla "
+        "metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh. Quisque volutpat "
+        "condimentum velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, "
+        "per inceptos himenaeos. Nam nec ante. Sed lacinia, urna non tincidunt mattis, tortor "
+        "neque adipiscing diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla. "
+        "Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet. Vestibulum sapien. "
+        "Proin quam. Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed lectus. "
+        "Integer euismod lacus luctus magna. Quisque cursus, metus vitae pharetra auctor, sem "
+        'massa mattis sem, at interdum magna augue eget diam."]',
+    ),
+    # long and complex json: 3k chars
+    (
+        r"""{
+    "web-app": {
+    "servlet": [
+        {
+        "servlet-name": "cofaxCDS",
+        "servlet-class": "org.cofax.cds.CDSServlet",
+        "init-param": {
+            "configGlossary:installationAt": "Philadelphia, PA",
+            "configGlossary:adminEmail": "ksm@pobox.com",
+            "configGlossary:poweredBy": "Cofax",
+            "configGlossary:poweredByIcon": "/images/cofax.gif",
+            "configGlossary:staticPath": "/content/static",
+            "templateProcessorClass": "org.cofax.WysiwygTemplate",
+            "templateLoaderClass": "org.cofax.FilesTemplateLoader",
+            "templatePath": "templates",
+            "templateOverridePath": "",
+            "defaultListTemplate": "listTemplate.htm",
+            "defaultFileTemplate": "articleTemplate.htm",
+            "useJSP": false,
+            "jspListTemplate": "listTemplate.jsp",
+            "jspFileTemplate": "articleTemplate.jsp",
+            "cachePackageTagsTrack": 200,
+            "cachePackageTagsStore": 200,
+            "cachePackageTagsRefresh": 60,
+            "cacheTemplatesTrack": 100,
+            "cacheTemplatesStore": 50,
+            "cacheTemplatesRefresh": 15,
+            "cachePagesTrack": 200,
+            "cachePagesStore": 100,
+            "cachePagesRefresh": 10,
+            "cachePagesDirtyRead": 10,
+            "searchEngineListTemplate": "forSearchEnginesList.htm",
+            "searchEngineFileTemplate": "forSearchEngines.htm",
+            "searchEngineRobotsDb": "WEB-INF/robots.db",
+            "useDataStore": true,
+            "dataStoreClass": "org.cofax.SqlDataStore",
+            "redirectionClass": "org.cofax.SqlRedirection",
+            "dataStoreName": "cofax",
+            "dataStoreDriver": "com.microsoft.jdbc.sqlserver.SQLServerDriver",
+            "dataStoreUrl": "jdbc:microsoft:sqlserver://LOCALHOST:1433;DatabaseName=goon",
+            "dataStoreUser": "sa",
+            "dataStorePassword": "dataStoreTestQuery",
+            "dataStoreTestQuery": "SET NOCOUNT ON;select test='test';",
+            "dataStoreLogFile": "/usr/local/tomcat/logs/datastore.log",
+            "dataStoreInitConns": 10,
+            "dataStoreMaxConns": 100,
+            "dataStoreConnUsageLimit": 100,
+            "dataStoreLogLevel": "debug",
+            "maxUrlLength": 500
+        }
+        },
+        {
+        "servlet-name": "cofaxEmail",
+        "servlet-class": "org.cofax.cds.EmailServlet",
+        "init-param": {
+            "mailHost": "mail1",
+            "mailHostOverride": "mail2"
+        }
+        },
+        {
+        "servlet-name": "cofaxAdmin",
+        "servlet-class": "org.cofax.cds.AdminServlet"
+        },
+        {
+        "servlet-name": "fileServlet",
+        "servlet-class": "org.cofax.cds.FileServlet"
+        },
+        {
+        "servlet-name": "cofaxTools",
+        "servlet-class": "org.cofax.cms.CofaxToolsServlet",
+        "init-param": {
+            "templatePath": "toolstemplates/",
+            "log": 1,
+            "logLocation": "/usr/local/tomcat/logs/CofaxTools.log",
+            "logMaxSize": "",
+            "dataLog": 1,
+            "dataLogLocation": "/usr/local/tomcat/logs/dataLog.log",
+            "dataLogMaxSize": "",
+            "removePageCache": "/content/admin/remove?cache=pages&id=",
+            "removeTemplateCache": "/content/admin/remove?cache=templates&id=",
+            "fileTransferFolder": "/usr/local/tomcat/webapps/content/fileTransferFolder",
+            "lookInContext": 1,
+            "adminGroupID": 4,
+            "betaServer": true
+        }
+        }
+    ],
+    "servlet-mapping": {
+        "cofaxCDS": "/",
+        "cofaxEmail": "/cofaxutil/aemail/*",
+        "cofaxAdmin": "/admin/*",
+        "fileServlet": "/static/*",
+        "cofaxTools": "/tools/*"
+    },
+    "taglib": {
+        "taglib-uri": "cofax.tld",
+        "taglib-location": "/WEB-INF/tlds/cofax.tld"
+    }
+    }
+}    """,
+    ),
+)
+
+
+def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
+    assert GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_pressure)
+
+
+(input_find_rejected_tokens, expected_rejected_sizes) = tvm.testing.parameters(
+    (
+        # short test
+        '{"id": 1,"name": "Example"} ',
+        [
+            # fmt: off
+            31989, 31907, 278, 278, 278, 31973, 31841, 31841, 31948, 31910, 278, 278, 278, 278,
+            278, 31973, 31841, 31841, 271, 271, 271, 271, 271, 271, 271, 271, 31974, 31980, 31980
+            # fmt: on
+        ],
+    ),
+    (
+        # long test
+        """{
+"id": 1,
+"na": "ex",
+"ac": True,
+"t": ["t1", "t2"],
+"ne": {"lv2": {"val": "dp"}, "arr": [1, 2, 3]},
+"res": "res"
+}
+""",
+        [
+            # fmt: off
+            31989, 31907, 31907, 278, 278, 278, 31973, 31841, 31841, 31948, 31910, 31910, 278, 278,
+            278, 31973, 31841, 31841, 271, 271, 271, 31974, 31910, 31910, 278, 278, 278, 31973,
+            31841, 31841, 31841, 31841, 31841, 31841, 31841, 31841, 271, 271, 31974, 31974, 31974,
+            31974, 31974, 31974, 31974, 31974, 31910, 31910, 278, 278, 278, 31973, 31973, 31973,
+            31973, 31973, 31973, 31973, 31973, 31841, 31841, 31903, 278, 278, 278, 278, 31973,
+            31841, 31841, 31901, 278, 278, 278, 278, 31973, 31841, 31841, 270, 270, 270, 31968,
+            31970, 31910, 31910, 278, 278, 278, 278, 31973, 31841, 31841, 31835, 31943, 31841,
+            31841, 31943, 31841, 31841, 31943, 31970, 31974, 31910, 31910, 278, 278, 278, 278,
+            31973, 31841, 31841, 271, 271, 271, 271, 31974, 31974, 31980, 31980
+            # fmt: on
+        ],
+    ),
+)
+
+
+def test_find_rejected_tokens(
+    json_grammar: BNFGrammar, input_find_rejected_tokens: str, expected_rejected_sizes: List[int]
+):
+    tokenizer_path = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
+    tokenizer = Tokenizer(tokenizer_path)
+    grammar_state_matcher = GrammarStateMatcher(json_grammar, tokenizer)
+
+    real_sizes = []
+    for c in input_find_rejected_tokens:
+        rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
+        real_sizes.append(len(rejected_token_ids))
+        print("Accepting char:", c)
+        grammar_state_matcher.debug_accept_char(ord(c))
+    rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
+    real_sizes.append(len(rejected_token_ids))
+    print(real_sizes)
+    print(expected_rejected_sizes)
+    assert real_sizes == expected_rejected_sizes
+
+
+def test_accept_token(json_grammar: BNFGrammar):
+    token_table = [
+        # fmt: off
+        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
+        # fmt: on
+    ]
+    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}", "\n"]
+    input_ids = [token_table.index(t) for t in input_splitted]
+
+    grammar_state_matcher = GrammarStateMatcher(json_grammar, token_table)
+
+    result = []
+
+    expected = [
+        ["{"],
+        ['"', "}", "\n", " ", '"a":true'],
+        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " "],
+        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " "],
+        [":", "\n", " ", ':"'],
+        ['"', "{", "6", "\n", " "],
+        ["}", ", ", "6", "\n", " "],
+        [" ", "\n", '"', '"a":true'],
+        [" ", "\n", '"', '"a":true'],
+        ["}", ", ", "\n", " "],
+        ["</s>", "\n", " "],
+        ["</s>", "\n", " "],
+    ]
+
+    for id in input_ids:
+        rejected = grammar_state_matcher.find_next_rejected_tokens()
+        accepted = list(set(range(len(token_table))) - set(rejected))
+        accepted_tokens = [token_table[i] for i in accepted]
+        result.append(accepted_tokens)
+        assert id in accepted
+        grammar_state_matcher.accept_token(id)
+
+    rejected = grammar_state_matcher.find_next_rejected_tokens()
+    accepted = list(set(range(len(token_table))) - set(rejected))
+    accepted_tokens = [token_table[i] for i in accepted]
+    result.append(accepted_tokens)
+
+    assert result == expected
+
+
+def test_rollback(json_grammar: BNFGrammar):
+    token_table = [
+        # fmt: off
+        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
+        # fmt: on
+    ]
+    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', " ", "}", "\n"]
+    input_ids = [token_table.index(t) for t in input_splitted]
+
+    grammar_state_matcher = GrammarStateMatcher(json_grammar, token_table, 5)
+
+    assert grammar_state_matcher.max_rollback_steps() == 5
+
+    input_ids_splitted = [input_ids[i : i + 2] for i in range(0, len(input_ids), 2)]
+
+    for i_1, i_2 in input_ids_splitted:
+        orig_result = []
+        orig_result.append(grammar_state_matcher.find_next_rejected_tokens())
+        grammar_state_matcher.accept_token(i_1)
+        orig_result.append(grammar_state_matcher.find_next_rejected_tokens())
+        grammar_state_matcher.accept_token(i_2)
+        grammar_state_matcher.rollback(2)
+        result_after_rollback = []
+        result_after_rollback.append(grammar_state_matcher.find_next_rejected_tokens())
+        grammar_state_matcher.accept_token(i_1)
+        result_after_rollback.append(grammar_state_matcher.find_next_rejected_tokens())
+        grammar_state_matcher.accept_token(i_2)
+        assert orig_result == result_after_rollback
+
+
+def test_reset(json_grammar: BNFGrammar):
+    token_table = [
+        # fmt: off
+        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
+        # fmt: on
+    ]
+    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', " ", "}", "\n"]
+    input_ids = [token_table.index(t) for t in input_splitted]
+
+    grammar_state_matcher = GrammarStateMatcher(json_grammar, token_table)
+
+    orig_result = []
+
+    for i in input_ids:
+        orig_result.append(grammar_state_matcher.find_next_rejected_tokens())
+        grammar_state_matcher.accept_token(i)
+
+    grammar_state_matcher.reset_state()
+
+    result_after_reset = []
+
+    for i in input_ids:
+        result_after_reset.append(grammar_state_matcher.find_next_rejected_tokens())
+        grammar_state_matcher.accept_token(i)
+
+    assert orig_result == result_after_reset
+
+
+if __name__ == "__main__":
+    # Run a benchmark to show the performance before running tests
+    test_find_rejected_tokens(
+        BNFGrammar.get_grammar_of_json(),
+        '{"id": 1,"name": "Example"} ',
+        [
+            # fmt: off
+            31989, 31907, 278, 278, 278, 31973, 31841, 31841, 31948, 31910, 278, 278, 278, 278,
+            278, 31973, 31841, 31841, 271, 271, 271, 271, 271, 271, 271, 271, 31974, 31980, 31980
+            # fmt: on
+        ],
+    )
+
+    tvm.testing.main()

--- a/tests/python/serve/test_grammar_state_matcher.py
+++ b/tests/python/serve/test_grammar_state_matcher.py
@@ -266,8 +266,6 @@ def test_find_rejected_tokens(
         grammar_state_matcher.debug_accept_char(ord(c))
     rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
     real_sizes.append(len(rejected_token_ids))
-    print(real_sizes)
-    print(expected_rejected_sizes)
     assert real_sizes == expected_rejected_sizes
 
 


### PR DESCRIPTION
This PR brings is the 2nd part of the support of grammar guided generation. It
- designs a visitor for visiting and mutating the BNF AST, provides a normalizer utility, and
- brings an effecient implementation of non-deterministic pushdown automata (NPDA) to match a character sequence to the specified grammar.

See grammar_state_matcher.h and grammar_state_matcher.cc for more details.

### API
```
class GrammarStateMatcherNode : public Object {
 public:
  /*!
   * \brief Accept one token and update the state of the matcher.
   * \param token_id The id of the token to accept.
   * \return Whether the token is accepted.
   */
  virtual bool AcceptToken(int32_t token_id) = 0;

  /*!
   * \brief Find the set of tokens that are acceptable for the next step and store them in a
   * bitmask.
   * \param next_token_bitmask The bitmask to store the result. The bitmask must be pre-allocated,
   * and its shape needs to be (ceil(vocab_size, 32),), with a dtype of uint32.
   */
  virtual void FindNextTokenBitmask(DLTensor* next_token_bitmask) = 0;

  /*!
   * \brief Rollback the matcher to a previous state.
   * \param num_tokens The number of tokens to rollback. It cannot exceed the current number of
   * steps, nor can it exceed the specified maximum number of rollback steps.
   */
  virtual void Rollback(int num_tokens) = 0;

  /*! \brief Get the maximum number of rollback steps allowed. */
  virtual int MaxRollbackSteps() = 0;

  /*! \brief Reset the matcher to the initial state. */
  virtual void ResetState() = 0;
};

class GrammarStateMatcher : public ObjectRef {
 public:
  /*!
   * \brief Construct a GrammarStateMatcher from the preprocessing result of type
   * GrammarStateInitContext.
   * \param init_ctx The init context. It is obtained through
   * CreateInitContext as a result of preprocessing the grammar and tokenizer.
   */
  GrammarStateMatcher(std::shared_ptr<GrammarStateInitContext> init_ctx,
                      int max_rollback_steps = 0);

  /*!
   * \brief Specify a grammar and token_table to return their preprocessing results. These results
   * are used to construct a GrammarStateMatcher. They can be stored elsewhere for quick
   * construction of GrammarStateMatcher.
   * \param grammar The grammar that the matcher follows.
   * \param token_table The tokens that the matcher requires for matching.
   */
  static std::shared_ptr<GrammarStateInitContext> CreateInitContext(
      const BNFGrammar& grammar, const std::vector<std::string>& token_table);
};
```

### Usage
```
Tokenizer tokenizer = ...;
auto init_ctx = GrammarStateMatcher::CreateInitContext(grammar, tokenizer->TokenTable());
GrammarStateMatcher matcher(init_ctx, 10);
matcher->AcceptToken(67);

// Construct a DLTensor with shape (tokenizer.GetVocabSize() + 31) / 32, and dtype uint32.
DLTensor next_token_bitmask = ...;
matcher->FindNextTokenBitmask(&next_token_bitmask);

// Rollback is supported
matcher->Rollback(1);
```

### Performance test
See `tests/python/serve/test_grammar_state_matcher.py::test_find_rejected_tokens`:

```
FindNextTokenBitmask takes 2us, found accepted: 12, rejected: 31988
Accepting char: {
FindNextTokenBitmask takes 3us, found accepted: 94, rejected: 31906
Accepting char: "
FindNextTokenBitmask takes 14us, found accepted: 31850, rejected: 150
Accepting char: i
...
FindNextTokenBitmask takes 14us, found accepted: 31857, rejected: 143
Accepting char: "
FindNextTokenBitmask takes 3us, found accepted: 27, rejected: 31973
Accepting char: }
FindNextTokenBitmask takes 0us, found accepted: 21, rejected: 31979
Accepting char:  
FindNextTokenBitmask takes 0us, found accepted: 21, rejected: 31979
```

Typical performance indicators: For JSON grammar, 
- `380 us` for matching a string with 3.8k characters (~0.1us/char)
- `<16 us` for finding all possible tokens in LLaMA tokenizer for a grammar matcher state

Thanks to the discussion with @tqchen 
cc @MasterJH5574