### PR TITLE
[Serving] Add Phi-2 conv template to mlc serve

### DIFF
--- a/python/mlc_chat/conversation_template.py
+++ b/python/mlc_chat/conversation_template.py
@@ -114,3 +114,22 @@ ConvTemplateRegistry.register_conv_template(
         stop_token_ids=[2],
     )
 )
+
+# Phi-2
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="phi-2",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={
+            "user": "Instruct",
+            "assistant": "Output",
+            "tool": "Instruct",
+        },
+        seps=["\n"],
+        role_content_sep=": ",
+        role_empty_sep=":",
+        stop_str=["<|endoftext|>"],
+        stop_token_ids=[50256],
+    )
+)


### PR DESCRIPTION
This PR adds the phi-2 model template to MLC serve.

For testing
1. Start server
```python -m mlc_chat.serve.server --model ./dist/phi-2-q4f16_1-MLC/ --model-lib-path ./dist/phi-2-q4f16_1-MLC/phi-2-q4f16_1-cuda.so --device auto --max-batch-size 2 --enable-tracing --host 127.0.0.1 --port 8000 --max-total-seq-length 8000```
2. Send request
```python test_server_rest_api.py```

```python
# test_server_rest_api.py
import requests
import json

model = "./dist/phi-2-q4f16_1-MLC/"
port = 8000
payload = {
    "model": f"{model}",
    "messages": [{"role": "user", "content": "Tell me about Machine Learning in 200 words."}],
    "stream": False,
}
r = requests.post(f"http://127.0.0.1:{port}/v1/chat/completions", json=payload)
if r.status_code != 200:
    print(r.json())
else:
    print(r.json()["choices"][0]["message"]["content"])
```

cc @tqchen 