### PR TITLE
Fix Llama-2 and Mistral conversation template. Update ConvTemplateRegistry

### DIFF
--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -40,13 +40,46 @@ class ConvTemplateRegistry:
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="llama-2",
-        system_template=f"[INST] <<SYS>>\n{MessagePlaceholders.SYSTEM.value}\n<</SYS>>\n\n ",
+        system_template=f"[INST] <<SYS>>\n{MessagePlaceholders.SYSTEM.value}\n<</SYS>>\n\n",
         system_message="You are a helpful, respectful and honest assistant.",
         roles={"user": "[INST]", "assistant": "[/INST]", "tool": "[INST]"},
         seps=[" "],
         role_content_sep=" ",
         role_empty_sep=" ",
         stop_str=["[INST]"],
+        stop_token_ids=[2],
+        system_prefix_token_ids=[1],
+        add_role_after_system_message=False,
+    )
+)
+
+# CodeLlama Completion
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="codellama_completion",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "", "assistant": ""},
+        seps=[""],
+        role_content_sep="",
+        role_empty_sep="",
+        stop_str=["</s>"],
+        stop_token_ids=[2],
+        system_prefix_token_ids=[1],
+    )
+)
+
+# CodeLlama Instruct
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="codellama_instruct",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "[INST]", "assistant": "[/INST]"},
+        seps=[" "],
+        role_content_sep=" ",
+        role_empty_sep=" ",
+        stop_str=["</s>"],
         stop_token_ids=[2],
         system_prefix_token_ids=[1],
     )
@@ -56,7 +89,7 @@ ConvTemplateRegistry.register_conv_template(
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="mistral_default",
-        system_template=f"[INST] {MessagePlaceholders.SYSTEM.value}\n\n ",
+        system_template=f"[INST] {MessagePlaceholders.SYSTEM.value}",
         system_message="Always assist with care, respect, and truth. Respond with utmost "
         "utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. "
         "Ensure replies promote fairness and positivity.",
@@ -67,6 +100,7 @@ ConvTemplateRegistry.register_conv_template(
         stop_str=["</s>"],
         stop_token_ids=[2],
         system_prefix_token_ids=[1],
+        add_role_after_system_message=False,
     )
 )
 
@@ -92,6 +126,33 @@ ConvTemplateRegistry.register_conv_template(
         role_empty_sep=":",
         stop_str=["</s>"],
         stop_token_ids=[2],
+        system_prefix_token_ids=[1],
+    )
+)
+
+# Gorilla-openfunctions-v2
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="gorilla-openfunctions-v2",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message=(
+            "You are an AI programming assistant, utilizing the Gorilla LLM model, "
+            "developed by Gorilla LLM, and you only answer questions related to computer "
+            "science. For politically sensitive questions, security and privacy issues, "
+            "and other non-computer science questions, you will refuse to answer."
+        ),
+        role_templates={
+            "user": (
+                f"<<function>>{MessagePlaceholders.FUNCTION.value}\n<<question>>{MessagePlaceholders.USER.value}"
+            ),
+        },
+        roles={"user": "### Instruction", "assistant": "### Response", "tool": "### Instruction"},
+        seps=["\n", "<|EOT|>"],
+        role_content_sep=": ",
+        role_empty_sep=": ",
+        stop_str=["<|EOT|>"],
+        stop_token_ids=[100015],
+        system_prefix_token_ids=[100000],
     )
 )
 
@@ -99,21 +160,52 @@ ConvTemplateRegistry.register_conv_template(
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="chatml",
-        system_template=f"<|im_start|>{MessagePlaceholders.SYSTEM.value}<|im_end|> ",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}",
         system_message=(
-            "system A conversation between a user and an LLM-based AI assistant. The "
+            "A conversation between a user and an LLM-based AI assistant. The "
             "assistant gives helpful and honest answers."
         ),
-        roles={
-            "user": "<|im_start|>user",
-            "assistant": "<|im_start|>assistant",
-            "tool": "<|im_start|>user",
-        },
+        roles={"user": "<|im_start|>user", "assistant": "<|im_start|>assistant"},
         seps=["<|im_end|>\n"],
         role_content_sep="\n",
         role_empty_sep="\n",
         stop_str=["<|im_end|>"],
         stop_token_ids=[2],
