### PR TITLE
[Serving] Support NVTX for benchmarking

### DIFF
--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -6,6 +6,7 @@
 #include "logit_processor.h"
 
 #include <picojson.h>
+#include <tvm/runtime/nvtx.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/threading_backend.h>
@@ -69,6 +70,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
                            const Array<String>& request_ids,               //
                            const std::vector<int>* cum_num_token,          //
                            const std::vector<std::vector<SampleResult>>* draft_tokens) final {
+    NVTXScopedRange nvtx_scope("Logit inplace update");
     CHECK_EQ(logits->ndim, 2);
     CHECK_EQ(logits->shape[1], vocab_size_);
     CHECK(logits.DataType() == DataType::Float(32));
@@ -109,6 +111,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
   NDArray ComputeProbsFromLogits(NDArray logits, const Array<GenerationConfig>& generation_cfg,
                                  const Array<String>& request_ids,
                                  const std::vector<int>* cum_num_token) final {
+    NVTXScopedRange nvtx_scope("Compute probs from logits");
     // logits: (n, v)
     CHECK_EQ(logits->ndim, 2);
     CHECK_LE(logits->shape[0], max_num_token_);

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -7,6 +7,7 @@
 
 #include <picojson.h>
 #include <tvm/runtime/memory/memory_manager.h>
+#include <tvm/runtime/nvtx.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>
 
@@ -71,13 +72,18 @@ class ModelImpl : public ModelObj {
   /*********************** Model Computation  ***********************/
 
   ObjectRef TokenEmbed(IntTuple token_ids, ObjectRef* dst, int offset) final {
+    NVTXScopedRange nvtx_scope("TokenEmbed");
     int num_tokens = token_ids.size();
     // Copy input token ids to device.
     DLDataType dtype(DataType::Int(32));
-    NDArray token_ids_nd = token_ids_storage_->AllocNDArray(offset * 4, {num_tokens}, dtype);
-    int* p_token_ids = static_cast<int*>(token_ids_nd->data) + (token_ids_nd->byte_offset) / 4;
-    for (int i = 0; i < num_tokens; ++i) {
-      p_token_ids[i] = token_ids[i];
+    NDArray token_ids_nd;
+    {
+      NVTXScopedRange nvtx_scope("Allocate token_ids at offset");
+      token_ids_nd = token_ids_storage_->AllocNDArray(offset * 4, {num_tokens}, dtype);
+      int* p_token_ids = static_cast<int*>(token_ids_nd->data) + (token_ids_nd->byte_offset) / 4;
+      for (int i = 0; i < num_tokens; ++i) {
+        p_token_ids[i] = token_ids[i];
+      }
     }
     ICHECK_EQ(token_ids_nd->ndim, 1);
     ICHECK_EQ(token_ids_nd->shape[0], num_tokens);
@@ -95,6 +101,7 @@ class ModelImpl : public ModelObj {
   }
 
   ObjectRef ImageEmbed(const NDArray& image, ObjectRef* dst, int offset) final {
+    NVTXScopedRange nvtx_scope("ImageEmbed");
     CHECK(ft_.image_embed_func_.defined()) << "`image_embed` function is not found in the model. ";
     auto image_dref_or_nd = ft_.CopyToWorker0(image, "image", image.Shape());
     ObjectRef embeddings = ft_.image_embed_func_(image_dref_or_nd, params_);
@@ -110,6 +117,7 @@ class ModelImpl : public ModelObj {
 
   NDArray BatchPrefill(const ObjectRef& embeddings, const std::vector<int64_t>& seq_ids,
                        const std::vector<int>& lengths) final {
+    NVTXScopedRange nvtx_scope("BatchPrefill");
     CHECK(!seq_ids.empty());
     CHECK_EQ(seq_ids.size(), lengths.size());
     int num_sequences = seq_ids.size();
@@ -177,6 +185,7 @@ class ModelImpl : public ModelObj {
   }
 
   NDArray BatchDecode(const ObjectRef& embeddings, const std::vector<int64_t>& seq_ids) final {
+    NVTXScopedRange nvtx_scope("BatchDecode");
     int num_sequence = seq_ids.size();
 
     CHECK(ft_.decode_func_.defined())
@@ -235,6 +244,7 @@ class ModelImpl : public ModelObj {
 
   NDArray BatchVerify(const ObjectRef& embeddings, const std::vector<int64_t>& seq_ids,
                       const std::vector<int>& lengths) final {
+    NVTXScopedRange nvtx_scope("BatchVerify");
     CHECK(!seq_ids.empty());
     CHECK_EQ(seq_ids.size(), lengths.size());
     int num_sequences = seq_ids.size();

--- a/cpp/serve/sampler/gpu_sampler.cc
+++ b/cpp/serve/sampler/gpu_sampler.cc
@@ -4,6 +4,7 @@
  * \brief The implementation for GPU sampler functions.
  */
 #include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/nvtx.h>
 #include <tvm/runtime/packed_func.h>
 
 #include "../../random.h"
@@ -61,6 +62,7 @@ class GPUSampler : public SamplerObj {
                                               const Array<GenerationConfig>& generation_cfg,  //
                                               const std::vector<RandomGenerator*>& rngs,      //
                                               std::vector<NDArray>* output_prob_dist) final {
+    NVTXScopedRange nvtx_scope("BatchSampleTokens");
     // probs_on_device: (n, v)
     RECORD_EVENT(trace_recorder_, request_ids, "start sampling");
     CHECK_EQ(probs_on_device->ndim, 2);


### PR DESCRIPTION
This PR supports MLC serve with NVTX which helps analyzing benchmarking results.

**Note.** To enable NVTX, please add `set(USE_NVTX ON)` to file `build/config.cmake`.