### PR TITLE
[Model] Remove redundant `batch_forward` and move broadcast

### DIFF
--- a/python/mlc_chat/model/baichuan/baichuan_model.py
+++ b/python/mlc_chat/model/baichuan/baichuan_model.py
@@ -2,6 +2,7 @@
 Implementation for BAICHUAN architecture.
 TODO: add docstring
 """
+
 import dataclasses
 from typing import Any, Dict, Optional
 
@@ -37,6 +38,7 @@ class BaichuanConfig(ConfigBase):  # pylint: disable=too-many-instance-attribute
     context_window_size: int = 0
     prefill_chunk_size: int = 0
     tensor_parallel_shards: int = 1
+    max_batch_size: int = 1
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -100,17 +102,6 @@ class BaichuanAttention(nn.Module):  # pylint: disable=too-many-instance-attribu
         attn_output = self.o_proj(output)
         return attn_output
 
-    def batch_forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
-        d, h = self.head_dim, self.num_heads
-        b, s, _ = hidden_states.shape
-        qkv = self.W_pack(hidden_states)
-        qkv = op.reshape(qkv, (b, s, 3 * h, d))
-        output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads), (b, s, h * d)
-        )
-        attn_output = self.o_proj(output)
-        return attn_output
-
 
 class BaichuanMLP(nn.Module):
     def __init__(self, config: BaichuanConfig):
@@ -142,15 +133,6 @@ class BaichuanDecoderLayer(nn.Module):
         hidden_states = out + hidden_states
         return hidden_states
 
-    def batch_forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
-        out = self.self_attn.batch_forward(
-            self.input_layernorm(hidden_states), paged_kv_cache, layer_id
-        )
-        hidden_states = out + hidden_states
-        out = self.mlp(self.post_attention_layernorm(hidden_states))
-        hidden_states = out + hidden_states
-        return hidden_states
-
 
 class BaichuanModel(nn.Module):
     def __init__(self, config: BaichuanConfig):
@@ -165,13 +147,6 @@ class BaichuanModel(nn.Module):
         hidden_states = inputs
         for layer_id, layer in enumerate(self.layers):
             hidden_states = layer(hidden_states, paged_kv_cache, layer_id)
-        hidden_states = self.norm(hidden_states)
-        return hidden_states
-
-    def batch_forward(self, inputs: Tensor, paged_kv_cache: PagedKVCache):
-        hidden_states = inputs
-        for layer_id, layer in enumerate(self.layers):
-            hidden_states = layer.batch_forward(hidden_states, paged_kv_cache, layer_id)
         hidden_states = self.norm(hidden_states)
         return hidden_states
 
@@ -203,7 +178,7 @@ class BaichuanForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
     ):
         op_ext.configure()
 
-        hidden_states = self.model.batch_forward(input_embeds, paged_kv_cache)
+        hidden_states = self.model(input_embeds, paged_kv_cache)
         if logit_positions is not None:
             hidden_states = op.take(hidden_states, logit_positions, axis=1)
         logits = self.lm_head(hidden_states)

--- a/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
+++ b/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
@@ -34,6 +34,7 @@ class GPTBigCodeConfig(ConfigBase):  # pylint: disable=too-many-instance-attribu
     context_window_size: int = 0
     prefill_chunk_size: int = 0
     tensor_parallel_shards: int = 1
+    max_batch_size: int = 1
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -108,28 +109,12 @@ class GPTBigCodeAttention(nn.Module):  # pylint: disable=too-many-instance-attri
             bias=True,
         )
 
-        self.k_cache = nn.KVCache(config.context_window_size, [self.num_kv_heads, self.head_dim])
-        self.v_cache = nn.KVCache(config.context_window_size, [self.num_kv_heads, self.head_dim])
-
     def forward(
         self,
         hidden_states: Tensor,
         paged_kv_cache: PagedKVCache,
         layer_id: int,
     ):
-        d, h_q, h_kv = self.head_dim, self.num_q_heads, self.num_kv_heads
-        b, s, _ = hidden_states.shape
-
-        # QKV Projection
-        qkv = self.c_attn(hidden_states)
-        qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
-        # Attention
-        output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, h_q), (b, s, h_q * d)
-        )
-        return self.c_proj(output)
-
-    def batch_forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
         d, h_q, h_kv = self.head_dim, self.num_q_heads, self.num_kv_heads
         b, s, _ = hidden_states.shape
 
@@ -173,13 +158,6 @@ class GPTBigCodeBlock(nn.Module):
         hidden_states = out + hidden_states
         return hidden_states
 
-    def batch_forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
-        out = self.attn.batch_forward(self.ln_1(hidden_states), paged_kv_cache, layer_id)
-        hidden_states = out + hidden_states
-        out = self.mlp(self.ln_2(hidden_states))
-        hidden_states = out + hidden_states
-        return hidden_states
-
 
 class GPTBigCodeModel(nn.Module):
     def __init__(self, config: GPTBigCodeConfig):
@@ -188,12 +166,8 @@ class GPTBigCodeModel(nn.Module):
         self.wpe = nn.Embedding(config.n_positions, config.n_embd)
         self.h = nn.ModuleList([GPTBigCodeBlock(config) for _ in range(config.n_layer)])
         self.ln_f = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
-        self.tensor_parallel_shards = config.tensor_parallel_shards
 
     def forward(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
-        if self.tensor_parallel_shards > 1:
-            input_embed = op.ccl_broadcast_from_worker0(input_embed)
-
         # Position Embeddings
         # shape[1] indicates the total query length in the batch
         input_positions = paged_kv_cache.get_query_positions(input_embed.shape[1])
@@ -203,23 +177,6 @@ class GPTBigCodeModel(nn.Module):
         hidden_states = input_embed + pos_embd
         for layer_id, layer in enumerate(self.h):
             hidden_states = layer(hidden_states, paged_kv_cache, layer_id)
-        hidden_states = self.ln_f(hidden_states)
-
-        return hidden_states
-
-    def batch_forward(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
-        if self.tensor_parallel_shards > 1:
-            input_embed = op.ccl_broadcast_from_worker0(input_embed)
-
-        # Position Embeddings
-        # shape[1] indicates the total query length in the batch
-        input_positions = paged_kv_cache.get_query_positions(input_embed.shape[1])
-        pos_embd = self.wpe(input_positions)
-
-        # apply position embeddings
-        hidden_states = input_embed + pos_embd
-        for layer_id, layer in enumerate(self.h):
-            hidden_states = layer.batch_forward(hidden_states, paged_kv_cache, layer_id)
         hidden_states = self.ln_f(hidden_states)
 
         return hidden_states
@@ -234,6 +191,7 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
         self.num_q_heads = config.n_head // config.tensor_parallel_shards
         self.num_kv_heads = 1
         self.head_dim = config.n_embd // config.n_head
+        self.tensor_parallel_shards = config.tensor_parallel_shards
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -249,7 +207,7 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
     ):
         op_ext.configure()
 
-        hidden_states = self.transformer.batch_forward(input_embed, paged_kv_cache)
+        hidden_states = self.transformer(input_embed, paged_kv_cache)
         if logit_positions is not None:
             hidden_states = op.take(hidden_states, logit_positions, axis=1)
         logits = self.lm_head(hidden_states)
@@ -258,6 +216,8 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
         return logits
 
     def embed(self, input_ids: Tensor):
+        if self.tensor_parallel_shards > 1:
+            input_ids = op.ccl_broadcast_from_worker0(input_ids)
         return self.transformer.wte(input_ids)
 
     def prefill(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
@@ -313,8 +273,8 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
             prefill_chunk_size=prefill_chunk_size,
             page_size=page_size,
             num_hidden_layers=self.n_layer,
-            num_attention_heads=self.num_q_heads,
-            num_key_value_heads=self.num_kv_heads,
+            num_attention_heads=self.num_q_heads // self.tensor_parallel_shards,
+            num_key_value_heads=self.num_kv_heads // self.tensor_parallel_shards,
             head_dim=self.head_dim,
             rope_mode=RopeMode.NONE,
             rope_scale=-1,

--- a/python/mlc_chat/model/mixtral/mixtral_model.py
+++ b/python/mlc_chat/model/mixtral/mixtral_model.py
@@ -1,4 +1,5 @@
 """Implementation for Mistral architecture."""
+
 import dataclasses
 
 from tvm import tir
@@ -144,9 +145,7 @@ class MixtralDecoderLayer(nn.Module):
         return hidden_states
 
     def batch_forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
-        out = self.self_attn.batch_forward(
-            self.input_layernorm(hidden_states), paged_kv_cache, layer_id
-        )
+        out = self.self_attn(self.input_layernorm(hidden_states), paged_kv_cache, layer_id)
         hidden_states = self._apply_residual(out, residual=hidden_states)
         out = self.moe(self.post_attention_layernorm(hidden_states))
         hidden_states = self._apply_residual(out, residual=hidden_states)


### PR DESCRIPTION
This PR contains four changes:

1. It removes the duplicate `batch_forward` defined in model definitions. This function was widely used prior to our migration to PagedKVCache, since before migration the attention codepath of single sequence forward and batch forward differ. But since our migration, the codepaths are unified into one, and therefore we can safely remove most `batch_forward` functions.

2. It moves `op.ccl_broadcast_from_worker0` from model main forward (which will be called at the beginning of prefill/decode) to embedding. This change has two benefits. Firstly, the token ids taken by `embed` was not broadcasted across workers, and it is possible for workers other than 0 to have illegal token ids which is not in the range of vocab size, and moving the broadcasting to `embed` perfectly address this issue. Secondly, broadcasting token ids in `embed` is more lightweight than broadcasting embeddings in `prefill`/`decode`, since the tensor size of token ids is much smaller.

3. It adds `max_batch_size` to the config class of models, so that they are potentially compatible with batching and MLC serve.

4. It removes the `k_cache` and `v_cache` effects from the models that have switched to PagedKVCache support.

Randomly picked a few models (as below) to run the engine test, and all of them are passed:

* phi-2 with tp=2,
* RedPajama with tp=2,
* stablelm with tp=2 (since stablelm does not support TP right now).