### PR TITLE
[LLaVa] Fix random token output after first sentence

### DIFF
--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -284,7 +284,7 @@ ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="llava",
         system_template=f"{MessagePlaceholders.SYSTEM.value}",
-        system_message="",
+        system_message="\n",
         roles={"user": "USER", "assistant": "ASSISTANT"},
         seps=[" "],
         role_content_sep=": ",


### PR DESCRIPTION
This PR fixes a bug in LLaVa which used to output a random token after the first `.` token (i.e. after the end of the first sentence). 
In the [HF reference](https://huggingface.co/docs/transformers/en/model_doc/llava), there is supposed to be a newline (`\n`) between the image and the prompt. It turns out having a newline anywhere in the prompt fixes this issue. So passing it as part of the system prompt.