### PR TITLE
[Serving][Fix] Fix problems in PopenServer

### DIFF
--- a/python/mlc_llm/serve/server/popen_server.py
+++ b/python/mlc_llm/serve/server/popen_server.py
@@ -1,4 +1,5 @@
 """The MLC LLM server launched in a subprocess."""
+
 import subprocess
 import sys
 import time
@@ -64,13 +65,17 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         openai_v1_models_url = "http://127.0.0.1:8000/v1/models"
         query_result = None
         timeout = 60
-        attempts = 0
+        attempts = 0.0
         while query_result is None and attempts < timeout:
             try:
                 query_result = requests.get(openai_v1_models_url, timeout=60)
+                if query_result.status_code != 200:
+                    query_result = None
+                    attempts += 0.1
+                    time.sleep(0.1)
             except:  # pylint: disable=bare-except
-                attempts += 1
-                time.sleep(1)
+                attempts += 0.1
+                time.sleep(0.1)
 
         # Check if the subprocess terminates unexpectedly or
         # the queries reach the timeout.
@@ -117,3 +122,12 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         except subprocess.TimeoutExpired:
             pass
         self._proc = None
+
+    def __enter__(self):
+        """Start the server."""
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Terminate the server."""
+        self.terminate()

--- a/tests/python/serve/server/conftest.py
+++ b/tests/python/serve/server/conftest.py
@@ -28,8 +28,6 @@ def launch_server(served_model):  # pylint: disable=redefined-outer-name
         model_lib_path=served_model[1],
         enable_tracing=True,
     )
-    server.start()
-    yield
 
-    # Fixture teardown code.
-    server.terminate()
+    with server:
+        yield


### PR DESCRIPTION
This PR fixes several problems in the PopenServer:
- Add check for the server is not started and the request returns a fail number, e.g. 502. And changed the retry time to 0.1s.
- Add a `__enter__` and `__exit__` method for PopenServer. When the program is interrupted, using `with` clause (`__enter__` and `__exit__`) can ensure the server always terminates. When using `start()` and `terminate()`, the server  may still be staying in the background even though the parent process ends.


cc @MasterJH5574 