### PR TITLE
[Serving][Grammar] Add grammar termination as a stop condition

### DIFF
--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -126,7 +126,7 @@ inline bool GrammarStateMatcherBase::AcceptCodepoint(TCodepoint codepoint, bool 
 
   tmp_new_stack_tops_.clear();
   for (auto prev_top : prev_stack_tops) {
-    const auto& cur_rule_position = tree_[prev_top];
+    auto cur_rule_position = tree_[prev_top];
     auto current_sequence = grammar_->GetRuleExpr(cur_rule_position.sequence_id);
     if (cur_rule_position.parent_id == RulePosition::kNoParent &&
         cur_rule_position.element_id == current_sequence.size()) {

--- a/cpp/serve/grammar/grammar_state_matcher_state.h
+++ b/cpp/serve/grammar/grammar_state_matcher_state.h
@@ -101,8 +101,14 @@ class RulePositionBuffer {
   }
 
   /*! \brief Get the RulePosition with the given id. */
-  RulePosition& operator[](int32_t id) { return buffer_[id]; }
-  const RulePosition& operator[](int32_t id) const { return buffer_[id]; }
+  RulePosition& operator[](int32_t id) {
+    DCHECK(id < static_cast<int32_t>(buffer_.size()) && buffer_[id] != kInvalidRulePosition);
+    return buffer_[id];
+  }
+  const RulePosition& operator[](int32_t id) const {
+    DCHECK(id < static_cast<int32_t>(buffer_.size()) && buffer_[id] != kInvalidRulePosition);
+    return buffer_[id];
+  }
 
   void Reset() {
     buffer_.clear();

--- a/tests/python/serve/test_serve_engine_grammar.py
+++ b/tests/python/serve/test_serve_engine_grammar.py
@@ -26,7 +26,8 @@ def test_batch_generation_with_grammar():
     # Create engine
     engine = Engine(model, kv_cache_config)
 
-    prompts = prompts_list * 2
+    prompt_len = len(prompts_list)
+    prompts = prompts_list * 3
 
     temperature = 1
     repetition_penalty = 1
@@ -45,7 +46,17 @@ def test_batch_generation_with_grammar():
         stop_token_ids=[2],
         response_format=ResponseFormat(type="json_object"),
     )
-    all_generation_configs = [generation_config_no_json] * 3 + [generation_config_json] * 3
+    generation_config_json_no_stop_token = GenerationConfig(
+        temperature=temperature,
+        repetition_penalty=repetition_penalty,
+        max_tokens=max_tokens,
+        response_format=ResponseFormat(type="json_object"),
+    )
+    all_generation_configs = (
+        [generation_config_no_json] * prompt_len
+        + [generation_config_json] * prompt_len
+        + [generation_config_json_no_stop_token] * prompt_len
+    )
 
     # Generate output.
     output_texts, _ = engine.generate(prompts, all_generation_configs)


### PR DESCRIPTION
This PR adds the termination of GrammarStateMatcher as a stop condition. 

This is useful in cases where stop token check is disabled, but the GrammarStateMatcher terminates due to a stop token is generated. In such cases, the generation should also be terminated. 

cc @MasterJH5574 