### PR TITLE
[GPTNeoX] Remove the "effect" KV Cache

### DIFF
--- a/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
@@ -105,12 +105,6 @@ class GPTNeoXAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         self.dense = nn.Linear(
             self.num_attention_heads * self.head_dim, self.hidden_size, bias=True
         )
-        self.k_cache = nn.KVCache(
-            config.context_window_size, [self.num_attention_heads, self.head_dim]
-        )
-        self.v_cache = nn.KVCache(
-            config.context_window_size, [self.num_attention_heads, self.head_dim]
-        )
 
     def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
         # hidden_states: [batch_size, seq_len, hidden_size]


### PR DESCRIPTION
Given we have switched over to use PagedKVCache, the previous effect-based KV cache can be removed so that they will not be initialzied at runtime (where the initialization may cause extra memory usage).