### PR TITLE
[CompilerFlag] Detect if FlashInfer is enabled from libinfo

### DIFF
--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -1,7 +1,10 @@
 """Flags for overriding model config."""
+
 import dataclasses
 from io import StringIO
 from typing import Optional
+
+import tvm
 
 from mlc_llm.support import argparse, logging
 from mlc_llm.support.config import ConfigOverrideBase
@@ -64,6 +67,8 @@ class OptimizationFlags:
             if not self.flashinfer:
                 return False
             if target.kind.name != "cuda":
+                return False
+            if tvm.get_global_func("support.GetLibInfo")()["USE_FLASHINFER"] != "ON":
                 return False
             arch_list = detect_cuda_arch_list(target)
             for arch in arch_list:


### PR DESCRIPTION
This PR supports the detection of if FlashInfer is enabled when building TVM, so that FlashInfer won't be enabled when TVM is not built with FlashInfer enabled.