### PR TITLE
[Model] Skip TVMSynchronize when tracing is not enabled

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -72,7 +72,8 @@ class EngineImpl : public Engine {
       String model_path = std::get<1>(model_info);
       DLDevice device = std::get<2>(model_info);
       Model model = Model::Create(model_lib, std::move(model_path), device,
-                                  kv_cache_config_->max_num_sequence);
+                                  kv_cache_config_->max_num_sequence,
+                                  /*trace_enabled=*/trace_recorder.defined());
       model->CreateKVCache(this->kv_cache_config_);
       CHECK_GE(model->GetMaxWindowSize(), this->max_single_sequence_length_)
           << "The window size of the model, " << model->GetMaxWindowSize()

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -206,10 +206,11 @@ class Model : public ObjectRef {
    * \param model_path The path to the model weight parameters.
    * \param device The device to run the model on.
    * \param max_num_sequence The maximum number of sequences to be processed
+   * \param trace_enabled A boolean indicating whether tracing is enabled.
    * \return The created runtime module.
    */
   TVM_DLL static Model Create(TVMArgValue reload_lib, String model_path, DLDevice device,
-                              int max_num_sequence);
+                              int max_num_sequence, bool trace_enabled);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Model, ObjectRef, ModelObj);
 };


### PR DESCRIPTION
This PR removes the synchronization in `Model` when Chrome tracing is not enabled. It can help some logit process kernels launching earlier.