### PR TITLE
[Utils] Allow ReorderTransformFunc to be used without param manager

### DIFF
--- a/mlc_llm/relax_model/param_manager.py
+++ b/mlc_llm/relax_model/param_manager.py
@@ -837,11 +837,13 @@ class ParamManager:
         tvm.transform.Pass
             The transformation
         """
-        return ReorderTransformFunc(
-            self.pidx2pname,
-            self.torch_pname2binname,
-            self.f_convert_pname_fwd,
-        )
+
+        pidx2binname: Dict[int, str] = {
+            pidx: self.torch_pname2binname[self.f_convert_pname_fwd(pname)[0]]
+            for pidx, pname in self.pidx2pname.items()
+            if self.f_convert_pname_fwd(pname)[0] in self.torch_pname2binname
+        }
+        return ReorderTransformFunc(pidx2binname)
 
 
 @mutator


### PR DESCRIPTION
Prior to this commit, the `ReorderTransformFunc` required several components of the `ParamManager` to use.  The functionality it provides, reordering dataflow blocks to minimize the liveset, is useful outside of the context of the `ParamManager`.  This commit makes the following changes, allowing it to be used independently of the `ParamManager`.

- Generate the `pidx2binname` dictionary outside of `ReorderTransformFunc`

- Allow parameters to be separate `func.params`, rather than a single bundled tuple parameter.