### PR TITLE
[Serving] Add missing header for `std::iota`

### DIFF
--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -3,6 +3,8 @@
  * \file serve/engine_actions/batch_decode.cc
  */
 
+#include <numeric>
+
 #include "../../random.h"
 #include "../config.h"
 #include "../model.h"

--- a/cpp/serve/engine_actions/batch_draft.cc
+++ b/cpp/serve/engine_actions/batch_draft.cc
@@ -3,6 +3,8 @@
  * \file serve/engine_actions/batch_draft.cc
  */
 
+#include <numeric>
+
 #include "../config.h"
 #include "../model.h"
 #include "../sampler.h"


### PR DESCRIPTION
The header `<numeric>` was missed, which may have caused build failure on Windows. This PR adds the header.