### PR TITLE
[Pipeline] Defer GPU IPC memory lowering

### DIFF
--- a/python/mlc_llm/compiler_pass/pipeline.py
+++ b/python/mlc_llm/compiler_pass/pipeline.py
@@ -155,9 +155,9 @@ def _mlc_llm_pipeline(  # pylint: disable=too-many-arguments
                     else tvm.transform.Sequential([])
                 ),
                 tvm.relax.transform.StaticPlanBlockMemory(),
-                tvm.relax.transform.LowerGPUIPCAllocStorage(),
                 AttachMetadataWithMemoryUsage(metadata),
                 tvm.relax.transform.RewriteCUDAGraph(),
+                tvm.relax.transform.LowerGPUIPCAllocStorage(),
                 tvm.relax.transform.LowerAllocTensor(),
                 tvm.relax.transform.KillAfterLastUse(),
                 tvm.relax.transform.VMBuiltinLower(),


### PR DESCRIPTION
This PR moves the position of GPU IPC memory lowering pass in pipeline, so that it applies after the CUDA graph rewrite to enable CUDA graph with the customized all-reduce kernels.