### PR TITLE
[Build] Replace mod_transform_before_build with IRModule pass

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -550,41 +550,12 @@ def get_cuda_sm_version():
     return sm
 
 
-def mod_transform_before_build(
-    mod: tvm.IRModule,
-    param_manager: param_manager.ParamManager,
+def optimize_mod_pipeline(
     args: argparse.Namespace,
     config: Dict,
-) -> tvm.IRModule:
+) -> tvm.ir.transform.Pass:
     """First-stage: Legalize ops and trace"""
-    if args.model.startswith("minigpt"):
-        model_names = ["embed"]
-    else:
-        model_names = [
-            "prefill",
-            "decode",
-        ]
-
-        if not args.use_vllm_attention:
-            model_names += [
-                "create_kv_cache",
-                "softmax_with_temperature",
-                "get_metadata",
-            ]
-        else:
-            # This is equivalent to prefill but without KV cache. It is used for
-            # determining the number of paged cache blocks that can be allocated.
-            model_names.append("evaluate")
-
-        if args.sep_embed:
-            model_names = ["embed", "prefill_with_embed"] + model_names[1:]
-            if args.enable_batching:
-                model_names[2] = "decode_with_embed"
-        if args.model.lower().startswith("rwkv-"):
-            model_names += ["reset_kv_cache"]
-
-    mod = param_manager.transform_dequantize()(mod)
-    mod = relax.transform.BundleModelParams()(mod)
+    seq = []
 
     use_ft_quant = args.quantization.name in [
         "q4f16_ft",
@@ -592,7 +563,7 @@ def mod_transform_before_build(
         "q4f16_ft_group",
         "q8f16_ft_group",
     ]
-    mod = mlc_llm.transform.FuseDecodeTranspose(skip_gemm=not use_ft_quant)(mod)
+    seq.append(mlc_llm.transform.FuseDecodeTranspose(skip_gemm=not use_ft_quant))
 
     if (
         not args.enable_batching
@@ -610,12 +581,12 @@ def mod_transform_before_build(
         if max_seq_len:
             num_key_value_heads = config.get_num_key_value_heads()
             # pylint: disable=no-value-for-parameter
-            mod = fuse_split_rotary_embedding(
+            seq.append(fuse_split_rotary_embedding(
                 config.num_attention_heads // args.num_shards,
                 num_key_value_heads // args.num_shards,
                 config.hidden_size // args.num_shards,
                 config.position_embedding_base,
-            )(mod)
+            )
 
     if args.target_kind == "cuda":
         patterns = []
@@ -625,8 +596,8 @@ def mod_transform_before_build(
         if has_cutlass and not args.no_cutlass_attn:
             # pylint: disable=no-value-for-parameter
             if args.use_flash_attn_mqa:
-                mod = rewrite_attention(use_flash_mqa=True)(mod)
-            mod = rewrite_attention(use_flash_mqa=False)(mod)
+                seq.append(rewrite_attention(use_flash_mqa=True))
+            seq.append(rewrite_attention(use_flash_mqa=False))
             patterns += get_patterns_with_prefix("cutlass.attention")
 
         if has_cutlass and not args.no_cutlass_norm:
@@ -650,31 +621,37 @@ def mod_transform_before_build(
             if hasattr(config, "rms_norm_eps"):
                 options["cutlass"]["rms_eps"] = config.rms_norm_eps
 
-            mod = tvm.transform.Sequential(
+            seq.extend(
                 [
                     relax.transform.FuseOpsByPattern(
                         patterns, bind_constants=False, annotate_codegen=True
                     ),
                     annotate_workspace,
                     relax.transform.AllocateWorkspace(),
-                    relax.transform.RunCodegen(options, entry_functions=model_names),
+                    relax.transform.RunCodegen(options),
                 ]
-            )(mod)
+            )
 
     if args.target_kind == "android":
-        mod = mlc_llm.transform.FuseTranspose1Matmul()(mod)
-        mod = mlc_llm.transform.FuseTranspose2Matmul()(mod)
-    mod = mlc_llm.transform.FuseTransposeMatmul()(mod)
-    mod = relax.pipeline.get_pipeline()(mod)  # pylint: disable=no-value-for-parameter
-    mod = mlc_llm.transform.FuseDecodeMatmulEwise()(mod)
-    mod = mlc_llm.transform.FuseDecodeTake()(mod)
-    mod = relax.transform.DeadCodeElimination(model_names)(mod)
-    mod = mlc_llm.transform.CleanUpTIRAttrs()(mod)
-    mod_deploy = mod
+        seq.extend(
+            [
+                mlc_llm.transform.FuseTranspose1Matmul(),
+                mlc_llm.transform.FuseTranspose2Matmul(),
+            ]
+        )
+    seq.extend(
+        [
+            mlc_llm.transform.FuseTransposeMatmul(),
+            relax.pipeline.get_pipeline(),
+            mlc_llm.transform.FuseDecodeMatmulEwise(),
+            mlc_llm.transform.FuseDecodeTake(),
+            relax.transform.DeadCodeElimination(),
+            mlc_llm.transform.CleanUpTIRAttrs(),
+        ]
+    )
 
-    utils.debug_dump_script(mod_deploy, "mod_deploy.py", args)
+    return tvm.ir.transform.Sequential(seq, name="mlc_llm.core.optimize_mod_pipeline")
 
-    return mod_deploy
 
 
 def dump_mlc_chat_config(
@@ -867,6 +844,7 @@ def build_model_from_args(args: argparse.Namespace):
         for qspec_updater_class in param_manager.qspec_updater_classes:
             qspec_updater = qspec_updater_class(param_manager)
             qspec_updater.visit_module(mod)
+        mod = param_manager.transform_dequantize()(mod)
 
         if not args.build_model_only:
             parameter_transforms = []
@@ -958,7 +936,7 @@ def build_model_from_args(args: argparse.Namespace):
         if args.convert_weights_only:
             exit(0)
 
-        mod = mod_transform_before_build(mod, param_manager, args, model_config)
+        mod = optimize_mod_pipeline(args, model_config)(mod)
         if args.num_shards > 1:
             # We require a "create_sharding_info" function for all
             # multi-GPU models, even if they are using pre-sharded


### PR DESCRIPTION
Instead of a python function that returns an updated `IRModule`, the new `optimize_mod_pipeline` function returns a `tvm.ir.transform.Pass` which can be applied to an `IRModule`.