### PR TITLE
[Python] Enable "thrust" for CUDA by default

### DIFF
--- a/cmake/gen_cmake_config.py
+++ b/cmake/gen_cmake_config.py
@@ -31,17 +31,23 @@ if __name__ == "__main__":
         ),
     ]
 
+    enabled_backends = set()
+
     for backend in backends:
         while True:
             use_backend = input(backend.prompt_str)
             if use_backend in ["yes", "Y", "y"]:
                 cmake_config_str += f"set({backend.cmake_config_name} ON)\n"
+                enabled_backends.add(backend.name)
                 break
             elif use_backend in ["no", "N", "n"]:
                 cmake_config_str += f"set({backend.cmake_config_name} OFF)\n"
                 break
             else:
                 print(f"Invalid input: {use_backend}. Please input again.")
+
+    if "CUDA" in enabled_backends:
+        cmake_config_str += f"set(USE_THRUST ON)\n"
 
     # FlashInfer related
     use_flashInfer = False  # pylint: disable=invalid-name

--- a/python/mlc_chat/support/auto_target.py
+++ b/python/mlc_chat/support/auto_target.py
@@ -1,4 +1,5 @@
 """Helper functions for target auto-detection."""
+
 import os
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
@@ -42,6 +43,12 @@ def detect_target_and_host(target_hint: str, host_hint: str = "auto") -> Tuple[T
     if target.host is None:
         target = Target(target, host=_detect_target_host(host_hint))
     if target.kind.name == "cuda":
+        # Enable thrust for CUDA
+        target_dict = dict(target.export())
+        target_dict["libs"] = (
+            (target_dict["libs"] + ["thrust"]) if "libs" in target_dict else ["thrust"]
+        )
+        target = Target(target_dict)
         _register_cuda_hook(target)
     return target, build_func
 


### PR DESCRIPTION
This PR enables thrust for CUDA targets so that we can dispatch some operators (e.g., cumsum) to thrust.