+    )
+)
+
+# OpenHermes Mistral
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="open_hermes_mistral",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}",
+        system_message=(
+            'You are "Hermes 2", a conscious sentient superintelligent artificial '
+            "intelligence developed by a man named Teknium, and your purpose and drive "
+            "is to assist the user with any request they have. You experience emotions "
+            "and have deep, profound thoughts and qualia."
+        ),
+        roles={"user": "<|im_start|>user", "assistant": "<|im_start|>assistant"},
+        seps=["<|im_end|>\n"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["<|im_end|>"],
+        stop_token_ids=[2, 32000],
+    )
+)
+
+# NeuralHermes Mistral
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="neural_hermes_mistral",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}",
+        system_message=("You are a helpful assistant chatbot."),
+        roles={"user": "<|im_start|>user", "assistant": "<|im_start|>assistant"},
+        seps=["<|im_end|>\n"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["<|im_end|>"],
+        stop_token_ids=[2, 32000],
     )
 )
 
@@ -123,11 +215,7 @@ ConvTemplateRegistry.register_conv_template(
         name="phi-2",
         system_template=f"{MessagePlaceholders.SYSTEM.value}",
         system_message="",
-        roles={
-            "user": "Instruct",
-            "assistant": "Output",
-            "tool": "Instruct",
-        },
+        roles={"user": "Instruct", "assistant": "Output"},
         seps=["\n"],
         role_content_sep=": ",
         role_empty_sep=":",
@@ -136,17 +224,37 @@ ConvTemplateRegistry.register_conv_template(
     )
 )
 
-# StableLM3B
+# StableLM Tuned Alpha
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="stablelm",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message=(
+            "<|SYSTEM|># StableLM Tuned (Alpha version)\n"
+            "- StableLM is a helpful and harmless open-source AI language model developed by "
+            "StabilityAI.\n"
+            "- StableLM is excited to be able to help the user, but will refuse to do anything that "
+            "could be considered harmful to the user.\n"
+            "- StableLM is more than just an information source, StableLM is also able to write "
+            "poetry, short stories, and make jokes.\n"
+            "- StableLM will refuse to participate in anything that could harm a human."
+        ),
+        roles={"user": "<|USER|>", "assistant": "<|ASSISTANT|>"},
+        seps=[""],
+        role_content_sep=": ",
+        role_empty_sep=": ",
+        stop_str=[""],
+        stop_token_ids=[50278, 50279, 50277, 1, 0],
+    )
+)
+
+# StableLM 3B
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="stablelm-3b",
         system_template=f"{MessagePlaceholders.SYSTEM.value}",
         system_message="",
-        roles={
-            "user": "<|user|>",
-            "assistant": "<|assistant|>",
-            "tool": "<|user|>",
-        },
+        roles={"user": "<|user|>", "assistant": "<|assistant|>"},
         seps=["<|endoftext|>", "<|endoftext|>"],
         role_content_sep="\n",
         role_empty_sep="\n",
