### PR TITLE
[Serving] Avoid unnecessary worker sync in Model

### DIFF
--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -49,13 +49,14 @@ struct FunctionTable {
 
   ObjectRef Empty(ShapeTuple shape, DataType dtype, Device device) const;
 
-  ObjectRef CopyToWorker0(const NDArray& host_array, String tensor_name,
+  ObjectRef CopyToWorker0(const NDArray& host_array, String buffer_cache_key,
                           ShapeTuple max_reserved_shape);
 
   bool use_disco = false;
+  Device local_gpu_device;
   Session sess{nullptr};
   DRef disco_mod{nullptr};
-  Map<String, DRef> disco_buffers{nullptr};
+  Map<String, ObjectRef> cached_buffers{nullptr};
   tvm::runtime::Module local_vm{nullptr};
   picojson::object model_config;
 


### PR DESCRIPTION
Following up #1906, this PR removes the synchronization given it is avoidable. We use another approach to avoid the write-after-write issue.

The key to address the issue is to make sure the addresses to be copied to worker 0 is not rewritten before the copy actually happens. So we pre-allocate a large host array to hold all the token ids, and for each sequence, we copy its token ids to the offset given when calling TokenEmbed, so that we can make sure an address will not be written twice before copy happens.