### PR TITLE
[Compiler] Support IPC memory and customized all-reduce kernels

### DIFF
--- a/python/mlc_llm/interface/compile.py
+++ b/python/mlc_llm/interface/compile.py
@@ -184,6 +184,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
                     flashinfer=args.opt.flashinfer,
                     cublas_gemm=args.opt.cublas_gemm,
                     faster_transformer=args.opt.faster_transformer,
+                    allreduce_strategy=args.opt.allreduce_strategy,
                     variable_bounds=variable_bounds,
                     additional_tirs=additional_tirs,
                     ext_mods=ext_mods,


### PR DESCRIPTION
This PR introduces the IPC memory and customized all-reduce kernel dispatches for tensor parallelism. We add a new compiler flag `--allreduce-strategy`, which supports `"ring"`, `"one-shot"` and `"two-shot"`. The flag defaults to `"ring"`, which means this PR makes no difference if people do not manually change the all-reduce strategy.

As of now the IPC-memory-backed customized all-reduce kernels are only available on CUDA.

To enable all-reduce strategies other than "ring", here are some example compile commands:
```python
python -m mlc_llm compile model/mlc-chat-config.json --device cuda --opt "allreduce-strategy=one-shot" -o model/lib.so
python -m mlc_llm compile model/mlc-chat-config.json --device cuda --opt "allreduce-strategy=two-shot" -o model/lib.so
```

Please be aware that, you probably also need to specify other compiler flags, for example, like `--opt "cublas_gemm=1;allreduce-strategy=one-shot"`.