### PR TITLE
[Compiler] Support AUTO mode for all-reduce strategy

### DIFF
--- a/python/mlc_llm/compiler_pass/pipeline.py
+++ b/python/mlc_llm/compiler_pass/pipeline.py
@@ -9,7 +9,7 @@ from tvm import dlight as dl
 from tvm.relax import register_pipeline  # pylint: disable=no-name-in-module
 from tvm.relax.frontend import nn
 
-from mlc_llm.interface.compiler_flags import AllReduceStrategyType
+from mlc_llm.interface.compiler_flags import IPCAllReduceStrategyType
 from mlc_llm.support import logging
 
 from .attach_embedding_allocator import AttachAllocEmbeddingTensorFunc
@@ -76,7 +76,7 @@ def _mlc_llm_pipeline(  # pylint: disable=too-many-arguments
     flashinfer: bool = False,
     cublas_gemm: bool = False,
     faster_transformer: bool = False,  # pylint: disable=unused-argument
-    allreduce_strategy: AllReduceStrategyType = AllReduceStrategyType.RING,
+    allreduce_strategy: IPCAllReduceStrategyType = IPCAllReduceStrategyType.NONE,
     variable_bounds: Dict[str, int] = None,
     additional_tirs: Dict[str, tvm.tir.PrimFunc] = None,
     metadata: Dict[str, Any] = None,
@@ -151,7 +151,7 @@ def _mlc_llm_pipeline(  # pylint: disable=too-many-arguments
                 tvm.relax.transform.CallTIRRewrite(),
                 (
                     tvm.relax.transform.IPCAllReduceRewrite(allreduce_strategy)
-                    if allreduce_strategy != AllReduceStrategyType.RING
+                    if allreduce_strategy != IPCAllReduceStrategyType.NONE
                     else tvm.transform.Sequential([])
                 ),
                 tvm.relax.transform.StaticPlanBlockMemory(),

--- a/python/mlc_llm/interface/compile.py
+++ b/python/mlc_llm/interface/compile.py
@@ -184,7 +184,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
                     flashinfer=args.opt.flashinfer,
                     cublas_gemm=args.opt.cublas_gemm,
                     faster_transformer=args.opt.faster_transformer,
-                    allreduce_strategy=args.opt.allreduce_strategy,
+                    allreduce_strategy=args.opt.ipc_allreduce_strategy,
                     variable_bounds=variable_bounds,
                     additional_tirs=additional_tirs,
                     ext_mods=ext_mods,


### PR DESCRIPTION
This PR supports the auto mode for IPC all-reduce strategy. It renames the strategy from `allreduce-strategy` to `ipc-allreduce-strategy` in the compiler optimization flags. The default RING mode is renamed to NONE mode, which, when specified, uses nccl all-reduce without any IPC memory rewrite.

So right now to enable IPC all-reduce, the ideal way is to do `ipc-allreduce-strategy=auto`.