### PR TITLE
[Serving][Grammar] Integrate JSON grammar into the generation pipeline

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -130,6 +130,26 @@ GenerationConfig::GenerationConfig(String config_json_str) {
     CHECK(config["ignore_eos"].is<bool>());
     n->ignore_eos = config["ignore_eos"].get<bool>();
   }
+
+  if (config.count("response_format")) {
+    CHECK(config["response_format"].is<picojson::object>());
+    picojson::object response_format_json = config["response_format"].get<picojson::object>();
+    ResponseFormat response_format;
+    if (response_format_json.count("type")) {
+      CHECK(response_format_json["type"].is<std::string>());
+      response_format.type = response_format_json["type"].get<std::string>();
+    }
+    if (response_format_json.count("json_schema")) {
+      if (response_format_json["json_schema"].is<picojson::null>()) {
+        response_format.json_schema = NullOpt;
+      } else {
+        CHECK(response_format_json["json_schema"].is<std::string>());
+        response_format.json_schema = response_format_json["json_schema"].get<std::string>();
+      }
+    }
+    n->response_format = response_format;
+  }
+
   data_ = std::move(n);
 }
 
@@ -165,6 +185,13 @@ String GenerationConfigNode::AsJSONString() const {
 
   // Params for benchmarking. Not the part of openai spec.
   config["ignore_eos"] = picojson::value(this->ignore_eos);
+
+  picojson::object response_format;
+  response_format["type"] = picojson::value(this->response_format.type);
+  response_format["json_schema"] = this->response_format.json_schema
+                                       ? picojson::value(this->response_format.json_schema.value())
+                                       : picojson::value();
+  config["response_format"] = picojson::value(response_format);
 
   return picojson::value(config).serialize(true);
 }

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -13,9 +13,16 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
+using namespace tvm;
 using namespace tvm::runtime;
 
 /****************** GenerationConfig ******************/
