### PR TITLE
[Conv] Add bos_token to llama and mistral in ConvTemplateRegistry

### DIFF
--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -48,6 +48,7 @@ ConvTemplateRegistry.register_conv_template(
         role_empty_sep=" ",
         stop_str=["[INST]"],
         stop_token_ids=[2],
+        system_prefix_token_ids=[1],
     )
 )
 
@@ -65,6 +66,7 @@ ConvTemplateRegistry.register_conv_template(
         role_empty_sep="",
         stop_str=["</s>"],
         stop_token_ids=[2],
+        system_prefix_token_ids=[1],
     )
 )
 


### PR DESCRIPTION
Since we don't have the `add_bos` field: https://github.com/mlc-ai/mlc-llm/blob/main/cpp/conversation.h#L73 in the new Conversation template, we should add the bos token into the system_prefix_token_ids, so that it will be added to the tokenized prompt.