### PR TITLE
[Fix] Fix handling of non-numerical cuda arch

### DIFF
--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -1,8 +1,8 @@
 """Flags for overriding model config."""
 
 import dataclasses
-from io import StringIO
 import re
+from io import StringIO
 from typing import Optional
 
 import tvm

--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 from io import StringIO
+import re
 from typing import Optional
 
 import tvm
@@ -72,7 +73,7 @@ class OptimizationFlags:
                 return False
             arch_list = detect_cuda_arch_list(target)
             for arch in arch_list:
-                if arch < 80:
+                if int(re.findall(r"\d+", arch)[0]) < 80:
                     logger.warning("flashinfer is not supported on CUDA arch < 80")
                     return False
             return True

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -255,10 +255,10 @@ def detect_cuda_arch_list(target: Target) -> List[int]:
     """Detect the CUDA architecture list from the target."""
     assert target.kind.name == "cuda", f"Expect target to be CUDA, but got {target}"
     if MLC_MULTI_ARCH is not None:
-        multi_arch = [int(x.strip()) for x in MLC_MULTI_ARCH.split(",")]
+        multi_arch = [x.strip() for x in MLC_MULTI_ARCH.split(",")]
     else:
         assert target.arch.startswith("sm_")
-        multi_arch = [int(target.arch[3:])]
+        multi_arch = [target.arch[3:]]
     multi_arch = list(set(multi_arch))
     return multi_arch
 

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -251,7 +251,7 @@ def _build_default():
     return build
 
 
-def detect_cuda_arch_list(target: Target) -> List[int]:
+def detect_cuda_arch_list(target: Target) -> List[str]:
     """Detect the CUDA architecture list from the target."""
     assert target.kind.name == "cuda", f"Expect target to be CUDA, but got {target}"
     if MLC_MULTI_ARCH is not None:


### PR DESCRIPTION
In the latest gpu, cuda arch may not be integer, e.g `sm_90a`. This fixes a few places that rely on integer parsing.

cc @tqchen @MasterJH5574 