### PR TITLE
[KVCache]Migrate Qwen2 model to PagedKVCache

### DIFF
--- a/python/mlc_chat/model/qwen2/qwen2_model.py
+++ b/python/mlc_chat/model/qwen2/qwen2_model.py
@@ -173,7 +173,7 @@ class QWen2Model(nn.Module):
         return hidden_states
 
 
-class QWen2LMHeadModel(nn.Module):
+class QWen2LMHeadModel(nn.Module):    # pylint: disable=too-many-instance-attributes
     def __init__(self, config: QWen2Config):
         self.model = QWen2Model(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)

--- a/python/mlc_chat/model/qwen2/qwen2_model.py
+++ b/python/mlc_chat/model/qwen2/qwen2_model.py
@@ -126,7 +126,6 @@ ACT2FN = {
 }
 
 
-
 class QWen2MLP(nn.Module):
     def __init__(self, config: QWen2Config):
         self.gate_up_proj = nn.Linear(config.hidden_size, 2 * config.intermediate_size, bias=False)

--- a/python/mlc_chat/model/qwen2/qwen2_model.py
+++ b/python/mlc_chat/model/qwen2/qwen2_model.py
@@ -11,6 +11,7 @@ from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_chat import op as op_ext
+from mlc_chat.nn import PagedKVCache, RopeMode
 from mlc_chat.support import logging
 from mlc_chat.support.config import ConfigBase
 from mlc_chat.support.style import bold
@@ -31,7 +32,6 @@ class QWen2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     rms_norm_eps: float
     rope_theta: int
     vocab_size: int
-
     context_window_size: int = 0
     prefill_chunk_size: int = 0
     tensor_parallel_shards: int = 1
@@ -73,7 +73,6 @@ class QWen2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
                 bold("context_window_size"),
             )
             self.prefill_chunk_size = self.context_window_size
-        assert self.tensor_parallel_shards == 1, "QWEN currently does not support sharding."
 
 
 # pylint: disable=invalid-name,missing-docstring,too-many-locals
@@ -105,27 +104,18 @@ class QWen2Attention(nn.Module):  # pylint: disable=too-many-instance-attributes
         self.num_key_value_heads = config.num_key_value_heads
         self.rope_theta = config.rope_theta
 
-    def forward(self, hidden_states: Tensor, attention_mask: Tensor, total_seq_len: tir.Var):
-        bsz, sl, _ = hidden_states.shape
-        assert bsz == 1, "Only support batch size 1 at this moment."
-        # Step 1. QKV Projection
-        qkv = self.c_attn(hidden_states)
-        num_heads = 2 * self.num_key_value_heads + self.num_attention_heads
-        qkv = op.reshape(qkv, (bsz, sl, num_heads, self.head_dim))
-        # Step 2. Apply QK rotary embedding
-        q, k, v = op_ext.llama_rope(
-            qkv, total_seq_len, self.rope_theta, self.num_attention_heads, self.num_key_value_heads
-        )
-        # Step 3. Query and update KVCache
-        self.k_cache.append(op.squeeze(k, axis=0))
-        self.v_cache.append(op.squeeze(v, axis=0))
-        k = self.k_cache.view(total_seq_len)
-        v = self.v_cache.view(total_seq_len)
-        # Step 4. Compute softmax(Q @ K^T / sqrt(d)) @ V
-        output = op_ext.attention(q, k, v, casual_mask=attention_mask)
-        # Step 5. Apply output projection
-        return self.o_proj(output)
+    def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
 
+        d, h_q, h_kv = self.head_dim, self.num_attention_heads, self.num_key_value_heads
+        b, s, _ = hidden_states.shape
+        qkv = self.c_attn(hidden_states)
+        qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
+        output = op.reshape(
+            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_attention_heads),
+            (b, s, h_q * d),
+        )
+        attn_output = self.o_proj(output)
+        return attn_output
 
 ACT2FN = {
     "gelu": partial(nn.gelu, approximate=False),
@@ -157,16 +147,14 @@ class QWen2DecoderLayer(nn.Module):
             config.hidden_size, -1, config.rms_norm_eps, bias=False
         )
 
-    def forward(self, hidden_states: Tensor, attention_mask: Tensor, total_seq_len: tir.Var):
+    def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
         out = self.input_layernorm(hidden_states)
-        out = self.self_attn(out, attention_mask, total_seq_len)
+        out = self.self_attn(out, paged_kv_cache, layer_id)
         hidden_states = out + hidden_states
-
         out = self.post_attention_layernorm(hidden_states)
         out = self.mlp(out)
         hidden_states = out + hidden_states
         return hidden_states
-
 
 class QWen2Model(nn.Module):
     def __init__(self, config: QWen2Config):
@@ -176,10 +164,10 @@ class QWen2Model(nn.Module):
         )
         self.norm = nn.RMSNorm(config.hidden_size, -1, config.rms_norm_eps, bias=False)
 