+
+/*! \brief The response format of a request. */
+struct ResponseFormat {
+  String type = "text";
+  Optional<String> json_schema = NullOpt;
+};
 
 /*! \brief The generation configuration of a request. */
 class GenerationConfigNode : public Object {
@@ -34,6 +41,8 @@ class GenerationConfigNode : public Object {
   int max_tokens = 128;
   Array<String> stop_strs;
   std::vector<int> stop_token_ids;
+
+  ResponseFormat response_format;
 
   String AsJSONString() const;
 

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -66,6 +66,14 @@ void ActionStepPostProcess(Array<Request> requests, EngineState estate, Array<Mo
       continue;
     }
 
+    // Update the grammar matcher state if it exists.
+    if (rstate->mstates[0]->grammar_state_matcher) {
+      const auto& grammar_state_matcher = rstate->mstates[0]->grammar_state_matcher.value();
+      for (auto token_id : delta_token_ids) {
+        grammar_state_matcher->AcceptToken(token_id);
+      }
+    }
+
     callback_delta_outputs.push_back(RequestStreamOutput(
         request->id, delta_token_ids,
         request->generation_cfg->logprobs > 0 ? delta_logprob_json_strs : Optional<Array<String>>(),

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -87,6 +87,7 @@ void FunctionTable::Init(TVMArgValue reload_lib, Device device, picojson::object
     this->sess->InitCCL(ccl, ShapeTuple(device_ids));
     this->disco_mod = sess->CallPacked(sess->GetGlobalFunc("runtime.disco.load_vm_module"),
                                        lib_path, null_device);
+    this->disco_buffers = Map<String, DRef>();
     this->mod_get_func = [this,
                           fmodule_get_function = sess->GetGlobalFunc("runtime.ModuleGetFunction")](
                              const std::string& name) -> PackedFunc {

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -55,7 +55,7 @@ struct FunctionTable {
   bool use_disco = false;
   Session sess{nullptr};
   DRef disco_mod{nullptr};
-  Map<String, DRef> disco_buffers;
+  Map<String, DRef> disco_buffers{nullptr};
   tvm::runtime::Module local_vm{nullptr};
   picojson::object model_config;
 

--- a/cpp/serve/grammar/grammar.cc
+++ b/cpp/serve/grammar/grammar.cc
@@ -43,8 +43,8 @@ TVM_REGISTER_GLOBAL("mlc.serve.BNFGrammarFromJSON").set_body_typed([](String jso
 
 const std::string kJSONGrammarString = R"(
 main ::= (
-    "{" ws members_or_embrace ws |
-    "[" ws elements_or_embrace ws
+    "{" ws members_or_embrace |
+    "[" ws elements_or_embrace
 )
 value ::= (
     "{" ws members_or_embrace |
@@ -102,7 +102,7 @@ elements_rest ::= (
     "\n" ws "," ws elements |
     "\t" ws "," ws elements
 )
-characters ::= "" | [^"\\] characters | "\\" escape characters
+characters ::= "" | [^"\\\r\n] characters | "\\" escape characters
 escape ::= "\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
 digits ::= [0-9] | [0-9] digits
 fraction ::= "" | "." digits

--- a/cpp/serve/grammar/grammar_state_matcher.h
+++ b/cpp/serve/grammar/grammar_state_matcher.h
@@ -77,7 +77,7 @@ class GrammarStateMatcherNode : public Object {
   virtual void Rollback(int num_tokens) = 0;
 
   /*! \brief Get the maximum number of rollback steps allowed. */
-  virtual int MaxRollbackSteps() = 0;
+  virtual int MaxRollbackSteps() const = 0;
 
   /*! \brief Reset the matcher to the initial state. */
   virtual void ResetState() = 0;

--- a/cpp/serve/grammar/grammar_state_matcher_preproc.h
+++ b/cpp/serve/grammar/grammar_state_matcher_preproc.h
@@ -55,7 +55,8 @@ struct CatagorizedTokens {
  */
 class GrammarStateInitContext {
  public:
-  BNFGrammar grammar;
+  /******************* Information about the tokenizer *******************/
+
   /*! \brief The vocabulary size of the tokenizer. */
   size_t vocab_size;
   /*! \brief The sorted token and its id. Tokens are sorted to reuse the common prefix during
@@ -69,6 +70,12 @@ class GrammarStateInitContext {
   /*! \brief The special tokens. Currently we will ignore these tokens during grammar-guided
    * matching. */
   std::vector<int32_t> special_token_ids;
+
+  /******************* Information about the grammar *******************/
+
+  BNFGrammar grammar;
+
+  /******************* Grammar-specific tokenizer information *******************/
 
   /*! \brief A sequence id and its position. */
   struct SequenceIdAndPosition {
@@ -232,7 +239,7 @@ inline std::string ReplaceUnderscoreWithSpace(const std::string& str,
   return res;
 }
 
-inline std::shared_ptr<GrammarStateInitContext> CreateInitContext(
+inline std::shared_ptr<GrammarStateInitContext> GrammarStateMatcher::CreateInitContext(
     const BNFGrammar& grammar, const std::vector<std::string>& token_table) {
   using RuleExprType = BNFGrammarNode::RuleExprType;
   auto ptr = std::make_shared<GrammarStateInitContext>();
@@ -252,7 +259,8 @@ inline std::shared_ptr<GrammarStateInitContext> CreateInitContext(
       ptr->stop_token_ids.push_back(i);
     } else if (token.size() == 1 &&
                (static_cast<unsigned char>(token[0]) >= 128 || token[0] == 0)) {
-      // Currently we consider all tokens with one character that >= 128 as special tokens.
+      // Currently we consider all tokens with one character that >= 128 as special tokens,
+      // and will ignore generating them during grammar-guided generation.
       ptr->special_token_ids.push_back(i);
     } else {
       // First replace the special underscore with space.

--- a/cpp/serve/grammar/support.h
+++ b/cpp/serve/grammar/support.h
@@ -50,7 +50,7 @@ class BitsetManager {
  * \brief Let lhs be the union of lhs and rhs. Suppose that both sets are sorted.
  * \note No additional vectors are allocated, and the time complexity is O(n)
  */
-void IntsetUnion(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
+inline void IntsetUnion(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
   int original_lhs_size = lhs->size();
   int rhs_size = rhs.size();
 
@@ -91,7 +91,7 @@ void IntsetUnion(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
  * \note Support the case where lhs is the universal set by setting lhs to {-1}. The result will be
  * rhs then.
  */
-void IntsetIntersection(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
+inline void IntsetIntersection(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
   if (lhs->size() == 1 && (*lhs)[0] == -1) {
     *lhs = rhs;
     return;

--- a/python/mlc_chat/compiler_pass/attach_to_ir_module.py
+++ b/python/mlc_chat/compiler_pass/attach_to_ir_module.py
@@ -145,7 +145,7 @@ def _apply_bitmask_inplace(
     num_seq = T.int32(is_size_var=True)
     logits = T.match_buffer(var_logits, (batch_size, vocab_size), "float32")
     seq_ids = T.match_buffer(var_seq_ids, (num_seq,), "int32")
-    bitmask = T.match_buffer(var_bitmask, (num_seq, (vocab_size + 31 // 32)), "int32")
+    bitmask = T.match_buffer(var_bitmask, (batch_size, (vocab_size + 31) // 32), "int32")
 
     for fused_s_v_0 in T.thread_binding(0, (num_seq * vocab_size + 1023) // 1024, "blockIdx.x"):
         for fused_s_v_1 in T.thread_binding(0, 1024, "threadIdx.x"):
@@ -154,7 +154,7 @@ def _apply_bitmask_inplace(
                 vv = T.axis.spatial(vocab_size, (fused_s_v_0 * 1024 + fused_s_v_1) % vocab_size)
                 T.where(fused_s_v_0 * 1024 + fused_s_v_1 < num_seq * vocab_size)
                 logits[seq_ids[vs], vv] = T.if_then_else(
-                    (bitmask[vs, vv // 32] >> (vv % 32)) & 1 == 1,
+                    (bitmask[seq_ids[vs], vv // 32] >> (vv % 32)) & 1 == 1,
                     logits[seq_ids[vs], vv],
                     T.float32(-1e10),
                 )

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -65,6 +65,11 @@ class ModelResponse(BaseModel):
 ################ v1/completions ################
 
 
+class ResponseFormat(BaseModel):
+    type: Literal["text", "json_object"] = "text"
+    json_schema: Optional[str] = None
+
+
 class CompletionRequest(BaseModel):
     """OpenAI completion request protocol.
     API reference: https://platform.openai.com/docs/api-reference/completions/create
@@ -89,6 +94,7 @@ class CompletionRequest(BaseModel):
     top_p: float = 1.0
     user: Optional[str] = None
     ignore_eos: bool = False
+    response_format: ResponseFormat = ResponseFormat()
 
     @field_validator("frequency_penalty", "presence_penalty")
     @classmethod
@@ -193,7 +199,6 @@ class ChatCompletionRequest(BaseModel):
     logit_bias: Optional[Dict[int, float]] = None
     max_tokens: Optional[int] = None
     n: int = 1
-    response_format: Literal["text", "json_object"] = "text"
     seed: Optional[int] = None
     stop: Optional[Union[str, List[str]]] = None
     stream: bool = False
@@ -203,6 +208,7 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None
     user: Optional[str] = None
     ignore_eos: bool = False
+    response_format: ResponseFormat = ResponseFormat()
 
     @field_validator("frequency_penalty", "presence_penalty")
     @classmethod
@@ -291,7 +297,6 @@ def openai_api_get_unsupported_fields(
     unsupported_field_default_values: List[Tuple[str, Any]] = [
         ("best_of", 1),
         ("n", 1),
-        ("response_format", "text"),
     ]
 
     unsupported_fields: List[str] = []
@@ -326,4 +331,5 @@ def openai_api_get_generation_config(
         kwargs["max_tokens"] = -1
     if request.stop is not None:
         kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
+    kwargs["response_format"] = request.response_format.model_dump()
     return kwargs

--- a/python/mlc_chat/protocol/protocol_utils.py
+++ b/python/mlc_chat/protocol/protocol_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
-from ..serve.config import GenerationConfig
+from ..serve.config import GenerationConfig, ResponseFormat
 from . import RequestProtocol
 from .openai_api_protocol import ChatCompletionRequest as OpenAIChatCompletionRequest
 from .openai_api_protocol import CompletionRequest as OpenAICompletionRequest
@@ -42,6 +42,9 @@ def get_generation_config(
         kwargs = openai_api_get_generation_config(request)
     else:
         raise RuntimeError("Cannot reach here")
+
+    response_format_dict = kwargs.get("response_format", {})
+    kwargs["response_format"] = ResponseFormat(**response_format_dict)
 
     if extra_stop_token_ids is not None:
         stop_token_ids = kwargs.get("stop_token_ids", [])

--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -2,7 +2,17 @@
 
 import json
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
+
+
+@dataclass
+class ResponseFormat:
+    type: Literal["text", "json_object"] = "text"
+    json_schema: Optional[str] = None
+
+    def __post_init__(self):
+        if self.json_schema is not None and self.type != "json_object":
+            raise ValueError("JSON json_schema is only supported in JSON response format")
 
 
 @dataclass
@@ -16,7 +26,7 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
 
     top_p : float
         In sampling, only the most probable tokens with probabilities summed up to
-        `top_k` are kept for sampling.
+        `top_p` are kept for sampling.
 
     frequency_penalty : float
         Positive values penalize new tokens based on their existing frequency
@@ -79,6 +89,8 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
     stop_strs: List[str] = field(default_factory=list)
     stop_token_ids: List[int] = field(default_factory=list)
     ignore_eos: bool = False
+
+    response_format: ResponseFormat = ResponseFormat(type="text")
 
     def asjson(self) -> str:
         """Return the config in string of JSON format."""

--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -7,6 +7,20 @@ from typing import Dict, List, Literal, Optional
 
 @dataclass
 class ResponseFormat:
+    """The response format dataclass.
+
+    Parameters
+    ----------
+    type : Literal["text", "json_object"]
+        The type of response format. Default: "text".
+
+    json_schema : Optional[str]
+        The JSON schema string for the JSON response format. If None, a legal json string without
+        special restrictions will be generated.
+
+        Could be specified when the response format is "json_object". Default: None.
+    """
+
     type: Literal["text", "json_object"] = "text"
     json_schema: Optional[str] = None
 
@@ -73,6 +87,9 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
     ignore_eos: bool
         When it is true, ignore the eos token and generate tokens until `max_tokens`.
         Default is set to False.
+
+    response_format : ResponseFormat
+        The response format of the generation output.
     """
 
     temperature: float = 0.8

--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -107,7 +107,7 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
     stop_token_ids: List[int] = field(default_factory=list)
     ignore_eos: bool = False
 
-    response_format: ResponseFormat = ResponseFormat(type="text")
+    response_format: ResponseFormat = field(default_factory=ResponseFormat)
 
     def asjson(self) -> str:
         """Return the config in string of JSON format."""

--- a/tests/python/serve/server/test_server.py
+++ b/tests/python/serve/server/test_server.py
@@ -64,8 +64,6 @@ def check_openai_nonstream_response(
     choices = response["choices"]
     assert isinstance(choices, list)
     assert len(choices) == num_choices
-    if isinstance(finish_reason, str):
-        finish_reason = [finish_reason]
 
     for idx, choice in enumerate(choices):
         assert choice["index"] == idx

--- a/tests/python/serve/server/test_server.py
+++ b/tests/python/serve/server/test_server.py
@@ -35,6 +35,14 @@ OPENAI_V1_CHAT_COMPLETION_URL = "http://127.0.0.1:8000/v1/chat/completions"
 DEBUG_DUMP_EVENT_TRACE_URL = "http://127.0.0.1:8000/debug/dump_event_trace"
 
 
+def is_json_or_json_prefix(s: str) -> bool:
+    try:
+        json.loads(s)
+        return True
+    except json.JSONDecodeError as e:
+        return e.pos == len(s)
+
+
 def check_openai_nonstream_response(
     response: Dict,
     *,
@@ -48,6 +56,7 @@ def check_openai_nonstream_response(
     suffix: Optional[str] = None,
     stop: Optional[List[str]] = None,
     require_substr: Optional[List[str]] = None,
+    json_mode: bool = False,
 ):
     assert response["model"] == model
     assert response["object"] == object_str
@@ -55,6 +64,9 @@ def check_openai_nonstream_response(
     choices = response["choices"]
     assert isinstance(choices, list)
     assert len(choices) == num_choices
+    if isinstance(finish_reason, str):
+        finish_reason = [finish_reason]
+
     for idx, choice in enumerate(choices):
         assert choice["index"] == idx
         assert choice["finish_reason"] in finish_reasons
@@ -79,6 +91,8 @@ def check_openai_nonstream_response(
         if require_substr is not None:
             for substr in require_substr:
                 assert substr in text
+        if json_mode:
+            assert is_json_or_json_prefix(text)
 
     usage = response["usage"]
     assert isinstance(usage, dict)
@@ -101,6 +115,7 @@ def check_openai_stream_response(
     suffix: Optional[str] = None,
     stop: Optional[List[str]] = None,
     require_substr: Optional[List[str]] = None,
+    json_mode: bool = False,
 ):
     assert len(responses) > 0
 
@@ -154,6 +169,8 @@ def check_openai_stream_response(
         if require_substr is not None:
             for substr in require_substr:
                 assert substr in output
+        if json_mode:
+            assert is_json_or_json_prefix(output)
 
 
 def expect_error(response_str: str, msg_prefix: Optional[str] = None):
@@ -481,6 +498,55 @@ def test_openai_v1_completions_temperature(
             object_str="text_completion",
             num_choices=1,
             finish_reasons=["length"],
+        )
+
+
+# TODO(yixin): support eos_token_id for tokenizer
+@pytest.mark.skip("JSON test for completion api requires internal eos_token_id support")
+@pytest.mark.parametrize("stream", [False, True])
+def test_openai_v1_completions_json(
+    served_model: Tuple[str, str],
+    launch_server,  # pylint: disable=unused-argument
+    stream: bool,
+):
+    # `served_model` and `launch_server` are pytest fixtures
+    # defined in conftest.py.
+
+    prompt = "Response with a json object:"
+    max_tokens = 128
+    payload = {
+        "model": served_model[0],
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "stream": stream,
+        "response_format": {"type": "json_object"},
+    }
+
+    response = requests.post(OPENAI_V1_COMPLETION_URL, json=payload, timeout=60)
+    if not stream:
+        check_openai_nonstream_response(
+            response.json(),
+            is_chat_completion=False,
+            model=served_model[0],
+            object_str="text_completion",
+            num_choices=1,
+            finish_reasons=["length", "stop"],
+            json_mode=True,
+        )
+    else:
+        responses = []
+        for chunk in response.iter_lines(chunk_size=512):
+            if not chunk or chunk == b"data: [DONE]":
+                continue
+            responses.append(json.loads(chunk.decode("utf-8")[6:]))
+        check_openai_stream_response(
+            responses,
+            is_chat_completion=False,
+            model=served_model[0],
+            object_str="text_completion",
+            num_choices=1,
+            finish_reasons=["length", "stop"],
+            json_mode=True,
         )
 
 
@@ -889,6 +955,53 @@ def test_openai_v1_chat_completions_max_tokens(
 
 
 @pytest.mark.parametrize("stream", [False, True])
+def test_openai_v1_chat_completions_json(
+    served_model: Tuple[str, str],
+    launch_server,  # pylint: disable=unused-argument
+    stream: bool,
+):
+    # `served_model` and `launch_server` are pytest fixtures
+    # defined in conftest.py.
+
+    messages = [{"role": "user", "content": "Response with a json object:"}]
+    max_tokens = 128
+    payload = {
+        "model": served_model[0],
+        "messages": messages,
+        "stream": stream,
+        "max_tokens": max_tokens,
+        "response_format": {"type": "json_object"},
+    }
+
+    response = requests.post(OPENAI_V1_CHAT_COMPLETION_URL, json=payload, timeout=60)
+    if not stream:
+        check_openai_nonstream_response(
+            response.json(),
+            is_chat_completion=True,
+            model=served_model[0],
+            object_str="chat.completion",
+            num_choices=1,
+            finish_reasons=["length", "stop"],
+            json_mode=True,
+        )
+    else:
+        responses = []
+        for chunk in response.iter_lines(chunk_size=512):
+            if not chunk or chunk == b"data: [DONE]":
+                continue
+            responses.append(json.loads(chunk.decode("utf-8")[6:]))
+        check_openai_stream_response(
+            responses,
+            is_chat_completion=True,
+            model=served_model[0],
+            object_str="chat.completion.chunk",
+            num_choices=1,
+            finish_reasons=["length", "stop"],
+            json_mode=True,
+        )
+
+
+@pytest.mark.parametrize("stream", [False, True])
 def test_openai_v1_chat_completions_ignore_eos(
     served_model: Tuple[str, str],
     launch_server,  # pylint: disable=unused-argument
@@ -1028,6 +1141,8 @@ if __name__ == "__main__":
         test_openai_v1_chat_completions_openai_package(MODEL, None, stream=True, messages=msg)
     test_openai_v1_chat_completions_max_tokens(MODEL, None, stream=False)
     test_openai_v1_chat_completions_max_tokens(MODEL, None, stream=True)
+    test_openai_v1_chat_completions_json(MODEL, None, stream=False)
+    test_openai_v1_chat_completions_json(MODEL, None, stream=True)
     test_openai_v1_chat_completions_ignore_eos(MODEL, None, stream=False)
     test_openai_v1_chat_completions_ignore_eos(MODEL, None, stream=True)
     test_openai_v1_chat_completions_system_prompt_wrong_pos(MODEL, None, stream=False)

--- a/tests/python/serve/test_grammar_state_matcher.py
+++ b/tests/python/serve/test_grammar_state_matcher.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 # pylint: disable=redefined-outer-name,unbalanced-tuple-unpacking
+import sys
 from typing import List
 
 import pytest
@@ -17,7 +18,7 @@ def json_grammar():
 
 (json_input_accepted,) = tvm.testing.parameters(
     ('{"name": "John"}',),
-    ('{ "name" : "John" } \n',),
+    ('{ "name" : "John" }',),
     ("{}",),
     ("[]",),
     ('{"name": "Alice", "age": 30, "city": "New York"}',),
@@ -54,19 +55,17 @@ def test_json_accept(json_grammar: BNFGrammar, json_input_accepted: str):
     assert GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_accepted)
 
 
-# test_json_accept(json_grammar(), '{"name": "John"}')
-# exit()
-
 (json_input_refused,) = tvm.testing.parameters(
     (r'{ name: "John" }',),
-    (r'{ "name": "John", "age": 30, }',),  # x
+    (r'{ "name": "John" } ',),  # trailing space is not accepted
+    (r'{ "name": "John", "age": 30, }',),
     (r'{ "name": "John", "address": { "street": "123 Main St", "city": "New York" }',),
-    (r'{ "name": "John", "age": 30, "hobbies": ["reading", "traveling",], }',),  # x
+    (r'{ "name": "John", "age": 30, "hobbies": ["reading", "traveling",], }',),
     (r'{ "name": "John", "age": 30.5.7 }',),
     (r'{ "name": "John, "age": 30, "hobbies": ["reading", "traveling"] }',),
     (
         r'{ "name": "John", "age": 30, "hobbies": ["reading", { "type": "outdoor", "list": '
-        r'["hiking", "swimming",]}] }',  #
+        r'["hiking", "swimming",]}] }',
     ),
     (r'{ "name": "John", "age": 30, "status": "\P\J" }',),
     (
@@ -203,7 +202,7 @@ def test_json_refuse(json_grammar: BNFGrammar, json_input_refused):
         "taglib-location": "/WEB-INF/tlds/cofax.tld"
     }
     }
-}    """,
+}""",
     ),
 )
 
@@ -215,11 +214,11 @@ def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
 (input_find_rejected_tokens, expected_rejected_sizes) = tvm.testing.parameters(
     (
         # short test
-        '{"id": 1,"name": "Example"} ',
+        '{"id": 1,"name": "Example"}',
         [
             # fmt: off
-            31989, 31907, 278, 278, 278, 31973, 31841, 31841, 31948, 31910, 278, 278, 278, 278,
-            278, 31973, 31841, 31841, 271, 271, 271, 271, 271, 271, 271, 271, 31974, 31980, 31980
+            31989, 31912, 299, 299, 299, 31973, 31846, 31846, 31948, 31915, 299, 299, 299, 299,
+            299, 31973, 31846, 31846, 292, 292, 292, 292, 292, 292, 292, 292, 31974, 31999
             # fmt: on
         ],
     ),
@@ -228,30 +227,29 @@ def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
         """{
 "id": 1,
 "na": "ex",
-"ac": True,
+"ac": true,
 "t": ["t1", "t2"],
 "ne": {"lv2": {"val": "dp"}, "arr": [1, 2, 3]},
 "res": "res"
-}
-""",
+}""",
         [
             # fmt: off
-            31989, 31907, 31907, 278, 278, 278, 31973, 31841, 31841, 31948, 31910, 31910, 278, 278,
-            278, 31973, 31841, 31841, 271, 271, 271, 31974, 31910, 31910, 278, 278, 278, 31973,
-            31841, 31841, 31841, 31841, 31841, 31841, 31841, 31841, 271, 271, 31974, 31974, 31974,
-            31974, 31974, 31974, 31974, 31974, 31910, 31910, 278, 278, 278, 31973, 31973, 31973,
-            31973, 31973, 31973, 31973, 31973, 31841, 31841, 31903, 278, 278, 278, 278, 31973,
-            31841, 31841, 31901, 278, 278, 278, 278, 31973, 31841, 31841, 270, 270, 270, 31968,
-            31970, 31910, 31910, 278, 278, 278, 278, 31973, 31841, 31841, 31835, 31943, 31841,
-            31841, 31943, 31841, 31841, 31943, 31970, 31974, 31910, 31910, 278, 278, 278, 278,
-            31973, 31841, 31841, 271, 271, 271, 271, 31974, 31974, 31980, 31980
+            31989, 31912, 31912, 299, 299, 299, 31973, 31846, 31846, 31948, 31915, 31915, 299, 299,
+            299, 31973, 31846, 31846, 292, 292, 292, 31974, 31915, 31915, 299, 299, 299, 31973,
+            31846, 31846, 31997, 31997, 31998, 31974, 31915, 31915, 299, 299, 31973, 31846, 31846,
+            31840, 291, 291, 291, 31969, 31846, 31846, 291, 291, 291, 31969, 31974, 31915, 31915,
+            299, 299, 299, 31973, 31846, 31846, 31908, 299, 299, 299, 299, 31973, 31846, 31846,
+            31906, 299, 299, 299, 299, 31973, 31846, 31846, 291, 291, 291, 31968, 31970, 31915,
+            31915, 299, 299, 299, 299, 31973, 31846, 31846, 31840, 31943, 31846, 31846, 31943,
+            31846, 31846, 31943, 31970, 31974, 31915, 31915, 299, 299, 299, 299, 31973, 31846,
+            31846, 292, 292, 292, 292, 31974, 31974, 31999
             # fmt: on
         ],
     ),
 )
 
 
-def test_find_rejected_tokens(
+def test_find_next_rejected_tokens(
     json_grammar: BNFGrammar, input_find_rejected_tokens: str, expected_rejected_sizes: List[int]
 ):
     tokenizer_path = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
@@ -262,10 +260,11 @@ def test_find_rejected_tokens(
     for c in input_find_rejected_tokens:
         rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
         real_sizes.append(len(rejected_token_ids))
-        print("Accepting char:", c)
-        grammar_state_matcher.debug_accept_char(ord(c))
+        print("Accepting char:", c, file=sys.stderr)
+        assert grammar_state_matcher.debug_accept_char(ord(c))
     rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
     real_sizes.append(len(rejected_token_ids))
+    print(real_sizes)
     assert real_sizes == expected_rejected_sizes
 
 
@@ -275,7 +274,7 @@ def test_accept_token(json_grammar: BNFGrammar):
         "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
         # fmt: on
     ]
-    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}", "\n"]
+    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}"]
     input_ids = [token_table.index(t) for t in input_splitted]
 
     grammar_state_matcher = GrammarStateMatcher(json_grammar, token_table)
@@ -285,16 +284,15 @@ def test_accept_token(json_grammar: BNFGrammar):
     expected = [
         ["{"],
         ['"', "}", "\n", " ", '"a":true'],
-        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " "],
-        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " "],
+        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", " "],
+        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", " "],
         [":", "\n", " ", ':"'],
         ['"', "{", "6", "\n", " "],
         ["}", ", ", "6", "\n", " "],
         [" ", "\n", '"', '"a":true'],
         [" ", "\n", '"', '"a":true'],
         ["}", ", ", "\n", " "],
-        ["</s>", "\n", " "],
-        ["</s>", "\n", " "],
+        ["</s>"],
     ]
 
     for id in input_ids:
@@ -303,7 +301,7 @@ def test_accept_token(json_grammar: BNFGrammar):
         accepted_tokens = [token_table[i] for i in accepted]
         result.append(accepted_tokens)
         assert id in accepted
-        grammar_state_matcher.accept_token(id)
+        assert grammar_state_matcher.accept_token(id)
 
     rejected = grammar_state_matcher.find_next_rejected_tokens()
     accepted = list(set(range(len(token_table))) - set(rejected))
@@ -319,7 +317,7 @@ def test_rollback(json_grammar: BNFGrammar):
         "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
         # fmt: on
     ]
-    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', " ", "}", "\n"]
+    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}"]
     input_ids = [token_table.index(t) for t in input_splitted]
 
     grammar_state_matcher = GrammarStateMatcher(json_grammar, token_table, 5)
@@ -331,15 +329,15 @@ def test_rollback(json_grammar: BNFGrammar):
     for i_1, i_2 in input_ids_splitted:
         orig_result = []
         orig_result.append(grammar_state_matcher.find_next_rejected_tokens())
-        grammar_state_matcher.accept_token(i_1)
+        assert grammar_state_matcher.accept_token(i_1)
         orig_result.append(grammar_state_matcher.find_next_rejected_tokens())
-        grammar_state_matcher.accept_token(i_2)
+        assert grammar_state_matcher.accept_token(i_2)
         grammar_state_matcher.rollback(2)
         result_after_rollback = []
         result_after_rollback.append(grammar_state_matcher.find_next_rejected_tokens())
-        grammar_state_matcher.accept_token(i_1)
+        assert grammar_state_matcher.accept_token(i_1)
         result_after_rollback.append(grammar_state_matcher.find_next_rejected_tokens())
-        grammar_state_matcher.accept_token(i_2)
+        assert grammar_state_matcher.accept_token(i_2)
         assert orig_result == result_after_rollback
 
 
@@ -349,7 +347,7 @@ def test_reset(json_grammar: BNFGrammar):
         "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
         # fmt: on
     ]
-    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', " ", "}", "\n"]
+    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}"]
     input_ids = [token_table.index(t) for t in input_splitted]
 
     grammar_state_matcher = GrammarStateMatcher(json_grammar, token_table)
@@ -358,7 +356,7 @@ def test_reset(json_grammar: BNFGrammar):
 
     for i in input_ids:
         orig_result.append(grammar_state_matcher.find_next_rejected_tokens())
-        grammar_state_matcher.accept_token(i)
+        assert grammar_state_matcher.accept_token(i)
 
     grammar_state_matcher.reset_state()
 
@@ -366,20 +364,20 @@ def test_reset(json_grammar: BNFGrammar):
 
     for i in input_ids:
         result_after_reset.append(grammar_state_matcher.find_next_rejected_tokens())
-        grammar_state_matcher.accept_token(i)
+        assert grammar_state_matcher.accept_token(i)
 
     assert orig_result == result_after_reset
 
 
 if __name__ == "__main__":
     # Run a benchmark to show the performance before running tests
-    test_find_rejected_tokens(
+    test_find_next_rejected_tokens(
         BNFGrammar.get_grammar_of_json(),
-        '{"id": 1,"name": "Example"} ',
+        '{"id": 1,"name": "Example"}',
         [
             # fmt: off
-            31989, 31907, 278, 278, 278, 31973, 31841, 31841, 31948, 31910, 278, 278, 278, 278,
-            278, 31973, 31841, 31841, 271, 271, 271, 271, 271, 271, 271, 271, 31974, 31980, 31980
+            31989, 31912, 299, 299, 299, 31973, 31846, 31846, 31948, 31915, 299, 299, 299, 299,
+            299, 31973, 31846, 31846, 292, 292, 292, 292, 292, 292, 292, 292, 31974, 31999
             # fmt: on
         ],
     )

--- a/tests/python/serve/test_serve_engine_grammar.py
+++ b/tests/python/serve/test_serve_engine_grammar.py
@@ -1,0 +1,136 @@
+# pylint: disable=chained-comparison,line-too-long,missing-docstring,
+# pylint: disable=too-many-arguments,too-many-locals,unused-argument,unused-variable
+import asyncio
+from typing import List
+from mlc_chat.serve.config import ResponseFormat
+
+import numpy as np
+
+from mlc_chat.serve import (
+    Engine,
+    GenerationConfig,
+    KVCacheConfig,
+)
+from mlc_chat.serve.async_engine import AsyncThreadedEngine
+from mlc_chat.serve.engine import ModelInfo
+import pytest
+
+prompts_list = [
+    "Generate a JSON string containing 20 objects:",
+    "Generate a JSON containing a list:",
+    "Generate a JSON with 5 elements:",
+]
+model_path = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
+model_lib_path = "dist/libs/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+
+
+def test_batch_generation_with_grammar():
+    # Initialize model loading info and KV cache config
+    model = ModelInfo(model_path, model_lib_path=model_lib_path)
+    kv_cache_config = KVCacheConfig(page_size=16)
+    # Create engine
+    engine = Engine(model, kv_cache_config)
+
+    prompts = prompts_list * 2
+
+    temperature = 1
+    repetition_penalty = 1
+    max_tokens = 512
+    generation_config_no_json = GenerationConfig(
+        temperature=temperature,
+        repetition_penalty=repetition_penalty,
+        max_tokens=max_tokens,
+        stop_token_ids=[2],
+        response_format=ResponseFormat(type="text"),
+    )
+    generation_config_json = GenerationConfig(
+        temperature=temperature,
+        repetition_penalty=repetition_penalty,
+        max_tokens=max_tokens,
+        stop_token_ids=[2],
+        response_format=ResponseFormat(type="json_object"),
+    )
+    all_generation_configs = [generation_config_no_json] * 3 + [generation_config_json] * 3
+
+    # Generate output.
+    output_texts, _ = engine.generate(prompts, all_generation_configs)
+    for req_id, output in enumerate(output_texts):
+        print(f"Prompt {req_id}: {prompts[req_id]}")
+        print(f"Output {req_id}: {output}\n")
+
+
+async def run_async_engine():
+    # Initialize model loading info and KV cache config
+    model = ModelInfo(model_path, model_lib_path=model_lib_path)
+    kv_cache_config = KVCacheConfig(page_size=16)
+    # Create engine
+    async_engine = AsyncThreadedEngine(model, kv_cache_config, enable_tracing=True)
+
+    prompts = prompts_list * 20
+
+    max_tokens = 256
+    temperature = 1
+    repetition_penalty = 1
+    max_tokens = 512
+    generation_config = GenerationConfig(
+        temperature=temperature,
+        repetition_penalty=repetition_penalty,
+        max_tokens=max_tokens,
+        stop_token_ids=[2],
+        response_format=ResponseFormat(type="json_object"),
+    )
+
+    outputs: List[str] = ["" for _ in range(len(prompts))]
+
+    async def generate_task(
+        async_engine: AsyncThreadedEngine,
+        prompt: str,
+        generation_cfg: GenerationConfig,
+        request_id: str,
+    ):
+        print(f"Start generation task for request {request_id}")
+        rid = int(request_id)
+        async for delta_text, _, _, _ in async_engine.generate(
+            prompt, generation_cfg, request_id=request_id
+        ):
+            outputs[rid] += delta_text
+
+    tasks = [
+        asyncio.create_task(
+            generate_task(async_engine, prompts[i], generation_config, request_id=str(i))
+        )
+        for i in range(len(prompts))
+    ]
+
+    await asyncio.gather(*tasks)
+
+    # Print output.
+    print("All finished")
+    for req_id, output in enumerate(outputs):
+        print(f"Prompt {req_id}: {prompts[req_id]}")
+        print(f"Output {req_id}: {output}\n")
+
+    print(async_engine.trace_recorder.dump_json(), file=open("tmpfiles/tmp.json", "w"))
+
+    async_engine.terminate()
+
+
+def test_async_engine():
+    asyncio.run(run_async_engine())
+
+
+def test_generation_config_error():
+    with pytest.raises(ValueError):
+        GenerationConfig(
+            temperature=1.0,
+            repetition_penalty=1.0,
+            max_tokens=128,
+            stop_token_ids=[2],
+            response_format=ResponseFormat(type="text", json_schema="{}"),
+        )
+
+
+if __name__ == "__main__":
+    test_batch_generation_with_grammar()
+    test_async_engine()
+    test_generation_config_error()

--- a/tests/python/serve/test_serve_engine_grammar.py
+++ b/tests/python/serve/test_serve_engine_grammar.py
@@ -2,18 +2,13 @@
 # pylint: disable=too-many-arguments,too-many-locals,unused-argument,unused-variable
 import asyncio
 from typing import List
-from mlc_chat.serve.config import ResponseFormat
 
-import numpy as np
-
-from mlc_chat.serve import (
-    Engine,
-    GenerationConfig,
-    KVCacheConfig,
-)
-from mlc_chat.serve.async_engine import AsyncThreadedEngine
-from mlc_chat.serve.engine import ModelInfo
 import pytest
+
+from mlc_chat.serve import Engine, GenerationConfig, KVCacheConfig
+from mlc_chat.serve.async_engine import AsyncThreadedEngine
+from mlc_chat.serve.config import ResponseFormat
+from mlc_chat.serve.engine import ModelInfo
 
 prompts_list = [
     "Generate a JSON string containing 20 objects:",


### PR DESCRIPTION
This PR is the 3rd part of the grammar-guided generation. This intregrates the grammar framework into the generation process, and supports JSON output for now.

The API this PR provides is compatible with the OpenAI api.

### APIs
#### Python API
```
@dataclass
class ResponseFormat:
    type: Literal["text", "json_object"] = "text"
    json_schema: Optional[str] = None

@dataclass
class GenerationConfig:
        response_format: ResponseFormat = ResponseFormat(type="text")
```

#### Rest API
```
response_format: { "type": "text" } # text generation, by default
response_format: { "type": "json_object" } # json generation
response_format: { "type": "json_object", json_schema="..."} # json generation with schema
```

JSON generation with schema is not supported yet, but has been planned to be realized in the future.

### Performance
#### Without JSON
```
Single token prefill latency: 891.2234 ms/tok
Single token decode latency: 31.3399 ms/tok
Prefill token throughput: 4693.3077 tok/s
Decode token throughput: 226.4406 tok/s
Overall token throughput: 470.3180 tok/s
```
#### With JSON
```
Single token prefill latency: 219.2287 ms/tok
Single token decode latency: 29.1399 ms/tok
Prefill token throughput: 7392.1555 tok/s
Decode token throughput: 179.2296 tok/s
Overall token throughput: 1052.1996 tok/s
```

We observed a slight decrease in performance under JSON mode. This will be further optimized in the future.



Thanks to @tqchen and @MasterJH5574 

