### PR TITLE
[Disco] Set worker CPU affinity with env variable

### DIFF
--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2023 by Contributors
+ * \file utils.h
+ * \brief Utility functions.
+ */
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace mlc {
+namespace llm {
+
+inline std::vector<std::string> Split(const std::string& str, char delim) {
+  std::string item;
+  std::istringstream is(str);
+  std::vector<std::string> ret;
+  while (std::getline(is, item, delim)) {
+    ret.push_back(item);
+  }
+  return ret;
+}
+
+}  // namespace llm
+}  // namespace mlc


### PR DESCRIPTION
This PR enables setting the CPU affinity of disco workers in MLC, following the support in apache/tvm#16807. The purpose is to try reduce the CPU core switch overhead brought to disco workers which may cause extra bubble times in disco workers before/during tasks.

We use a macro `MLC_DISCO_WORKER_CPU_BINDING` to specify the CPU affinities of workers. This is by default not used. To enable it, you can run the command like

```shell
MLC_DISCO_WORKER_CPU_BINDING=64,65,66,67 python some_mlc_app.py
```

to specify the four CPU core ids for the four workers.