### PR TITLE
[Serving] Support "n" for parallel generation

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -29,6 +29,11 @@ GenerationConfig::GenerationConfig(String config_json_str) {
   ObjectPtr<GenerationConfigNode> n = make_object<GenerationConfigNode>();
 
   picojson::object config = config_json.get<picojson::object>();
+  if (config.count("n")) {
+    CHECK(config["n"].is<int64_t>());
+    n->n = config["n"].get<int64_t>();
+    CHECK_GT(n->n, 0) << "\"n\" should be at least 1";
+  }
   if (config.count("temperature")) {
     CHECK(config["temperature"].is<double>());
     n->temperature = config["temperature"].get<double>();
@@ -155,6 +160,7 @@ GenerationConfig::GenerationConfig(String config_json_str) {
 
 String GenerationConfigNode::AsJSONString() const {
   picojson::object config;
+  config["n"] = picojson::value(static_cast<int64_t>(this->n));
   config["temperature"] = picojson::value(this->temperature);
   config["top_p"] = picojson::value(this->top_p);
   config["frequency_penalty"] = picojson::value(this->frequency_penalty);

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -27,6 +27,7 @@ struct ResponseFormat {
 /*! \brief The generation configuration of a request. */
 class GenerationConfigNode : public Object {
  public:
+  int n = 1;
   double temperature = 0.8;
   double top_p = 0.95;
   double frequency_penalty = 0.0;

--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -141,22 +141,22 @@ std::string SampleResult::GetLogProbJSON(const Tokenizer& tokenizer, bool logpro
 
 TVM_REGISTER_OBJECT_TYPE(RequestStreamOutputObj);
 
-RequestStreamOutput::RequestStreamOutput(String request_id,
-                                         const std::vector<int32_t>& delta_token_ids,
-                                         Optional<Array<String>> delta_logprob_json_strs,
-                                         Optional<String> finish_reason) {
+RequestStreamOutput::RequestStreamOutput(
+    String request_id, Array<IntTuple> group_delta_token_ids,
+    Optional<Array<Array<String>>> group_delta_logprob_json_strs,
+    Array<Optional<String>> group_finish_reason) {
   ObjectPtr<RequestStreamOutputObj> n = make_object<RequestStreamOutputObj>();
   n->request_id = std::move(request_id);
-  n->delta_token_ids = IntTuple{delta_token_ids.begin(), delta_token_ids.end()};
-  n->delta_logprob_json_strs = std::move(delta_logprob_json_strs);
-  n->finish_reason = std::move(finish_reason);
+  n->group_delta_token_ids = std::move(group_delta_token_ids);
+  n->group_delta_logprob_json_strs = std::move(group_delta_logprob_json_strs);
+  n->group_finish_reason = std::move(group_finish_reason);
   data_ = std::move(n);
 }
 
 TVM_REGISTER_GLOBAL("mlc.serve.RequestStreamOutputUnpack")
     .set_body_typed([](RequestStreamOutput output) {
-      return Array<ObjectRef>{output->request_id, output->delta_token_ids,
-                              output->delta_logprob_json_strs, output->finish_reason};
+      return Array<ObjectRef>{output->request_id, output->group_delta_token_ids,
+                              output->group_delta_logprob_json_strs, output->group_finish_reason};
     });
 
 }  // namespace serve

--- a/cpp/serve/data.h
+++ b/cpp/serve/data.h
@@ -128,14 +128,14 @@ class RequestStreamOutputObj : public Object {
    * \brief The new generated token ids since the last callback invocation
    * for the input request.
    */
-  IntTuple delta_token_ids;
+  Array<IntTuple> group_delta_token_ids;
   /*! \brief The logprobs JSON strings of the new generated tokens since last invocation. */
-  Optional<Array<String>> delta_logprob_json_strs;
+  Optional<Array<Array<String>>> group_delta_logprob_json_strs;
   /*!
    * \brief The finish reason of the request when it is finished,
    * of None if the request has not finished yet.
    */
-  Optional<String> finish_reason;
+  Array<Optional<String>> group_finish_reason;
 
   static constexpr const char* _type_key = "mlc.serve.RequestStreamOutput";
   static constexpr const bool _type_has_method_sequal_reduce = false;
@@ -149,9 +149,9 @@ class RequestStreamOutputObj : public Object {
  */
 class RequestStreamOutput : public ObjectRef {
  public:
-  explicit RequestStreamOutput(String request_id, const std::vector<int32_t>& delta_token_ids,
-                               Optional<Array<String>> delta_logprob_json_strs,
-                               Optional<String> finish_reason);
+  explicit RequestStreamOutput(String request_id, Array<IntTuple> group_delta_token_ids,
+                               Optional<Array<Array<String>>> group_delta_logprob_json_strs,
+                               Array<Optional<String>> finish_reason);
 
   TVM_DEFINE_OBJECT_REF_METHODS(RequestStreamOutput, ObjectRef, RequestStreamOutputObj);
 };

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -13,6 +13,7 @@
 #include <tvm/runtime/threading_backend.h>
 
 #include <tuple>
+#include <unordered_set>
 
 #include "../tokenizers.h"
 #include "engine_actions/action.h"
@@ -91,6 +92,7 @@ class EngineImpl : public Engine {
                                           logit_processor,         //
                                           sampler,                 //
                                           this->kv_cache_config_,  //
+                                          this->engine_mode_,      //
                                           this->trace_recorder_),
           EngineAction::BatchDraft(this->models_, logit_processor, sampler, this->trace_recorder_,
                                    this->engine_mode_->spec_draft_length),
@@ -101,6 +103,7 @@ class EngineImpl : public Engine {
                                                         logit_processor,         //
                                                         sampler,                 //
                                                         this->kv_cache_config_,  //
+                                                        this->engine_mode_,      //
                                                         this->trace_recorder_),
                         EngineAction::BatchDecode(this->models_, logit_processor, sampler,
                                                   this->trace_recorder_)};
@@ -135,9 +138,27 @@ class EngineImpl : public Engine {
     ICHECK_NE(request->input_total_length, -1);
     // Append to the waiting queue and create the request state.
     estate_->waiting_queue.push_back(request);
-    estate_->request_states.emplace(
-        request->id, RequestState(request, models_.size(), estate_->id_manager.GetNewId(),
-                                  token_table_, json_grammar_state_init_ctx_));
+
+    int n = request->generation_cfg->n;
+    int rng_seed = request->generation_cfg->seed;
+
+    RequestState rstate;
+    // Create the request state entry for the input.
+    rstate.emplace_back(request, models_.size(), estate_->id_manager.GetNewId(), rng_seed,
+                        token_table_, json_grammar_state_init_ctx_);
+    if (n > 1) {
+      // Then create a request state entry for each parallel generation branch.
+      // We add a offset to the rng seed so that to make generations different.
+      rstate.reserve(n + 1);
+      rstate[0]->children_idx.reserve(n);
+      for (int i = 0; i < n; ++i) {
+        rstate[0]->children_idx.push_back(rstate.size());
+        rstate.emplace_back(request, models_.size(), estate_->id_manager.GetNewId(),
+                            rng_seed + i + 1, token_table_, json_grammar_state_init_ctx_,
+                            /*parent_idx=*/0);
+      }
+    }
+    estate_->request_states.emplace(request->id, rstate);
   }
 
   void AbortRequest(const String& request_id) final {
@@ -148,26 +169,39 @@ class EngineImpl : public Engine {
     }
 
     RequestState rstate = it_rstate->second;
-    Request request = rstate->request;
+    Request request = rstate[0]->request;
 
     // - Check if the request is running or pending.
     auto it_running =
         std::find(estate_->running_queue.begin(), estate_->running_queue.end(), request);
     auto it_waiting =
         std::find(estate_->waiting_queue.begin(), estate_->waiting_queue.end(), request);
-    ICHECK(it_running != estate_->running_queue.end() ||
-           it_waiting != estate_->waiting_queue.end());
 
-    int64_t req_internal_id = rstate->mstates[0]->internal_id;
-    estate_->id_manager.RecycleId(req_internal_id);
+    for (const RequestStateEntry& rsentry : rstate) {
+      estate_->id_manager.RecycleId(rsentry->mstates[0]->internal_id);
+    }
     estate_->request_states.erase(request->id);
     if (it_running != estate_->running_queue.end()) {
       // The request to abort is in running queue
       estate_->running_queue.erase(it_running);
-      estate_->stats.current_total_seq_len -=
-          request->input_total_length + rstate->mstates[0]->committed_tokens.size() - 1;
-      RemoveRequestFromModel(estate_, req_internal_id, models_);
-    } else {
+
+      // Reduce the input length.
+      estate_->stats.current_total_seq_len -= request->input_total_length;
+      // Reduce the generated length.
+      for (int i = 0; i < static_cast<int>(rstate.size()); ++i) {
+        if (rstate[i]->status != RequestStateStatus::kAlive) {
+          continue;
+        }
+        estate_->stats.current_total_seq_len -= rstate[i]->mstates[0]->committed_tokens.size();
+        RemoveRequestFromModel(estate_, rstate[i]->mstates[0]->internal_id, models_);
+        if (rstate[i]->children_idx.empty()) {
+          // For each running leaf state, length 1 is over reduced since the last
+          // token is not added into KV cache. So we add the length back.
+          ++estate_->stats.current_total_seq_len;
+        }
+      }
+    }
+    if (it_waiting != estate_->waiting_queue.end()) {
       // The request to abort is in waiting queue
       estate_->waiting_queue.erase(it_waiting);
     }

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -56,11 +56,13 @@ class EngineAction : public ObjectRef {
    * \param logit_processor The logit processor.
    * \param sampler The sampler to sample new tokens.
    * \param kv_cache_config The KV cache config to help decide prefill is doable.
+   * \param engine_mode The engine operation mode.
    * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction NewRequestPrefill(Array<Model> models, LogitProcessor logit_processor,
                                         Sampler sampler, KVCacheConfig kv_cache_config,
+                                        EngineMode engine_mode,
                                         Optional<EventTraceRecorder> trace_recorder);
   /*!
    * \brief Create the action that runs one-step decode for requests in the

--- a/cpp/serve/engine_state.cc
+++ b/cpp/serve/engine_state.cc
@@ -50,7 +50,9 @@ void EngineStateObj::Reset() {
 }
 
 RequestState EngineStateObj::GetRequestState(Request request) {
-  return request_states.at(request->id);
+  auto it = request_states.find(request->id);
+  ICHECK(it != request_states.end());
+  return it->second;
 }
 
 }  // namespace serve

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -204,6 +204,8 @@ void FunctionTable::_InitFunctions() {
   this->reset_kv_cache_func_ = get_global_func("vm.builtin.paged_attention_kv_cache_clear");
   this->kv_cache_add_sequence_func_ =
       get_global_func("vm.builtin.paged_attention_kv_cache_add_sequence");
+  this->kv_cache_fork_sequence_func_ =
+      get_global_func("vm.builtin.paged_attention_kv_cache_fork_sequence");
   this->kv_cache_remove_sequence_func_ =
       get_global_func("vm.builtin.paged_attention_kv_cache_remove_sequence");
   this->kv_cache_begin_forward_func_ =

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -78,6 +78,7 @@ struct FunctionTable {
   PackedFunc reset_kv_cache_func_;
   bool support_backtracking_kv_;
   PackedFunc kv_cache_add_sequence_func_;
+  PackedFunc kv_cache_fork_sequence_func_;
   PackedFunc kv_cache_remove_sequence_func_;
   PackedFunc kv_cache_begin_forward_func_;
   PackedFunc kv_cache_end_forward_func_;

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -371,6 +371,10 @@ class ModelImpl : public ModelObj {
 
   void AddNewSequence(int64_t seq_id) final { ft_.kv_cache_add_sequence_func_(kv_cache_, seq_id); }
 
+  void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id) final {
+    ft_.kv_cache_fork_sequence_func_(kv_cache_, parent_seq_id, child_seq_id);
+  }
+
   /*! \brief Remove the given sequence from the KV cache in the model. */
   void RemoveSequence(int64_t seq_id) final {
     ft_.kv_cache_remove_sequence_func_(kv_cache_, seq_id);

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -105,6 +105,9 @@ class ModelObj : public Object {
   /*! \brief Add a new sequence with the given sequence id to the KV cache. */
   virtual void AddNewSequence(int64_t seq_id) = 0;
 
+  /*! \brief Fork a sequence from a given parent sequence. */
+  virtual void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id) = 0;
+
   /*! \brief Remove the given sequence from the KV cache in the model. */
   virtual void RemoveSequence(int64_t seq_id) = 0;
 

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -119,10 +119,57 @@ struct DeltaRequestReturn {
   Optional<String> finish_reason;
 };
 
-class RequestStateNode : public Object {
+/****************** Request States ******************/
+
+/*!
+ * \brief For each request, we maintain its "request state" in the
+ * engine. Generally, the state of a request contains the information
+ * of the request's generation at the current moment, including
+ * the generated token ids, the grammar handler, etc.
+ *
+ * When a request has multiple parallel generations (e.g., the field
+ * `n` of its generation config is more than 1), each generation will
+ * have different states all the time.
+ *
+ * Therefore, to better support parallel generations, we denote the
+ * state of a single generation as a "RequestStateEntry" instance,
+ * and denote the state of a request's all generations using a vector,
+ * named as a "RequestState" instance.
+ *
+ * A request's all state entries are organized as a tree structure
+ * when there are parallel generations.
+ * - the request input has the root status entry,
+ * - each parallel generation is a child of the root.
+ * This tree structure may be further extended to more complicated
+ * cases in the future. As of now, for the case of `n > 1`, there
+ * will be (n + 1) entries in total. In a "RequestState", the root
+ * entry always has index 0. And we guarantee that the entry order
+ * from the vector begin to the end is always a topological order
+ * of the tree.
+ */
+
+/*! \brief Request state status. */
+enum class RequestStateStatus : int {
+  kPending = 0,
+  kAlive = 1,
+  kFinished = 2,
+};
+
+class RequestStateEntryNode : public Object {
  public:
+  /*! \brief The status of the request state. */
+  RequestStateStatus status;
   /*! \brief The request that this state corresponds to. */
   Request request;
+  /*!
+   * \brief The idx of the parent request state of this state.
+   * Being -1 means the state has no parent and is the foremost
+   * "prefix" state or the only state.
+   */
+  int parent_idx = -1;
+  /*! \brief The children indices of the request state. */
+  std::vector<int> children_idx;
+
   /*!
    * \brief The state with regard to each model.
    * \sa RequestModelState
@@ -154,20 +201,24 @@ class RequestStateNode : public Object {
    */
   DeltaRequestReturn GetReturnTokenIds(const Tokenizer& tokenizer, int max_single_sequence_length);
 
-  static constexpr const char* _type_key = "mlc.serve.RequestState";
+  static constexpr const char* _type_key = "mlc.serve.RequestStateEntry";
   static constexpr const bool _type_has_method_sequal_reduce = false;
   static constexpr const bool _type_has_method_shash_reduce = false;
-  TVM_DECLARE_FINAL_OBJECT_INFO(RequestStateNode, Object);
+  TVM_DECLARE_FINAL_OBJECT_INFO(RequestStateEntryNode, Object);
 };
 
-class RequestState : public ObjectRef {
+class RequestStateEntry : public ObjectRef {
  public:
-  explicit RequestState(Request request, int num_models, int64_t internal_id,
-                        const std::vector<std::string>& token_table,
-                        std::shared_ptr<GrammarStateInitContext> json_grammar_state_init_ctx);
+  explicit RequestStateEntry(Request request, int num_models, int64_t internal_id, int rng_seed,
+                             const std::vector<std::string>& token_table,
+                             std::shared_ptr<GrammarStateInitContext> json_grammar_state_init_ctx,
+                             int parent_idx = -1);
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(RequestState, ObjectRef, RequestStateNode);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(RequestStateEntry, ObjectRef, RequestStateEntryNode);
 };
+
+/*! \brief A request's state, which groups all the request state entries. */
+typedef std::vector<RequestStateEntry> RequestState;
 
 }  // namespace serve
 }  // namespace llm

--- a/cpp/serve/sampler.h
+++ b/cpp/serve/sampler.h
@@ -39,15 +39,25 @@ class SamplerObj : public Object {
    * \param generation_cfg The generation config of each request
    * in the input batch.
    * \param rngs The random number generator of each sequence.
+   * \param prob_indices The indices of probability distribution in `probs_device`
+   * that each request in `request_ids` samples from.
+   * It defaults to nullptr, which means each request samples from the
+   * corresponding index in `prob_indices`.
+   * In usual cases, we only sample one token for each prob distribution
+   * in the batch, and `prob_indices` is nullptr in such cases.
+   * When we want to sample multiple tokens from a prob distribution (e.g.,
+   * starting parallel generation after prefill the input), we use `prob_indices`
+   * to represent which distribution a token should be sampled from
    * \param output_prob_dist The output probability distribution
    * \return The batch of sampling results, which contain the sampled token id
    * and other probability info.
    */
   virtual std::vector<SampleResult> BatchSampleTokens(
-      NDArray probs_device,                           //
-      const Array<String>& request_ids,               //
-      const Array<GenerationConfig>& generation_cfg,  //
-      const std::vector<RandomGenerator*>& rngs,      //
+      NDArray probs_device,                            //
+      const Array<String>& request_ids,                //
+      const Array<GenerationConfig>& generation_cfg,   //
+      const std::vector<RandomGenerator*>& rngs,       //
+      const std::vector<int>* prob_indices = nullptr,  //
       std::vector<NDArray>* output_prob_dist = nullptr) = 0;
 
   /*!

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -296,7 +296,6 @@ def openai_api_get_unsupported_fields(
     """Get the unsupported fields in the request."""
     unsupported_field_default_values: List[Tuple[str, Any]] = [
         ("best_of", 1),
-        ("n", 1),
     ]
 
     unsupported_fields: List[str] = []
@@ -312,6 +311,7 @@ def openai_api_get_generation_config(
     """Create the generation config from the given request."""
     kwargs: Dict[str, Any] = {}
     arg_names = [
+        "n",
         "temperature",
         "top_p",
         "max_tokens",

--- a/python/mlc_chat/serve/async_engine.py
+++ b/python/mlc_chat/serve/async_engine.py
@@ -5,6 +5,7 @@ Acknowledgment: Part of the code was adapted from the vLLM project.
 import asyncio
 import sys
 import threading
+from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, Union
 
 import tvm
@@ -16,6 +17,32 @@ from .config import EngineMode, GenerationConfig, KVCacheConfig
 from .engine import ModelInfo, _estimate_max_total_sequence_length, _process_model_args
 from .event_trace_recorder import EventTraceRecorder
 from .request import Request
+
+
+@dataclass
+class AsyncStreamOutput:
+    """The output of AsyncThreadedEngine.generate
+
+    Attributes
+    ----------
+    delta_text : str
+        The delta text generated since the last output.
+
+    num_delta_tokens : int
+        The number of delta tokens generated since the last output.
+
+    delta_logprob_json_strs : Optional[List[str]]
+        The list of logprob JSON strings since the last output,
+        or None if the request does not require logprobs.
+
+    finish_reason : Optional[str]
+        The finish reason of the request, or None if unfinished.
+    """
+
+    delta_text: str
+    num_delta_tokens: int
+    delta_logprob_json_strs: Optional[List[str]]
+    finish_reason: Optional[str]
 
 
 class AsyncRequestStream:
@@ -30,14 +57,11 @@ class AsyncRequestStream:
     can use to iterates all the generated tokens in order asynchronously.
     """
 
-    # The asynchronous queue to hold elements of
-    # - either a tuple of (str, int, List[str], Optional[str]), denoting the
-    #   delta output text, the number of delta tokens, the logprob JSON strings
-    #   of delta tokens, and the optional finish reason respectively,
-    # - or an exception.
+    # The asynchronous queue to hold elements of either a list of
+    # AsyncStreamOutput or an exception.
     if sys.version_info >= (3, 9):
         _queue: asyncio.Queue[  # pylint: disable=unsubscriptable-object
-            Union[Tuple[str, int, Optional[List[str]], Optional[str]], Exception]
+            Union[List[AsyncStreamOutput], Exception]
         ]
     else:
         _queue: asyncio.Queue
@@ -48,10 +72,7 @@ class AsyncRequestStream:
         self._queue = asyncio.Queue()
         self._finished = False
 
-    def push(
-        self,
-        item_or_exception: Union[Tuple[str, int, Optional[List[str]], Optional[str]], Exception],
-    ) -> None:
+    def push(self, item_or_exception: Union[List[AsyncStreamOutput], Exception]) -> None:
         """Push a new token to the stream."""
         if self._finished:
             # No new item is expected after finish.
@@ -72,7 +93,7 @@ class AsyncRequestStream:
     def __aiter__(self):
         return self
 
-    async def __anext__(self) -> Tuple[str, int, Optional[List[str]], Optional[str]]:
+    async def __anext__(self) -> List[AsyncStreamOutput]:
         result = await self._queue.get()
         if isinstance(result, StopIteration):
             raise StopAsyncIteration
@@ -156,7 +177,8 @@ class AsyncThreadedEngine:  # pylint: disable=too-many-instance-attributes
             engine_mode = EngineMode()
 
         # The mapping from request ids to request asynchronous stream.
-        self._request_tools: Dict[str, Tuple[AsyncRequestStream, TextStreamer]] = {}
+        self._request_tools: Dict[str, Tuple[AsyncRequestStream, List[TextStreamer]]] = {}
+        self._num_unfinished_generations: Dict[str, int] = {}
 
         def _background_loop():
             self._ffi["init_background_engine"](
@@ -186,14 +208,11 @@ class AsyncThreadedEngine:  # pylint: disable=too-many-instance-attributes
 
     async def generate(
         self, prompt: Union[str, List[int]], generation_config: GenerationConfig, request_id: str
-    ) -> AsyncGenerator[Tuple[str, int, Optional[List[str]], Optional[str]], Any]:
+    ) -> AsyncGenerator[List[AsyncStreamOutput], Any]:
         """Asynchronous text generation interface.
-        The method is a coroutine that streams a tuple at a time via yield.
-        Each tuple is contained of
-        - the delta text in type str,
-        - the number of delta tokens in type int,
-        - the logprob JSON strings of delta tokens,
-        - the optional finish reason in type Optional[str].
+        The method is a coroutine that streams a list of AsyncStreamOutput
+        at a time via yield. The returned list length is the number of
+        parallel generations specified by `generation_config.n`.
 
         Parameters
         ----------
@@ -230,7 +249,11 @@ class AsyncThreadedEngine:  # pylint: disable=too-many-instance-attributes
             )
         else:
             # Record the stream in the tracker
-            self._request_tools[request_id] = (stream, TextStreamer(self.tokenizer))
+            self._request_tools[request_id] = (
+                stream,
+                [TextStreamer(self.tokenizer) for _ in range(generation_config.n)],
+            )
+            self._num_unfinished_generations[request_id] = generation_config.n
             self._ffi["add_request"](request)
 
         # Iterate the stream asynchronously and yield the token.
@@ -282,28 +305,39 @@ class AsyncThreadedEngine:  # pylint: disable=too-many-instance-attributes
     def _request_stream_callback_impl(self, delta_outputs: List[data.RequestStreamOutput]) -> None:
         """The underlying implementation of request stream callback."""
         for delta_output in delta_outputs:
-            (
-                request_id,
-                delta_token_ids,
-                delta_logprob_json_strs,
-                finish_reason,
-            ) = delta_output.unpack()
+            request_id, stream_outputs = delta_output.unpack()
             tools = self._request_tools.get(request_id, None)
             if tools is None:
                 continue
 
             self.record_event(request_id, event="start callback")
-            stream, text_streamer = tools
+            stream, text_streamers = tools
+            outputs = []
+            for stream_output, text_streamer in zip(stream_outputs, text_streamers):
+                self.record_event(request_id, event="start detokenization")
+                delta_text = (
+                    text_streamer.put(stream_output.delta_token_ids)
+                    if len(stream_output.delta_token_ids) > 0
+                    else ""
+                )
+                if stream_output.finish_reason is not None:
+                    delta_text += text_streamer.finish()
+                self.record_event(request_id, event="finish detokenization")
 
-            self.record_event(request_id, event="start detokenization")
-            delta_text = text_streamer.put(delta_token_ids)
-            if finish_reason is not None:
-                delta_text += text_streamer.finish()
-            self.record_event(request_id, event="finish detokenization")
+                outputs.append(
+                    AsyncStreamOutput(
+                        delta_text=delta_text,
+                        num_delta_tokens=len(stream_output.delta_token_ids),
+                        delta_logprob_json_strs=stream_output.delta_logprob_json_strs,
+                        finish_reason=stream_output.finish_reason,
+                    )
+                )
+                if stream_output.finish_reason is not None:
+                    self._num_unfinished_generations[request_id] -= 1
 
             # Push new delta text to the stream.
-            stream.push((delta_text, len(delta_token_ids), delta_logprob_json_strs, finish_reason))
-            if finish_reason is not None:
+            stream.push(outputs)
+            if self._num_unfinished_generations[request_id] == 0:
                 stream.finish()
                 self._request_tools.pop(request_id, None)
             self.record_event(request_id, event="finish callback")

--- a/python/mlc_chat/serve/config.py
+++ b/python/mlc_chat/serve/config.py
@@ -35,6 +35,9 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
 
     Parameters
     ----------
+    n : int
+        How many chat completion choices to generate for each input message.
+
     temperature : float
         The value that applies to logits and modulates the next token probabilities.
 
@@ -92,6 +95,7 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
         The response format of the generation output.
     """
 
+    n: int = 1
     temperature: float = 0.8
     top_p: float = 0.95
     frequency_penalty: float = 0.0

--- a/python/mlc_chat/serve/engine.py
+++ b/python/mlc_chat/serve/engine.py
@@ -352,11 +352,11 @@ class Engine:
         )
         self.tokenizer = Tokenizer(tokenizer_path)
 
-    def generate(
+    def generate(  # pylint: disable=too-many-locals
         self,
         prompts: Union[str, List[str], List[int], List[List[int]]],
         generation_config: Union[GenerationConfig, List[GenerationConfig]],
-    ) -> Tuple[List[str], List[Optional[List[str]]]]:
+    ) -> Tuple[List[List[str]], List[Optional[List[List[str]]]]]:
         """Generate texts for a list of input prompts.
         Each prompt can be a string or a list of token ids.
         The generation for each prompt is independent.
@@ -377,10 +377,12 @@ class Engine:
 
         Returns
         -------
-        output_text : List[str]
-            The text generation results, one string for each input prompt.
+        output_text : List[List[str]]
+            The text generation results, one list of strings for each input prompt.
+            The length of each list is the parallel generation `n` in
+            generation config.
 
-        output_logprobs_str : List[Optional[List[str]]]
+        output_logprobs_str : List[Optional[List[List[str]]]]
             The logprob strings of each token for each input prompt, or None
             if an input prompt does not require logprobs.
         """
@@ -406,14 +408,21 @@ class Engine:
             len(generation_config) == num_requests
         ), "Number of generation config and number of prompts mismatch"
 
-        num_finished_requests = 0
-        output_texts: List[str] = []
-        output_logprobs_str: List[Optional[List[str]]] = []
-        text_streamers: List[TextStreamer] = []
+        num_finished_generations = 0
+        output_texts: List[List[str]] = []
+        output_logprobs_str: List[Optional[List[List[str]]]] = []
+        text_streamers: List[List[TextStreamer]] = []
         for i in range(num_requests):
-            output_texts.append("")
+            output_texts.append([])
             output_logprobs_str.append([] if generation_config[i].logprobs else None)
-            text_streamers.append(TextStreamer(self.tokenizer))
+            text_streamers.append([])
+            for _ in range(generation_config[i].n):
+                output_texts[i].append("")
+                text_streamers[i].append(TextStreamer(self.tokenizer))
+                if output_logprobs_str[i] is not None:
+                    output_logprobs_str[i].append([])
+
+        num_total_generations = sum(cfg.n for cfg in generation_config)
 
         # Save a copy of the original function callback since `generate`
         # overrides the callback function.
@@ -422,27 +431,30 @@ class Engine:
 
         # Define the callback function for request generation results
         def request_stream_callback(delta_outputs: List[data.RequestStreamOutput]):
-            nonlocal num_finished_requests
+            nonlocal num_finished_generations
             for delta_output in delta_outputs:
-                (
-                    request_id,
-                    delta_token_ids,
-                    delta_logprob_json_strs,
-                    finish_reason,
-                ) = delta_output.unpack()
+                request_id, stream_outputs = delta_output.unpack()
                 rid = int(request_id)
-                text_streamer = text_streamers[rid]
-                if output_logprobs_str[rid] is not None:
-                    assert delta_logprob_json_strs is not None
-                    output_logprobs_str[rid] += delta_logprob_json_strs
 
-                delta_text = text_streamer.put(delta_token_ids)
-                if finish_reason is not None:
-                    delta_text += text_streamer.finish()
+                assert len(stream_outputs) == generation_config[rid].n
+                for i, (stream_output, text_streamer) in enumerate(
+                    zip(stream_outputs, text_streamers[rid])
+                ):
+                    if output_logprobs_str[rid] is not None:
+                        assert stream_output.delta_logprob_json_strs is not None
+                        output_logprobs_str[rid][i] += stream_output.delta_logprob_json_strs
 
-                output_texts[rid] += delta_text
-                if finish_reason is not None:
-                    num_finished_requests += 1
+                    delta_text = (
+                        text_streamer.put(stream_output.delta_token_ids)
+                        if len(stream_output.delta_token_ids) > 0
+                        else ""
+                    )
+                    if stream_output.finish_reason is not None:
+                        delta_text += text_streamer.finish()
+
+                    output_texts[rid][i] += delta_text
+                    if stream_output.finish_reason is not None:
+                        num_finished_generations += 1
 
         # Override the callback function in engine.
         self._ffi["set_request_stream_callback"](request_stream_callback)
@@ -462,7 +474,7 @@ class Engine:
                 )
             )
 
-        while num_finished_requests != num_requests:
+        while num_finished_generations != num_total_generations:
             self.step()
 
         # Restore the callback function in engine.

--- a/tests/python/serve/test_serve_async_engine_spec.py
+++ b/tests/python/serve/test_serve_async_engine_spec.py
@@ -44,7 +44,9 @@ async def test_engine_generate():
     max_tokens = 256
     generation_cfg = GenerationConfig(max_tokens=max_tokens)
 
-    outputs: List[str] = ["" for _ in range(num_requests)]
+    output_texts: List[List[str]] = [
+        ["" for _ in range(generation_cfg.n)] for _ in range(num_requests)
+    ]
 
     async def generate_task(
         async_engine: AsyncThreadedEngine,
@@ -54,10 +56,12 @@ async def test_engine_generate():
     ):
         print(f"generate task for request {request_id}")
         rid = int(request_id)
-        async for delta_text, _, _, _ in async_engine.generate(
+        async for delta_outputs in async_engine.generate(
             prompt, generation_cfg, request_id=request_id
         ):
-            outputs[rid] += delta_text
+            assert len(delta_outputs) == generation_cfg.n
+            for i, delta_output in enumerate(delta_outputs):
+                output_texts[rid][i] += delta_output.delta_text
 
     tasks = [
         asyncio.create_task(
@@ -70,9 +74,13 @@ async def test_engine_generate():
 
     # Print output.
     print("All finished")
-    for req_id, output in enumerate(outputs):
+    for req_id, outputs in enumerate(output_texts):
         print(f"Prompt {req_id}: {prompts[req_id]}")
-        print(f"Output {req_id}:{output}\n")
+        if len(outputs) == 1:
+            print(f"Output {req_id}:{outputs[0]}\n")
+        else:
+            for i, output in enumerate(outputs):
+                print(f"Output {req_id}({i}):{output}\n")
 
     async_engine.terminate()
     del async_engine


### PR DESCRIPTION
This PR brings field `n` to generation config and thereby supports parallel generation. This parallel generation effectively leverages the "fork" functionality of paged KV cache.

This PR supports specifying the number of parallel generation `n` in stardard OpenAI ChatCompletion API. This is the last feature towards the OpenAI API feature completeness.