### PR TITLE
[Model] Eliminate the reshape in embedding func

### DIFF
--- a/python/mlc_chat/compiler_pass/attach_to_ir_module.py
+++ b/python/mlc_chat/compiler_pass/attach_to_ir_module.py
@@ -86,7 +86,7 @@ class AttachAllocEmbeddingTensorFunc:  # pylint: disable=too-few-public-methods
             bb.emit_func_output(
                 bb.emit(
                     relax.op.builtin.alloc_tensor(
-                        relax.ShapeExpr([1, self.metadata["prefill_chunk_size"], hidden_size]),
+                        relax.ShapeExpr([self.metadata["prefill_chunk_size"], hidden_size]),
                         dtype,
                         runtime_device_index=0,
                     )

--- a/python/mlc_chat/model/baichuan/baichuan_model.py
+++ b/python/mlc_chat/model/baichuan/baichuan_model.py
@@ -254,7 +254,7 @@ class BaichuanForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/gemma/gemma_model.py
+++ b/python/mlc_chat/model/gemma/gemma_model.py
@@ -316,7 +316,7 @@ class GemmaForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribut
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/gpt2/gpt2_model.py
+++ b/python/mlc_chat/model/gpt2/gpt2_model.py
@@ -308,7 +308,7 @@ class GPT2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
+++ b/python/mlc_chat/model/gpt_bigcode/gpt_bigcode_model.py
@@ -285,7 +285,7 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_chat/model/gpt_neox/gpt_neox_model.py
@@ -340,7 +340,7 @@ class GPTNeoXForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/internlm/internlm_model.py
+++ b/python/mlc_chat/model/internlm/internlm_model.py
@@ -255,7 +255,7 @@ class InternLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/llama/llama_model.py
+++ b/python/mlc_chat/model/llama/llama_model.py
@@ -299,7 +299,7 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/orion/orion_model.py
+++ b/python/mlc_chat/model/orion/orion_model.py
@@ -300,7 +300,7 @@ class OrionForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/phi/phi_model.py
+++ b/python/mlc_chat/model/phi/phi_model.py
@@ -410,7 +410,7 @@ class PhiForCausalLM(nn.Module):
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/qwen/qwen_model.py
+++ b/python/mlc_chat/model/qwen/qwen_model.py
@@ -260,7 +260,7 @@ class QWenLMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/qwen2/qwen2_model.py
+++ b/python/mlc_chat/model/qwen2/qwen2_model.py
@@ -278,7 +278,7 @@ class QWen2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribut
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/rwkv5/rwkv5_model.py
+++ b/python/mlc_chat/model/rwkv5/rwkv5_model.py
@@ -389,7 +389,7 @@ class RWKV5_ForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribu
         batch_size = 1
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_chat/model/stable_lm/stablelm_model.py
+++ b/python/mlc_chat/model/stable_lm/stablelm_model.py
@@ -265,7 +265,7 @@ class StableLmForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
     def get_default_spec(self):
         mod_spec = {
             "embed": {
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",


### PR DESCRIPTION
Prior to this PR, there is a trailing reshape kernel at the end of the embedding func. The reshape is not necessarily needed to be as a kernel, which consumes extra time during execution. This PR eliminates the reshape in the embedding function by updating the signature of the embedding func, so that now it only takes the plain 1D token ids as input.