### PR TITLE
[Serving][Grammar] Enhance GrammarStateMatcher to support general grammar

### DIFF
--- a/cpp/serve/grammar/grammar.cc
+++ b/cpp/serve/grammar/grammar.cc
@@ -103,7 +103,7 @@ elements_rest ::= (
     "\t" ws "," ws elements
 )
 characters ::= "" | [^"\\\r\n] characters | "\\" escape characters
-escape ::= "\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
 digits ::= [0-9] | [0-9] digits
 fraction ::= "" | "." digits
 exponent ::= "" |  "e" sign digits | "E" sign digits

--- a/cpp/serve/grammar/grammar.h
+++ b/cpp/serve/grammar/grammar.h
@@ -100,7 +100,7 @@ class BNFGrammarNode : public Object {
     // data format: [rule_expr_id0, rule_expr_id1, ...]
     kChoices,
     // data format: [rule_expr_id]
-    kStarQuantifier,
+    kCharacterClassStar,
   };
 
   /*! \brief The object representing a rule expr. */

--- a/cpp/serve/grammar/grammar_builder.h
+++ b/cpp/serve/grammar/grammar_builder.h
@@ -106,11 +106,11 @@ class BNFGrammarBuilder {
     return AddRuleExpr({RuleExprType::kChoices, data.data(), static_cast<int32_t>(data.size())});
   }
 
-  int32_t AddStarQuantifier(int32_t element) {
+  int32_t AddCharacterClassStar(int32_t element) {
     std::vector<int32_t> data;
     data.push_back(element);
     return AddRuleExpr(
-        {RuleExprType::kStarQuantifier, data.data(), static_cast<int32_t>(data.size())});
+        {RuleExprType::kCharacterClassStar, data.data(), static_cast<int32_t>(data.size())});
   }
 
   size_t NumRuleExprs() const { return grammar_->NumRuleExprs(); }

--- a/cpp/serve/grammar/grammar_serializer.cc
+++ b/cpp/serve/grammar/grammar_serializer.cc
@@ -40,8 +40,8 @@ std::string BNFGrammarPrinter::PrintRuleExpr(const RuleExpr& rule_expr) {
       return PrintSequence(rule_expr);
     case RuleExprType::kChoices:
       return PrintChoices(rule_expr);
-    case RuleExprType::kStarQuantifier:
-      return PrintStarQuantifier(rule_expr);
+    case RuleExprType::kCharacterClassStar:
+      return PrintCharacterClassStar(rule_expr);
     default:
       LOG(FATAL) << "Unexpected RuleExpr type: " << static_cast<int>(rule_expr.type);
   }
@@ -103,7 +103,7 @@ std::string BNFGrammarPrinter::PrintChoices(const RuleExpr& rule_expr) {
   return result;
 }
 
-std::string BNFGrammarPrinter::PrintStarQuantifier(const RuleExpr& rule_expr) {
+std::string BNFGrammarPrinter::PrintCharacterClassStar(const RuleExpr& rule_expr) {
   return PrintRuleExpr(rule_expr[0]) + "*";
 }
 

--- a/cpp/serve/grammar/grammar_serializer.h
+++ b/cpp/serve/grammar/grammar_serializer.h
@@ -73,7 +73,7 @@ class BNFGrammarPrinter : public BNFGrammarSerializer {
   /*! \brief Print a RuleExpr for rule_expr choices. */
   std::string PrintChoices(const RuleExpr& rule_expr);
   /*! \brief Print a RuleExpr for star quantifier. */
-  std::string PrintStarQuantifier(const RuleExpr& rule_expr);
+  std::string PrintCharacterClassStar(const RuleExpr& rule_expr);
 };
 
 /*!

--- a/cpp/serve/grammar/grammar_simplifier.h
+++ b/cpp/serve/grammar/grammar_simplifier.h
@@ -73,8 +73,8 @@ class BNFGrammarMutator {
         return VisitCharacterClass(rule_expr);
       case RuleExprType::kRuleRef:
         return VisitRuleRef(rule_expr);
-      case RuleExprType::kStarQuantifier:
-        return VisitStarQuantifier(rule_expr);
+      case RuleExprType::kCharacterClassStar:
+        return VisitCharacterClassStar(rule_expr);
       default:
         LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(rule_expr.type);
     }
@@ -135,11 +135,11 @@ class BNFGrammarMutator {
   virtual T VisitRuleRef(const RuleExpr& rule_expr) { return VisitElement(rule_expr); }
 
   /*! \brief Visit a star quantifier RuleExpr. */
-  virtual T VisitStarQuantifier(const RuleExpr& rule_expr) {
+  virtual T VisitCharacterClassStar(const RuleExpr& rule_expr) {
     if constexpr (std::is_same<T, void>::value) {
       VisitExpr(grammar_->GetRuleExpr(rule_expr[0]));
     } else if constexpr (std::is_same<T, int32_t>::value) {
-      return builder_.AddStarQuantifier(VisitExpr(grammar_->GetRuleExpr(rule_expr[0])));
+      return builder_.AddCharacterClassStar(VisitExpr(grammar_->GetRuleExpr(rule_expr[0])));
     } else {
       return T();
     }

--- a/cpp/serve/grammar/grammar_state_matcher.cc
+++ b/cpp/serve/grammar/grammar_state_matcher.cc
@@ -450,8 +450,15 @@ GrammarStateMatcher::GrammarStateMatcher(std::shared_ptr<GrammarStateInitContext
 
 TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFromTokenizer")
     .set_body_typed([](BNFGrammar grammar, Optional<Tokenizer> tokenizer, int max_rollback_steps) {
+      auto preproc_start = std::chrono::high_resolution_clock::now();
       auto init_ctx = GrammarStateMatcher::CreateInitContext(
           grammar, tokenizer ? tokenizer.value()->TokenTable() : std::vector<std::string>());
+      auto preproc_end = std::chrono::high_resolution_clock::now();
+      std::cerr << "Preprocess takes "
+                << std::chrono::duration_cast<std::chrono::microseconds>(preproc_end -
+                                                                         preproc_start)
+                       .count()
+                << "us";
       return GrammarStateMatcher(init_ctx, max_rollback_steps);
     });
 

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -58,8 +58,44 @@ class GrammarStateMatcherBase {
   // If init_rule_position is {}, init the stack with the main rule.
   void InitStackState(RulePosition init_rule_position = {});
 
-  // Update the old stack top to the next position, and push the new stack tops to new_stack_tops.
-  void UpdateNewStackTops(int32_t old_node_id, std::vector<int32_t>* new_stack_tops);
+  // Update the char_class_star_id field of the given rule_position, if it refers to a character
+  // class star rule.
+  void UpdateCharClassStarId(RulePosition* rule_position) const;
+
+  /*!
+   * \brief Find the next position in the rule. If the next position is at the end of the rule,
+   * the result depends on the consider_parent parameter:
+   * - false: kInvalidRulePosition will be returned.
+   * - true: the next position of the parent rule will be returned. If the current rule is the root
+   * rule, the RulePosition will be returned as is to indicate the end of the grammar.
+   * \param rule_position The current position.
+   * \param consider_parent Whether to consider the parent position if the current position is at
+   * the end of the rule.
+   */
+  RulePosition IterateToNextPosition(const RulePosition& rule_position, bool consider_parent) const;
+
+  /*!
+   * \brief Expand the given rule position (may be a RuleRef element) s.t. every new position is a
+   * CharacterClass or refers to a CharacterClassStar rule. Push all new positions into
+   * new_stack_tops.
+   * \details This method will start from cur_rule_position and continuously iterate to the next
+   * position as long as the current position can be empty (e.g. the current position is a
+   * reference to an rule that can be empty, or to a character class star rule). If the current
+   * position can not be empty, stop expanding. All positions collected will be pushed into
+   * new_stack_tops.
+   *
+   * If the end of the current rule is reached:
+   * - If is_outmost_level is true, we can go to the next position in the parent rule.
+   * - Otherwise, stop iteration.
+   * \param cur_rule_position The current rule position.
+   * \param new_stack_tops The vector to store the new stack tops.
+   * \param is_outmost_level Whether the current position is the outmost level of the rule.
+   * \param first_id_if_inserted Being not -1 means the first node is already inserted. This is the
+   * id of the first node. This is used to avoid inserting the same node twice.
+   * \return Whether the end of the rule can be reached. Used as the condition of recursion.
+   */
+  bool ExpandRulePosition(RulePosition cur_rule_position, std::vector<int32_t>* new_stack_tops,
+                          bool is_outmost_level, int32_t first_id_if_inserted = -1);
 
   BNFGrammar grammar_;
   RulePositionTree tree_;
@@ -89,28 +125,34 @@ inline bool GrammarStateMatcherBase::AcceptCodepoint(TCodepoint codepoint, bool 
   const auto& prev_stack_tops = stack_tops_history_.GetLatest();
 
   tmp_new_stack_tops_.clear();
-  for (auto old_top : prev_stack_tops) {
-    const auto& rule_position = tree_[old_top];
-    auto current_sequence = grammar_->GetRuleExpr(rule_position.sequence_id);
-    if (rule_position.parent_id == RulePosition::kNoParent &&
-        rule_position.element_id == current_sequence.size()) {
+  for (auto prev_top : prev_stack_tops) {
+    const auto& cur_rule_position = tree_[prev_top];
+    auto current_sequence = grammar_->GetRuleExpr(cur_rule_position.sequence_id);
+    if (cur_rule_position.parent_id == RulePosition::kNoParent &&
+        cur_rule_position.element_id == current_sequence.size()) {
       // This RulePosition means previous elements has matched the complete rule.
       // But we are still need to accept a new character, so this stack will become invalid.
       continue;
     }
-    auto current_char_class = grammar_->GetRuleExpr(current_sequence[rule_position.element_id]);
-    // Special support for star quantifiers of character classes.
-    if (current_char_class.type == RuleExprType::kRuleRef) {
-      DCHECK(rule_position.char_class_id != -1);
-      current_char_class = grammar_->GetRuleExpr(rule_position.char_class_id);
-    }
+
+    auto current_char_class =
+        cur_rule_position.char_class_star_id != -1
+            ? grammar_->GetRuleExpr(cur_rule_position.char_class_star_id)
+            : grammar_->GetRuleExpr(current_sequence[cur_rule_position.element_id]);
     DCHECK(current_char_class.type == RuleExprType::kCharacterClass ||
            current_char_class.type == RuleExprType::kNegCharacterClass);
     auto ok = CharacterClassContains(current_char_class, codepoint);
     if (!ok) {
       continue;
     }
-    UpdateNewStackTops(old_top, &tmp_new_stack_tops_);
+
+    if (cur_rule_position.char_class_star_id == -1) {
+      auto next_rule_position = IterateToNextPosition(cur_rule_position, true);
+      DCHECK(next_rule_position != kInvalidRulePosition);
+      ExpandRulePosition(next_rule_position, &tmp_new_stack_tops_, true);
+    } else {
+      ExpandRulePosition(cur_rule_position, &tmp_new_stack_tops_, true, prev_top);
+    }
   }
   if (tmp_new_stack_tops_.empty()) {
     if (verbose) {
@@ -125,6 +167,9 @@ inline bool GrammarStateMatcherBase::AcceptCodepoint(TCodepoint codepoint, bool 
               << "\" Accepted" << std::endl;
     std::cout << "Stack after accepting: " << PrintStackState() << std::endl;
   }
+#if TVM_LOG_DEBUG
+  stack_tops_history_.CheckWellFormed();
+#endif
   return true;
 }
 
@@ -150,12 +195,12 @@ inline void GrammarStateMatcherBase::InitStackState(RulePosition init_rule_posit
   if (init_rule_position == kInvalidRulePosition) {
     // Initialize the stack with the main rule.
     auto main_rule = grammar_->GetRule(0);
-    auto main_rule_expr = grammar_->GetRuleExpr(main_rule.body_expr_id);
+    auto main_rule_body = grammar_->GetRuleExpr(main_rule.body_expr_id);
     std::vector<int32_t> new_stack_tops;
-    for (auto i : main_rule_expr) {
-      DCHECK(grammar_->GetRuleExpr(i).type == RuleExprType::kSequence ||
-             grammar_->GetRuleExpr(i).type == RuleExprType::kEmptyStr);
-      new_stack_tops.push_back(tree_.NewNode(RulePosition(0, i, 0, RulePosition::kNoParent)));
+    for (auto i : main_rule_body) {
+      auto init_rule_position = RulePosition(0, i, 0, RulePosition::kNoParent);
+      UpdateCharClassStarId(&init_rule_position);
+      ExpandRulePosition(init_rule_position, &new_stack_tops, true);
     }
     stack_tops_history_.PushHistory(new_stack_tops);
   } else {
@@ -163,70 +208,110 @@ inline void GrammarStateMatcherBase::InitStackState(RulePosition init_rule_posit
   }
 }
 
-inline void GrammarStateMatcherBase::UpdateNewStackTops(int32_t old_node_id,
-                                                        std::vector<int32_t>* new_stack_tops) {
-  const auto& old_rule_position = tree_[old_node_id];
-  // For char_class*, the old rule position itself is also the next position
-  if (old_rule_position.char_class_id != -1) {
-    new_stack_tops->push_back(tree_.NewNode(old_rule_position));
+inline void GrammarStateMatcherBase::UpdateCharClassStarId(RulePosition* rule_position) const {
+  auto rule_expr = grammar_->GetRuleExpr(rule_position->sequence_id);
+  auto element = grammar_->GetRuleExpr(rule_expr[rule_position->element_id]);
+  if (element.type == RuleExprType::kRuleRef) {
+    auto sub_rule_body = grammar_->GetRuleExpr(grammar_->GetRule(element[0]).body_expr_id);
+    if (sub_rule_body.type == RuleExprType::kCharacterClassStar) {
+      rule_position->char_class_star_id = sub_rule_body[0];
+    }
+  }
+}
+
+inline RulePosition GrammarStateMatcherBase::IterateToNextPosition(
+    const RulePosition& rule_position, bool consider_parent) const {
+  auto next_position = RulePosition(rule_position.rule_id, rule_position.sequence_id,
+                                    rule_position.element_id + 1, rule_position.parent_id);
+  auto rule_expr = grammar_->GetRuleExpr(rule_position.sequence_id);
+  auto current_sequence_length = rule_expr.size();
+  DCHECK(next_position.element_id <= current_sequence_length);
+
+  if (next_position.element_id < current_sequence_length) {
+    // Update char_class_star_id if the position refers to a character class star rule.
+    UpdateCharClassStarId(&next_position);
+    return next_position;
   }
 
-  auto cur_rule_position = tree_.GetNextPosition(tree_[old_node_id]);
+  if (!consider_parent) {
+    return kInvalidRulePosition;
+  }
 
-  // Continuously iterate to the next position (if reachs the end of the current rule, go to the
-  // next position of the parent rule). Push it into new_stack_tops. If this position can not
-  // be empty, exit the loop.
-  // Positions that can be empty: reference to a rule that can be empty, or a star quantifier
-  // rule.
-  for (; !tree_.IsEndPosition(cur_rule_position);
-       cur_rule_position = tree_.GetNextPosition(cur_rule_position)) {
+  if (next_position.parent_id == RulePosition::kNoParent) {
+    return next_position;
+  } else {
+    auto parent_rule_position = tree_[next_position.parent_id];
+    return IterateToNextPosition(parent_rule_position, true);
+  }
+}
+
+inline bool GrammarStateMatcherBase::ExpandRulePosition(RulePosition cur_rule_position,
+                                                        std::vector<int32_t>* new_stack_tops,
+                                                        bool is_outmost_level,
+                                                        int32_t first_id_if_inserted) {
+  bool is_first = false;
+
+  for (; cur_rule_position != kInvalidRulePosition;
+       cur_rule_position = IterateToNextPosition(cur_rule_position, is_outmost_level)) {
+    // Insert the node to the tree, if not inserted before.
+    int32_t new_node_id;
+    if (is_first && first_id_if_inserted != -1) {
+      new_node_id = first_id_if_inserted;
+    } else {
+      new_node_id = tree_.NewNode(cur_rule_position);
+    }
+    is_first = false;
+
+    // Case 1. The current position points to the end of the grammar.
+    if (is_outmost_level) {
+      if (tree_.IsEndPosition(cur_rule_position)) {
+        new_stack_tops->push_back(new_node_id);
+        return true;
+      }
+    } else {
+      DCHECK(!tree_.IsEndPosition(cur_rule_position));
+    }
+
+    // Case 2. The current position refers to a character class star rule. It can be empty.
+    if (cur_rule_position.char_class_star_id != -1) {
+      new_stack_tops->push_back(new_node_id);
+      continue;
+    }
+
+    // Case 3. Character class: cannot be empty.
     auto sequence = grammar_->GetRuleExpr(cur_rule_position.sequence_id);
     auto element = grammar_->GetRuleExpr(sequence[cur_rule_position.element_id]);
     if (element.type == RuleExprType::kCharacterClass ||
         element.type == RuleExprType::kNegCharacterClass) {
-      // Character class: cannot be empty. Break the loop.
-      new_stack_tops->push_back(tree_.NewNode(cur_rule_position));
-      break;
-    } else {
-      // RuleRef
-      DCHECK(element.type == RuleExprType::kRuleRef);
-      auto new_rule_id = element[0];
-      auto new_rule = grammar_->GetRule(new_rule_id);
-      auto new_rule_expr = grammar_->GetRuleExpr(new_rule.body_expr_id);
-      if (new_rule_expr.type == RuleExprType::kStarQuantifier) {
-        cur_rule_position.char_class_id = new_rule_expr[0];
-        new_stack_tops->push_back(tree_.NewNode(cur_rule_position));
-      } else {
-        DCHECK(new_rule_expr.type == RuleExprType::kChoices);
+      new_stack_tops->push_back(new_node_id);
+      return false;
+    }
 
-        bool contain_empty = false;
+    // Case 4. The current position refers to a normal rule, i.e. a rule of choices of sequences.
+    DCHECK(element.type == RuleExprType::kRuleRef);
+    auto sub_rule_id = element[0];
+    auto sub_rule = grammar_->GetRule(sub_rule_id);
+    auto sub_rule_body = grammar_->GetRuleExpr(sub_rule.body_expr_id);
+    DCHECK(sub_rule_body.type == RuleExprType::kChoices);
 
-        // For rule containing choices, expand the rule and push all positions into new_stack_tops
-        for (auto j : new_rule_expr) {
-          auto sequence = grammar_->GetRuleExpr(j);
-          if (sequence.type == RuleExprType::kEmptyStr) {
-            contain_empty = true;
-            continue;
-          }
-          DCHECK(sequence.type == RuleExprType::kSequence);
-          DCHECK(grammar_->GetRuleExpr(sequence[0]).type == RuleExprType::kCharacterClass ||
-                 grammar_->GetRuleExpr(sequence[0]).type == RuleExprType::kNegCharacterClass);
-          // Note: rule_position is not inserted to the tree yet, so it need to be inserted first
-          auto parent_id = tree_.NewNode(cur_rule_position);
-          new_stack_tops->push_back(tree_.NewNode(RulePosition(new_rule_id, j, 0, parent_id)));
-        }
+    bool contain_empty = false;
 
-        if (!contain_empty) {
-          break;
-        }
+    for (auto sequence_id : sub_rule_body) {
+      auto sequence = grammar_->GetRuleExpr(sequence_id);
+      if (sequence.type == RuleExprType::kEmptyStr) {
+        contain_empty = true;
+        continue;
       }
+      auto sub_rule_position = RulePosition(sub_rule_id, sequence_id, 0, new_node_id);
+      UpdateCharClassStarId(&sub_rule_position);
+      contain_empty |= ExpandRulePosition(sub_rule_position, new_stack_tops, false);
+    }
+
+    if (!contain_empty) {
+      return false;
     }
   }
-
-  // Reaches the end of the main rule. Insert a special node to indicate the end.
-  if (tree_.IsEndPosition(cur_rule_position)) {
-    new_stack_tops->push_back(tree_.NewNode(cur_rule_position));
-  }
+  return true;
 }
 
 }  // namespace serve

--- a/cpp/serve/grammar/grammar_state_matcher_preproc.h
+++ b/cpp/serve/grammar/grammar_state_matcher_preproc.h
@@ -277,12 +277,12 @@ inline std::shared_ptr<GrammarStateInitContext> GrammarStateMatcher::CreateInitC
 
   // Find the corresponding catagorized tokens for:
   // 1. All character elements in the grammar
-  // 2. All RuleRef elements that refers to a rule of a StarQuantifier of a character class
+  // 2. All RuleRef elements that refers to a rule containing a CharacterClassStar RuleExpr.
   for (int i = 0; i < static_cast<int>(grammar->NumRules()); ++i) {
     auto rule = grammar->GetRule(i);
     auto rule_expr = grammar->GetRuleExpr(rule.body_expr_id);
-    // Skip StarQuantifier since we just handle it at the reference element during matching.
-    if (rule_expr.type == RuleExprType::kStarQuantifier) {
+    // Skip CharacterClassStar since we just handle it at the reference element during matching.
+    if (rule_expr.type == RuleExprType::kCharacterClassStar) {
       continue;
     }
     DCHECK(rule_expr.type == RuleExprType::kChoices);
@@ -301,8 +301,8 @@ inline std::shared_ptr<GrammarStateInitContext> GrammarStateMatcher::CreateInitC
           if (ref_rule_expr.type == RuleExprType::kChoices) {
             continue;
           } else {
-            // Reference to a StarQuantifier of a character class.
-            cur_rule_position.char_class_id = ref_rule_expr[0];
+            // Reference to a CharacterClassStar of a character class.
+            cur_rule_position.char_class_star_id = ref_rule_expr[0];
           }
         }
 

--- a/python/mlc_chat/serve/grammar.py
+++ b/python/mlc_chat/serve/grammar.py
@@ -239,7 +239,7 @@ class GrammarStateMatcher(Object):
         return _ffi_api.GrammarStateMatcherIsTerminated(self)  # type: ignore  # pylint: disable=no-member
 
     def debug_accept_char(self, codepoint: int) -> bool:
-        """Accept one unicode codepoint to the current state.
+        """Accept one unicode codepoint to the current state. For test purposes.
 
         Parameters
         ----------
@@ -251,8 +251,8 @@ class GrammarStateMatcher(Object):
         )
 
     def debug_match_complete_string(self, string: str) -> bool:
-        """Check if a matcher can accept the complete string, and then reach the end of the
-        grammar.
+        """Check if the matcher can accept the complete string, and then reach the end of the
+        grammar. For test purposes.
 
         Parameters
         ----------

--- a/tests/python/serve/test_grammar_parser.py
+++ b/tests/python/serve/test_grammar_parser.py
@@ -24,17 +24,41 @@ c ::= (([c]))
 
 def test_ebnf():
     before = """main ::= b c | b main
-b ::= "b"*
+b ::= "ab"*
 c ::= [acep-z]+
 d ::= "d"?
 """
     expected = """main ::= ((b c) | (b main))
-b ::= [b]*
-c ::= ((c_2))
+b ::= ((b_1))
+c ::= ((c_1))
 d ::= ((d_1))
-c_1 ::= (([acep-z]))
-c_2 ::= ((c_1 c_2) | (c_1))
+b_1 ::= ("" | ([a] [b] b_1))
+c_1 ::= (([acep-z] c_1) | ([acep-z]))
 d_1 ::= ("" | ([d]))
+"""
+    bnf_grammar = BNFGrammar.from_ebnf_string(before, True, False)
+    after = bnf_grammar.to_string()
+    assert after == expected
+
+
+def test_star_quantifier():
+    before = """main ::= b c d
+b ::= [b]*
+c ::= "b"*
+d ::= ([b] [c] [d] | ([p] [q]))*
+e ::= [e]* [f]* | [g]*
+"""
+    expected = """main ::= ((b c d))
+b ::= [b]*
+c ::= ((c_1))
+d ::= ((d_1))
+e ::= ((e_star e_star_1) | (e_star_2))
+c_1 ::= ("" | ([b] c_1))
+d_1 ::= ("" | (d_1_choice d_1))
+e_star ::= [e]*
+e_star_1 ::= [f]*
+e_star_2 ::= [g]*
+d_1_choice ::= (([b] [c] [d]) | ([p] [q]))
 """
     bnf_grammar = BNFGrammar.from_ebnf_string(before, True, False)
     after = bnf_grammar.to_string()

--- a/tests/python/serve/test_grammar_state_matcher_custom.py
+++ b/tests/python/serve/test_grammar_state_matcher_custom.py
@@ -1,0 +1,214 @@
+# pylint: disable=missing-module-docstring,missing-function-docstring
+# pylint: disable=redefined-outer-name,unbalanced-tuple-unpacking
+"""This test is adopted from test_grammar_state_matcher_json.py, but the grammar is parsed from
+a unoptimized, non-simplified EBNF string. This is to test the robustness of the grammar state
+matcher."""
+import sys
+from typing import List, Optional
+
+import pytest
+import tvm
+import tvm.testing
+
+from mlc_chat.serve import BNFGrammar, GrammarStateMatcher
+from mlc_chat.tokenizer import Tokenizer
+
+
+def get_json_grammar():
+    json_grammar_ebnf = r"""
+main ::= basic_array | basic_object
+basic_any ::= basic_integer | basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
+basic_integer ::= ("0" | "-"? [1-9] [0-9]*) ".0"?
+basic_number ::= ("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
+basic_string ::= (([\"] basic_string_1 [\"]))
+basic_string_1 ::= "" | [^"\\\r\n] basic_string_1 | "\\" escape basic_string_1
+escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+basic_boolean ::= "true" | "false"
+basic_null ::= "null"
+basic_array ::= "[" ("" | ws basic_any (ws "," ws basic_any)*) ws "]"
+basic_object ::= "{" ("" | ws basic_string ws ":" ws basic_any ( ws "," ws basic_string ws ":" ws basic_any)*) ws "}"
+ws ::= [ \n\t]*
+"""
+    grammar = BNFGrammar.from_ebnf_string(json_grammar_ebnf)
+    print(grammar)
+    return grammar
+
+
+@pytest.fixture(scope="function")
+def json_grammar():
+    return get_json_grammar()
+
+
+(json_input_accepted,) = tvm.testing.parameters(
+    ('{"name": "John"}',),
+    ('{ "name" : "John" }',),
+    ("{}",),
+    ("[]",),
+    ('{"name": "Alice", "age": 30, "city": "New York"}',),
+    ('{"name": "Mike", "hobbies": ["reading", "cycling", "hiking"]}',),
+    ('{"name": "Emma", "address": {"street": "Maple Street", "city": "Boston"}}',),
+    ('[{"name": "David"}, {"name": "Sophia"}]',),
+    (
+        '{"name": "William", "age": null, "married": true, "children": ["Liam", "Olivia"],'
+        ' "hasPets": false}',
+    ),
+    (
+        '{"name": "Olivia", "contact": {"email": "olivia@example.com", "address": '
+        '{"city": "Chicago", "zipcode": "60601"}}}',
+    ),
+    (
+        '{"name": "Liam", "skills": ["Java", "Python"], "experience": '
+        '[{"company": "CompanyA", "years": 5}, {"company": "CompanyB", "years": 3}]}',
+    ),
+    (
+        '{"person": {"name": "Ethan", "age": 40}, "education": {"degree": "Masters", '
+        '"university": "XYZ University"}, "work": [{"company": "ABC Corp", "position": '
+        '"Manager"}, {"company": "DEF Corp", "position": "Senior Manager"}]}',
+    ),
+    (
+        '{"name": "Charlotte", "details": {"personal": {"age": 35, "hobbies": ["gardening", '
+        '"painting"]}, "professional": {"occupation": "Engineer", "skills": '
+        '["CAD", "Project Management"], "projects": [{"name": "Project A", '
+        '"status": "Completed"}, {"name": "Project B", "status": "In Progress"}]}}}',
+    ),
+)
+
+
+def test_json_accept(json_grammar: BNFGrammar, json_input_accepted: str):
+    assert GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_accepted)
+
+
+(json_input_refused,) = tvm.testing.parameters(
+    (r'{ name: "John" }',),
+    (r'{ "name": "John" } ',),  # trailing space is not accepted
+    (r'{ "name": "John", "age": 30, }',),
+    (r'{ "name": "John", "address": { "street": "123 Main St", "city": "New York" }',),
+    (r'{ "name": "John", "age": 30, "hobbies": ["reading", "traveling",], }',),
+    (r'{ "name": "John", "age": 30.5.7 }',),
+    (r'{ "name": "John, "age": 30, "hobbies": ["reading", "traveling"] }',),
+    (
+        r'{ "name": "John", "age": 30, "hobbies": ["reading", { "type": "outdoor", "list": '
+        r'["hiking", "swimming",]}] }',
+    ),
+    (r'{ "name": "John", "age": 30, "status": "\P\J" }',),
+    (
+        r'{ "name": "John", "age": 30, "hobbies": ["reading", "traveling"], "address": '
+        r'{ "street": "123 Main St", "city": "New York", "coordinates": { "latitude": 40.7128, '
+        r'"longitude": -74.0060 }}}, "work": { "company": "Acme", "position": "developer" }}',
+    ),
+)
+
+
+def test_json_refuse(json_grammar: BNFGrammar, json_input_refused):
+    assert not GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_refused)
+
+
+(input_find_rejected_tokens, expected_rejected_sizes) = tvm.testing.parameters(
+    (
+        # short test
+        '{"id": 1,"name": "Example"}',
+        [
+            # fmt: off
+            31989, 31912, 299, 299, 299, 31973, 31846, 31846, 31948, 31915, 299, 299, 299, 299,
+            299, 31973, 31846, 31846, 292, 292, 292, 292, 292, 292, 292, 292, 31974, 31999
+            # fmt: on
+        ],
+    ),
+    (
+        # long test
+        """{
+"id": 1,
+"na": "ex",
+"ac": true,
+"t": ["t1", "t2"],
+"ne": {"lv2": {"val": "dp"}, "arr": [1, 2, 3]},
+"res": "res"
+}""",
+        [
+            # fmt: off
+            31989, 31912, 31912, 299, 299, 299, 31973, 31846, 31846, 31948, 31915, 31915, 299, 299,
+            299, 31973, 31846, 31846, 292, 292, 292, 31974, 31915, 31915, 299, 299, 299, 31973,
+            31846, 31846, 31997, 31997, 31998, 31974, 31915, 31915, 299, 299, 31973, 31846, 31846,
+            31840, 291, 291, 291, 31969, 31846, 31846, 291, 291, 291, 31969, 31974, 31915, 31915,
+            299, 299, 299, 31973, 31846, 31846, 31908, 299, 299, 299, 299, 31973, 31846, 31846,
+            31906, 299, 299, 299, 299, 31973, 31846, 31846, 291, 291, 291, 31968, 31970, 31915,
+            31915, 299, 299, 299, 299, 31973, 31846, 31846, 31840, 31943, 31846, 31846, 31943,
+            31846, 31846, 31943, 31970, 31974, 31915, 31915, 299, 299, 299, 299, 31973, 31846,
+            31846, 292, 292, 292, 292, 31974, 31974, 31999
+            # fmt: on
+        ],
+    ),
+)
+
+
+def test_find_next_rejected_tokens(
+    json_grammar: BNFGrammar,
+    input_find_rejected_tokens: str,
+    expected_rejected_sizes: Optional[List[int]] = None,
+):
+    tokenizer_path = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
+    tokenizer = Tokenizer(tokenizer_path)
+    grammar_state_matcher = GrammarStateMatcher(json_grammar, tokenizer)
+
+    real_sizes = []
+    for c in input_find_rejected_tokens:
+        rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
+        real_sizes.append(len(rejected_token_ids))
+        print("Accepting char:", c, file=sys.stderr)
+        assert grammar_state_matcher.debug_accept_char(ord(c))
+    rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
+    real_sizes.append(len(rejected_token_ids))
+
+    if expected_rejected_sizes is not None:
+        assert real_sizes == expected_rejected_sizes
+
+
+def test_token_based_operations(json_grammar: BNFGrammar):
+    """Test accepting token and finding the next token mask."""
+    token_table = [
+        # fmt: off
+        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
+        # fmt: on
+    ]
+    input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}"]
+    input_ids = [token_table.index(t) for t in input_splitted]
+
+    grammar_state_matcher = GrammarStateMatcher(json_grammar, token_table)
+
+    expected = [
+        ["{"],
+        ['"', "}", "\n", " ", '"a":true'],
+        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", " "],
+        ["a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", " "],
+        [":", "\n", " ", ':"'],
+        ['"', "{", "6", "\n", " "],
+        ["}", ", ", "6", "\n", " "],
+        [" ", "\n", '"', '"a":true'],
+        [" ", "\n", '"', '"a":true'],
+        ["}", ", ", "\n", " "],
+        ["</s>"],
+    ]
+
+    result = []
+
+    for id in input_ids:
+        rejected = grammar_state_matcher.find_next_rejected_tokens()
+        accepted = list(set(range(len(token_table))) - set(rejected))
+        accepted_tokens = [token_table[i] for i in accepted]
+        result.append(accepted_tokens)
+        assert id in accepted
+        assert grammar_state_matcher.accept_token(id)
+
+    rejected = grammar_state_matcher.find_next_rejected_tokens()
+    accepted = list(set(range(len(token_table))) - set(rejected))
+    accepted_tokens = [token_table[i] for i in accepted]
+    result.append(accepted_tokens)
+
+    assert result == expected
+
+
+if __name__ == "__main__":
+    # Run a benchmark to show the performance before running tests
+    test_find_next_rejected_tokens(get_json_grammar(), '{"id": 1,"name": "Example"}')
+
+    tvm.testing.main()

--- a/tests/python/serve/test_grammar_state_matcher_json.py
+++ b/tests/python/serve/test_grammar_state_matcher_json.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 # pylint: disable=redefined-outer-name,unbalanced-tuple-unpacking
+"""This test uses the optimized JSON grammar provided by the grammar library."""
 import sys
-from typing import List
+from typing import List, Optional
 
 import pytest
 import tvm
@@ -251,7 +252,9 @@ def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
 
 
 def test_find_next_rejected_tokens(
-    json_grammar: BNFGrammar, input_find_rejected_tokens: str, expected_rejected_sizes: List[int]
+    json_grammar: BNFGrammar,
+    input_find_rejected_tokens: str,
+    expected_rejected_sizes: Optional[List[int]] = None,
 ):
     tokenizer_path = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
     tokenizer = Tokenizer(tokenizer_path)
@@ -265,8 +268,8 @@ def test_find_next_rejected_tokens(
         assert grammar_state_matcher.debug_accept_char(ord(c))
     rejected_token_ids = grammar_state_matcher.find_next_rejected_tokens()
     real_sizes.append(len(rejected_token_ids))
-    print(real_sizes)
-    assert real_sizes == expected_rejected_sizes
+    if expected_rejected_sizes is not None:
+        assert real_sizes == expected_rejected_sizes
 
 
 def test_token_based_operations(json_grammar: BNFGrammar):
@@ -404,15 +407,6 @@ def test_termination(json_grammar: BNFGrammar):
 
 if __name__ == "__main__":
     # Run a benchmark to show the performance before running tests
-    test_find_next_rejected_tokens(
-        BNFGrammar.get_grammar_of_json(),
-        '{"id": 1,"name": "Example"}',
-        [
-            # fmt: off
-            31989, 31912, 299, 299, 299, 31973, 31846, 31846, 31948, 31915, 299, 299, 299, 299,
-            299, 31973, 31846, 31846, 292, 292, 292, 292, 292, 292, 292, 292, 31974, 31999
-            # fmt: on
-        ],
-    )
+    test_find_next_rejected_tokens(BNFGrammar.get_grammar_of_json(), '{"id": 1,"name": "Example"}')
 
     tvm.testing.main()


### PR DESCRIPTION
This PR enhances GrammarStateMatcher to support general grammar that can be provided as EBNF. This PR makes to enhancements:
- Support rules starting with reference to another rule. Previously every rule must start with a character class.
- Support both character range + star (`[a-z]*`) and expression + star (`("a" | another_rule "b")*`)

When the user provides some special grammars, especially those containing deep nesting or providing many parsing possiblities when parsing prefixes, the performance will significantly decrease. This will be further optimized in the following pull requests.

cc @tqchen @MasterJH5574 