### PR TITLE
[LLaVa] Follow-up for TODOs in LLaVa model

### DIFF
--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -276,6 +276,8 @@ ConvTemplateRegistry.register_conv_template(
         role_empty_sep=":",
         stop_str=["</s>"],
         stop_token_ids=[2],
+        system_prefix_token_ids=[1],
+        add_role_after_system_message=False,
     )
 )
 

--- a/python/mlc_llm/protocol/openai_api_protocol.py
+++ b/python/mlc_llm/protocol/openai_api_protocol.py
@@ -180,7 +180,7 @@ class ChatToolCall(BaseModel):
 
 
 class ChatCompletionMessage(BaseModel):
-    content: Optional[Union[str, List[Dict[str, str]]]] = None
+    content: Optional[Union[str, List[Dict]]] = None
     role: Literal["system", "user", "assistant", "tool"]
     name: Optional[str] = None
     tool_calls: Optional[List[ChatToolCall]] = None

--- a/python/mlc_llm/serve/entrypoints/entrypoint_utils.py
+++ b/python/mlc_llm/serve/entrypoints/entrypoint_utils.py
@@ -98,27 +98,42 @@ def process_prompts(
     return output_prompts
 
 
-def get_image_from_url(url: str):
+def get_image_from_url(url: str, config: Dict) -> data.ImageData:
     """Get the image from the given URL, process and return the image tensor as TVM NDArray."""
 
     # pylint: disable=import-outside-toplevel, import-error
+    import base64
+
     import requests
     import tvm
     from PIL import Image
     from transformers import CLIPImageProcessor
 
-    response = requests.get(url, timeout=5)
-    image_tensor = Image.open(BytesIO(response.content)).convert("RGB")
+    if url.startswith("data:image"):
+        # The image is encoded in base64 format
+        base64_image = url.split(",")[1]
+        image_data = base64.b64decode(base64_image)
+        image_tensor = Image.open(BytesIO(image_data)).convert("RGB")
+    elif url.startswith("http"):
+        response = requests.get(url, timeout=5)
+        image_tensor = Image.open(BytesIO(response.content)).convert("RGB")
+    else:
+        raise ValueError(f"Unsupported image URL format: {url}")
+
+    image_input_size = get_image_input_size(config)
+    image_embed_size = get_image_embed_size(config)
 
     image_processor = CLIPImageProcessor(
-        size={"shortest_edge": 336}, crop_size={"height": 336, "width": 336}
+        size={"shortest_edge": image_input_size},
+        crop_size={"height": image_input_size, "width": image_input_size},
     )
     image_features = tvm.nd.array(
         image_processor.preprocess(image_tensor, return_tensors="np")["pixel_values"].astype(
             "float16"
         )
     )
-    return image_features
+    image_data = data.ImageData(image_features, image_embed_size)
+    return image_data
 
 
 def get_image_embed_size(config: Dict) -> int:
@@ -127,3 +142,9 @@ def get_image_embed_size(config: Dict) -> int:
     patch_size = config["model_config"]["vision_config"]["patch_size"]
     embed_size = (image_size // patch_size) ** 2
     return embed_size
+
+
+def get_image_input_size(config: Dict) -> int:
+    """Get the image input size from the model config file."""
+    image_size = config["model_config"]["vision_config"]["image_size"]
+    return image_size


### PR DESCRIPTION
This is a follow-up PR to #1974 . 
1. Added base64 image support
2. Merged the `as_prompt` and `as_prompt_list` functions in `conversation_protocol.py`
3. `get_image_from_url` uses model config to determine image input size