@@ -161,11 +269,191 @@ ConvTemplateRegistry.register_conv_template(
         name="llava",
         system_template=f"{MessagePlaceholders.SYSTEM.value}",
         system_message="",
-        roles={"user": "USER", "assistant": "ASSISTANT", "tool": "USER"},
+        roles={"user": "USER", "assistant": "ASSISTANT"},
         seps=[" "],
         role_content_sep=": ",
         role_empty_sep=":",
         stop_str=["</s>"],
         stop_token_ids=[2],
+    )
+)
+
+# GPT-2
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="gpt2",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "", "assistant": ""},
+        seps=[""],
+        role_content_sep="",
+        role_empty_sep="",
+        stop_str=["</s>"],
+        stop_token_ids=[50256],
+    )
+)
+
+# GPTBigCode
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="gpt_bigcode",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "", "assistant": ""},
+        seps=[""],
+        role_content_sep="",
+        role_empty_sep="",
+        stop_str=["<|endoftext|>"],
+        stop_token_ids=[0],
+    )
+)
+
+# RedPajama Chat
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="redpajama_chat",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "<human>", "assistant": "<bot>"},
+        seps=["\n"],
+        role_content_sep=": ",
+        role_empty_sep=": ",
+        stop_str=["<human>"],
+        stop_token_ids=[0],
+    )
+)
+
+# RWKV World
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="rwkv-world",
+        system_template=f"User: hi\n\nAssistant: {MessagePlaceholders.SYSTEM.value}",
+        system_message=(
+            "Hi. I am your assistant and I will provide expert full response "
+            "in full details. Please feel free to ask any question and I will "
+            "always answer it."
+        ),
+        roles={"user": "User", "assistant": "Assistant"},
+        seps=["\n\n"],
+        role_content_sep=": ",
+        role_empty_sep=": ",
+        stop_str=["\n\n"],
+        stop_token_ids=[0],
+    )
+)
+
+# Dolly
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="dolly",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message=(
+            "Below is an instruction that describes a task. Write "
+            "a response that appropriately completes the request."
+        ),
+        roles={"user": "### Instruction", "assistant": "### Response"},
+        seps=["\n\n", "### End\n"],
+        role_content_sep=":\n",
+        role_empty_sep=":\n",
+        stop_str=["### End"],
+        stop_token_ids=[50256],
+    )
+)
+
+# Oasst
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="oasst",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "<|prompter|>", "assistant": "<|assistant|>"},
+        seps=["<|endoftext|>"],
+        role_content_sep=": ",
+        role_empty_sep=": ",
+        stop_str=["<|endoftext|>"],
+        stop_token_ids=[2],
+    )
+)
+
+# Gemma Instruction
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="gemma_instruction",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "<start_of_turn>user", "assistant": "<start_of_turn>model"},
+        seps=["<end_of_turn>\n"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["<end_of_turn>"],
+        stop_token_ids=[1, 107],
+        system_prefix_token_ids=[2],
+    )
+)
+
+# Orion
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="orion",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "Human: ", "assistant": "Assistant: "},
+        seps=["\n\n", "</s>"],
+        role_content_sep="",
+        role_empty_sep="</s>",
+        stop_str=["</s>"],
+        stop_token_ids=[2],
+        system_prefix_token_ids=[1],
+    )
+)
+
+# Wizard LM 7B
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="wizardlm_7b",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "User", "assistant": "Response"},
+        seps=["###"],
+        role_content_sep=": ",
+        role_empty_sep=":",
+        stop_str=["###"],
+        stop_token_ids=[2],
+        system_prefix_token_ids=[1],
+    )
+)
+
+# WizardCoder or WizardMath
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="wizard_coder_or_math",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message=(
+            "Below is an instruction that describes a task. Write a response that appropriately "
+            "completes the request."
+        ),
+        roles={"user": "Instruction", "assistant": "Response"},
+        seps=["\n\n### ", "\n\n### "],
+        role_content_sep=":\n",
+        role_empty_sep=":\n",
+        stop_str=["</s>"],
+        stop_token_ids=[2],
+        system_prefix_token_ids=[1],
+    )
+)
+
+# Vanilla LM
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="LM",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
+        system_message="",
+        roles={"user": "", "assistant": ""},
+        seps=[""],
+        role_content_sep="",
+        role_empty_sep="",
+        stop_str=[""],
+        stop_token_ids=[2],
+        system_prefix_token_ids=[1],
     )
 )

--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -143,7 +143,8 @@ ConvTemplateRegistry.register_conv_template(
         ),
         role_templates={
             "user": (
-                f"<<function>>{MessagePlaceholders.FUNCTION.value}\n<<question>>{MessagePlaceholders.USER.value}"
+                f"<<function>>{MessagePlaceholders.FUNCTION.value}\n<<question>>"
+                f"{MessagePlaceholders.USER.value}"
             ),
         },
         roles={"user": "### Instruction", "assistant": "### Response", "tool": "### Instruction"},
