### PR TITLE
[Serve] add allocator in Storage as the upstream change

### DIFF
--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -63,8 +63,8 @@ class ModelImpl : public ModelObj {
     memory::Allocator* allocator =
         memory::MemoryManager::GetOrCreateAllocator(device_host, memory::AllocatorType::kNaive);
     ICHECK_NOTNULL(allocator);
-    token_ids_storage_ =
-        memory::Storage(allocator->Alloc(device_host, {prefill_chunk_size_}, DataType::Int(32)), allocator);
+    token_ids_storage_ = memory::Storage(
+        allocator->Alloc(device_host, {prefill_chunk_size_}, DataType::Int(32)), allocator);
     this->logit_pos_arr_ = NDArray::Empty({max_num_sequence}, DataType::Int(32), device_host);
   }
 

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -64,7 +64,7 @@ class ModelImpl : public ModelObj {
         memory::MemoryManager::GetOrCreateAllocator(device_host, memory::AllocatorType::kNaive);
     ICHECK_NOTNULL(allocator);
     token_ids_storage_ =
-        memory::Storage(allocator->Alloc(device_host, {prefill_chunk_size_}, DataType::Int(32)));
+        memory::Storage(allocator->Alloc(device_host, {prefill_chunk_size_}, DataType::Int(32)), allocator);
     this->logit_pos_arr_ = NDArray::Empty({max_num_sequence}, DataType::Int(32), device_host);
   }
 


### PR DESCRIPTION
The changes in https://github.com/apache/tvm/pull/16750 modified the signature of the Storage, this pull request updates the caller code in mlc-llm to accommodate the new Storage class signature. Ran into build error w/o the change.

```
mlc-llm/cpp/serve/model.cc:67:96: error: no matching function for call to ‘tvm::runtime::memory::Storage::Storage(tvm::runtime::memory::Buffer)’
   67 |         memory::Storage(allocator->Alloc(device_host, {prefill_chunk_size_}, DataType::Int(32)));
```
cc: @MasterJH5574 @vinx13 @tqchen