### PR TITLE
[Serving][Grammar] Support termination state in GrammarStateMatcher

### DIFF
--- a/ci/task/pylint.sh
+++ b/ci/task/pylint.sh
@@ -7,7 +7,7 @@ set -x
 export PYTHONPATH="./python":${PYTHONPATH:-""}
 
 # TVM Unity is a dependency to this testing
-pip install --quiet --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
+# pip install --quiet --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 
 pylint --jobs $NUM_THREADS ./python/
 pylint --jobs $NUM_THREADS --recursive=y ./tests/python/

--- a/ci/task/pylint.sh
+++ b/ci/task/pylint.sh
@@ -7,7 +7,7 @@ set -x
 export PYTHONPATH="./python":${PYTHONPATH:-""}
 
 # TVM Unity is a dependency to this testing
-# pip install --quiet --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
+pip install --quiet --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 
 pylint --jobs $NUM_THREADS ./python/
 pylint --jobs $NUM_THREADS --recursive=y ./tests/python/

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -120,13 +120,6 @@ void ActionStepPostProcess(Array<Request> requests, EngineState estate, Array<Mo
 
       if (!delta_request_ret.delta_token_ids.empty()) {
         invoke_callback = true;
-        // Update the grammar matcher state if it exists.
-        if (rsentry->mstates[0]->grammar_state_matcher) {
-          const auto& grammar_state_matcher = rsentry->mstates[0]->grammar_state_matcher.value();
-          for (int32_t token_id : delta_request_ret.delta_token_ids) {
-            grammar_state_matcher->AcceptToken(token_id);
-          }
-        }
       }
     }
 

