### PR TITLE
[Python] Lazy import of transformers for tiktoken conversion

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -108,6 +108,7 @@ def main():
             "tqdm",
             "tiktoken",
             "prompt_toolkit",
+            "openai",
         ],
         distclass=BinaryDistribution,
         **setup_kwargs,


### PR DESCRIPTION
This PR moves the import of transformers into the function body of tiktoken tokenizer conversion, so we do not have a force dependency on transformers.