### PR TITLE
[Attn][Adreno][OpenCL] Fix workgroup size

### DIFF
--- a/python/mlc_chat/nn/kv_cache.py
+++ b/python/mlc_chat/nn/kv_cache.py
@@ -824,7 +824,9 @@ def _attention_decode(
     for name in ["max_threads_per_block", "max_num_threads"]:
         if max_threads is None:
             max_threads = target.attrs.get(name, None)
-    thread_limit = 512 if max_threads is None else max_threads
+    thread_limit = 512
+    if max_threads is not None:
+        thread_limit = min(max_threads, thread_limit)
 
     GROUP_SIZE = H_qo // H_kv
     VEC_SIZE = min(max(8 // qkv_dtype_bytes, D // 32), 4)

--- a/python/mlc_chat/nn/kv_cache.py
+++ b/python/mlc_chat/nn/kv_cache.py
@@ -820,7 +820,11 @@ def _attention_decode(
     H_kv = num_kv_heads
     D = head_dim
 
-    thread_limit = 512 if str(target.kind) != "webgpu" else 256
+    max_threads = None
+    for name in ["max_threads_per_block", "max_num_threads"]:
+        if max_threads is None:
+            max_threads = target.attrs.get(name, None)
+    thread_limit = 512 if max_threads is None else max_threads
 
     GROUP_SIZE = H_qo // H_kv
     VEC_SIZE = min(max(8 // qkv_dtype_bytes, D // 32), 4)


### PR DESCRIPTION
It was impossible to execute Llama model on Snapdragon 888 because of OpenCL error `CL_INVALID_WORK_GROUP_SIZE`. To fix this issue for OpenCL and other targets, it was decided to take the value of thread limit from the target attributes.

This regression was introduced in #1698.