-    def forward(self, input_ids: Tensor, attention_mask: Tensor, total_seq_len: tir.Var):
-        hidden_states = self.embed_tokens(input_ids)
-        for layer in self.layers:
-            hidden_states = layer(hidden_states, attention_mask, total_seq_len)
+    def forward(self, inputs: Tensor, paged_kv_cache: PagedKVCache):
+        hidden_states = inputs
+        for layer_id, layer in enumerate(self.layers):
+            hidden_states = layer(hidden_states, paged_kv_cache, layer_id)
         hidden_states = self.norm(hidden_states)
         return hidden_states
 
@@ -189,79 +177,166 @@ class QWen2LMHeadModel(nn.Module):
         self.model = QWen2Model(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.dtype = config.dtype
+        self.hidden_size = config.hidden_size
+        self.num_hidden_layers = config.num_hidden_layers
+        self.intermediate_size = config.intermediate_size
+        self.num_attention_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.rms_norm_eps = config.rms_norm_eps
+        self.rope_theta = config.rope_theta
+        self.vocab_size = config.vocab_size
+        self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.head_dim = config.hidden_size // config.num_attention_heads
 
     def to(self, dtype: Optional[str] = None):
         super().to(dtype=dtype)
         if dtype is not None:
             self.dtype = dtype
 
-    def forward(self, inputs: Tensor, attention_mask: Tensor, total_seq_len: tir.Var):
-        def _index(x: te.Tensor):  # x[:-1,:]
-            b, s, d = x.shape
-            return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
+    def batch_forward(
+        self,
+        input_embeds: Tensor,
+        paged_kv_cache: PagedKVCache,
+        logit_positions: Optional[Tensor] = None,
+    ):
+        op_ext.configure()
 
-        hidden_states = self.model(inputs, attention_mask, total_seq_len)
-        hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
+        hidden_states = self.model(input_embeds, paged_kv_cache)
+        if logit_positions is not None:
+            hidden_states = op.take(hidden_states, logit_positions, axis=1)
         logits = self.lm_head(hidden_states)
         if logits.dtype != "float32":
             logits = logits.astype("float32")
         return logits
 
-    def prefill(self, inputs: Tensor, total_seq_len: tir.Var):
-        def _attention_mask(batch_size, seq_len, total_seq_len):
-            return te.compute(
-                (batch_size, 1, seq_len, total_seq_len),
-                lambda b, _, i, j: tir.if_then_else(
-                    i < j - (total_seq_len - seq_len),
-                    tir.min_value(self.dtype),
-                    tir.max_value(self.dtype),
-                ),
-                name="attention_mask_prefill",
-            )
+    def embed(self, input_ids: Tensor):
+        return self.model.embed_tokens(input_ids)
 
-        batch_size, seq_len = inputs.shape
-        attention_mask = op.tensor_expr_op(
-            _attention_mask,
-            name_hint="attention_mask_prefill",
-            args=[batch_size, seq_len, total_seq_len],
-        )
-        return self.forward(inputs, attention_mask, total_seq_len)
+    def prefill(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
+        op_ext.configure()
 
-    def decode(self, inputs: Tensor, total_seq_len: tir.Var):
-        batch_size, seq_len = inputs.shape
-        attention_mask = op.full(
-            shape=[batch_size, 1, seq_len, total_seq_len],
-            fill_value=tir.max_value(self.dtype),
+        def _index(x: te.Tensor):  # x[:-1,:]
+            b, s, d = x.shape
+            return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
+
+        hidden_states = self.model(input_embed, paged_kv_cache)
+        hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
+        logits = self.lm_head(hidden_states)
+        if logits.dtype != "float32":
+            logits = logits.astype("float32")
+        return logits, paged_kv_cache
+
+    def decode(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
+        op_ext.configure()
+
+        hidden_states = self.model(input_embed, paged_kv_cache)
+        logits = self.lm_head(hidden_states)
+        if logits.dtype != "float32":
+            logits = logits.astype("float32")
+        return logits, paged_kv_cache
+
+    def batch_prefill(
+        self, input_embeds: Tensor, logit_positions: Tensor, paged_kv_cache: PagedKVCache
+    ):
+        logits = self.batch_forward(input_embeds, paged_kv_cache, logit_positions)
+        return logits, paged_kv_cache
+
+    def batch_decode(self, input_embeds: Tensor, paged_kv_cache: PagedKVCache):
+        logits = self.batch_forward(input_embeds, paged_kv_cache)
+        return logits, paged_kv_cache
+
+    def batch_verify(self, input_embeds: Tensor, paged_kv_cache: PagedKVCache):
+        logits = self.batch_forward(input_embeds, paged_kv_cache)
+        return logits, paged_kv_cache
+
+    def softmax_with_temperature(self, logits: Tensor, temperature: Tensor):
+        return op.softmax(logits / op.reshape(temperature, (temperature.shape[0], 1, 1)), axis=-1)
+
+    def create_paged_kv_cache(
+        self,
+        max_batch_size: tir.Var,
+        max_total_seq_len: tir.Var,
+        prefill_chunk_size: tir.Var,
+        page_size: tir.Var,
+    ) -> PagedKVCache:
+        return PagedKVCache.create_generic(
+            max_batch_size=max_batch_size,
+            max_total_seq_len=max_total_seq_len,
+            prefill_chunk_size=prefill_chunk_size,
+            page_size=page_size,
+            num_hidden_layers=self.num_hidden_layers,
+            num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
+            num_key_value_heads=self.num_attention_heads // self.tensor_parallel_shards,
+            head_dim=self.head_dim,
+            rope_mode=RopeMode.NORMAL,
+            rope_scale=1,
+            rope_theta=self.rope_theta,
             dtype=self.dtype,
         )
-        return self.forward(inputs, attention_mask, total_seq_len)
-
-    @staticmethod
-    def softmax_with_temperature(logits: Tensor, temperature: Tensor):
-        return op.softmax(logits / temperature, axis=-1)
 
     def get_default_spec(self):
-        batch_size = 1
         mod_spec = {
-            "prefill": {
-                "inputs": nn.spec.Tensor([batch_size, "seq_len"], "int32"),
-                "total_seq_len": int,
+            "embed": {
+                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
-                    "effect_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "prefill": {
+                "input_embed": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
                 },
             },
             "decode": {
-                "inputs": nn.spec.Tensor([batch_size, 1], "int32"),
-                "total_seq_len": int,
+                "input_embed": nn.spec.Tensor([1, 1, self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
                 "$": {
                     "param_mode": "packed",
-                    "effect_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "batch_prefill": {
+                "input_embeds": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
+                "logit_positions": nn.spec.Tensor(["batch_size"], "int32"),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "batch_decode": {
+                "input_embeds": nn.spec.Tensor(["batch_size", 1, self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "batch_verify": {
+                "input_embeds": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
                 },
             },
             "softmax_with_temperature": {
-                "logits": nn.spec.Tensor([1, 1, "vocab_size"], "float32"),
-                "temperature": nn.spec.Tensor([], "float32"),
+                "logits": nn.spec.Tensor(["batch_size", 1, "vocab_size"], "float32"),
+                "temperature": nn.spec.Tensor(["batch_size"], "float32"),
+                "$": {
+                    "param_mode": "none",
+                    "effect_mode": "none",
+                },
+            },
+            "create_paged_kv_cache": {
+                "max_batch_size": int,
+                "max_total_seq_len": int,
+                "prefill_chunk_size": int,
+                "page_size": int,
                 "$": {
                     "param_mode": "none",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/qwen2/qwen2_model.py
+++ b/python/mlc_chat/model/qwen2/qwen2_model.py
@@ -173,7 +173,7 @@ class QWen2Model(nn.Module):
         return hidden_states
 
 
-class QWen2LMHeadModel(nn.Module):    # pylint: disable=too-many-instance-attributes
+class QWen2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attributes
     def __init__(self, config: QWen2Config):
         self.model = QWen2Model(config)
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)

--- a/python/mlc_chat/model/qwen2/qwen2_model.py
+++ b/python/mlc_chat/model/qwen2/qwen2_model.py
@@ -105,7 +105,6 @@ class QWen2Attention(nn.Module):  # pylint: disable=too-many-instance-attributes
         self.rope_theta = config.rope_theta
 
     def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
-
         d, h_q, h_kv = self.head_dim, self.num_attention_heads, self.num_key_value_heads
         b, s, _ = hidden_states.shape
         qkv = self.c_attn(hidden_states)
@@ -117,6 +116,7 @@ class QWen2Attention(nn.Module):  # pylint: disable=too-many-instance-attributes
         attn_output = self.o_proj(output)
         return attn_output
 
+
 ACT2FN = {
     "gelu": partial(nn.gelu, approximate=False),
     "relu": nn.relu,
@@ -124,6 +124,7 @@ ACT2FN = {
     "swish": nn.silu,
     "gelu_new": partial(nn.gelu, approximate=True),
 }
+
 
 
 class QWen2MLP(nn.Module):
@@ -155,6 +156,7 @@ class QWen2DecoderLayer(nn.Module):
         out = self.mlp(out)
         hidden_states = out + hidden_states
         return hidden_states
+
 
 class QWen2Model(nn.Module):
     def __init__(self, config: QWen2Config):


### PR DESCRIPTION
This PR migrates Qwen2 model to the new PagedKVCache interface.
Screenshot
![image](https://github.com/mlc-ai/mlc-llm/assets/68688494/68c53e1a-a668-45a5-9d38-cda632ba0886)
