### PR TITLE
[ChatModule] Read bos/eos from mlc-chat-config.json

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -550,6 +550,14 @@ class LLMChat {
     } else {
       CHECK(partial_update) << "Key \"conv_template\" and \"conv_config\" not found.";
     }
+    if (config.count("bos_token_id")) {
+      CHECK(config["bos_token_id"].is<int64_t>());
+      this->bos_token_id_ = config["bos_token_id"].get<int64_t>();
+    }
+    if (config.count("eos_token_id")) {
+      CHECK(config["eos_token_id"].is<int64_t>());
+      this->eos_token_id_ = config["eos_token_id"].get<int64_t>();
+    }
   }
 
   /*!


### PR DESCRIPTION
This PR supports reading eos/bos token id from mlc-chat-config.json to handle models that have different bos/eos.

Co-authored-by: Charlie Ruan <53290280+CharlieFRuan@users.noreply.github.com>