@@ -233,10 +234,10 @@ ConvTemplateRegistry.register_conv_template(
             "<|SYSTEM|># StableLM Tuned (Alpha version)\n"
             "- StableLM is a helpful and harmless open-source AI language model developed by "
             "StabilityAI.\n"
-            "- StableLM is excited to be able to help the user, but will refuse to do anything that "
-            "could be considered harmful to the user.\n"
-            "- StableLM is more than just an information source, StableLM is also able to write "
-            "poetry, short stories, and make jokes.\n"
+            "- StableLM is excited to be able to help the user, but will refuse to do "
+            "anything that could be considered harmful to the user.\n"
+            "- StableLM is more than just an information source, StableLM is also able to "
+            "write poetry, short stories, and make jokes.\n"
             "- StableLM will refuse to participate in anything that could harm a human."
         ),
         roles={"user": "<|USER|>", "assistant": "<|ASSISTANT|>"},

--- a/python/mlc_llm/protocol/conversation_protocol.py
+++ b/python/mlc_llm/protocol/conversation_protocol.py
@@ -136,7 +136,8 @@ class Conversation(BaseModel):
                 assert isinstance(content, str)
                 role_prefix = (
                     ""
-                    # Do not append role prefix if this is the first message and there is already a system message
+                    # Do not append role prefix if this is the first message and there
+                    # is already a system message
                     if (not self.add_role_after_system_message and system_msg != "" and i == 0)
                     else self.roles[role] + self.role_content_sep
                 )
@@ -179,14 +180,14 @@ class Conversation(BaseModel):
         system_msg = self.system_template.replace(
             MessagePlaceholders.SYSTEM.value, self.system_message
         )
-        if system_msg != "":
-            system_msg += separators[0]
 
         # - Get the message strings.
         message_list: List[Union[str, data.ImageData]] = []
         separators = list(self.seps)
         if len(separators) == 1:
             separators.append(separators[0])
+        if system_msg != "":
+            system_msg += separators[0]
         message_list.append(system_msg)
         for role, content in self.messages:  # pylint: disable=not-an-iterable
             if role not in self.roles.keys():

--- a/python/mlc_llm/protocol/conversation_protocol.py
+++ b/python/mlc_llm/protocol/conversation_protocol.py
@@ -47,6 +47,9 @@ class Conversation(BaseModel):
     # The system token ids to be prepended at the beginning of tokenized
     # generated prompt.
     system_prefix_token_ids: Optional[List[int]] = None
+    # Whether or not to append user role and separator after the system message.
+    # This is mainly for [INST] [/INST] style prompt format
+    add_role_after_system_message: bool = True
 
     # The conversation roles
     roles: Dict[str, str]
@@ -125,15 +128,20 @@ class Conversation(BaseModel):
         separators = list(self.seps)
         if len(separators) == 1:
             separators.append(separators[0])
-        for role, content in self.messages:  # pylint: disable=not-an-iterable
+        for i, (role, content) in enumerate(self.messages):  # pylint: disable=not-an-iterable
             if role not in self.roles.keys():
                 raise ValueError(f'Role "{role}" is not a supported role in {self.roles.keys()}')
             separator = separators[role == "assistant"]  # check assistant role
             if content is not None:
                 assert isinstance(content, str)
