### PR TITLE
[Serving][Grammar] Utility to convert json schema to EBNF grammar

### DIFF
--- a/cpp/serve/grammar/grammar.cc
+++ b/cpp/serve/grammar/grammar.cc
@@ -20,8 +20,9 @@ std::ostream& operator<<(std::ostream& os, const BNFGrammar& grammar) {
   return os;
 }
 
-BNFGrammar BNFGrammar::FromEBNFString(const String& ebnf_string, bool normalize, bool simplify) {
-  auto grammar = EBNFParser::Parse(ebnf_string);
+BNFGrammar BNFGrammar::FromEBNFString(const String& ebnf_string, const String& main_rule,
+                                      bool normalize, bool simplify) {
+  auto grammar = EBNFParser::Parse(ebnf_string, main_rule);
   if (normalize) {
     grammar = NestedRuleUnwrapper(grammar).Apply();
   }
@@ -29,8 +30,8 @@ BNFGrammar BNFGrammar::FromEBNFString(const String& ebnf_string, bool normalize,
 }
 
 TVM_REGISTER_GLOBAL("mlc.serve.BNFGrammarFromEBNFString")
-    .set_body_typed([](String ebnf_string, bool normalize, bool simplify) {
-      return BNFGrammar::FromEBNFString(ebnf_string, normalize, simplify);
+    .set_body_typed([](String ebnf_string, String main_rule, bool normalize, bool simplify) {
+      return BNFGrammar::FromEBNFString(ebnf_string, main_rule, normalize, simplify);
     });
 
 BNFGrammar BNFGrammar::FromJSON(const String& json_string) {
@@ -112,7 +113,8 @@ ws ::= [ \n\t]*
 )";
 
 BNFGrammar BNFGrammar::GetGrammarOfJSON() {
-  static const BNFGrammar grammar = BNFGrammar::FromEBNFString(kJSONGrammarString, true, false);
+  static const BNFGrammar grammar =
+      BNFGrammar::FromEBNFString(kJSONGrammarString, "main", true, false);
   return grammar;
 }
 

--- a/cpp/serve/grammar/grammar.h
+++ b/cpp/serve/grammar/grammar.h
@@ -84,6 +84,12 @@ class BNFGrammarNode : public Object {
         << "rule_id " << rule_id << " is out of bound";
     return rules_[rule_id];
   }
+  /*! \brief Get the main rule of the grammar. */
+  const Rule& GetMainRule() const {
+    DCHECK(main_rule_id_ >= 0 && main_rule_id_ < static_cast<int32_t>(rules_.size()))
+        << "main_rule_id " << main_rule_id_ << " is out of bound";
+    return rules_[main_rule_id_];
+  }
 
   /*! \brief The type of the rule expr. */
   enum class RuleExprType : int32_t {
@@ -149,6 +155,8 @@ class BNFGrammarNode : public Object {
   /*! \brief The start index of every rule_expr in rule_expr_data_. rule_expr_id corresponds the
    * index of this vector. */
   std::vector<int32_t> rule_expr_indptr_;
+  /*! \brief The id of the main rule. */
+  int32_t main_rule_id_ = -1;
 
   friend class BNFGrammarBuilder;
   friend class BNFGrammarJSONSerializer;
@@ -161,6 +169,7 @@ class BNFGrammar : public ObjectRef {
    * \brief Construct a BNF grammar with a EBNF-formatted string. Will parse the string and
    * transform it into BNF AST.
    * \param ebnf_string The EBNF-formatted string.
+   * \param main_rule The name of the main rule.
    * \param normalize Whether to normalize the grammar. Default: true. Only set to false for the
    * purpose of testing.
    *
@@ -173,8 +182,8 @@ class BNFGrammar : public ObjectRef {
    * \param simplify Whether to simplify the grammar to make matching more efficient. Default: true.
    * Not implemented yet.
    */
-  static BNFGrammar FromEBNFString(const String& ebnf_string, bool normalize = true,
-                                   bool simplify = true);
+  static BNFGrammar FromEBNFString(const String& ebnf_string, const String& main_rule,
+                                   bool normalize = true, bool simplify = true);
 
   /*!
    * \brief Construct a BNF grammar from the dumped JSON string.

--- a/cpp/serve/grammar/grammar_builder.h
+++ b/cpp/serve/grammar/grammar_builder.h
@@ -6,8 +6,9 @@
 
 #ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_BUILDER_H_
 #define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_BUILDER_H_
-
 #include <tvm/runtime/object.h>
+
+#include <cstdint>
 
 #include "grammar.h"
 
@@ -31,19 +32,17 @@ class BNFGrammarBuilder {
   BNFGrammarBuilder() : grammar_(make_object<BNFGrammarNode>()) {}
 
   /*!
-   * \brief Create grammar containing the rules and rule_exprs of an existing grammar. The old
-   * grammar remains unchanged.
-   * \param grammar The existing grammar.
+   * \brief Get the result grammar. This function will also set the main rule to the rule with the
+   * specified name. The rule should be already added to the grammar.
+   * \param main_rule The name of the main rule. Default is "main".
    */
-  explicit BNFGrammarBuilder(const BNFGrammar& grammar)
-      : grammar_(make_object<BNFGrammarNode>(*grammar.get())) {
-    // for (size_t i = 0; i < grammar_->rules_.size(); ++i) {
-    //   rule_name_to_id_[grammar_->rules_[i].name] = i;
-    // }
-  }
+  BNFGrammar Get(const std::string& main_rule = "main") {
+    int32_t main_rule_id = GetRuleId(main_rule);
+    CHECK(main_rule_id != -1) << "The in rule with name \"" << main_rule << "\" is not found.";
+    grammar_->main_rule_id_ = main_rule_id;
 
-  /*! \brief Get the result grammar. */
-  BNFGrammar Get() { return BNFGrammar(grammar_); }
+    return BNFGrammar(grammar_);
+  }
 
   /****************** RuleExpr handling ******************/
 
@@ -124,7 +123,7 @@ class BNFGrammarBuilder {
     int32_t id = grammar_->rules_.size();
     auto rules = grammar_->rules_;
     grammar_->rules_.push_back(rule);
-    ICHECK_EQ(rule_name_to_id_.count(rule.name), 0);
+    CHECK_EQ(rule_name_to_id_.count(rule.name), 0);
     rule_name_to_id_[rule.name] = id;
     return id;
   }

--- a/cpp/serve/grammar/grammar_parser.cc
+++ b/cpp/serve/grammar/grammar_parser.cc
@@ -16,7 +16,7 @@ namespace serve {
 class EBNFParserImpl {
  public:
   /*! \brief The logic of parsing the grammar string. */
-  BNFGrammar DoParse(String ebnf_string);
+  BNFGrammar DoParse(String ebnf_string, String main_rule);
 
  private:
   using Rule = BNFGrammarNode::Rule;
@@ -391,7 +391,7 @@ void EBNFParserImpl::ResetStringIterator(const char* cur) {
   in_parentheses_ = false;
 }
 
-BNFGrammar EBNFParserImpl::DoParse(String ebnf_string) {
+BNFGrammar EBNFParserImpl::DoParse(String ebnf_string, String main_rule) {
   ResetStringIterator(ebnf_string.c_str());
   BuildRuleNameToId();
 
@@ -404,16 +404,17 @@ BNFGrammar EBNFParserImpl::DoParse(String ebnf_string) {
     ConsumeSpace();
   }
 
-  if (builder_.GetRuleId("main") == -1) {
-    ThrowParseError("There must be a rule named \"main\"");
+  // Check that the main rule is defined
+  if (builder_.GetRuleId(main_rule) == -1) {
+    ThrowParseError("The main rule with name \"" + main_rule + "\" is not found.");
   }
 
-  return builder_.Get();
+  return builder_.Get(main_rule);
 }
 
-BNFGrammar EBNFParser::Parse(String ebnf_string) {
+BNFGrammar EBNFParser::Parse(String ebnf_string, String main_rule) {
   EBNFParserImpl parser;
-  return parser.DoParse(ebnf_string);
+  return parser.DoParse(ebnf_string, main_rule);
 }
 
 BNFGrammar BNFJSONParser::Parse(String json_string) {

--- a/cpp/serve/grammar/grammar_parser.h
+++ b/cpp/serve/grammar/grammar_parser.h
@@ -34,9 +34,10 @@ class EBNFParser {
   /*!
    * \brief Parse the grammar string. If fails, throw ParseError with the error message.
    * \param ebnf_string The grammar string.
+   * \param main_rule The name of the main rule. Default is "main".
    * \return The parsed grammar.
    */
-  static BNFGrammar Parse(String ebnf_string);
+  static BNFGrammar Parse(String ebnf_string, String main_rule = "main");
 
   /*!
    * \brief The exception thrown when parsing fails.

--- a/cpp/serve/grammar/grammar_simplifier.cc
+++ b/cpp/serve/grammar/grammar_simplifier.cc
@@ -61,7 +61,7 @@ class NestedRuleUnwrapperImpl : public BNFGrammarMutator<int32_t, BNFGrammar> {
       auto new_body_expr_id = VisitRuleBody(rule_expr);
       builder_.UpdateRuleBody(i, new_body_expr_id);
     }
-    return builder_.Get();
+    return builder_.Get(grammar_->GetMainRule().name);
   }
 
  private:

--- a/cpp/serve/grammar/grammar_simplifier.h
+++ b/cpp/serve/grammar/grammar_simplifier.h
@@ -48,7 +48,7 @@ class BNFGrammarMutator {
         auto new_body_expr_id = VisitExpr(rule_expr);
         builder_.AddRule(rule.name, new_body_expr_id);
       }
-      return builder_.Get();
+      return builder_.Get(grammar_->GetMainRule().name);
     } else if constexpr (!std::is_same<ReturnType, void>::value) {
       return ReturnType();
     }

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -194,7 +194,7 @@ inline std::string GrammarStateMatcherBase::PrintStackState(int steps_behind_lat
 inline void GrammarStateMatcherBase::InitStackState(RulePosition init_rule_position) {
   if (init_rule_position == kInvalidRulePosition) {
     // Initialize the stack with the main rule.
-    auto main_rule = grammar_->GetRule(0);
+    auto main_rule = grammar_->GetMainRule();
     auto main_rule_body = grammar_->GetRuleExpr(main_rule.body_expr_id);
     std::vector<int32_t> new_stack_tops;
     for (auto i : main_rule_body) {

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -119,8 +119,9 @@ inline bool CharacterClassContains(const BNFGrammarNode::RuleExpr& rule_expr,
 }
 
 inline bool GrammarStateMatcherBase::AcceptCodepoint(TCodepoint codepoint, bool verbose) {
+  verbose = true;
   if (verbose) {
-    std::cout << "Stack before accepting: " << PrintStackState() << std::endl;
+    // std::cout << "Stack before accepting: " << PrintStackState() << std::endl;
   }
   const auto& prev_stack_tops = stack_tops_history_.GetLatest();
 
@@ -165,7 +166,7 @@ inline bool GrammarStateMatcherBase::AcceptCodepoint(TCodepoint codepoint, bool 
   if (verbose) {
     std::cout << "Codepoint: " << codepoint << " \"" << CodepointToPrintable(codepoint)
               << "\" Accepted" << std::endl;
-    std::cout << "Stack after accepting: " << PrintStackState() << std::endl;
+    // std::cout << "Stack after accepting: " << PrintStackState() << std::endl;
   }
 #if TVM_LOG_DEBUG
   stack_tops_history_.CheckWellFormed();

--- a/cpp/serve/grammar/grammar_state_matcher_state.h
+++ b/cpp/serve/grammar/grammar_state_matcher_state.h
@@ -146,9 +146,9 @@ class RulePositionTree {
   }
 
   /*!
-   * \brief Check if the given RulePosition points to the end of the grammar. We use
-   * (main_rule_id, sequence_id, length_of_sequence) to represent the end position. Here the
-   * element_id is the length of the sequence.
+   * \brief Check if the given RulePosition points to the end of the grammar. For a position, if its
+   * rule id is the main rule id, and the element id equals to the length of the sequence it refers
+   * to, it would be the end position.
    */
   bool IsEndPosition(const RulePosition& rule_position) const;
 
@@ -181,7 +181,10 @@ class RulePositionTree {
     return node_buffer_[id];
   }
 
-  /*! \brief Print the node with the given id to a string. */
+  /*! \brief Print the given rule_position to a string. */
+  std::string PrintNode(const RulePosition& rule_position) const;
+
+  /*! \brief Print the rule_position associated with the given id to a string. */
   std::string PrintNode(int32_t id) const;
 
   /*! \brief Print the stack with the given top id to a string. */
@@ -317,10 +320,13 @@ inline bool RulePositionTree::IsEndPosition(const RulePosition& rule_position) c
 }
 
 inline std::string RulePositionTree::PrintNode(int32_t id) const {
+  return "id: " + std::to_string(id) + ", " + PrintNode(node_buffer_[id]);
+}
+
+inline std::string RulePositionTree::PrintNode(const RulePosition& rule_position) const {
   std::stringstream ss;
-  const auto& rule_position = node_buffer_[id];
-  ss << "id: " << id;
-  ss << ", rule " << rule_position.rule_id << ": " << grammar_->GetRule(rule_position.rule_id).name;
+  ss << "RulePosition: rule " << rule_position.rule_id << ": "
+     << grammar_->GetRule(rule_position.rule_id).name;
   ss << ", sequence " << rule_position.sequence_id << ": "
      << BNFGrammarPrinter(grammar_).PrintRuleExpr(rule_position.sequence_id);
   ss << ", element id: " << rule_position.element_id;

--- a/python/mlc_llm/serve/grammar.py
+++ b/python/mlc_llm/serve/grammar.py
@@ -18,7 +18,10 @@ class BNFGrammar(Object):
 
     @staticmethod
     def from_ebnf_string(
-        ebnf_string: str, normalize: bool = True, simplify: bool = True
+        ebnf_string: str,
+        main_rule: str = "main",
+        normalize: bool = True,
+        simplify: bool = True,
     ) -> "BNFGrammar":
         r"""Parse a BNF grammar from a string in BNF/EBNF format.
 
@@ -35,6 +38,9 @@ class BNFGrammar(Object):
         ----------
         ebnf_string : str
             The grammar string.
+
+        main_rule : str
+            The name of the main rule. Default: "main".
 
         normalize : bool
             Whether to normalize the grammar. Default: true. Only set to false for the purpose of
@@ -57,7 +63,7 @@ class BNFGrammar(Object):
             The parsed BNF grammar.
         """
         return _ffi_api.BNFGrammarFromEBNFString(  # type: ignore  # pylint: disable=no-member
-            ebnf_string, normalize, simplify
+            ebnf_string, main_rule, normalize, simplify
         )
 
     def to_string(self) -> str:
@@ -252,7 +258,7 @@ class GrammarStateMatcher(Object):
 
     def debug_match_complete_string(self, string: str) -> bool:
         """Check if the matcher can accept the complete string, and then reach the end of the
-        grammar. For test purposes.
+        grammar. Does not change the state of the GrammarStateMatcher. For test purposes.
 
         Parameters
         ----------

--- a/python/mlc_llm/serve/json_schema_converter.py
+++ b/python/mlc_llm/serve/json_schema_converter.py
@@ -4,10 +4,24 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 
 SchemaType = Union[Dict[str, Any], bool]
+"""
+JSON schema specification defines the schema type could be a dictionary or a boolean value.
+"""
 
 
 class IndentManager:
-    def __init__(self, indent: Union[int, None], separator: str):
+    """Manage the indent and separator for the generation of EBNF grammar.
+
+    Parameters
+    ----------
+    indent : Optional[int]
+        The number of spaces for each indent. If it is None, there will be no indent or newline.
+
+    separator : str
+        The separator between different elements in json. Examples include "," and ", ".
+    """
+
+    def __init__(self, indent: Optional[int], separator: str):
         self.enable_newline = indent is not None
         self.indent = indent or 0
         self.separator = separator
@@ -15,14 +29,38 @@ class IndentManager:
         self.is_first = [True]
 
     def __enter__(self):
+        """Enter a new indent level."""
         self.total_indent += self.indent
         self.is_first.append(True)
 
     def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the current indent level."""
         self.total_indent -= self.indent
         self.is_first.pop()
 
     def get_sep(self, is_end: bool = False) -> str:
+        """Get the separator according to the current state. When first called in the current level,
+        the starting separator will be returned. When called again, the middle separator will be
+        returned. When called with `is_end=True`, the ending separator will be returned.
+
+        Parameters
+        ----------
+        is_end : bool
+            Get the separator for the end of the current level.
+
+        Examples
+        --------
+        >>> indent_manager = IndentManager(2, ", ")
+        >>> with indent_manager:
+        ...     print(indent_manager.get_sep()) # get the start separator
+        ...     print(indent_manager.get_sep()) # get the middle separator
+        ...     print(indent_manager.get_sep(is_end=True)) # get the end separator
+
+        Output:
+        "\n  "
+        ",\n  "
+        "\n"
+        """
         res = ""
 
         if not self.is_first[-1] and not is_end:
@@ -41,11 +79,15 @@ class IndentManager:
 
 
 class JSONSchemaToEBNFConverter:
+    """Convert JSON schema string to EBNF grammar string. The parameters follow
+    `json_schema_to_ebnf()`.
+    """
+
     def __init__(
         self,
         json_schema: SchemaType,
-        indent: Union[int, None] = None,
-        separators: Union[Tuple[str, str], None] = None,
+        indent: Optional[int] = None,
+        separators: Optional[Tuple[str, str]] = None,
         strict_mode: bool = False,
     ):
         self.json_schema = json_schema
@@ -62,13 +104,14 @@ class JSONSchemaToEBNFConverter:
         self.add_basic_rules()
 
     def convert(self) -> str:
+        """Main method. Convert the JSON schema to EBNF grammar string."""
         self.create_rule_with_schema(self.json_schema, "main")
         res = ""
         for rule_name, rule in self.rules:
             res += f"{rule_name} ::= {rule}\n"
         return res
 
-    # Basic rules
+    # The name of the basic rules
     BASIC_ANY = "basic_any"
     BASIC_INTEGER = "basic_integer"
     BASIC_NUMBER = "basic_number"
@@ -78,11 +121,12 @@ class JSONSchemaToEBNFConverter:
     BASIC_ARRAY = "basic_array"
     BASIC_OBJECT = "basic_object"
 
-    # Helper rules to construct basic rules
+    # The name of the helper rules to construct basic rules
     BASIC_ESCAPE = "basic_escape"
     BASIC_STRING_SUB = "basic_string_sub"
 
     def add_basic_rules(self):
+        """Add the basic rules to the rules list and the basic_rules_cache."""
         past_strict_mode = self.strict_mode
         self.strict_mode = False
         past_indent_manager = self.indent_manager
@@ -103,6 +147,7 @@ class JSONSchemaToEBNFConverter:
         self.indent_manager = past_indent_manager
 
     def add_helper_rules(self):
+        """Add helper rules for the basic rules."""
         self.rules.append(
             (
                 self.BASIC_ESCAPE,
@@ -122,10 +167,12 @@ class JSONSchemaToEBNFConverter:
         self.basic_rules_cache[self.get_schema_cache_index(schema)] = rule_name
 
     def get_sep(self, is_end: bool = False):
+        """Get the separator from the indent manager."""
         return self.indent_manager.get_sep(is_end)
 
     @staticmethod
     def warn_unsupported_keywords(schema: SchemaType, keywords: Union[str, List[str]]):
+        """Warn if any keyword is existing in the schema but not supported."""
         if isinstance(keywords, str):
             keywords = [keywords]
         for keyword in keywords:
@@ -133,6 +180,13 @@ class JSONSchemaToEBNFConverter:
                 logging.warning(f"Keyword {keyword} is not supported in schema {schema}")
 
     def create_rule_with_schema(self, schema: SchemaType, rule_name_hint: str) -> str:
+        """Create a rule with the given schema and rule name hint.
+
+        Returns
+        -------
+        The name of the rule will be returned. That is not necessarily the same as the
+        rule_name_hint due to the caching mechanism.
+        """
         idx = self.get_schema_cache_index(schema)
         if idx in self.basic_rules_cache:
             return self.basic_rules_cache[idx]
@@ -142,6 +196,7 @@ class JSONSchemaToEBNFConverter:
         self.rules.append((rule_name_hint, self.visit_schema(schema, rule_name_hint)))
         return rule_name_hint
 
+    # The keywords that will be ignored when finding the cached rule for a schema
     SKIPPED_KEYS = [
         "title",
         "default",
@@ -156,6 +211,7 @@ class JSONSchemaToEBNFConverter:
 
     @staticmethod
     def remove_skipped_keys_recursive(obj: Any) -> Any:
+        """Remove the skipped keys from the schema recursively."""
         if isinstance(obj, dict):
             return {
                 k: JSONSchemaToEBNFConverter.remove_skipped_keys_recursive(v)
@@ -168,6 +224,7 @@ class JSONSchemaToEBNFConverter:
             return obj
 
     def get_schema_cache_index(self, schema: SchemaType) -> str:
+        """Get the index for the schema in the cache."""
         return json.dumps(
             JSONSchemaToEBNFConverter.remove_skipped_keys_recursive(schema),
             sort_keys=True,
@@ -175,6 +232,7 @@ class JSONSchemaToEBNFConverter:
         )
 
     def visit_schema(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit the schema and return the rule body for later constructing the rule."""
         assert schema is not False
         if schema is True:
             return self.visit_any(schema, rule_name)
@@ -224,6 +282,7 @@ class JSONSchemaToEBNFConverter:
             return self.visit_any(schema, rule_name)
 
     def visit_ref(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit a reference schema."""
         assert "$ref" in schema
         new_schema = self.uri_to_schema(schema["$ref"]).copy()
         if not (isinstance(new_schema, bool)):
@@ -231,6 +290,7 @@ class JSONSchemaToEBNFConverter:
         return self.visit_schema(new_schema, rule_name)
 
     def uri_to_schema(self, uri: str) -> SchemaType:
+        """Get the schema from the URI."""
         if uri.startswith("#/$defs/"):
             return self.json_schema["$defs"][uri[len("#/$defs/") :]]
         else:
@@ -238,10 +298,12 @@ class JSONSchemaToEBNFConverter:
             return True
 
     def visit_const(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit a const schema."""
         assert "const" in schema
         return '"' + self.json_str_to_printable_str(json.dumps(schema["const"])) + '"'
 
     def visit_enum(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit an enum schema."""
         assert "enum" in schema
         res = ""
         for i, enum_value in enumerate(schema["enum"]):
@@ -256,11 +318,13 @@ class JSONSchemaToEBNFConverter:
     }
 
     def json_str_to_printable_str(self, json_str: str) -> str:
+        """Convert the JSON string to a printable string in BNF."""
         for k, v in self.REPLACE_MAPPING.items():
             json_str = json_str.replace(k, v)
         return json_str
 
     def visit_anyof(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit an anyOf schema."""
         assert "anyOf" in schema
         res = ""
         for i, anyof_schema in enumerate(schema["anyOf"]):
@@ -270,6 +334,7 @@ class JSONSchemaToEBNFConverter:
         return res
 
     def visit_any(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit a true schema that can match anything."""
         # note integer is a subset of number, so we don't need to add integer here
         return (
             f"{self.BASIC_NUMBER} | {self.BASIC_STRING} | {self.BASIC_BOOLEAN} | "
@@ -277,6 +342,7 @@ class JSONSchemaToEBNFConverter:
         )
 
     def visit_integer(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit an integer schema."""
         assert schema["type"] == "integer"
         JSONSchemaToEBNFConverter.warn_unsupported_keywords(
             schema, ["multipleOf", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"]
@@ -284,6 +350,7 @@ class JSONSchemaToEBNFConverter:
         return '("0" | "-"? [1-9] [0-9]*) ".0"?'
 
     def visit_number(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit a number schema."""
         assert schema["type"] == "number"
         JSONSchemaToEBNFConverter.warn_unsupported_keywords(
             schema, ["multipleOf", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"]
@@ -291,6 +358,7 @@ class JSONSchemaToEBNFConverter:
         return '("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?'
 
     def visit_string(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit a string schema."""
         assert schema["type"] == "string"
         JSONSchemaToEBNFConverter.warn_unsupported_keywords(
             schema, ["minLength", "maxLength", "pattern", "format"]
@@ -298,16 +366,37 @@ class JSONSchemaToEBNFConverter:
         return f'["] {self.BASIC_STRING_SUB} ["]'
 
     def visit_boolean(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit a boolean schema."""
         assert schema["type"] == "boolean"
 
         return '"true" | "false"'
 
     def visit_null(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit a null schema."""
         assert schema["type"] == "null"
 
         return '"null"'
 
     def visit_array(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit an array schema.
+
+        Examples
+        --------
+        Schema:
+        {
+            "type": "array",
+            "prefixItems": [
+                {"type": "boolean"},
+                {"type": "integer"}
+            ],
+            "items": {
+                "type": "string"
+            }
+        }
+
+        Rule (not considering the indent):
+        main ::= "[" basic_boolean ", " basic_integer (", " basic_string)* "]"
+        """
         assert schema["type"] == "array"
         JSONSchemaToEBNFConverter.warn_unsupported_keywords(
             schema,
@@ -317,13 +406,16 @@ class JSONSchemaToEBNFConverter:
         res = '"["'
 
         with self.indent_manager:
+            # 1. Handle prefix items
             have_prefix_items = False
             if "prefixItems" in schema:
                 for i, prefix_item in enumerate(schema["prefixItems"]):
                     assert prefix_item is not False
-                    res += " " + self.get_partial_rule_for_item(prefix_item, f"{rule_name}_{i}")
+                    item = self.create_rule_with_schema(prefix_item, f"{rule_name}_{i}")
+                    res += f" {self.get_sep()} {item}"
                     have_prefix_items = True
 
+            # 2. Find additional items
             additional_item = None
             additional_suffix = ""
 
@@ -338,6 +430,7 @@ class JSONSchemaToEBNFConverter:
                 additional_item = unevaluated
                 additional_suffix = "uneval"
 
+            # 3. Handle additional items and the end separator
             if additional_item is None:
                 res += f" {self.get_sep(is_end=True)}"
             else:
@@ -355,11 +448,46 @@ class JSONSchemaToEBNFConverter:
         res += ' "]"'
         return res
 
-    def get_partial_rule_for_item(self, schema: SchemaType, sub_rule_name: str) -> str:
-        item = self.create_rule_with_schema(schema, sub_rule_name)
-        return f"{self.get_sep()} {item}"
-
     def visit_object(self, schema: SchemaType, rule_name: str) -> str:
+        """Visit an object schema.
+
+        Examples
+        --------
+        Schema:
+        {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"}
+            },
+            "required": ["a"],
+            "additionalProperties": true
+        }
+
+        Rule (not considering the indent):
+        main ::= "{" "a" ":" basic_string (", " "b" ":" basic_integer)*
+                 (", " basic_string ": " basic_any)* "}"
+
+        We need special handling when all properties are optional, since the handling of separators
+        is tricky in this case. E.g.
+
+        Schema:
+        {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"},
+                "c": {"type": "boolean"}
+            },
+            "additionalProperties": true
+        }
+
+        Rule (indent=2):
+        main ::= "{" ("\n  " (a main_sub_1 | b main_sub_2 | c main_sub_3 | d main_sub_3) "\n" | "") "}"
+        main_sub_1 ::= ",\n  " b r2 | r2
+        main_sub_2 ::= ",\n  " c r3 | r3
+        main_sub_3 ::= (",\n  " d)*
+        """
         assert schema["type"] == "object"
         JSONSchemaToEBNFConverter.warn_unsupported_keywords(
             schema, ["patternProperties", "minProperties", "maxProperties", "propertyNames"]
@@ -370,6 +498,7 @@ class JSONSchemaToEBNFConverter:
         required = schema.get("required", [])
 
         with self.indent_manager:
+            # 1. Find additional properties
             additional_property = None
             additional_suffix = ""
 
@@ -383,15 +512,18 @@ class JSONSchemaToEBNFConverter:
                 additional_property = unevaluated
                 additional_suffix = "uneval"
 
+            # 2. Handle properties
             properties_obj = schema.get("properties", {})
             properties = list(properties_obj.items())
 
             properties_all_optional = all(prop_name not in required for prop_name, _ in properties)
             if properties_all_optional and len(properties) > 0:
+                # 3.1 Case 1: properties are defined and all properties are optional
                 res += " " + self.get_partial_rule_for_properties_all_optional(
                     properties, additional_property, rule_name, additional_suffix
                 )
             elif len(properties) > 0:
+                # 3.2 Case 2: properties are defined and some properties are required
                 res += " " + self.get_partial_rule_for_properties_contain_required(
                     properties, required, rule_name
                 )
@@ -402,6 +534,7 @@ class JSONSchemaToEBNFConverter:
                     res += f" ({self.get_sep()} {other_property_pattern})*"
                 res += " " + self.get_sep(is_end=True)
             elif additional_property is not None:
+                # 3.3 Case 3: no properties are defined and additional properties are allowed
                 other_property_pattern = self.get_other_property_pattern(
                     self.BASIC_STRING, additional_property, rule_name, additional_suffix
                 )
@@ -413,20 +546,22 @@ class JSONSchemaToEBNFConverter:
         res += ' "}"'
         return res
 
-    def get_other_property_pattern(
-        self, key_pattern: str, prop_schema: SchemaType, rule_name: str, rule_name_suffix: str
-    ) -> str:
-        colon = f'"{self.colon}"'
-        value = self.create_rule_with_schema(prop_schema, rule_name + "_" + rule_name_suffix)
-        return f"{key_pattern} {colon} {value}"
-
     def get_property_pattern(self, prop_name: str, prop_schema: SchemaType, rule_name: str) -> str:
+        """Get the pattern for a property in the object schema."""
         # the outer quote is for the string in EBNF grammar, and the inner quote is for
         # the string in JSON
         key = f'"\\"{prop_name}\\""'
         colon = f'"{self.colon}"'
         value = self.create_rule_with_schema(prop_schema, rule_name + "_" + prop_name)
         return f"{key} {colon} {value}"
+
+    def get_other_property_pattern(
+        self, key_pattern: str, prop_schema: SchemaType, rule_name: str, rule_name_suffix: str
+    ) -> str:
+        """Get the pattern for the additional/unevaluated properties in the object schema."""
+        colon = f'"{self.colon}"'
+        value = self.create_rule_with_schema(prop_schema, rule_name + "_" + rule_name_suffix)
+        return f"{key_pattern} {colon} {value}"
 
     def get_partial_rule_for_properties_all_optional(
         self,
@@ -435,8 +570,9 @@ class JSONSchemaToEBNFConverter:
         rule_name: str,
         additional_suffix: str = "",
     ) -> str:
+        """Get the partial rule for the properties when all properties are optional. See the
+        above example."""
         assert len(properties) >= 1
-        # ("," (("a" ("" | "," b) | b) ("" | "," c) | c)) | ""
 
         first_sep = self.get_sep()
         mid_sep = self.get_sep()
@@ -451,19 +587,19 @@ class JSONSchemaToEBNFConverter:
 
         rule_names = [None] * len(properties)
 
+        # construct the last rule
         if additional is not None:
             additional_prop_pattern = self.get_other_property_pattern(
                 self.BASIC_STRING, additional, rule_name, additional_suffix
             )
-            last_rule_body = (
-                f'("" | {mid_sep} {additional_prop_pattern} ({mid_sep} {additional_prop_pattern})*)'
-            )
+            last_rule_body = f"({mid_sep} {additional_prop_pattern})*"
             last_rule_name = f"{rule_name}_sub_{len(properties)-1}"
             self.rules.append((last_rule_name, last_rule_body))
             rule_names[-1] = last_rule_name
         else:
             rule_names[-1] = '""'
 
+        # construct 0~(len(properties) - 2) rules
         for i in reversed(range(0, len(properties) - 1)):
             prop_pattern = prop_patterns[i + 1]
             last_rule_name = rule_names[i + 1]
@@ -472,6 +608,7 @@ class JSONSchemaToEBNFConverter:
             self.rules.append((cur_rule_name, cur_rule_body))
             rule_names[i] = cur_rule_name
 
+        # construct the main rule
         for i, prop_pattern in enumerate(prop_patterns):
             if i != 0:
                 res += " | "
@@ -480,6 +617,7 @@ class JSONSchemaToEBNFConverter:
         if additional is not None:
             res += f" | {additional_prop_pattern} {rule_names[-1]}"
 
+        # add separators and the empty string option
         res = f'({first_sep} ({res}) {last_sep} | "")'
         return res
 
@@ -489,6 +627,21 @@ class JSONSchemaToEBNFConverter:
         required: List[str],
         rule_name: str,
     ) -> str:
+        """Get the partial rule for the properties when some properties are required. See the
+        above example.
+
+        The constructed rule should be:
+
+        start_separator (optional_property separator)? (optional_property separator)? ...
+        first_required_property (separator optional_property)? separator required_property ...
+        end_separator
+
+        i.e. Before the first required property, all properties are in the form
+        (property separator); and after the first required property, all properties are in the form
+        (separator property).
+        """
+
+        # Find the index of the first required property
         first_required_idx = next(
             (i for i, (prop_name, _) in enumerate(properties) if prop_name in required),
             len(properties),
@@ -497,16 +650,19 @@ class JSONSchemaToEBNFConverter:
 
         res = self.get_sep()
 
+        # Handle the properties before the first required property
         for prop_name, prop_schema in properties[:first_required_idx]:
             assert prop_schema is not False
             property_pattern = self.get_property_pattern(prop_name, prop_schema, rule_name)
             res += f" ({property_pattern} {self.get_sep()})?"
 
+        # Handle the first required property
         property_pattern = self.get_property_pattern(
             properties[first_required_idx][0], properties[first_required_idx][1], rule_name
         )
         res += f" {property_pattern}"
 
+        # Handle the properties after the first required property
         for prop_name, prop_schema in properties[first_required_idx + 1 :]:
             assert prop_schema is not False
             property_pattern = self.get_property_pattern(prop_name, prop_schema, rule_name)
@@ -521,9 +677,30 @@ class JSONSchemaToEBNFConverter:
 def json_schema_to_ebnf(
     json_schema: str,
     *,
-    indent: Union[int, None] = None,
-    separators: Union[Tuple[str, str], None] = None,
+    indent: Optional[int] = None,
+    separators: Optional[Tuple[str, str]] = None,
     strict_mode: bool = True,
 ) -> str:
+    """Convert JSON schema string to EBNF grammar string.
+
+    Parameters
+    ----------
+    json_schema : str
+        The JSON schema string.
+
+    indent : Optional[int]
+        The number of spaces for each indent. If it is None, there will be no indent or newline.
+        The indent and separators parameters follow the same convention as
+        `json.dumps()`.
+
+    separators : Optional[Tuple[str, str]]
+        The separator between different elements in json. Examples include "," and ", ".
+
+    strict_mode : bool
+        Whether to use strict mode. In strict mode, the generated grammar will not allow
+        unevaluatedProperties and unevaluatedItems, i.e. these will be set to false by default.
+        This helps LLM to generate accurate output in the grammar-guided generation with JSON
+        schema.
+    """
     json_schema_schema = json.loads(json_schema)
     return JSONSchemaToEBNFConverter(json_schema_schema, indent, separators, strict_mode).convert()

--- a/python/mlc_llm/serve/json_schema_converter.py
+++ b/python/mlc_llm/serve/json_schema_converter.py
@@ -1,0 +1,258 @@
+import json
+import logging
+from typing import Any, Dict, List, Tuple, Union
+
+from numpy import sort
+
+
+SchemaType = Union[Dict[str, Any], bool]
+
+
+class JSONSchemaToBNF:
+    @staticmethod
+    def vto_bnf(
+        json_schema: str,
+        *,
+        indent: Union[int, None] = None,
+        separators: Union[Tuple[str, str], None] = None,
+    ) -> str:
+        json_schema_schema = json.loads(json_schema)
+        return JSONSchemaToBNF(json_schema_schema, indent, separators).get_bnf_grammar()
+
+    def __init__(
+        self,
+        json_schema: SchemaType,
+        indent: Union[int, None] = None,
+        separators: Union[Tuple[str, str], None] = None,
+    ):
+        # todo: allow_additional_properties
+        # todo: allow_additional_items
+        self.json_schema = json_schema
+        self.indent = indent
+
+        if separators is None:
+            separators = (", ", ": ") if indent is None else (",", ": ")
+        else:
+            assert len(separators) == 2
+        self.separators = separators
+
+        self.rules: List[Tuple[str, str]] = []
+        self.cache_schema_to_rule: Dict[str, str] = {}
+        self.init_basic_rules()
+
+    def get_bnf_grammar(self) -> str:
+        self.schema_to_rule(self.json_schema, "main")
+        res = ""
+        for rule_name, rule in self.rules:
+            res += f"{rule_name} ::= {rule}\n"
+        return res
+
+    def init_basic_rules(self):
+        self.schema_to_rule(True, "basic_any")
+        self.schema_to_rule({"type": "integer"}, "basic_integer")
+        self.schema_to_rule({"type": "number"}, "basic_number")
+        self.schema_to_rule({"type": "string"}, "basic_string")
+        self.schema_to_rule({"type": "boolean"}, "basic_boolean")
+        self.schema_to_rule({"type": "null"}, "basic_null")
+        self.schema_to_rule({"type": "array"}, "basic_array")
+        self.schema_to_rule({"type": "object"}, "basic_object")
+
+    @staticmethod
+    def warn_unsupported_keywords(schema: SchemaType, keywords: Union[str, List[str]]):
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        for keyword in keywords:
+            if keyword in schema:
+                # todo: test and output format
+                logging.warning(f"Keyword {keyword} is not supported in schema {schema}")
+
+    def schema_to_rule(self, schema: SchemaType, rule_name: str) -> str:
+        schema_key = self.schema_to_str_key(schema)
+        if schema_key in self.cache_schema_to_rule:
+            return self.cache_schema_to_rule[schema_key]
+
+        self.cache_schema_to_rule[schema_key] = rule_name
+        self.rules.append((rule_name, self.convert(schema, rule_name)))
+        return rule_name
+
+    SKIPPED_KEYS = [
+        "title",
+        "description",
+        "examples",
+        "deprecated",
+        "readOnly",
+        "writeOnly",
+        "$comment",
+    ]
+
+    @staticmethod
+    def remove_skipped_keys_recursive(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {
+                k: JSONSchemaToBNF.remove_skipped_keys_recursive(v)
+                for k, v in obj.items()
+                if k not in JSONSchemaToBNF.SKIPPED_KEYS
+            }
+        elif isinstance(obj, list):
+            return [JSONSchemaToBNF.remove_skipped_keys_recursive(v) for v in obj]
+        else:
+            return obj
+
+    def schema_to_str_key(self, schema: SchemaType) -> str:
+        return json.dumps(
+            JSONSchemaToBNF.remove_skipped_keys_recursive(schema), sort_keys=True, indent=None
+        )
+
+    def convert(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema is not False
+        if schema is True:
+            return self.convert_any(schema, rule_name)
+        if "type" in schema:
+            match schema["type"]:
+                case "integer":
+                    return self.convert_integer(schema, rule_name)
+                case "number":
+                    return self.convert_number(schema, rule_name)
+                case "string":
+                    return self.convert_string(schema, rule_name)
+                case "boolean":
+                    return self.convert_boolean(schema, rule_name)
+                case "null":
+                    return self.convert_null(schema, rule_name)
+                case "array":
+                    return self.convert_array(schema, rule_name)
+                case "object":
+                    return self.convert_object(schema, rule_name)
+                case _:
+                    raise ValueError(f"Unsupported type {schema['type']}")
+        else:
+            return self.convert_union(schema, rule_name)
+
+    def convert_any(self, schema: SchemaType, rule_name: str) -> str:
+        return "basic_integer | basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object"
+
+    def convert_union(self, schema: SchemaType, rule_name: str) -> str:
+        return ""
+
+    def convert_integer(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema["type"] == "integer"
+        JSONSchemaToBNF.warn_unsupported_keywords(
+            schema, ["multipleOf", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"]
+        )
+        return '("0" | "-"? [1-9] [0-9]*) ".0"?'
+
+    def convert_number(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema["type"] == "number"
+        JSONSchemaToBNF.warn_unsupported_keywords(
+            schema, ["multipleOf", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"]
+        )
+        return '("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?'
+
+    def convert_string(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema["type"] == "string"
+        JSONSchemaToBNF.warn_unsupported_keywords(
+            schema, ["minLength", "maxLength", "pattern", "format"]
+        )
+
+        return (
+            '"\\"" ([^"\\\\\\u0000-\\u001F] | "\\\\" ([\\\\"/bfnrt] | '
+            '"u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\\""'
+        )
+
+    def convert_boolean(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema["type"] == "boolean"
+
+        return '"true" | "false"'
+
+    def convert_null(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema["type"] == "null"
+
+        return '"null"'
+
+    def convert_array(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema["type"] == "array"
+        JSONSchemaToBNF.warn_unsupported_keywords(
+            schema,
+            ["uniqueItems", "contains", "minContains", "maxContains", "minItems", "maxItems"],
+        )
+
+        res = '"["'
+
+        separator = f'"{self.separators[0]}"'
+
+        if "prefixItems" in schema:
+            for i, prefix_item in enumerate(schema["prefixItems"]):
+                assert prefix_item is not False
+                if i != 0:
+                    res += separator
+                res += self.schema_to_rule(prefix_item, f"{rule_name}_{i}")
+
+        if "items" in schema and schema["items"] is not False:
+            item_rule_name = self.schema_to_rule(schema["items"], f"{rule_name}__item")
+            additional_separator = separator if res != '"["' else ""
+            res += f'("" | {additional_separator} {item_rule_name} ({separator} {item_rule_name})*)'
+
+        disallow_other_items = "items" in schema or (
+            "unevaluatedItems" in schema and schema["unevaluatedItems"] is False
+        )
+
+        if not disallow_other_items:
+            rest_schema = schema.get("unevaluatedItems", True)
+            rest_schema_rule = self.schema_to_rule(rest_schema, f"{rule_name}_rest")
+            additional_separator = separator if res != '"["' else ""
+            res += f'("" | {additional_separator} {rest_schema_rule} ({separator} {rest_schema_rule})*)'
+
+        res += '"]"'
+        return res
+
+    def convert_object(self, schema: SchemaType, rule_name: str) -> str:
+        assert schema["type"] == "object"
+        JSONSchemaToBNF.warn_unsupported_keywords(
+            schema, ["patternProperties", "minProperties", "maxProperties", "propertyNames"]
+        )
+
+        res = '"{"'
+
+        separator = f'"{self.separators[0]}"'
+        colon = f'"{self.separators[1]}"'
+
+        # Now we only consider the required list for the properties field
+        required = schema.get("required", None)
+
+        if "properties" in schema:
+            for prop_name, prop_schema in schema["properties"].items():
+                assert prop_schema is not False
+                prop_rule_name = self.schema_to_rule(prop_schema, f"{rule_name}_{prop_name}")
+                additional_separator = separator if res != '"{"' else ""
+                if required is not None and prop_name in required:
+                    res += f'{additional_separator} "{prop_name}" {colon} {prop_rule_name}'
+                else:
+                    res += f'{additional_separator} ("{prop_name}" {colon} {prop_rule_name})?'
+
+        if "additionalProperties" in schema and schema["additionalProperties"] is not False:
+            additional_properties_rule = self.schema_to_rule(
+                schema["additionalProperties"], f"{rule_name}__addi"
+            )
+            property_with_name = f"basic_string {colon} {additional_properties_rule}"
+
+            if res != '"{"':
+                res += f"({separator} {property_with_name})*"
+            else:
+                res += f'("" | {property_with_name} ({separator} {property_with_name})*)'
+
+        disallow_other_items = "additionalProperties" in schema or (
+            "unevaluatedProperties" in schema and schema["unevaluatedProperties"] is False
+        )
+
+        if not disallow_other_items:
+            uneval_schema = schema.get("unevaluatedProperties", True)
+            unevaluated_properties_rule = self.schema_to_rule(uneval_schema, f"{rule_name}__uneval")
+            property_with_name = f"basic_string {colon} {unevaluated_properties_rule}"
+
+            if res != '"{"':
+                res += f"({separator} {property_with_name})*"
+            else:
+                res += f'("" | {property_with_name} ({separator} {property_with_name})*)'
+
+        res += '"}"'
+        return res

--- a/python/mlc_llm/serve/json_schema_converter.py
+++ b/python/mlc_llm/serve/json_schema_converter.py
@@ -2,22 +2,20 @@ import json
 import logging
 from typing import Any, Dict, List, Tuple, Union
 
-from numpy import sort
-
 
 SchemaType = Union[Dict[str, Any], bool]
 
 
-class JSONSchemaToBNF:
+class JSONSchemaConverter:
     @staticmethod
-    def vto_bnf(
+    def to_ebnf(
         json_schema: str,
         *,
         indent: Union[int, None] = None,
         separators: Union[Tuple[str, str], None] = None,
     ) -> str:
         json_schema_schema = json.loads(json_schema)
-        return JSONSchemaToBNF(json_schema_schema, indent, separators).get_bnf_grammar()
+        return JSONSchemaConverter(json_schema_schema, indent, separators).convert()
 
     def __init__(
         self,
@@ -40,22 +38,65 @@ class JSONSchemaToBNF:
         self.cache_schema_to_rule: Dict[str, str] = {}
         self.init_basic_rules()
 
-    def get_bnf_grammar(self) -> str:
+    def convert(self) -> str:
         self.schema_to_rule(self.json_schema, "main")
         res = ""
         for rule_name, rule in self.rules:
             res += f"{rule_name} ::= {rule}\n"
         return res
 
+    # Basic rules
+    BASIC_ANY = "basic_any"
+    BASIC_INTEGER = "basic_integer"
+    BASIC_NUMBER = "basic_number"
+    BASIC_STRING = "basic_string"
+    BASIC_BOOLEAN = "basic_boolean"
+    BASIC_NULL = "basic_null"
+    BASIC_ARRAY = "basic_array"
+    BASIC_OBJECT = "basic_object"
+
+    # Helper rules to construct basic rules
+    BASIC_DIGITS = "basic_digits"
+    BASIC_DECIMAL = "basic_decimal"
+    BASIC_EXP = "basic_exp"
+    BASIC_WS = "basic_ws"
+    BASIC_ESCAPE = "basic_escape"
+    BASIC_STRING_SUB = "basic_string_sub"
+
     def init_basic_rules(self):
-        self.schema_to_rule(True, "basic_any")
-        self.schema_to_rule({"type": "integer"}, "basic_integer")
-        self.schema_to_rule({"type": "number"}, "basic_number")
-        self.schema_to_rule({"type": "string"}, "basic_string")
-        self.schema_to_rule({"type": "boolean"}, "basic_boolean")
-        self.schema_to_rule({"type": "null"}, "basic_null")
-        self.schema_to_rule({"type": "array"}, "basic_array")
-        self.schema_to_rule({"type": "object"}, "basic_object")
+        self.init_helper_rules()
+        self.schema_to_rule(True, self.BASIC_ANY)
+        self.schema_to_rule({"type": "integer"}, self.BASIC_INTEGER)
+        self.schema_to_rule({"type": "number"}, self.BASIC_NUMBER)
+        self.schema_to_rule({"type": "string"}, self.BASIC_STRING)
+        self.schema_to_rule({"type": "boolean"}, self.BASIC_BOOLEAN)
+        self.schema_to_rule({"type": "null"}, self.BASIC_NULL)
+        self.schema_to_rule({"type": "array"}, self.BASIC_ARRAY)
+        self.schema_to_rule({"type": "object"}, self.BASIC_OBJECT)
+
+    def init_helper_rules(self):
+        self.rules.append((self.BASIC_DIGITS, "[0-9]*"))
+        self.rules.append((self.BASIC_DECIMAL, f'"" | "." [0-9] {self.BASIC_DIGITS}'))
+        self.rules.append(
+            (
+                self.BASIC_EXP,
+                f'"" | [eE] [0-9] {self.BASIC_DIGITS} | [eE] [+-] [0-9] {self.BASIC_DIGITS}',
+            )
+        )
+        self.rules.append((self.BASIC_WS, "[ \\n\\t]*"))
+        self.rules.append(
+            (
+                self.BASIC_ESCAPE,
+                '["\\\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]',
+            )
+        )
+        self.rules.append(
+            (
+                self.BASIC_STRING_SUB,
+                f'"" | [^"\\\\\\r\\n] {self.BASIC_STRING_SUB} | '
+                f'"\\\\" {self.BASIC_ESCAPE} {self.BASIC_STRING_SUB}',
+            )
+        )
 
     @staticmethod
     def warn_unsupported_keywords(schema: SchemaType, keywords: Union[str, List[str]]):
@@ -72,106 +113,175 @@ class JSONSchemaToBNF:
             return self.cache_schema_to_rule[schema_key]
 
         self.cache_schema_to_rule[schema_key] = rule_name
-        self.rules.append((rule_name, self.convert(schema, rule_name)))
+        self.rules.append((rule_name, self.visit_schema(schema, rule_name)))
         return rule_name
 
     SKIPPED_KEYS = [
         "title",
+        "default",
         "description",
         "examples",
         "deprecated",
         "readOnly",
         "writeOnly",
         "$comment",
+        "$schema",
     ]
 
     @staticmethod
     def remove_skipped_keys_recursive(obj: Any) -> Any:
         if isinstance(obj, dict):
             return {
-                k: JSONSchemaToBNF.remove_skipped_keys_recursive(v)
+                k: JSONSchemaConverter.remove_skipped_keys_recursive(v)
                 for k, v in obj.items()
-                if k not in JSONSchemaToBNF.SKIPPED_KEYS
+                if k not in JSONSchemaConverter.SKIPPED_KEYS
             }
         elif isinstance(obj, list):
-            return [JSONSchemaToBNF.remove_skipped_keys_recursive(v) for v in obj]
+            return [JSONSchemaConverter.remove_skipped_keys_recursive(v) for v in obj]
         else:
             return obj
 
     def schema_to_str_key(self, schema: SchemaType) -> str:
         return json.dumps(
-            JSONSchemaToBNF.remove_skipped_keys_recursive(schema), sort_keys=True, indent=None
+            JSONSchemaConverter.remove_skipped_keys_recursive(schema), sort_keys=True, indent=None
         )
 
-    def convert(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_schema(self, schema: SchemaType, rule_name: str) -> str:
         assert schema is not False
         if schema is True:
-            return self.convert_any(schema, rule_name)
-        if "type" in schema:
+            return self.visit_any(schema, rule_name)
+
+        JSONSchemaConverter.warn_unsupported_keywords(
+            schema,
+            [
+                "allof",
+                "oneof",
+                "not",
+                "if",
+                "then",
+                "else",
+                "dependentRequired",
+                "dependentSchemas",
+            ],
+        )
+
+        if "$ref" in schema:
+            return self.visit_ref(schema, rule_name)
+        elif "const" in schema:
+            return self.visit_const(schema, rule_name)
+        elif "enum" in schema:
+            return self.visit_enum(schema, rule_name)
+        elif "anyOf" in schema:
+            return self.visit_anyof(schema, rule_name)
+        elif "type" in schema:
             match schema["type"]:
                 case "integer":
-                    return self.convert_integer(schema, rule_name)
+                    return self.visit_integer(schema, rule_name)
                 case "number":
-                    return self.convert_number(schema, rule_name)
+                    return self.visit_number(schema, rule_name)
                 case "string":
-                    return self.convert_string(schema, rule_name)
+                    return self.visit_string(schema, rule_name)
                 case "boolean":
-                    return self.convert_boolean(schema, rule_name)
+                    return self.visit_boolean(schema, rule_name)
                 case "null":
-                    return self.convert_null(schema, rule_name)
+                    return self.visit_null(schema, rule_name)
                 case "array":
-                    return self.convert_array(schema, rule_name)
+                    return self.visit_array(schema, rule_name)
                 case "object":
-                    return self.convert_object(schema, rule_name)
+                    return self.visit_object(schema, rule_name)
                 case _:
                     raise ValueError(f"Unsupported type {schema['type']}")
         else:
-            return self.convert_union(schema, rule_name)
+            # no keyword is detected, we treat it as any
+            return self.visit_any(schema, rule_name)
 
-    def convert_any(self, schema: SchemaType, rule_name: str) -> str:
-        return "basic_integer | basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object"
+    def visit_ref(self, schema: SchemaType, rule_name: str) -> str:
+        assert "$ref" in schema
+        new_schema = self.uri_to_schema(schema["$ref"]).copy()
+        if not (isinstance(new_schema, bool)):
+            new_schema.update({k: v for k, v in schema.items() if k != "$ref"})
+        return self.visit_schema(new_schema, rule_name)
 
-    def convert_union(self, schema: SchemaType, rule_name: str) -> str:
-        return ""
+    def uri_to_schema(self, uri: str) -> SchemaType:
+        if uri.startswith("#/$defs/"):
+            return self.json_schema["$defs"][uri[len("#/$defs/") :]]
+        else:
+            logging.warning(f"Now only support URI starting with '#/$defs/' but got {uri}")
+            return True
 
-    def convert_integer(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_const(self, schema: SchemaType, rule_name: str) -> str:
+        assert "const" in schema
+        return '"' + self.json_str_to_printable_str(json.dumps(schema["const"])) + '"'
+
+    def visit_enum(self, schema: SchemaType, rule_name: str) -> str:
+        assert "enum" in schema
+        res = ""
+        for i, enum_value in enumerate(schema["enum"]):
+            if i != 0:
+                res += " | "
+            res += '("' + self.json_str_to_printable_str(json.dumps(enum_value)) + '")'
+        return res
+
+    REPLACE_MAPPING = {
+        "\\": "\\\\",
+        '"': '\\"',
+    }
+
+    def json_str_to_printable_str(self, json_str: str) -> str:
+        for k, v in self.REPLACE_MAPPING.items():
+            json_str = json_str.replace(k, v)
+        return json_str
+
+    def visit_anyof(self, schema: SchemaType, rule_name: str) -> str:
+        assert "anyOf" in schema
+        res = ""
+        for i, anyof_schema in enumerate(schema["anyOf"]):
+            if i != 0:
+                res += " | "
+            res += self.schema_to_rule(anyof_schema, f"{rule_name}_{i}")
+        return res
+
+    def visit_any(self, schema: SchemaType, rule_name: str) -> str:
+        # note integer is included in number
+        return (
+            f"{self.BASIC_NUMBER} | {self.BASIC_STRING} | {self.BASIC_BOOLEAN} | "
+            f"{self.BASIC_NULL} | {self.BASIC_ARRAY} | {self.BASIC_OBJECT}"
+        )
+
+    def visit_integer(self, schema: SchemaType, rule_name: str) -> str:
         assert schema["type"] == "integer"
-        JSONSchemaToBNF.warn_unsupported_keywords(
+        JSONSchemaConverter.warn_unsupported_keywords(
             schema, ["multipleOf", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"]
         )
         return '("0" | "-"? [1-9] [0-9]*) ".0"?'
 
-    def convert_number(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_number(self, schema: SchemaType, rule_name: str) -> str:
         assert schema["type"] == "number"
-        JSONSchemaToBNF.warn_unsupported_keywords(
+        JSONSchemaConverter.warn_unsupported_keywords(
             schema, ["multipleOf", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"]
         )
         return '("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?'
 
-    def convert_string(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_string(self, schema: SchemaType, rule_name: str) -> str:
         assert schema["type"] == "string"
-        JSONSchemaToBNF.warn_unsupported_keywords(
+        JSONSchemaConverter.warn_unsupported_keywords(
             schema, ["minLength", "maxLength", "pattern", "format"]
         )
+        return f'["] {self.BASIC_STRING_SUB} ["]'
 
-        return (
-            '"\\"" ([^"\\\\\\u0000-\\u001F] | "\\\\" ([\\\\"/bfnrt] | '
-            '"u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* "\\""'
-        )
-
-    def convert_boolean(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_boolean(self, schema: SchemaType, rule_name: str) -> str:
         assert schema["type"] == "boolean"
 
         return '"true" | "false"'
 
-    def convert_null(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_null(self, schema: SchemaType, rule_name: str) -> str:
         assert schema["type"] == "null"
 
         return '"null"'
 
-    def convert_array(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_array(self, schema: SchemaType, rule_name: str) -> str:
         assert schema["type"] == "array"
-        JSONSchemaToBNF.warn_unsupported_keywords(
+        JSONSchemaConverter.warn_unsupported_keywords(
             schema,
             ["uniqueItems", "contains", "minContains", "maxContains", "minItems", "maxItems"],
         )
@@ -205,9 +315,9 @@ class JSONSchemaToBNF:
         res += '"]"'
         return res
 
-    def convert_object(self, schema: SchemaType, rule_name: str) -> str:
+    def visit_object(self, schema: SchemaType, rule_name: str) -> str:
         assert schema["type"] == "object"
-        JSONSchemaToBNF.warn_unsupported_keywords(
+        JSONSchemaConverter.warn_unsupported_keywords(
             schema, ["patternProperties", "minProperties", "maxProperties", "propertyNames"]
         )
 
@@ -225,9 +335,9 @@ class JSONSchemaToBNF:
                 prop_rule_name = self.schema_to_rule(prop_schema, f"{rule_name}_{prop_name}")
                 additional_separator = separator if res != '"{"' else ""
                 if required is not None and prop_name in required:
-                    res += f'{additional_separator} "{prop_name}" {colon} {prop_rule_name}'
+                    res += f'{additional_separator} "\\"{prop_name}\\"" {colon} {prop_rule_name}'
                 else:
-                    res += f'{additional_separator} ("{prop_name}" {colon} {prop_rule_name})?'
+                    res += f'({additional_separator} "\\"{prop_name}\\"" {colon} {prop_rule_name})?'
 
         if "additionalProperties" in schema and schema["additionalProperties"] is not False:
             additional_properties_rule = self.schema_to_rule(

--- a/tests/python/serve/test_grammar_state_matcher_custom.py
+++ b/tests/python/serve/test_grammar_state_matcher_custom.py
@@ -17,7 +17,7 @@ from mlc_llm.tokenizer import Tokenizer
 def get_json_grammar():
     json_grammar_ebnf = r"""
 main ::= basic_array | basic_object
-basic_any ::= basic_integer | basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
+basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
 basic_integer ::= ("0" | "-"? [1-9] [0-9]*) ".0"?
 basic_number ::= ("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
 basic_string ::= (([\"] basic_string_1 [\"]))
@@ -30,7 +30,6 @@ basic_object ::= "{" ("" | ws basic_string ws ":" ws basic_any ( ws "," ws basic
 ws ::= [ \n\t]*
 """
     grammar = BNFGrammar.from_ebnf_string(json_grammar_ebnf)
-    print(grammar)
     return grammar
 
 
@@ -101,6 +100,137 @@ def test_json_accept(json_grammar: BNFGrammar, json_input_accepted: str):
 
 def test_json_refuse(json_grammar: BNFGrammar, json_input_refused):
     assert not GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_refused)
+
+
+(json_input_pressure,) = tvm.testing.parameters(
+    # Extra long string: 1k chars
+    (
+        '["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent '
+        "libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum "
+        "imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper "
+        "porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu "
+        "ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula "
+        "in libero. Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. "
+        "In scelerisque sem at dolor. Maecenas mattis. Sed convallis tristique sem. Proin ut "
+        "ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, "
+        "luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla "
+        "metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh. Quisque volutpat "
+        "condimentum velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, "
+        "per inceptos himenaeos. Nam nec ante. Sed lacinia, urna non tincidunt mattis, tortor "
+        "neque adipiscing diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla. "
+        "Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet. Vestibulum sapien. "
+        "Proin quam. Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed lectus. "
+        "Integer euismod lacus luctus magna. Quisque cursus, metus vitae pharetra auctor, sem "
+        'massa mattis sem, at interdum magna augue eget diam."]',
+    ),
+    # long and complex json: 3k chars
+    (
+        r"""{
+    "web-app": {
+    "servlet": [
+        {
+        "servlet-name": "cofaxCDS",
+        "servlet-class": "org.cofax.cds.CDSServlet",
+        "init-param": {
+            "configGlossary:installationAt": "Philadelphia, PA",
+            "configGlossary:adminEmail": "ksm@pobox.com",
+            "configGlossary:poweredBy": "Cofax",
+            "configGlossary:poweredByIcon": "/images/cofax.gif",
+            "configGlossary:staticPath": "/content/static",
+            "templateProcessorClass": "org.cofax.WysiwygTemplate",
+            "templateLoaderClass": "org.cofax.FilesTemplateLoader",
+            "templatePath": "templates",
+            "templateOverridePath": "",
+            "defaultListTemplate": "listTemplate.htm",
+            "defaultFileTemplate": "articleTemplate.htm",
+            "useJSP": false,
+            "jspListTemplate": "listTemplate.jsp",
+            "jspFileTemplate": "articleTemplate.jsp",
+            "cachePackageTagsTrack": 200,
+            "cachePackageTagsStore": 200,
+            "cachePackageTagsRefresh": 60,
+            "cacheTemplatesTrack": 100,
+            "cacheTemplatesStore": 50,
+            "cacheTemplatesRefresh": 15,
+            "cachePagesTrack": 200,
+            "cachePagesStore": 100,
+            "cachePagesRefresh": 10,
+            "cachePagesDirtyRead": 10,
+            "searchEngineListTemplate": "forSearchEnginesList.htm",
+            "searchEngineFileTemplate": "forSearchEngines.htm",
+            "searchEngineRobotsDb": "WEB-INF/robots.db",
+            "useDataStore": true,
+            "dataStoreClass": "org.cofax.SqlDataStore",
+            "redirectionClass": "org.cofax.SqlRedirection",
+            "dataStoreName": "cofax",
+            "dataStoreDriver": "com.microsoft.jdbc.sqlserver.SQLServerDriver",
+            "dataStoreUrl": "jdbc:microsoft:sqlserver://LOCALHOST:1433;DatabaseName=goon",
+            "dataStoreUser": "sa",
+            "dataStorePassword": "dataStoreTestQuery",
+            "dataStoreTestQuery": "SET NOCOUNT ON;select test='test';",
+            "dataStoreLogFile": "/usr/local/tomcat/logs/datastore.log",
+            "dataStoreInitConns": 10,
+            "dataStoreMaxConns": 100,
+            "dataStoreConnUsageLimit": 100,
+            "dataStoreLogLevel": "debug",
+            "maxUrlLength": 500
+        }
+        },
+        {
+        "servlet-name": "cofaxEmail",
+        "servlet-class": "org.cofax.cds.EmailServlet",
+        "init-param": {
+            "mailHost": "mail1",
+            "mailHostOverride": "mail2"
+        }
+        },
+        {
+        "servlet-name": "cofaxAdmin",
+        "servlet-class": "org.cofax.cds.AdminServlet"
+        },
+        {
+        "servlet-name": "fileServlet",
+        "servlet-class": "org.cofax.cds.FileServlet"
+        },
+        {
+        "servlet-name": "cofaxTools",
+        "servlet-class": "org.cofax.cms.CofaxToolsServlet",
+        "init-param": {
+            "templatePath": "toolstemplates/",
+            "log": 1,
+            "logLocation": "/usr/local/tomcat/logs/CofaxTools.log",
+            "logMaxSize": "",
+            "dataLog": 1,
+            "dataLogLocation": "/usr/local/tomcat/logs/dataLog.log",
+            "dataLogMaxSize": "",
+            "removePageCache": "/content/admin/remove?cache=pages&id=",
+            "removeTemplateCache": "/content/admin/remove?cache=templates&id=",
+            "fileTransferFolder": "/usr/local/tomcat/webapps/content/fileTransferFolder",
+            "lookInContext": 1,
+            "adminGroupID": 4,
+            "betaServer": true
+        }
+        }
+    ],
+    "servlet-mapping": {
+        "cofaxCDS": "/",
+        "cofaxEmail": "/cofaxutil/aemail/*",
+        "cofaxAdmin": "/admin/*",
+        "fileServlet": "/static/*",
+        "cofaxTools": "/tools/*"
+    },
+    "taglib": {
+        "taglib-uri": "cofax.tld",
+        "taglib-location": "/WEB-INF/tlds/cofax.tld"
+    }
+    }
+}""",
+    ),
+)
+
+
+def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
+    assert GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_pressure)
 
 
 (input_find_rejected_tokens, expected_rejected_sizes) = tvm.testing.parameters(
@@ -205,6 +335,21 @@ def test_token_based_operations(json_grammar: BNFGrammar):
     result.append(accepted_tokens)
 
     assert result == expected
+
+
+def test_custom_main_rule():
+    json_grammar_ebnf = r"""
+main ::= basic_object
+basic_any ::= basic_string | basic_object
+basic_string ::= (([\"] basic_string_1 [\"]))
+basic_string_1 ::= "" | [^"\\\r\n] basic_string_1 | "\\" escape basic_string_1
+escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+basic_object ::= "{" ("" | ws basic_string ws ":" ws basic_any ( ws "," ws basic_string ws ":" ws basic_any)*) ws "}"
+ws ::= [ \n\t]*
+"""
+    grammar = BNFGrammar.from_ebnf_string(json_grammar_ebnf, "basic_string")
+    assert GrammarStateMatcher(grammar).debug_match_complete_string(r'"abc\r\n"')
+    assert not GrammarStateMatcher(grammar).debug_match_complete_string(r'{"name": "John" }')
 
 
 if __name__ == "__main__":

--- a/tests/python/serve/test_json_schema_converter.py
+++ b/tests/python/serve/test_json_schema_converter.py
@@ -1,0 +1,44 @@
+import json
+from enum import Enum
+from typing import Dict, List, Tuple, Union
+from mlc_chat.serve.grammar import BNFGrammar
+from mlc_chat.serve.json_schema_converter import JSONSchemaToBNF
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+
+def test_simple():
+    class MainModel(BaseModel):
+        integer_field: int
+        number_field: float
+        boolean_field: bool
+        array_field: List[str]
+        tuple_field: Tuple[str, int, List[str]]
+        object_field: Dict[str, int]
+        nested_object_field: Dict[str, Dict[str, int]]
+
+    main_model_schema = MainModel.model_json_schema()
+    main_model_schema_str = json.dumps(main_model_schema, indent=2)
+    print(main_model_schema_str)
+
+    instance = MainModel(
+        integer_field=42,
+        number_field=3.14,
+        boolean_field=True,
+        array_field=["foo", "bar"],
+        tuple_field=("foo", 42, ["bar", "baz"]),
+        object_field={"foo": 42, "bar": 43},
+        nested_object_field={"foo": {"bar": 42}},
+    )
+    instance_json = instance.model_dump_json(round_trip=True)
+    print(instance_json)
+
+    bnf_grammar = JSONSchemaToBNF.to_bnf(main_model_schema_str, separators=(",", ":"))
+    print(bnf_grammar)
+
+    print(BNFGrammar.from_ebnf_string(bnf_grammar))
+
+
+
+if __name__ == "__main__":
+    test_simple()

--- a/tests/python/serve/test_json_schema_converter.py
+++ b/tests/python/serve/test_json_schema_converter.py
@@ -12,8 +12,8 @@ from mlc_llm.serve.json_schema_converter import json_schema_to_ebnf
 def check_schema_with_grammar(
     schema: Dict[str, Any],
     expected_grammar: str,
-    indent: Union[int, None] = None,
-    separators: Union[Tuple[str, str], None] = None,
+    indent: Optional[int] = None,
+    separators: Optional[Tuple[str, str]] = None,
     strict_mode: bool = True,
 ):
     schema_str = json.dumps(schema, indent=2)
@@ -30,8 +30,8 @@ def check_schema_with_json(
     schema: Dict[str, Any],
     json_str: str,
     check_accepted=True,
-    indent: Union[int, None] = None,
-    separators: Union[Tuple[str, str], None] = None,
+    indent: Optional[int] = None,
+    separators: Optional[Tuple[str, str]] = None,
     strict_mode: bool = True,
 ):
     schema_str = json.dumps(schema, indent=2)
@@ -54,8 +54,8 @@ def check_schema_with_instance(
     schema: Dict[str, Any],
     instance: BaseModel,
     check_accepted=True,
-    indent: Union[int, None] = None,
-    separators: Union[Tuple[str, str], None] = None,
+    indent: Optional[int] = None,
+    separators: Optional[Tuple[str, str]] = None,
     strict_mode: bool = True,
 ):
     instance_obj = instance.model_dump(mode="json", round_trip=True)
@@ -302,7 +302,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= "[" ("" | "" basic_any (", " basic_any)* "") "]"
 basic_object ::= "{" ("" basic_string ": " basic_any (", " basic_string ": " basic_any)* "" | "") "}"
-main_sub_2 ::= ("" | ", " basic_string ": " basic_any (", " basic_string ": " basic_any)*)
+main_sub_2 ::= (", " basic_string ": " basic_any)*
 main_sub_1 ::= main_sub_2 | ", " "\"num\"" ": " basic_number main_sub_2
 main_sub_0 ::= main_sub_1 | ", " "\"state\"" ": " basic_boolean main_sub_1
 main ::= "{" ("" (("\"size\"" ": " basic_integer main_sub_0) | ("\"state\"" ": " basic_boolean main_sub_1) | ("\"num\"" ": " basic_number main_sub_2) | basic_string ": " basic_any main_sub_2) "" | "") "}"

--- a/tests/python/serve/test_json_schema_converter.py
+++ b/tests/python/serve/test_json_schema_converter.py
@@ -6,12 +6,12 @@ import tvm.testing
 from pydantic import BaseModel, TypeAdapter
 
 from mlc_llm.serve.grammar import BNFGrammar, GrammarStateMatcher
-from mlc_llm.serve.json_schema_converter import JSONSchemaConverter
+from mlc_llm.serve.json_schema_converter import json_schema_to_ebnf
 
 
 def check_schema_with_grammar(schema: Dict[str, Any], expected_grammar: str):
     schema_str = json.dumps(schema, indent=2)
-    grammar = JSONSchemaConverter.to_ebnf(schema_str, separators=(",", ":"))
+    grammar = json_schema_to_ebnf(schema_str, separators=(",", ":"))
     print(grammar)
     print(expected_grammar)
     assert grammar == expected_grammar
@@ -20,7 +20,7 @@ def check_schema_with_grammar(schema: Dict[str, Any], expected_grammar: str):
 def check_schema_with_json(schema: Dict[str, Any], json_str: str, check_accepted=True):
     schema_str = json.dumps(schema, indent=2)
 
-    ebnf_grammar_str = JSONSchemaConverter.to_ebnf(schema_str, separators=(",", ":"))
+    ebnf_grammar_str = json_schema_to_ebnf(schema_str, separators=(",", ":"))
     ebnf_grammar = BNFGrammar.from_ebnf_string(ebnf_grammar_str)
     matcher = GrammarStateMatcher(ebnf_grammar)
 
@@ -41,6 +41,7 @@ def test_basic():
         integer_field: int
         number_field: float
         boolean_field: bool
+        any_array_field: List
         array_field: List[str]
         tuple_field: Tuple[str, int, List[str]]
         object_field: Dict[str, int]
@@ -68,29 +69,29 @@ main ::= "{" "\"integer_field\"" ":" basic_integer "," "\"number_field\"" ":" ba
         integer_field=42,
         number_field=3.14,
         boolean_field=True,
+        any_array_field=[3.14, "foo", [None, True]],
         array_field=["foo", "bar"],
         tuple_field=("foo", 42, ["bar", "baz"]),
         object_field={"foo": 42, "bar": 43},
         nested_object_field={"foo": {"bar": 42}},
-        optional_field=None,
     )
-    print(instance.model_dump_json(round_trip=True))
-    print(instance.model_dump_json(round_trip=True, indent=2))
-    print(
-        json.dumps(
-            json.loads(instance.model_dump_json(round_trip=True)), indent=2, separators=(",", ":")
-        )
-    )
-    print(
-        json.dumps(
-            json.loads(instance.model_dump_json(round_trip=True)),
-            indent=None,
-            separators=(",", ":"),
-        )
-    )
+    # print(instance.model_dump_json(round_trip=True))
+    # print(instance.model_dump_json(round_trip=True, indent=2))
+    # print(
+    #     json.dumps(
+    #         json.loads(instance.model_dump_json(round_trip=True)), indent=2, separators=(",", ":")
+    #     )
+    # )
+    # print(
+    #     json.dumps(
+    #         json.loads(instance.model_dump_json(round_trip=True)),
+    #         indent=None,
+    #         separators=(",", ":"),
+    #     )
+    # )
 
     # check_schema_with_grammar(MainModel.model_json_schema(), ebnf_grammar)
-    # check_schema_with_instance(MainModel.model_json_schema(), instance)
+    check_schema_with_instance(MainModel.model_json_schema(), instance)
 
 
 test_basic()

--- a/tests/python/serve/test_json_schema_converter.py
+++ b/tests/python/serve/test_json_schema_converter.py
@@ -1,13 +1,38 @@
 import json
 from enum import Enum
-from typing import Dict, List, Tuple, Union
-from mlc_chat.serve.grammar import BNFGrammar
-from mlc_chat.serve.json_schema_converter import JSONSchemaToBNF
-from pydantic import BaseModel, Field
-from pydantic.config import ConfigDict
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import tvm.testing
+from pydantic import BaseModel, TypeAdapter
+
+from mlc_chat.serve.grammar import BNFGrammar, GrammarStateMatcher
+from mlc_chat.serve.json_schema_converter import JSONSchemaConverter
 
 
-def test_simple():
+def check_schema_with_grammar(schema: Dict[str, Any], grammar: str):
+    schema_str = json.dumps(schema, indent=2)
+    bnf_grammar_str = JSONSchemaConverter.to_ebnf(schema_str, separators=(",", ":"))
+    assert bnf_grammar_str == grammar
+
+
+def check_schema_with_data(schema: Dict[str, Any], data: str, accepted=True):
+    schema_str = json.dumps(schema, indent=2)
+
+    bnf_grammar_str = JSONSchemaConverter.to_ebnf(schema_str, separators=(",", ":"))
+    bnf_grammar = BNFGrammar.from_ebnf_string(bnf_grammar_str)
+    matcher = GrammarStateMatcher(bnf_grammar)
+
+    if accepted:
+        assert matcher.debug_match_complete_string(data)
+    else:
+        assert not matcher.debug_match_complete_string(data)
+
+
+def check_schema_with_instance(schema: Dict[str, Any], instance: BaseModel):
+    check_schema_with_data(schema, instance.model_dump_json(round_trip=True))
+
+
+def test_basic():
     class MainModel(BaseModel):
         integer_field: int
         number_field: float
@@ -16,10 +41,6 @@ def test_simple():
         tuple_field: Tuple[str, int, List[str]]
         object_field: Dict[str, int]
         nested_object_field: Dict[str, Dict[str, int]]
-
-    main_model_schema = MainModel.model_json_schema()
-    main_model_schema_str = json.dumps(main_model_schema, indent=2)
-    print(main_model_schema_str)
 
     instance = MainModel(
         integer_field=42,
@@ -30,15 +51,80 @@ def test_simple():
         object_field={"foo": 42, "bar": 43},
         nested_object_field={"foo": {"bar": 42}},
     )
-    instance_json = instance.model_dump_json(round_trip=True)
-    print(instance_json)
 
-    bnf_grammar = JSONSchemaToBNF.to_bnf(main_model_schema_str, separators=(",", ":"))
-    print(bnf_grammar)
-
-    print(BNFGrammar.from_ebnf_string(bnf_grammar))
+    check_schema_with_instance(MainModel.model_json_schema(), instance)
 
 
+def test_enum_const():
+    class Field(Enum):
+        FOO = "foo"
+        BAR = "bar"
+
+    class MainModel(BaseModel):
+        bars: Literal["a"]
+        str_values: Literal['a\n\r"']
+        foo: Literal["a", "b", "c"]
+        values: Literal[1, "a", True]
+        field: Field
+
+    instance = MainModel(foo="a", values=1, bars="a", str_values='a\n\r"', field=Field.FOO)
+    check_schema_with_instance(MainModel.model_json_schema(), instance)
+
+
+def test_optional():
+    class MainModel(BaseModel):
+        size: Optional[float] = None
+
+    instance = MainModel(size=3.14)
+    check_schema_with_instance(MainModel.model_json_schema(), instance)
+
+    instance = MainModel()
+    check_schema_with_instance(MainModel.model_json_schema(), instance)
+
+    check_schema_with_data(MainModel.model_json_schema(), "{}")
+
+
+def test_reference():
+    class Foo(BaseModel):
+        count: int
+        size: Optional[float] = None
+
+    class Bar(BaseModel):
+        apple: str = "x"
+        banana: str = "y"
+
+    class MainModel(BaseModel):
+        foo: Foo
+        bars: List[Bar]
+
+    instance = MainModel(
+        foo=Foo(count=42, size=3.14),
+        bars=[Bar(apple="a", banana="b"), Bar(apple="c", banana="d")],
+    )
+
+    check_schema_with_instance(MainModel.model_json_schema(), instance)
+
+
+def test_union():
+    class Cat(BaseModel):
+        name: str
+        color: str
+
+    class Dog(BaseModel):
+        name: str
+        breed: str
+
+    ta = TypeAdapter(Union[Cat, Dog])
+
+    model_schema = ta.json_schema()
+
+    check_schema_with_instance(model_schema, Cat(name="kitty", color="black"))
+    check_schema_with_instance(model_schema, Dog(name="doggy", breed="bulldog"))
+    check_schema_with_data(model_schema, '{"name":"kitty","test":"black"}', False)
+
+
+def test_alias():
+    
 
 if __name__ == "__main__":
-    test_simple()
+    tvm.testing.main()

--- a/tests/python/serve/test_json_schema_converter.py
+++ b/tests/python/serve/test_json_schema_converter.py
@@ -11,6 +11,7 @@ from mlc_llm.serve.json_schema_converter import json_schema_to_ebnf
 
 def check_schema_with_grammar(schema: Dict[str, Any], expected_grammar: str):
     schema_str = json.dumps(schema, indent=2)
+    print(schema_str)
     grammar = json_schema_to_ebnf(schema_str, separators=(",", ":"))
     print(grammar)
     print(expected_grammar)
@@ -47,8 +48,7 @@ def test_basic():
         object_field: Dict[str, int]
         nested_object_field: Dict[str, Dict[str, int]]
 
-    ebnf_grammar = r"""basic_ws ::= [ \n\t]*
-basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+    ebnf_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
 basic_string_sub ::= "" | [^"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub
 basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
 basic_integer ::= ("0" | "-"? [1-9] [0-9]*) ".0"?
@@ -56,18 +56,21 @@ basic_number ::= ("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
 basic_string ::= ["] basic_string_sub ["]
 basic_boolean ::= "true" | "false"
 basic_null ::= "null"
-basic_array ::= "[" ("" | basic_any ("," basic_any)*) "]"
-basic_object ::= "{" ("" | basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
-main_array_field ::= "[" ("" | basic_string ("," basic_string)*) "]"
-main_tuple_field ::= "[" basic_string "," basic_integer "," main_array_field ("," basic_any)* "]"
-main_object_field ::= "{" ("" | basic_string ":" basic_integer ("," basic_string ":" basic_integer)*) "}"
-main_nested_object_field ::= "{" ("" | basic_string ":" main_object_field ("," basic_string ":" main_object_field)*) "}"
-main ::= "{" "\"integer_field\"" ":" basic_integer "," "\"number_field\"" ":" basic_number "," "\"boolean_field\"" ":" basic_boolean "," "\"array_field\"" ":" main_array_field "," "\"tuple_field\"" ":" main_tuple_field "," "\"object_field\"" ":" main_object_field "," "\"nested_object_field\"" ":" main_nested_object_field ("," basic_string ":" basic_any)* "}"
+basic_array ::= "[" ("" | "" basic_any ("," basic_any)*) "]"
+basic_object ::= "{" ("" | "" basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
+main_any_array_field ::= "[" ("" | "" basic_any ("," basic_any)*) "]"
+main_array_field ::= "[" ("" | "" basic_string ("," basic_string)*) "]"
+main_tuple_field_2 ::= "[" ("" | "" basic_string ("," basic_string)*) "]"
+main_tuple_field ::= "[" "" basic_string "," basic_integer "," main_tuple_field_2 ("" | "," basic_any ("," basic_any)*) "]"
+main_object_field ::= "{" ("" | "" basic_string ":" basic_integer ("," basic_string ":" basic_integer)*) "}"
+main_nested_object_field_add ::= "{" ("" | "" basic_string ":" basic_integer ("," basic_string ":" basic_integer)*) "}"
+main_nested_object_field ::= "{" ("" | "" basic_string ":" main_nested_object_field_add ("," basic_string ":" main_nested_object_field_add)*) "}"
+main ::= "{" "" "\"integer_field\"" ":" basic_integer "," "\"number_field\"" ":" basic_number "," "\"boolean_field\"" ":" basic_boolean "," "\"any_array_field\"" ":" main_any_array_field "," "\"array_field\"" ":" main_array_field "," "\"tuple_field\"" ":" main_tuple_field "," "\"object_field\"" ":" main_object_field "," "\"nested_object_field\"" ":" main_nested_object_field ("" | "," basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
 """
 
     instance = MainModel(
         integer_field=42,
-        number_field=3.14,
+        number_field=3.14e5,
         boolean_field=True,
         any_array_field=[3.14, "foo", [None, True]],
         array_field=["foo", "bar"],
@@ -75,27 +78,9 @@ main ::= "{" "\"integer_field\"" ":" basic_integer "," "\"number_field\"" ":" ba
         object_field={"foo": 42, "bar": 43},
         nested_object_field={"foo": {"bar": 42}},
     )
-    # print(instance.model_dump_json(round_trip=True))
-    # print(instance.model_dump_json(round_trip=True, indent=2))
-    # print(
-    #     json.dumps(
-    #         json.loads(instance.model_dump_json(round_trip=True)), indent=2, separators=(",", ":")
-    #     )
-    # )
-    # print(
-    #     json.dumps(
-    #         json.loads(instance.model_dump_json(round_trip=True)),
-    #         indent=None,
-    #         separators=(",", ":"),
-    #     )
-    # )
 
-    # check_schema_with_grammar(MainModel.model_json_schema(), ebnf_grammar)
+    check_schema_with_grammar(MainModel.model_json_schema(), ebnf_grammar)
     check_schema_with_instance(MainModel.model_json_schema(), instance)
-
-
-test_basic()
-exit()
 
 
 def test_enum_const():
@@ -110,22 +95,96 @@ def test_enum_const():
         values: Literal[1, "a", True]
         field: Field
 
+    ebnf_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+basic_string_sub ::= "" | [^"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub
+basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
+basic_integer ::= ("0" | "-"? [1-9] [0-9]*) ".0"?
+basic_number ::= ("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
+basic_string ::= ["] basic_string_sub ["]
+basic_boolean ::= "true" | "false"
+basic_null ::= "null"
+basic_array ::= "[" ("" | "" basic_any ("," basic_any)*) "]"
+basic_object ::= "{" ("" | "" basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
+main_bars ::= "\"a\""
+main_str_values ::= "\"a\\n\\r\\\"\""
+main_foo ::= ("\"a\"") | ("\"b\"") | ("\"c\"")
+main_values ::= ("1") | ("\"a\"") | ("true")
+main_field ::= ("\"foo\"") | ("\"bar\"")
+main ::= "{" "" "\"bars\"" ":" main_bars "," "\"str_values\"" ":" main_str_values "," "\"foo\"" ":" main_foo "," "\"values\"" ":" main_values "," "\"field\"" ":" main_field ("" | "," basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
+"""
+
     instance = MainModel(foo="a", values=1, bars="a", str_values='a\n\r"', field=Field.FOO)
+
     check_schema_with_instance(MainModel.model_json_schema(), instance)
+    check_schema_with_grammar(MainModel.model_json_schema(), ebnf_grammar)
 
 
 def test_optional():
     class MainModel(BaseModel):
+        num: int = 0
+        opt_bool: Optional[bool] = None
         size: Optional[float]
-        name: str = None
+        name: str = ""
 
-    instance = MainModel(size=3.14)
+    ebnf_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+basic_string_sub ::= "" | [^"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub
+basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
+basic_integer ::= ("0" | "-"? [1-9] [0-9]*) ".0"?
+basic_number ::= ("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
+basic_string ::= ["] basic_string_sub ["]
+basic_boolean ::= "true" | "false"
+basic_null ::= "null"
+basic_array ::= "[" ("" | "" basic_any ("," basic_any)*) "]"
+basic_object ::= "{" ("" | "" basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
+main_opt_bool ::= basic_boolean | basic_null
+main_size ::= basic_number | basic_null
+main ::= "{" "" ("\"num\"" ":" basic_integer ",")? ("\"opt_bool\"" ":" main_opt_bool ",")? "\"size\"" ":" main_size ("," "\"name\"" ":" basic_string)? ("" | "," basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
+"""
+
+    check_schema_with_grammar(MainModel.model_json_schema(), ebnf_grammar)
+
+    instance = MainModel(num=42, opt_bool=True, size=3.14, name="foo")
     check_schema_with_instance(MainModel.model_json_schema(), instance)
 
-    instance = MainModel()
+    instance = MainModel(size=None)
     check_schema_with_instance(MainModel.model_json_schema(), instance)
 
-    check_schema_with_json(MainModel.model_json_schema(), "{}")
+    check_schema_with_json(MainModel.model_json_schema(), '{"size":null}')
+    check_schema_with_json(MainModel.model_json_schema(), '{"size":null,"name":"foo"}')
+    check_schema_with_json(MainModel.model_json_schema(), '{"num":1,"size":null,"name":"foo"}')
+
+
+def test_all_optional():
+    class MainModel(BaseModel):
+        size: int = 0
+        state: bool = False
+        num: float = 0
+
+    ebnf_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+basic_string_sub ::= "" | [^"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub
+basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
+basic_integer ::= ("0" | "-"? [1-9] [0-9]*) ".0"?
+basic_number ::= ("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
+basic_string ::= ["] basic_string_sub ["]
+basic_boolean ::= "true" | "false"
+basic_null ::= "null"
+basic_array ::= "[" ("" | "" basic_any ("," basic_any)*) "]"
+basic_object ::= "{" ("" | "" basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
+main ::= "{" ("" ((("\"size\"" ":" basic_integer) ("" | "," "\"state\"" ":" basic_boolean) | "\"state\"" ":" basic_boolean) ("" | "," "\"num\"" ":" basic_number) | "\"num\"" ":" basic_number) | "") ("" | "," basic_string ":" basic_any ("," basic_string ":" basic_any)*) "}"
+"""
+
+    check_schema_with_grammar(MainModel.model_json_schema(), ebnf_grammar)
+
+    instance = MainModel(size=42, state=True, num=3.14)
+    check_schema_with_instance(MainModel.model_json_schema(), instance)
+
+    check_schema_with_json(MainModel.model_json_schema(), '{"state":false}')
+    check_schema_with_json(MainModel.model_json_schema(), '{"size":1,"num":1.5}')
+    check_schema_with_json(MainModel.model_json_schema(), '{"other": null}')
+
+
+test_all_optional()
+exit()
 
 
 def test_reference():

--- a/tests/python/serve/test_json_schema_converter.py
+++ b/tests/python/serve/test_json_schema_converter.py
@@ -17,12 +17,9 @@ def check_schema_with_grammar(
     strict_mode: bool = True,
 ):
     schema_str = json.dumps(schema, indent=2)
-    print(schema_str)
     grammar = json_schema_to_ebnf(
         schema_str, indent=indent, separators=separators, strict_mode=strict_mode
     )
-    print(grammar)
-    print(expected_grammar)
     assert grammar == expected_grammar
 
 
@@ -41,8 +38,6 @@ def check_schema_with_json(
     )
     ebnf_grammar = BNFGrammar.from_ebnf_string(ebnf_grammar_str)
     matcher = GrammarStateMatcher(ebnf_grammar)
-
-    print("json str:", json_str)
 
     if check_accepted:
         assert matcher.debug_match_complete_string(json_str)


### PR DESCRIPTION
This PR adds a generic utility to convert json schema, especially generated from pydantic, to EBNF grammar. This helps the grammar guided generation when we provide a json schema as the restriction.

This converter features the support of json standard indent style in the output grammar.

API:
```
def json_schema_to_ebnf(
    json_schema: str,
    *,
    indent: Optional[int] = None,
    separators: Optional[Tuple[str, str]] = None,
    strict_mode: bool = True,
) -> str:
    """Convert JSON schema string to EBNF grammar string.

    Parameters
    ----------
    json_schema : str
        The JSON schema string.

    indent : Optional[int]
        The number of spaces for each indent. If it is None, there will be no indent or newline.
        The indent and separators parameters follow the same convention as
        `json.dumps()`.

    separators : Optional[Tuple[str, str]]
        The separator between different elements in json. Examples include "," and ", ".

    strict_mode : bool
        Whether to use strict mode. In strict mode, the generated grammar will not allow
        unevaluatedProperties and unevaluatedItems, i.e. these will be set to false by default.
        This helps LLM to generate accurate output in the grammar-guided generation with JSON
        schema.
    """
    pass
```