### PR TITLE
[Serving][Grammar] Support specifying the main rule in grammar

### DIFF
--- a/cpp/serve/grammar/grammar.cc
+++ b/cpp/serve/grammar/grammar.cc
@@ -20,8 +20,9 @@ std::ostream& operator<<(std::ostream& os, const BNFGrammar& grammar) {
   return os;
 }
 
-BNFGrammar BNFGrammar::FromEBNFString(const String& ebnf_string, bool normalize, bool simplify) {
-  auto grammar = EBNFParser::Parse(ebnf_string);
+BNFGrammar BNFGrammar::FromEBNFString(const String& ebnf_string, const String& main_rule,
+                                      bool normalize, bool simplify) {
+  auto grammar = EBNFParser::Parse(ebnf_string, main_rule);
   if (normalize) {
     grammar = NestedRuleUnwrapper(grammar).Apply();
   }
@@ -29,8 +30,8 @@ BNFGrammar BNFGrammar::FromEBNFString(const String& ebnf_string, bool normalize,
 }
 
 TVM_REGISTER_GLOBAL("mlc.serve.BNFGrammarFromEBNFString")
-    .set_body_typed([](String ebnf_string, bool normalize, bool simplify) {
-      return BNFGrammar::FromEBNFString(ebnf_string, normalize, simplify);
+    .set_body_typed([](String ebnf_string, String main_rule, bool normalize, bool simplify) {
+      return BNFGrammar::FromEBNFString(ebnf_string, main_rule, normalize, simplify);
     });
 
 BNFGrammar BNFGrammar::FromJSON(const String& json_string) {
@@ -112,7 +113,8 @@ ws ::= [ \n\t]*
 )";
 
 BNFGrammar BNFGrammar::GetGrammarOfJSON() {
-  static const BNFGrammar grammar = BNFGrammar::FromEBNFString(kJSONGrammarString, true, false);
+  static const BNFGrammar grammar =
+      BNFGrammar::FromEBNFString(kJSONGrammarString, "main", true, false);
   return grammar;
 }
 

--- a/cpp/serve/grammar/grammar.h
+++ b/cpp/serve/grammar/grammar.h
@@ -84,6 +84,12 @@ class BNFGrammarNode : public Object {
         << "rule_id " << rule_id << " is out of bound";
     return rules_[rule_id];
   }
+  /*! \brief Get the main rule of the grammar. */
+  const Rule& GetMainRule() const {
+    DCHECK(main_rule_id_ >= 0 && main_rule_id_ < static_cast<int32_t>(rules_.size()))
+        << "main_rule_id " << main_rule_id_ << " is out of bound";
+    return rules_[main_rule_id_];
+  }
 
   /*! \brief The type of the rule expr. */
   enum class RuleExprType : int32_t {
@@ -149,6 +155,8 @@ class BNFGrammarNode : public Object {
   /*! \brief The start index of every rule_expr in rule_expr_data_. rule_expr_id corresponds the
    * index of this vector. */
   std::vector<int32_t> rule_expr_indptr_;
+  /*! \brief The id of the main rule. */
+  int32_t main_rule_id_ = -1;
 
   friend class BNFGrammarBuilder;
   friend class BNFGrammarJSONSerializer;
@@ -161,6 +169,7 @@ class BNFGrammar : public ObjectRef {
    * \brief Construct a BNF grammar with a EBNF-formatted string. Will parse the string and
    * transform it into BNF AST.
    * \param ebnf_string The EBNF-formatted string.
+   * \param main_rule The name of the main rule.
    * \param normalize Whether to normalize the grammar. Default: true. Only set to false for the
    * purpose of testing.
    *
@@ -173,8 +182,8 @@ class BNFGrammar : public ObjectRef {
    * \param simplify Whether to simplify the grammar to make matching more efficient. Default: true.
    * Not implemented yet.
    */
-  static BNFGrammar FromEBNFString(const String& ebnf_string, bool normalize = true,
-                                   bool simplify = true);
+  static BNFGrammar FromEBNFString(const String& ebnf_string, const String& main_rule,
+                                   bool normalize = true, bool simplify = true);
 
   /*!
    * \brief Construct a BNF grammar from the dumped JSON string.

--- a/cpp/serve/grammar/grammar_builder.h
+++ b/cpp/serve/grammar/grammar_builder.h
@@ -6,8 +6,9 @@
 
 #ifndef MLC_LLM_SERVE_GRAMMAR_GRAMMAR_BUILDER_H_
 #define MLC_LLM_SERVE_GRAMMAR_GRAMMAR_BUILDER_H_
-
 #include <tvm/runtime/object.h>
+
+#include <cstdint>
 
 #include "grammar.h"
 
@@ -31,19 +32,17 @@ class BNFGrammarBuilder {
   BNFGrammarBuilder() : grammar_(make_object<BNFGrammarNode>()) {}
 
   /*!
-   * \brief Create grammar containing the rules and rule_exprs of an existing grammar. The old
-   * grammar remains unchanged.
-   * \param grammar The existing grammar.
+   * \brief Get the result grammar. This function will also set the main rule to the rule with the
+   * specified name. The rule should be already added to the grammar.
+   * \param main_rule The name of the main rule. Default is "main".
    */
-  explicit BNFGrammarBuilder(const BNFGrammar& grammar)
-      : grammar_(make_object<BNFGrammarNode>(*grammar.get())) {
-    // for (size_t i = 0; i < grammar_->rules_.size(); ++i) {
-    //   rule_name_to_id_[grammar_->rules_[i].name] = i;
-    // }
-  }
+  BNFGrammar Get(const std::string& main_rule = "main") {
+    int32_t main_rule_id = GetRuleId(main_rule);
+    CHECK(main_rule_id != -1) << "The in rule with name \"" << main_rule << "\" is not found.";
+    grammar_->main_rule_id_ = main_rule_id;
 
-  /*! \brief Get the result grammar. */
-  BNFGrammar Get() { return BNFGrammar(grammar_); }
+    return BNFGrammar(grammar_);
+  }
 
   /****************** RuleExpr handling ******************/
 
@@ -124,7 +123,7 @@ class BNFGrammarBuilder {
     int32_t id = grammar_->rules_.size();
     auto rules = grammar_->rules_;
     grammar_->rules_.push_back(rule);
-    ICHECK_EQ(rule_name_to_id_.count(rule.name), 0);
+    CHECK_EQ(rule_name_to_id_.count(rule.name), 0);
     rule_name_to_id_[rule.name] = id;
     return id;
   }

--- a/cpp/serve/grammar/grammar_parser.cc
+++ b/cpp/serve/grammar/grammar_parser.cc
@@ -16,7 +16,7 @@ namespace serve {
 class EBNFParserImpl {
  public:
   /*! \brief The logic of parsing the grammar string. */
-  BNFGrammar DoParse(String ebnf_string);
+  BNFGrammar DoParse(String ebnf_string, String main_rule);
 
  private:
   using Rule = BNFGrammarNode::Rule;
@@ -391,7 +391,7 @@ void EBNFParserImpl::ResetStringIterator(const char* cur) {
   in_parentheses_ = false;
 }
 
-BNFGrammar EBNFParserImpl::DoParse(String ebnf_string) {
+BNFGrammar EBNFParserImpl::DoParse(String ebnf_string, String main_rule) {
   ResetStringIterator(ebnf_string.c_str());
   BuildRuleNameToId();
 
@@ -404,16 +404,17 @@ BNFGrammar EBNFParserImpl::DoParse(String ebnf_string) {
     ConsumeSpace();
   }
 
-  if (builder_.GetRuleId("main") == -1) {
-    ThrowParseError("There must be a rule named \"main\"");
+  // Check that the main rule is defined
+  if (builder_.GetRuleId(main_rule) == -1) {
+    ThrowParseError("The main rule with name \"" + main_rule + "\" is not found.");
   }
 
-  return builder_.Get();
+  return builder_.Get(main_rule);
 }
 
-BNFGrammar EBNFParser::Parse(String ebnf_string) {
+BNFGrammar EBNFParser::Parse(String ebnf_string, String main_rule) {
   EBNFParserImpl parser;
-  return parser.DoParse(ebnf_string);
+  return parser.DoParse(ebnf_string, main_rule);
 }
 
 BNFGrammar BNFJSONParser::Parse(String json_string) {

--- a/cpp/serve/grammar/grammar_parser.h
+++ b/cpp/serve/grammar/grammar_parser.h
@@ -34,9 +34,10 @@ class EBNFParser {
   /*!
    * \brief Parse the grammar string. If fails, throw ParseError with the error message.
    * \param ebnf_string The grammar string.
+   * \param main_rule The name of the main rule. Default is "main".
    * \return The parsed grammar.
    */
-  static BNFGrammar Parse(String ebnf_string);
+  static BNFGrammar Parse(String ebnf_string, String main_rule = "main");
 
   /*!
    * \brief The exception thrown when parsing fails.

--- a/cpp/serve/grammar/grammar_simplifier.cc
+++ b/cpp/serve/grammar/grammar_simplifier.cc
@@ -61,7 +61,7 @@ class NestedRuleUnwrapperImpl : public BNFGrammarMutator<int32_t, BNFGrammar> {
       auto new_body_expr_id = VisitRuleBody(rule_expr);
       builder_.UpdateRuleBody(i, new_body_expr_id);
     }
-    return builder_.Get();
+    return builder_.Get(grammar_->GetMainRule().name);
   }
 
  private:

--- a/cpp/serve/grammar/grammar_simplifier.h
+++ b/cpp/serve/grammar/grammar_simplifier.h
@@ -48,7 +48,7 @@ class BNFGrammarMutator {
         auto new_body_expr_id = VisitExpr(rule_expr);
         builder_.AddRule(rule.name, new_body_expr_id);
       }
-      return builder_.Get();
+      return builder_.Get(grammar_->GetMainRule().name);
     } else if constexpr (!std::is_same<ReturnType, void>::value) {
       return ReturnType();
     }

--- a/cpp/serve/grammar/grammar_state_matcher.cc
+++ b/cpp/serve/grammar/grammar_state_matcher.cc
@@ -458,7 +458,7 @@ TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFromTokenizer")
                 << std::chrono::duration_cast<std::chrono::microseconds>(preproc_end -
                                                                          preproc_start)
                        .count()
-                << "us";
+                << "us" << std::endl;
       return GrammarStateMatcher(init_ctx, max_rollback_steps);
     });
 
@@ -501,7 +501,7 @@ TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherResetState")
     .set_body_typed([](GrammarStateMatcher matcher) { matcher->ResetState(); });
 
 /*! \brief Check if a matcher can accept the complete string, and then reach the end of the
- * grammar. For test purpose. */
+ * grammar. Does not change the state of the GrammarStateMatcher. For test purpose. */
 bool MatchCompleteString(GrammarStateMatcher matcher, String str) {
   auto mutable_node =
       const_cast<GrammarStateMatcherNodeImpl*>(matcher.as<GrammarStateMatcherNodeImpl>());
@@ -514,7 +514,9 @@ bool MatchCompleteString(GrammarStateMatcher matcher, String str) {
     }
     ++accepted_cnt;
   }
-  return mutable_node->CanReachEnd();
+  auto accepted = mutable_node->CanReachEnd();
+  mutable_node->RollbackCodepoints(accepted_cnt);
+  return accepted;
 }
 
 TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherDebugMatchCompleteString")

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -194,7 +194,7 @@ inline std::string GrammarStateMatcherBase::PrintStackState(int steps_behind_lat
 inline void GrammarStateMatcherBase::InitStackState(RulePosition init_rule_position) {
   if (init_rule_position == kInvalidRulePosition) {
     // Initialize the stack with the main rule.
-    auto main_rule = grammar_->GetRule(0);
+    auto main_rule = grammar_->GetMainRule();
     auto main_rule_body = grammar_->GetRuleExpr(main_rule.body_expr_id);
     std::vector<int32_t> new_stack_tops;
     for (auto i : main_rule_body) {

--- a/cpp/serve/grammar/grammar_state_matcher_state.h
+++ b/cpp/serve/grammar/grammar_state_matcher_state.h
@@ -146,9 +146,9 @@ class RulePositionTree {
   }
 
   /*!
-   * \brief Check if the given RulePosition points to the end of the grammar. We use
-   * (main_rule_id, sequence_id, length_of_sequence) to represent the end position. Here the
-   * element_id is the length of the sequence.
+   * \brief Check if the given RulePosition points to the end of the grammar. For a position, if its
+   * rule id is the main rule id, and the element id equals to the length of the sequence it refers
+   * to, it would be the end position.
    */
   bool IsEndPosition(const RulePosition& rule_position) const;
 
@@ -181,7 +181,10 @@ class RulePositionTree {
     return node_buffer_[id];
   }
 
-  /*! \brief Print the node with the given id to a string. */
+  /*! \brief Print the given rule_position to a string. */
+  std::string PrintNode(const RulePosition& rule_position) const;
+
+  /*! \brief Print the rule_position associated with the given id to a string. */
   std::string PrintNode(int32_t id) const;
 
   /*! \brief Print the stack with the given top id to a string. */
@@ -317,10 +320,13 @@ inline bool RulePositionTree::IsEndPosition(const RulePosition& rule_position) c
 }
 
 inline std::string RulePositionTree::PrintNode(int32_t id) const {
+  return "id: " + std::to_string(id) + ", " + PrintNode(node_buffer_[id]);
+}
+
+inline std::string RulePositionTree::PrintNode(const RulePosition& rule_position) const {
   std::stringstream ss;
-  const auto& rule_position = node_buffer_[id];
-  ss << "id: " << id;
-  ss << ", rule " << rule_position.rule_id << ": " << grammar_->GetRule(rule_position.rule_id).name;
+  ss << "RulePosition: rule " << rule_position.rule_id << ": "
+     << grammar_->GetRule(rule_position.rule_id).name;
   ss << ", sequence " << rule_position.sequence_id << ": "
      << BNFGrammarPrinter(grammar_).PrintRuleExpr(rule_position.sequence_id);
   ss << ", element id: " << rule_position.element_id;

--- a/python/mlc_llm/serve/grammar.py
+++ b/python/mlc_llm/serve/grammar.py
@@ -18,7 +18,10 @@ class BNFGrammar(Object):
 
     @staticmethod
     def from_ebnf_string(
-        ebnf_string: str, normalize: bool = True, simplify: bool = True
+        ebnf_string: str,
+        main_rule: str = "main",
+        normalize: bool = True,
+        simplify: bool = True,
     ) -> "BNFGrammar":
         r"""Parse a BNF grammar from a string in BNF/EBNF format.
 
@@ -35,6 +38,9 @@ class BNFGrammar(Object):
         ----------
         ebnf_string : str
             The grammar string.
+
+        main_rule : str
+            The name of the main rule. Default: "main".
 
         normalize : bool
             Whether to normalize the grammar. Default: true. Only set to false for the purpose of
@@ -57,7 +63,7 @@ class BNFGrammar(Object):
             The parsed BNF grammar.
         """
         return _ffi_api.BNFGrammarFromEBNFString(  # type: ignore  # pylint: disable=no-member
-            ebnf_string, normalize, simplify
+            ebnf_string, main_rule, normalize, simplify
         )
 
     def to_string(self) -> str:
@@ -252,7 +258,7 @@ class GrammarStateMatcher(Object):
 
     def debug_match_complete_string(self, string: str) -> bool:
         """Check if the matcher can accept the complete string, and then reach the end of the
-        grammar. For test purposes.
+        grammar. Does not change the state of the GrammarStateMatcher. For test purposes.
 
         Parameters
         ----------

--- a/tests/python/serve/test_grammar_state_matcher_custom.py
+++ b/tests/python/serve/test_grammar_state_matcher_custom.py
@@ -17,7 +17,7 @@ from mlc_llm.tokenizer import Tokenizer
 def get_json_grammar():
     json_grammar_ebnf = r"""
 main ::= basic_array | basic_object
-basic_any ::= basic_integer | basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
+basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
 basic_integer ::= ("0" | "-"? [1-9] [0-9]*) ".0"?
 basic_number ::= ("0" | "-"? [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
 basic_string ::= (([\"] basic_string_1 [\"]))
@@ -30,7 +30,6 @@ basic_object ::= "{" ("" | ws basic_string ws ":" ws basic_any ( ws "," ws basic
 ws ::= [ \n\t]*
 """
     grammar = BNFGrammar.from_ebnf_string(json_grammar_ebnf)
-    print(grammar)
     return grammar
 
 
@@ -101,6 +100,137 @@ def test_json_accept(json_grammar: BNFGrammar, json_input_accepted: str):
 
 def test_json_refuse(json_grammar: BNFGrammar, json_input_refused):
     assert not GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_refused)
+
+
+(json_input_pressure,) = tvm.testing.parameters(
+    # Extra long string: 1k chars
+    (
+        '["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent '
+        "libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum "
+        "imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper "
+        "porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu "
+        "ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula "
+        "in libero. Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. "
+        "In scelerisque sem at dolor. Maecenas mattis. Sed convallis tristique sem. Proin ut "
+        "ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, "
+        "luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla "
+        "metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh. Quisque volutpat "
+        "condimentum velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, "
+        "per inceptos himenaeos. Nam nec ante. Sed lacinia, urna non tincidunt mattis, tortor "
+        "neque adipiscing diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla. "
+        "Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet. Vestibulum sapien. "
+        "Proin quam. Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed lectus. "
+        "Integer euismod lacus luctus magna. Quisque cursus, metus vitae pharetra auctor, sem "
+        'massa mattis sem, at interdum magna augue eget diam."]',
+    ),
+    # long and complex json: 3k chars
+    (
+        r"""{
+    "web-app": {
+    "servlet": [
+        {
+        "servlet-name": "cofaxCDS",
+        "servlet-class": "org.cofax.cds.CDSServlet",
+        "init-param": {
+            "configGlossary:installationAt": "Philadelphia, PA",
+            "configGlossary:adminEmail": "ksm@pobox.com",
+            "configGlossary:poweredBy": "Cofax",
+            "configGlossary:poweredByIcon": "/images/cofax.gif",
+            "configGlossary:staticPath": "/content/static",
+            "templateProcessorClass": "org.cofax.WysiwygTemplate",
+            "templateLoaderClass": "org.cofax.FilesTemplateLoader",
+            "templatePath": "templates",
+            "templateOverridePath": "",
+            "defaultListTemplate": "listTemplate.htm",
+            "defaultFileTemplate": "articleTemplate.htm",
+            "useJSP": false,
+            "jspListTemplate": "listTemplate.jsp",
+            "jspFileTemplate": "articleTemplate.jsp",
+            "cachePackageTagsTrack": 200,
+            "cachePackageTagsStore": 200,
+            "cachePackageTagsRefresh": 60,
+            "cacheTemplatesTrack": 100,
+            "cacheTemplatesStore": 50,
+            "cacheTemplatesRefresh": 15,
+            "cachePagesTrack": 200,
+            "cachePagesStore": 100,
+            "cachePagesRefresh": 10,
+            "cachePagesDirtyRead": 10,
+            "searchEngineListTemplate": "forSearchEnginesList.htm",
+            "searchEngineFileTemplate": "forSearchEngines.htm",
+            "searchEngineRobotsDb": "WEB-INF/robots.db",
+            "useDataStore": true,
+            "dataStoreClass": "org.cofax.SqlDataStore",
+            "redirectionClass": "org.cofax.SqlRedirection",
+            "dataStoreName": "cofax",
+            "dataStoreDriver": "com.microsoft.jdbc.sqlserver.SQLServerDriver",
+            "dataStoreUrl": "jdbc:microsoft:sqlserver://LOCALHOST:1433;DatabaseName=goon",
+            "dataStoreUser": "sa",
+            "dataStorePassword": "dataStoreTestQuery",
+            "dataStoreTestQuery": "SET NOCOUNT ON;select test='test';",
+            "dataStoreLogFile": "/usr/local/tomcat/logs/datastore.log",
+            "dataStoreInitConns": 10,
+            "dataStoreMaxConns": 100,
+            "dataStoreConnUsageLimit": 100,
+            "dataStoreLogLevel": "debug",
+            "maxUrlLength": 500
+        }
+        },
+        {
+        "servlet-name": "cofaxEmail",
+        "servlet-class": "org.cofax.cds.EmailServlet",
+        "init-param": {
+            "mailHost": "mail1",
+            "mailHostOverride": "mail2"
+        }
+        },
+        {
+        "servlet-name": "cofaxAdmin",
+        "servlet-class": "org.cofax.cds.AdminServlet"
+        },
+        {
+        "servlet-name": "fileServlet",
+        "servlet-class": "org.cofax.cds.FileServlet"
+        },
+        {
+        "servlet-name": "cofaxTools",
+        "servlet-class": "org.cofax.cms.CofaxToolsServlet",
+        "init-param": {
+            "templatePath": "toolstemplates/",
+            "log": 1,
+            "logLocation": "/usr/local/tomcat/logs/CofaxTools.log",
+            "logMaxSize": "",
+            "dataLog": 1,
+            "dataLogLocation": "/usr/local/tomcat/logs/dataLog.log",
+            "dataLogMaxSize": "",
+            "removePageCache": "/content/admin/remove?cache=pages&id=",
+            "removeTemplateCache": "/content/admin/remove?cache=templates&id=",
+            "fileTransferFolder": "/usr/local/tomcat/webapps/content/fileTransferFolder",
+            "lookInContext": 1,
+            "adminGroupID": 4,
+            "betaServer": true
+        }
+        }
+    ],
+    "servlet-mapping": {
+        "cofaxCDS": "/",
+        "cofaxEmail": "/cofaxutil/aemail/*",
+        "cofaxAdmin": "/admin/*",
+        "fileServlet": "/static/*",
+        "cofaxTools": "/tools/*"
+    },
+    "taglib": {
+        "taglib-uri": "cofax.tld",
+        "taglib-location": "/WEB-INF/tlds/cofax.tld"
+    }
+    }
+}""",
+    ),
+)
+
+
+def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
+    assert GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_pressure)
 
 
 (input_find_rejected_tokens, expected_rejected_sizes) = tvm.testing.parameters(
@@ -205,6 +335,21 @@ def test_token_based_operations(json_grammar: BNFGrammar):
     result.append(accepted_tokens)
 
     assert result == expected
+
+
+def test_custom_main_rule():
+    json_grammar_ebnf = r"""
+main ::= basic_object
+basic_any ::= basic_string | basic_object
+basic_string ::= (([\"] basic_string_1 [\"]))
+basic_string_1 ::= "" | [^"\\\r\n] basic_string_1 | "\\" escape basic_string_1
+escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+basic_object ::= "{" ("" | ws basic_string ws ":" ws basic_any ( ws "," ws basic_string ws ":" ws basic_any)*) ws "}"
+ws ::= [ \n\t]*
+"""
+    grammar = BNFGrammar.from_ebnf_string(json_grammar_ebnf, "basic_string")
+    assert GrammarStateMatcher(grammar).debug_match_complete_string(r'"abc\r\n"')
+    assert not GrammarStateMatcher(grammar).debug_match_complete_string(r'{"name": "John" }')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR supports specifying the name of the main rule when parsing a grammar, and adds internal support for specifying the main rule in the grammar AST. New interface for parser:

```
    def from_ebnf_string(
        ebnf_string: str,
        main_rule: str = "main",
        normalize: bool = True,
        simplify: bool = True,
    ) -> "BNFGrammar":
        pass
```