### PR TITLE
[Fix] Add the missing BundleModelParams pass

### DIFF
--- a/mlc_llm/core.py
+++ b/mlc_llm/core.py
@@ -847,6 +847,7 @@ def build_model_from_args(args: argparse.Namespace):
             qspec_updater = qspec_updater_class(param_manager)
             qspec_updater.visit_module(mod)
         mod = param_manager.transform_dequantize()(mod)
+        mod = relax.transform.BundleModelParams()(mod)
 
         if not args.build_model_only:
             parameter_transforms = []


### PR DESCRIPTION
PR #1852 missed to apply the BundleModelParams pass and thus made the compiled models not runnable through ChatModule (#1864). This PR fixes the issue.