### PR TITLE
[Serving] Fix Model TokenEmbed function with TP

### DIFF
--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -109,6 +109,9 @@ class ModelImpl : public ModelObj {
     if (dst != nullptr) {
       CHECK(dst->defined());
       ft_.nd_copy_embedding_to_offset_func_(embeddings, *dst, offset);
+      if (ft_.use_disco) {
+        ft_.sess->SyncWorker(0);
+      }
       return *dst;
     } else {
       CHECK_EQ(offset, 0);


### PR DESCRIPTION
This PR fixes a severe bug introduced by #1899.

Since #1899, we no longer copy the embedding back from worker 0 when using tensor parallelism. However, we did not synchronize with the worker 0.

This will cause the following issue: in batch prefill, we will continuously call TokenEmbed for multiple times. Each time, we will copy the token ids to the `token_ids` NDArray on worker 0. If we do not synchronize with worker 0, then it is possible that the local token ids have been updated for multiple times, before the first `CopyToWorker0` really starts to execute on the worker 0 side. As a result, at the time of executing the token ids copy to worker 0, the local token ids might be wrong (by "wrong", say we are executing the copying of seq 0's token ids, then the actual local token ids array might have already been seq 3's token ids).

As a result, the issue will cause the batch prefill behave completely wrong. This PR adds a synchronization with worker 0 explicitly.