### PR TITLE
[Fix] Fix KV cache creation pass after nn.Module changes

### DIFF
--- a/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
+++ b/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
@@ -13,7 +13,7 @@ def extract_creation_args(func: relax.Function) -> Dict[str, Any]:
     assert isinstance(func.body, relax.SeqExpr)
     assert len(func.body.blocks) == 1
     assert isinstance(func.body.blocks[0], relax.DataflowBlock)
-    assert len(func.body.blocks[0].bindings) == 2
+    assert len(func.body.blocks[0].bindings) == 1
     assert isinstance(func.body.blocks[0].bindings[0], relax.VarBinding)
     assert isinstance(func.body.blocks[0].bindings[0].value, relax.Call)
     assert func.body.blocks[0].bindings[0].value.op == tvm.ir.Op.get("relax.call_pure_packed")


### PR DESCRIPTION
This PR corrects the assertion after latest changes in apache/tvm that updates some nn.Module behavior.