### PR TITLE
[Serving] Estimate KV cache memory usage with metadata

### DIFF
--- a/python/mlc_chat/cli/model_metadata.py
+++ b/python/mlc_chat/cli/model_metadata.py
@@ -1,4 +1,5 @@
 """A tool that inspects the metadata of a model lib."""
+
 import json
 import math
 from dataclasses import asdict
@@ -120,6 +121,10 @@ def _print_memory_usage_in_json(metadata: Dict[str, Any], config: Dict) -> None:
     )
 
 
+def _print_kv_cache_metadata_in_json(metadata: Dict[str, Any]) -> None:
+    print(json.dumps(metadata["kv_cache"]))
+
+
 def main():
     """Entry point for the model metadata tool."""
     parser = ArgumentParser(description="A tool that inspects the metadata of a model lib.")
@@ -154,6 +159,11 @@ def main():
         action="store_true",
         help="""If set, only inspect the metadata in memory usage and print usage in raw JSON.""",
     )
+    parser.add_argument(
+        "--print-kv-cache-metadata-in-json-only",
+        action="store_true",
+        help="""If set, only inspect the metadata in KV cache and print usage in raw JSON.""",
+    )
     parsed = parser.parse_args()
     # Load metadata from model lib
     try:
@@ -174,6 +184,8 @@ def main():
         _print_memory_usage_in_json(metadata, cfg)
     elif parsed.memory_only:
         _report_memory_usage(metadata, cfg)
+    elif parsed.print_kv_cache_metadata_in_json_only:
+        _print_kv_cache_metadata_in_json(metadata)
     else:
         _report_all(metadata)
 


### PR DESCRIPTION
Prior to this PR, the serving engine memory usage estimation reads model config for fields such as `num_key_value_heads`, `num_hidden_layers`, etc.. However, since not every model share the same set of config names (#1854), the estimation fails for models that do not have this set of config field names.

This PR makes the following changes. First, it attaches these field values into the model's metadata, in which way we unify the field names for different models effectively. Then, when estimating the memory usage, we read these fields from the metadata, rather than model config, so we are safe for the name inconsistency.