### PR TITLE
fix conv_template is None error when it's str in chat config

### DIFF
--- a/python/mlc_llm/chat_module.py
+++ b/python/mlc_llm/chat_module.py
@@ -20,6 +20,7 @@ from mlc_llm.protocol.conversation_protocol import Conversation
 from mlc_llm.support import logging
 from mlc_llm.support.auto_device import detect_device
 from mlc_llm.support.config import ConfigBase
+from mlc_llm.conversation_template import ConvTemplateRegistry
 
 from . import base as _
 
@@ -223,6 +224,8 @@ class ChatConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     def _from_json(cls, json_obj: dict):
         if "conv_template" in json_obj and isinstance(json_obj["conv_template"], dict):
             json_obj["conv_template"] = Conversation.from_json_dict(json_obj["conv_template"])
+        elif isinstance(json_obj["conv_template"], str):
+            json_obj["conv_template"] = ConvTemplateRegistry.get_conv_template(json_obj["conv_template"])
         return cls(**{k: v for k, v in json_obj.items() if k in inspect.signature(cls).parameters})
 
 


### PR DESCRIPTION
Hello,

when running the REST API server:
```
python3 -m mlc_llm.serve.server --model ./dist/gemma-2b-it-q4f16_0-MLC --model-lib-path ~/.cache/mlc_llm/model_lib/22099771f120d6a20bb12c7c39c25bb6.so
```
It throws an assertion error from below code: (in file `mlc_llm/serve/engine.py`, line 100)
```
        if conv_template_name is None:
            assert isinstance(chat_config.conv_template, Conversation)
            conv_template_name = chat_config.conv_template.name
```
where the conv_template of `https://huggingface.co/mlc-ai/gemma-2b-it-q4f16_0-MLC/blob/main/mlc-chat-config.json` is **str**.

This PR will fix this, tested from my local.


Thanks a lot