--- a/cpp/serve/grammar/grammar_state_matcher.h
+++ b/cpp/serve/grammar/grammar_state_matcher.h
@@ -58,6 +58,11 @@ class GrammarStateMatcherNode : public Object {
    * \brief Accept one token and update the state of the matcher.
    * \param token_id The id of the token to accept.
    * \return Whether the token is accepted.
+   * \note Termination state.
+   * When the end of the main rule is reached, the matcher can only accept the stop token.
+   * The matcher is terminated after accepting the stop token, i.e. no AcceptToken or
+   * FindNextTokenMask operations can be performed. The termination state can be canceled
+   * using Rollback().
    */
   virtual bool AcceptToken(int32_t token_id) = 0;
 
@@ -78,6 +83,12 @@ class GrammarStateMatcherNode : public Object {
 
   /*! \brief Get the maximum number of rollback steps allowed. */
   virtual int MaxRollbackSteps() const = 0;
+
+  /*!
+   * \brief Check if the matcher has accepted the stop token and terminated.
+   * \sa AcceptToken
+   */
+  virtual bool IsTerminated() const = 0;
 
   /*! \brief Reset the matcher to the initial state. */
   virtual void ResetState() = 0;

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -86,9 +86,9 @@ inline bool GrammarStateMatcherBase::AcceptCodepoint(TCodepoint codepoint, bool 
   if (verbose) {
     std::cout << "Stack before accepting: " << PrintStackState() << std::endl;
   }
-  tmp_new_stack_tops_.clear();
-
   const auto& prev_stack_tops = stack_tops_history_.GetLatest();
+
+  tmp_new_stack_tops_.clear();
   for (auto old_top : prev_stack_tops) {
     const auto& rule_position = tree_[old_top];
     auto current_sequence = grammar_->GetRuleExpr(rule_position.sequence_id);

--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -100,7 +100,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
 
     // Update 3. Vocabulary mask.
     RECORD_EVENT(trace_recorder_, request_ids, "start apply logit mask");
-    UpdateWithMask(logits, mstates, cum_num_token, draft_tokens, request_ids);
+    UpdateWithMask(logits, mstates, cum_num_token, draft_tokens);
     RECORD_EVENT(trace_recorder_, request_ids, "finish apply logit mask");
 
     RECORD_EVENT(trace_recorder_, request_ids, "finish update logits");
@@ -302,8 +302,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
 
   void UpdateWithMask(NDArray logits, const Array<RequestModelState>& mstates,
                       const std::vector<int>* cum_num_token,
-                      const std::vector<std::vector<SampleResult>>* draft_tokens,
-                      const Array<String>& request_ids) {
+                      const std::vector<std::vector<SampleResult>>* draft_tokens) {
     // Construct:
     // - seq_ids (max_num_token,) int32
     // - bitmask (max_num_token, ceildiv(vocab_size, 32)), int32
@@ -311,8 +310,6 @@ class LogitProcessorImpl : public LogitProcessorObj {
     uint32_t* p_bitmask = static_cast<uint32_t*>(bitmask_host_->data);
 
     // - Set arrays.
-    ICHECK(mstates.size() == request_ids.size());
-
     int batch_size = logits->shape[0];
     ICHECK((cum_num_token == nullptr && batch_size == mstates.size()) ||
            (cum_num_token != nullptr && batch_size == cum_num_token->size()));

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -49,6 +49,14 @@ void RequestModelStateNode::FindNextTokenBitmask(DLTensor* bitmask) {
 void RequestModelStateNode::CommitToken(SampleResult sampled_token) {
   committed_tokens.push_back(std::move(sampled_token));
   appeared_token_ids[sampled_token.sampled_token_id.first] += 1;
+
+  // Update the grammar matcher state if it exists.
+  if (grammar_state_matcher) {
+    bool accepted =
+        grammar_state_matcher.value()->AcceptToken(sampled_token.sampled_token_id.first);
+    ICHECK(accepted) << "Token id " << sampled_token.sampled_token_id.first
+                     << " is not accepted by the grammar state matcher.";
+  }
 }
 
 void RequestModelStateNode::AddDraftToken(SampleResult sampled_token, NDArray prob_dist) {

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -6,6 +6,7 @@ https://github.com/lm-sys/FastChat/blob/main/fastchat/protocol/openai_api_protoc
 # pylint: disable=missing-class-docstring
 import time
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from mlc_chat.serve.config import ResponseFormat
 
 import shortuuid
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -65,7 +66,7 @@ class ModelResponse(BaseModel):
 ################ v1/completions ################
 
 
-class ResponseFormat(BaseModel):
+class RequestResponseFormat(BaseModel):
     type: Literal["text", "json_object"] = "text"
     json_schema: Optional[str] = None
 
@@ -94,7 +95,7 @@ class CompletionRequest(BaseModel):
     top_p: float = 1.0
     user: Optional[str] = None
     ignore_eos: bool = False
-    response_format: ResponseFormat = ResponseFormat()
+    response_format: RequestResponseFormat = Field(default_factory=RequestResponseFormat)
 
     @field_validator("frequency_penalty", "presence_penalty")
     @classmethod
@@ -208,7 +209,7 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None
     user: Optional[str] = None
     ignore_eos: bool = False
-    response_format: ResponseFormat = ResponseFormat()
+    response_format: RequestResponseFormat = Field(default_factory=RequestResponseFormat)
 
     @field_validator("frequency_penalty", "presence_penalty")
     @classmethod
@@ -331,5 +332,5 @@ def openai_api_get_generation_config(
         kwargs["max_tokens"] = -1
     if request.stop is not None:
         kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
-    kwargs["response_format"] = request.response_format.model_dump()
+    kwargs["response_format"] = ResponseFormat(**request.response_format.model_dump())
     return kwargs

--- a/python/mlc_chat/protocol/openai_api_protocol.py
+++ b/python/mlc_chat/protocol/openai_api_protocol.py
@@ -6,10 +6,11 @@ https://github.com/lm-sys/FastChat/blob/main/fastchat/protocol/openai_api_protoc
 # pylint: disable=missing-class-docstring
 import time
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
-from mlc_chat.serve.config import ResponseFormat
 
 import shortuuid
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+from mlc_chat.serve.config import ResponseFormat
 
 ################ Commons ################
 

--- a/python/mlc_chat/protocol/protocol_utils.py
+++ b/python/mlc_chat/protocol/protocol_utils.py
@@ -43,9 +43,6 @@ def get_generation_config(
     else:
         raise RuntimeError("Cannot reach here")
 
-    response_format_dict = kwargs.get("response_format", {})
-    kwargs["response_format"] = ResponseFormat(**response_format_dict)
-
     if extra_stop_token_ids is not None:
         stop_token_ids = kwargs.get("stop_token_ids", [])
         assert isinstance(stop_token_ids, list)

--- a/python/mlc_chat/protocol/protocol_utils.py
+++ b/python/mlc_chat/protocol/protocol_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
-from ..serve.config import GenerationConfig, ResponseFormat
+from ..serve.config import GenerationConfig
 from . import RequestProtocol
 from .openai_api_protocol import ChatCompletionRequest as OpenAIChatCompletionRequest
 from .openai_api_protocol import CompletionRequest as OpenAICompletionRequest

--- a/python/mlc_chat/serve/grammar.py
+++ b/python/mlc_chat/serve/grammar.py
@@ -179,6 +179,15 @@ class GrammarStateMatcher(Object):
         -------
         accepted : bool
             Whether the token is accepted.
+
+        Note
+        ----
+        Termination state.
+
+        When the end of the main rule is reached, the matcher can only accept the stop token.
+        The matcher is terminated after accepting the stop token, i.e. no accept_token or
+        find_next_rejected_tokens operations can be performed. The termination state can be canceled
+        using Rollback().
         """
         return _ffi_api.GrammarStateMatcherAcceptToken(self, token_id)  # type: ignore  # pylint: disable=no-member
 
@@ -217,6 +226,17 @@ class GrammarStateMatcher(Object):
     def reset_state(self) -> None:
         """Reset the matcher to the initial state."""
         _ffi_api.GrammarStateMatcherResetState(self)  # type: ignore  # pylint: disable=no-member
+
+    def is_terminated(self) -> bool:
+        """Check if the matcher has accepted the stop token and terminated. See also
+        GrammarStateMatcher.accept_token.
+
+        Returns
+        -------
+        terminated : bool
+            Whether the matcher has terminated.
+        """
+        return _ffi_api.GrammarStateMatcherIsTerminated(self)
 
     def debug_accept_char(self, codepoint: int) -> bool:
         """Accept one unicode codepoint to the current state.

--- a/python/mlc_chat/serve/grammar.py
+++ b/python/mlc_chat/serve/grammar.py
@@ -236,7 +236,7 @@ class GrammarStateMatcher(Object):
         terminated : bool
             Whether the matcher has terminated.
         """
-        return _ffi_api.GrammarStateMatcherIsTerminated(self)
+        return _ffi_api.GrammarStateMatcherIsTerminated(self)  # type: ignore  # pylint: disable=no-member
 
     def debug_accept_char(self, codepoint: int) -> bool:
         """Accept one unicode codepoint to the current state.

--- a/tests/python/serve/test_grammar_parser.py
+++ b/tests/python/serve/test_grammar_parser.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 import tvm.testing
-from tvm._ffi.base import TVMError
+from tvm import TVMError
 
 from mlc_chat.serve import BNFGrammar
 


### PR DESCRIPTION
This PR adds a feature for GrammarStateMatcher that it can accept a stop token when previous accepted tokens reach the end of the grammar. 

This will help the caller side when enabling accepting the stop token will simplify the logic. For our case, we can accept tokens in RequestModelStateNode::CommitToken, that is, immidiately after generation and before checking if end token occurs.

The matcher is terminated after accepting the stop token, i.e. no accept_token or find_next_rejected_tokens operations can be performed. The termination state can be canceled using Rollback().

`is_terminated` method is used to detect if the matcher enters the termination mode:

```
    def is_terminated(self) -> bool:
        """Check if the matcher has accepted the stop token and terminated. See also
        GrammarStateMatcher.accept_token.
        Returns
        -------
        terminated : bool
            Whether the matcher has terminated.
        """
        pass
```

This pr also fixes problems mentioned in #1867.

cc @MasterJH5574 