### PR TITLE
Implement testing.DebugChat for end-to-end model debugging in Python

### DIFF
--- a/python/mlc_llm/testing/__init__.py
+++ b/python/mlc_llm/testing/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test and debug tools for MLC LLM
+"""

--- a/python/mlc_llm/testing/debug_chat.py
+++ b/python/mlc_llm/testing/debug_chat.py
@@ -1,0 +1,459 @@
+"""Debug compiled models with TVM instrument"""
+
+import json
+import random
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import tvm
+from tvm import relax
+from tvm.contrib import tvmjs
+from tvm.runtime import Device, Module, Object, ShapeTuple
+from tvm.runtime.relax_vm import VirtualMachine
+
+from mlc_llm.chat_module import (
+    ChatConfig,
+    GenerationConfig,
+    _get_chat_config,
+    _get_generation_config,
+    _get_model_path,
+)
+from mlc_llm.conversation_template import ConvTemplateRegistry
+from mlc_llm.help import HELP
+from mlc_llm.serve.entrypoints import entrypoint_utils
+from mlc_llm.support.argparse import ArgumentParser
+from mlc_llm.support.auto_device import detect_device
+from mlc_llm.support.style import green, red
+from mlc_llm.tokenizer import Tokenizer
+
+
+def _extract_metadata(mod: Module):
+    return json.loads(VirtualMachine(mod, tvm.runtime.device("cpu"))["_metadata"]())
+
+
+def _load_params(
+    model_weight_path: str, device: Device, model_metadata: Dict[str, Any]
+) -> List[tvm.nd.NDArray]:
+    params, meta = tvmjs.load_ndarray_cache(model_weight_path, device)
+    param_names = [param["name"] for param in model_metadata["params"]]
+    assert len(param_names) == meta["ParamSize"]
+
+    plist = []
+    for param_name in param_names:
+        plist.append(params[param_name])
+    return plist
+
+
+def _get_tvm_module(
+    model_weight_path: str, lib_path: str, device: Device, instrument: tvm.runtime.PackedFunc
+):
+    ex = tvm.runtime.load_module(lib_path)
+    vm = relax.VirtualMachine(ex, device)
+    vm.set_instrument(instrument)
+    metadata = _extract_metadata(ex)
+    params = _load_params(model_weight_path, device, metadata)
+    return vm.module, params, metadata
+
+
+class DefaultDebugInstrument:
+    """The default debug instrument to use if users don't specify
+    a customized one.
+
+    This debug instrument will dump the arguments and output of each
+    VM Call instruction into a .npz file. It will also alert the user
+    if any function outputs are NaN or INF.
+    """
+
+    def __init__(self, debug_out: Path):
+        """Constructor
+
+        Parameters
+        ----------
+        debug_out : Path
+            the directory to dump the .npz files
+        """
+        self.counter = 0
+        self.first_nan_occurred = False
+        self.first_inf_occurred = False
+        self.debug_out = debug_out
+        debug_out.mkdir(exist_ok=True, parents=True)
+
+    def reset(self, debug_out: Path):
+        """Reset the state of the Instrument class
+
+        Parameters
+        ----------
+        debug_out : Path
+            the directory to dump the .npz files
+        """
+        self.counter = 0
+        self.first_nan_occurred = False
+        self.first_inf_occurred = False
+        self.debug_out = debug_out
+        debug_out.mkdir(exist_ok=True, parents=True)
+
+    def __call__(self, func, name, before_run, ret_val, *args):
+        # Determine what functions to look at
+        if before_run:  # Whether before the function is called or after
+            return
+        if self.first_nan_occurred:
+            return
+        if self.first_inf_occurred:
+            return
+        if name.startswith("vm.builtin.") and "attention_with_fused_qkv" not in name:
+            return
+
+        # Decide what to print or save about the function's arguments (where args[-1] is the
+        # buffer we write the result to)
+        func_name = f"f{self.counter}_{name}"
+
+        # Write your own behavior below. For example, we can count the number of INF/NaN in args[-1]
+        num_nans = np.sum(np.isnan(args[-1].numpy()))
+        num_infs = np.sum(np.isinf(args[-1].numpy()))
+        if num_nans > 0:
+            print(f"{red(f'{func_name} has NaN')}: {num_nans}")
+            self.first_nan_occurred = True
+        if num_infs > 0:
+            print(f"{red(f'{func_name} has INF')}: {num_infs}")
+            self.first_inf_occurred = True
+
+        # Save the the arguments to npz
+        arg_dict = {}
+        for i, arg in enumerate(args):
+            if isinstance(arg, tvm.nd.NDArray):
+                arg_dict[f"arg_{i}"] = arg.numpy()
+
+        np.savez(self.debug_out / f"{func_name}.npz", **arg_dict)
+
+        self.counter += 1
+
+
+class DebugChat:  # pylint: disable=too-many-instance-attributes, too-few-public-methods
+    """A chat interface used only for debugging purpose.
+
+    It debugs autoregressive decoding fully in Python via the prefill and
+    decode interface. It supports debugging instrument (either default or
+    customized) to dump intermediate values for each VM function call.
+
+    Given a prompt, it also prints out the parsed prompt, input tokens, output
+    tokens and output text.
+
+    Sample usage:
+
+    dc = DebugChat(
+        model="./dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
+        debug_dir=Path("./debug-llama-2"),
+        model_lib_path="./dist/llama-2-7b-chat-q4f16_1-metal.so",
+    )
+    dc.generate("hello world", 3)
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        model: str,
+        model_lib_path: str,
+        debug_dir: Path,
+        device: Optional[str] = "auto",
+        chat_config: Optional[ChatConfig] = None,
+        debug_instrument: Optional[Any] = None,
+    ):
+        """_summary_
+
+        Parameters
+        ----------
+        model: str
+            The model folder after compiling with MLC-LLM build process. The parameter
+            can either be the model name with its quantization scheme
+            (e.g. ``Llama-2-7b-chat-hf-q4f16_1``), or a full path to the model
+            folder. In the former case, we will use the provided name to search
+            for the model folder over possible paths.
+
+        model_lib_path : str
+            The full path to the model library file to use (e.g. a ``.so`` file).
+
+        debug_dir: Path
+            The output folder to store the dumped debug files.
+
+        device : Optional[str]
+            The description of the device to run on. User should provide a string in the
+            form of 'device_name:device_id' or 'device_name', where 'device_name' is one of
+            'cuda', 'metal', 'vulkan', 'rocm', 'opencl', 'auto' (automatically detect the
+            local device), and 'device_id' is the device id to run on. If no 'device_id'
+            is provided, it will be set to 0 by default.
+
+        chat_config : Optional[ChatConfig]
+            A ``ChatConfig`` instance partially filled. Will be used to override the
+            ``mlc-chat-config.json``.
+
+        debug_instrument : Optional[Any]
+            An instrument function that will be called before/after each Call instruction.
+            The function have the following signature:
+
+            .. code:: python
+
+                def instrument(
+                    func: Union[VMClosure, PackedFunc],
+                    func_symbol: str,
+                    before_run: bool,
+                    ret_value: any,
+                    *args) -> bool:
+                    pass
+
+            The instrument takes the following parameters:
+            - func: function object to be called.
+            - func_symbol: the symbol name of the function.
+            - before_run: whether it is before or after call.
+            - ret_value: the return value of the call, only valid after run.
+            - args: the arguments being passed to call.
+        """
+        self.debug_dir = debug_dir
+        self.device = detect_device(device)
+        self.instrument = (
+            debug_instrument if debug_instrument else DefaultDebugInstrument(debug_dir / "prefill")
+        )
+        self.mod, self.params, self.metadata = _get_tvm_module(
+            model, model_lib_path, self.device, self.instrument
+        )
+        self.model_path, self.config_file_path = _get_model_path(model)
+        self.chat_config = _get_chat_config(self.config_file_path, chat_config)
+        conv_template = self.chat_config.conv_template
+        self.conversation = (
+            ConvTemplateRegistry.get_conv_template(conv_template)
+            if isinstance(conv_template, str)
+            else conv_template
+        )
+        self.tokenizer = Tokenizer(self.model_path)
+
+        self.add_sequence_func = tvm.get_global_func("vm.builtin.kv_state_add_sequence")
+        self.begin_forward_func = tvm.get_global_func("vm.builtin.kv_state_begin_forward")
+        self.end_forward_func = tvm.get_global_func("vm.builtin.kv_state_end_forward")
+        self.nd_view_func = tvm.get_global_func("vm.builtin.reshape")
+        self.sample_topp_from_prob_func = tvm.get_global_func("vm.builtin.sample_top_p_from_prob")
+
+        try:
+            self.embed_func = self.mod["embed"]
+        except AttributeError as exc:
+            raise RuntimeError("DebugChat only supports separate embedding layer") from exc
+
+        self.prefill_func = self.mod["prefill"]
+        self.decode_func = self.mod["decode"]
+        self.create_kv_cache_func = None
+        if self.mod.implements_function("create_flashinfer_paged_kv_cache"):
+            self.create_kv_cache_func = self.mod["create_flashinfer_paged_kv_cache"]
+        elif self.mod.implements_function("create_tir_paged_kv_cache"):
+            self.create_kv_cache_func = self.mod["create_tir_paged_kv_cache"]
+        else:
+            # TODO: Support RNN KVState # pylint: disable=fixme
+            raise RuntimeError("DebugChat cannot find create KV cache function")
+
+        self.appeared_token_freq: Dict[int, int] = {}
+
+    def _tokenize(self, prompt: str) -> tvm.nd.array:
+        print("======================= Starts Tokenization & Embedding =======================")
+        # Step 0. Generate prompt string using conversation template
+        self.conversation.messages.append(("user", prompt))
+        self.conversation.messages.append(("assistant", None))
+        with open(self.config_file_path, "r", encoding="utf-8") as file:
+            config = json.load(file)
+        parsed_prompt = self.conversation.as_prompt(config)
+        print(
+            "Parsed prompt using conversation template "
+            f"{green(self.conversation.name)}: {parsed_prompt}"
+        )
+        tokens = entrypoint_utils.process_prompts(parsed_prompt, self.tokenizer.encode)
+
+        # TODO: Handle ImageData in DebugChat # pylint: disable=fixme
+        assert len(tokens) == 1, "DebugChat will only handle TextData for now"
+        if self.conversation.system_prefix_token_ids is not None:
+            tokens[0] = self.conversation.system_prefix_token_ids + tokens[0]
+
+        tokens = tvm.nd.array(np.array(tokens[0]).astype("int32"), device=self.device)
+        return tokens
+
+    def _embed(self, tokens: tvm.nd.array) -> Tuple[tvm.nd.NDArray, int]:
+        input_len = tokens.shape[0]
+        embedding = self.embed_func(tokens, self.params)
+        embedding = self.nd_view_func(embedding, ShapeTuple([1, input_len, embedding.shape[1]]))
+        return embedding, input_len
+
+    def _prefill(self, embedding: tvm.nd.NDArray, input_len: int):
+        print("======================= Starts Prefill =======================")
+        seq_len_shape = ShapeTuple([input_len])
+        max_num_sequence = 1
+        page_size = 16
+        sliding_window_size = (
+            self.chat_config.sliding_window_size
+            if self.chat_config.sliding_window_size
+            else self.metadata["sliding_window_size"]
+        )
+        context_window_size = (
+            self.chat_config.context_window_size
+            if self.chat_config.context_window_size
+            else self.metadata["context_window_size"]
+        )
+        prefill_chunk_size = (
+            self.chat_config.prefill_chunk_size
+            if self.chat_config.prefill_chunk_size
+            else self.metadata["prefill_chunk_size"]
+        )
+        max_total_sequence_length = (
+            sliding_window_size if context_window_size == -1 else context_window_size
+        )
+        support_sliding_window = int(sliding_window_size != -1)
+
+        kv_caches = self.create_kv_cache_func(
+            ShapeTuple([max_num_sequence]),
+            ShapeTuple([max_total_sequence_length]),
+            ShapeTuple([prefill_chunk_size]),
+            ShapeTuple([page_size]),
+            ShapeTuple([support_sliding_window]),
+        )
+        self.add_sequence_func(kv_caches, 0)
+        self.begin_forward_func(kv_caches, ShapeTuple([0]), seq_len_shape)
+        logits, kv_caches = self.prefill_func(embedding, kv_caches, self.params)
+        self.end_forward_func(kv_caches)
+        return logits, kv_caches
+
+    def _decode(self, token: int, kv_caches: Object):
+        embedding, _ = self._embed(
+            tvm.nd.array(np.array([token]).astype("int32"), device=self.device)
+        )
+        self.begin_forward_func(kv_caches, ShapeTuple([0]), ShapeTuple([1]))
+        logits, kv_caches = self.decode_func(embedding, kv_caches, self.params)
+        self.end_forward_func(kv_caches)
+        return logits
+
+    def _softmax_with_temperature(self, logits: np.ndarray, temperature: float):
+        # Adjust logits based on the temperature
+        logits = np.array(logits) / temperature
+        logits -= np.max(logits, axis=-1, keepdims=True)
+
+        exp_logits = np.exp(logits, logits)
+        exp_logits /= np.sum(exp_logits, axis=-1, keepdims=True)
+        return exp_logits
+
+    def _apply_presence_and_freq_penalty(
+        self, logits: np.ndarray, presence_penalty: float, freq_penalty: float
+    ):
+        for token_id, freq in self.appeared_token_freq.items():
+            logits[:, :, token_id] -= freq * freq_penalty + presence_penalty
+
+    def _sample_token_from_logits(
+        self, logits: tvm.nd.NDArray, generation_config: GenerationConfig
+    ):
+        logits_np = logits.numpy()
+        temperature = generation_config.temperature if generation_config.temperature else 1.0
+        top_p = generation_config.top_p if generation_config.top_p else 0.95
+        presence_penalty = generation_config.presence_penalty
+        frequency_penalty = generation_config.frequency_penalty
+
+        if presence_penalty != 0.0 or frequency_penalty != 0.0:
+            self._apply_presence_and_freq_penalty(logits_np, presence_penalty, frequency_penalty)
+
+        self._softmax_with_temperature(logits_np, temperature)
+        logits = logits.copyfrom(logits_np)
+        next_token = self.sample_topp_from_prob_func(logits, top_p, random.random())
+        return next_token
+
+    def generate(
+        self,
+        prompt: str,
+        generate_length: int,
+        generation_config: Optional[GenerationConfig] = None,
+    ):
+        """Generates the response from the model given a user prompt. User will need to
+        specify the generation length for debugging purpose. For example, a generation
+        length of 3 will include 1 prefill step and 2 decode steps.
+
+        Parameters
+        ----------
+        prompt : str
+            The user input prompt.
+
+        generate_length : int
+            How many tokens to generate.
+
+        generation_config : Optional[GenerationConfig]
+            Will be used to override the GenerationConfig in ``mlc-chat-config.json``.
+        """
+        out_tokens = []
+
+        input_tokens = self._tokenize(prompt)
+        print(f"{green('Input tokens')}: {input_tokens.numpy()}")
+        embedding, input_len = self._embed(input_tokens)
+        logits, kv_caches = self._prefill(embedding, input_len)
+        generation_config = _get_generation_config(self.chat_config, generation_config)
+        next_token = self._sample_token_from_logits(logits, generation_config)
+        out_tokens.append(next_token)
+        path_str = (self.debug_dir / "prefill").as_posix()
+        print(f"Debug instrument output dumped to {green(path_str)}")
+
+        print("======================= Starts Decode =======================")
+        for i in range(generate_length - 1):
+            self.instrument.reset(self.debug_dir / f"decode_{i}")
+            logits = self._decode(next_token, kv_caches)
+            generation_config = _get_generation_config(self.chat_config, generation_config)
+            next_token = self._sample_token_from_logits(logits, generation_config)
+            out_tokens.append(next_token)
+            path_str = (self.debug_dir / f"decode_{i}").as_posix()
+            print(f"Debug instrument output dumped to {green(path_str)}")
+
+            if next_token in self.conversation.stop_token_ids:
+                break
+
+        print(f"{green('Generated output tokens')}: {np.array(out_tokens)}")
+
+        out_text = self.tokenizer.decode(out_tokens)
+        print(f"{green('Generated output text')}: {out_text}")
+
+
+def main():
+    """The main function to start a DebugChat CLI"""
+
+    parser = ArgumentParser("MLC LLM Chat Debug Tool")
+    parser.add_argument(
+        "prompt",
+        type=str,
+        help="The user input prompt.",
+    )
+    parser.add_argument(
+        "--generate-len", type=int, help="Number of output tokens to generate.", required=True
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        help="An MLC model directory that contains `mlc-chat-config.json`",
+        required=True,
+    )
+    parser.add_argument(
+        "--model-lib-path",
+        type=str,
+        help="The full path to the model library file to use (e.g. a ``.so`` file).",
+        required=True,
+    )
+    parser.add_argument(
+        "--debug-dir",
+        type=str,
+        help="The output folder to store the dumped debug files.",
+        required=True,
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="auto",
+        help=HELP["device_compile"] + ' (default: "%(default)s")',
+    )
+    parsed = parser.parse_args()
+    dc = DebugChat(
+        model=parsed.model,
+        model_lib_path=parsed.model_lib_path,
+        debug_dir=Path(parsed.debug_dir),
+        device=parsed.device,
+    )
+
+    dc.generate(parsed.prompt, parsed.generate_len)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR implements `testing.DebugChat` for end-to-end model debugging in Python.
- It debugs autoregressive decoding fully in Python via the `prefill` and `decode` interface. 
- It supports debugging instrument (either default or customized) to dump intermediate values for each VM function call.
- Given a prompt, it also prints out the parsed prompt, input tokens, output tokens and output text.
- The default instrument will dump intermediate values of all VM function calls into .npz files, and also alert user about `NaN` or `INF` values in the outputs.
- Also add a simple CLI for quick debugging.

