### PR TITLE
[Docs] Deprecating CUDA 11.7/11.8 support

### DIFF
--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -31,20 +31,6 @@ Select your operating system/compute platform and run the command in your termin
                     conda activate your-environment
                     python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly mlc-ai-nightly
 
-            .. tab:: CUDA 11.7
-
-                .. code-block:: bash
-
-                    conda activate your-environment
-                    python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu117 mlc-ai-nightly-cu117
-
-            .. tab:: CUDA 11.8
-
-                .. code-block:: bash
-
-                    conda activate your-environment
-                    python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu118 mlc-ai-nightly-cu118
-
             .. tab:: CUDA 12.1
 
                 .. code-block:: bash

--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -39,20 +39,6 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
               conda activate your-environment
               python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 
-         .. tab:: CUDA 11.7
-
-            .. code-block:: bash
-
-              conda activate your-environment
-              python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu117
-
-         .. tab:: CUDA 11.8
-
-            .. code-block:: bash
-
-              conda activate your-environment
-              python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu118
-
          .. tab:: CUDA 12.1
 
             .. code-block:: bash


### PR DESCRIPTION
We have deprecated the wheel support for CUDA 11.7/11.8 due to TVM thrust compatibility with old CUDA versions.