### PR TITLE
[iOS] Fix typo in prepare_model_lib.py

### DIFF
--- a/ios/prepare_model_lib.py
+++ b/ios/prepare_model_lib.py
@@ -36,7 +36,7 @@ def main():
             raise RuntimeError(
                 f"Cannot find iOS lib for {model} from the following candidate paths: {paths}"
             )
-        tar_list.append(valid_paths[ls0])
+        tar_list.append(valid_paths[0])
         model_set.add(model)
 
     lib_path = os.path.join("build", "lib", "libmodel_iphone.a")


### PR DESCRIPTION
`tar_list.append(valid_paths[ls0])` is introduced by mistake in https://github.com/mlc-ai/mlc-llm/pull/1993, which fails the prepare_libs.sh with error: 

```
ios/prepare_model_lib.py", line 39, in main
    tar_list.append(valid_paths[ls0])
                                ^^^
NameError: name 'ls0' is not defined
```