Example usage (under ROOT/python):
```
$ python mlc_llm/testing/debug_chat.py "hello there" --generate-len 3 --model ../dist/Llama-2-7b-chat-hf-q4f16_1-MLC --model-lib-path ../dist/libs/llama-2-7b-chat-q4f16_1-metal.so --debug-dir ../debug-llama
[2024-03-30 01:03:58] INFO auto_device.py:85: Not found device: cuda:0
[2024-03-30 01:03:59] INFO auto_device.py:85: Not found device: rocm:0
[2024-03-30 01:03:59] INFO auto_device.py:76: Found device: metal:0
[2024-03-30 01:04:00] INFO auto_device.py:85: Not found device: vulkan:0
[2024-03-30 01:04:00] INFO auto_device.py:85: Not found device: opencl:0
[2024-03-30 01:04:00] INFO auto_device.py:33: Using device: metal:0
[2024-03-30 01:04:01] INFO chat_module.py:379: Using model folder: /Users/cfruan/Documents/mlc-llm-repos/mlc-llm-head/dist/Llama-2-7b-chat-hf-q4f16_1-MLC
[2024-03-30 01:04:01] INFO chat_module.py:380: Using mlc chat config: /Users/cfruan/Documents/mlc-llm-repos/mlc-llm-head/dist/Llama-2-7b-chat-hf-q4f16_1-MLC/mlc-chat-config.json
======================= Starts Tokenization & Embedding =======================
Parsed prompt using conversation template llama-2: ['[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n hello there [/INST] ']
Input tokens: [    1   518 25580 29962  3532 14816 29903  6778    13  3492   526   263
  8444 29892  3390  1319   322 15993 20255 29889    13 29966   829 14816
 29903  6778    13    13 22172   727   518 29914 25580 29962 29871]
======================= Starts Prefill =======================
Debug instrument output dumped to ../debug-llama/prefill
======================= Starts Decode =======================
Debug instrument output dumped to ../debug-llama/decode_0
Debug instrument output dumped to ../debug-llama/decode_1
Generated output tokens: [15043   727 29991]
Generated output text: Hello there!
```

Recommend to install VSCode plugin: `vscode-pydata-viewer` to check the dumped `.npz` files in the output folder.

<img width="1218" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/22135348/6244fd42-7d65-4a12-bc85-6ac4186c26e7">