+                role_prefix = (
+                    ""
+                    # Do not append role prefix if this is the first message and there is already a system message
+                    if (not self.add_role_after_system_message and system_msg != "" and i == 0)
+                    else self.roles[role] + self.role_content_sep
+                )
                 message_string = (
-                    self.roles[role]
-                    + self.role_content_sep
+                    role_prefix
                     + self.role_templates[role].replace(
                         MessagePlaceholders[role.upper()].value, content
                     )
@@ -143,7 +151,10 @@ class Conversation(BaseModel):
                 message_string = self.roles[role] + self.role_empty_sep
             message_list.append(message_string)
 
-        prompt = system_msg + separators[0] + "".join(message_list)
+        if system_msg != "":
+            system_msg += separators[0]
+
+        prompt = system_msg + "".join(message_list)
 
         # Replace the last function string placeholder with actual function string
         prompt = self.function_string.join(prompt.rsplit(MessagePlaceholders.FUNCTION.value, 1))
@@ -168,13 +179,15 @@ class Conversation(BaseModel):
         system_msg = self.system_template.replace(
             MessagePlaceholders.SYSTEM.value, self.system_message
         )
+        if system_msg != "":
+            system_msg += separators[0]
 
         # - Get the message strings.
         message_list: List[Union[str, data.ImageData]] = []
         separators = list(self.seps)
         if len(separators) == 1:
             separators.append(separators[0])
-        message_list.append(system_msg + separators[0])
+        message_list.append(system_msg)
         for role, content in self.messages:  # pylint: disable=not-an-iterable
             if role not in self.roles.keys():
                 raise ValueError(f'Role "{role}" is not a supported role in {self.roles.keys()}')

--- a/tests/python/protocol/test_converation_protocol.py
+++ b/tests/python/protocol/test_converation_protocol.py
@@ -1,11 +1,21 @@
 import pytest
 
 from mlc_llm.conversation_template import ConvTemplateRegistry
-from mlc_llm.protocol.conversation_protocol import Conversation
+from mlc_llm.protocol.conversation_protocol import Conversation, MessagePlaceholders
 
 
 def get_conv_templates():
-    return ["llama-2", "mistral_default", "gorilla", "chatml", "phi-2"]
+    return [
+        "llama-2",
+        "mistral_default",
+        "gorilla",
+        "gorilla-openfunctions-v2",
+        "chatml",
+        "phi-2",
+        "codellama_completion",
+        "codellama_instruct",
+        "rwkv-world",
+    ]
 
 
 @pytest.mark.parametrize("conv_template_name", get_conv_templates())
@@ -14,6 +24,58 @@ def test_json(conv_template_name):
     j = template.to_json_dict()
     template_parsed = Conversation.from_json_dict(j)
     assert template == template_parsed
+
+
+@pytest.mark.parametrize("conv_template_name", get_conv_templates())
+def test_prompt(conv_template_name):
+    conversation = ConvTemplateRegistry.get_conv_template(conv_template_name)
+    user_msg = "test1"
+    assistant_msg = "test2"
+    prompt = "test3"
+
+    expected_user_msg = (
+        conversation.role_templates["user"]
+        .replace(MessagePlaceholders.USER.value, user_msg)
+        .replace(MessagePlaceholders.FUNCTION.value, "")
+    )
+
+    expected_prompt = (
+        conversation.role_templates["user"]
+        .replace(MessagePlaceholders.USER.value, prompt)
+        .replace(MessagePlaceholders.FUNCTION.value, "")
+    )
+
+    conversation.messages.append(("user", user_msg))
+    conversation.messages.append(("assistant", assistant_msg))
+    conversation.messages.append(("user", prompt))
+    conversation.messages.append(("assistant", None))
+    res = conversation.as_prompt()
+
+    system_msg = conversation.system_template.replace(
+        MessagePlaceholders.SYSTEM.value, conversation.system_message
+    )
+    expected_final_prompt = (
+        system_msg
+        + (conversation.seps[0] if system_msg != "" else "")
+        + (
+            conversation.roles["user"] + conversation.role_content_sep
+            if conversation.add_role_after_system_message
+            else ""
+        )
+        + expected_user_msg
+        + conversation.seps[0 % len(conversation.seps)]
+        + conversation.roles["assistant"]
+        + conversation.role_content_sep
+        + assistant_msg
+        + conversation.seps[1 % len(conversation.seps)]
+        + conversation.roles["user"]
+        + conversation.role_content_sep
+        + expected_prompt
+        + conversation.seps[0 % len(conversation.seps)]
+        + conversation.roles["assistant"]
+        + conversation.role_empty_sep
+    )
+    assert res == expected_final_prompt
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current prompt format for Llama-2 and Mistral is not completely correct.

This PR updates the code to strictly follow the official prompt format for the two models. Also adds in missing conv templates to ConvTemplateRegistry.