### PR TITLE
hotfix for the mixtral serving

### DIFF
--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -406,10 +406,9 @@ async def request_chat_completion(
     # - Check prompt length
     async_engine.record_event(request_id, event="start tokenization")
 
-    model_config = ServerContext.get_model_config(request.model)
-    image_embed_size = entrypoint_utils.get_image_embed_size(model_config)
-
     if content_has_list:
+        model_config = ServerContext.get_model_config(request.model)
+        image_embed_size = entrypoint_utils.get_image_embed_size(model_config)
         prompts = entrypoint_utils.process_prompts(
             conv_template.as_prompt_list(image_embed_size=image_embed_size),
             async_engine.tokenizer.encode,


### PR DESCRIPTION
This is a hotfix for the issue introduced by https://github.com/mlc-ai/mlc-llm/pull/1974 for mixtral serving, error as below. 

cc: @vinx13 @MasterJH5574 @tqchen 

```
  File "/home/yongwu/.local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/home/yongwu/.local/lib/python3.11/site-packages/starlette/routing.py", line 74, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/home/yongwu/.local/lib/python3.11/site-packages/fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yongwu/.local/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/scratch/yongwu/mlc-llm/python/mlc_llm/serve/entrypoints/openai_entrypoints.py", line 410, in request_chat_completion
    image_embed_size = entrypoint_utils.get_image_embed_size(model_config)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/scratch/yongwu/mlc-llm/python/mlc_llm/serve/entrypoints/entrypoint_utils.py", line 126, in get_image_embed_size
    image_size = config["model_config"]["vision_config"]["image_size"]
                 ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'vision_config'
INFO:     127.0.0.1:54940 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
```