### PR TITLE
Fix MLC-LLM website link weight convert not accessible

### DIFF
--- a/docs/compilation/compile_models.rst
+++ b/docs/compilation/compile_models.rst
@@ -5,8 +5,8 @@ Compile Model Libraries
 
 To run a model with MLC LLM in any platform, you need:
 
-1. **Model weights** converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-MLC 
-   <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-MLC/tree/main>`_.)
+1. **Model weights** converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC
+   <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC/tree/main>`_.)
 2. **Model library** that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
 
 If you are simply adding a model variant, follow :ref:`convert-weights-via-MLC` suffices.

--- a/docs/compilation/convert_weights.rst
+++ b/docs/compilation/convert_weights.rst
@@ -5,8 +5,8 @@ Convert Weights via MLC
 
 To run a model with MLC LLM in any platform, you need:
 
-1. **Model weights** converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-MLC 
-   <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-MLC/tree/main>`_.)
+1. **Model weights** converted to MLC format (e.g. `RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC
+   <https://huggingface.co/mlc-ai/RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC/tree/main`_.)
 2. **Model library** that comprises the inference logic (see repo `binary-mlc-llm-libs <https://github.com/mlc-ai/binary-mlc-llm-libs>`__).
 
 In many cases, we only need to convert weights and reuse existing model library. 


### PR DESCRIPTION
There's an link on the MLC-LLM that the link is expired (mentioned in one issue before). Updated the website with the new link