### PR TITLE
[Fix] Fix `u_char` for Windows build

### DIFF
--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -103,7 +103,7 @@ inline void TokenToLogProbJSON(const Tokenizer& tokenizer, const TokenProbPair& 
   (*os) << "\"bytes\": [";
   int token_len = token.size();
   for (int pos = 0; pos < token_len; ++pos) {
-    (*os) << static_cast<int>(static_cast<u_char>(token[pos]));
+    (*os) << static_cast<int>(static_cast<unsigned char>(token[pos]));
     if (pos != token_len - 1) {
       (*os) << ", ";
     }


### PR DESCRIPTION
Prior to this PR, `u_char` was used while it is not a standard type in C++, which causes Windows build failure.

This PR fixes it by using `unsigned char`.