### PR TITLE
[Mixtral] Fix indptr shape in dequantize_group_gemm

### DIFF
--- a/python/mlc_chat/op/moe_matmul.py
+++ b/python/mlc_chat/op/moe_matmul.py
@@ -416,14 +416,15 @@ def dequantize_group_gemm(
     assert BLK_K % 8 == 0
     tiles_per_row = (N + BLK_N - 1) // BLK_N
     zero = tir.const(0, model_dtype)
-    indptr_shape = (Ne + 1,) if indptr_dtype == "int32" else (Ne,)
+    if indptr_dtype == "int64":
+        indptr = op.pad(indptr, [1, 0], "constant", 0)
 
     @T.prim_func(private=True)
     def _func(
         var_x: T.handle,
         w: T.Buffer((Ne, N, num_storage), storage_dtype),
         scale: T.Buffer((Ne, N, num_group), model_dtype),
-        indptr: T.Buffer(indptr_shape, indptr_dtype),
+        indptr: T.Buffer((Ne + 1,), indptr_dtype),
         var_o: T.handle,
     ):
         T.func_attr({"tir.is_scheduled": 1, "tir.noalias": True})


### PR DESCRIPTION
This PR fixes a bug introduced by PR #1778 . When using `faster_transformer` the type of `indptr` is `int64`, and it's shape is `(num_experts,)` instead of `(num_experts+1,)`. The instances from `indptr[i]` to `indptr[i+1]` are assigned to the $i^{th}$ expert. The previous PR incorrectly calculates this assignment. We need to insert `0` at position 0 in `indptr` for correcting this.