### PR TITLE
[WebGPU] Add mlc wasm runtime, support grammar in web

### DIFF
--- a/ci/task/test_model_compile.sh
+++ b/ci/task/test_model_compile.sh
@@ -21,8 +21,9 @@ elif [[ ${GPU} == wasm* ]]; then
 	TARGET=wasm
 	pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 	export TVM_HOME=$(dirname $(python -c 'import tvm; print(tvm.__file__)'))
+	export MLC_LLM_HOME=$(dirname $(python -c 'import mlc_llm; print(mlc_llm.__file__)'))
 	cd $TVM_HOME/web/ && make -j${NUM_THREADS} && cd -
-	cd web/ && make -j${NUM_THREADS} && cd -
+	cd $MLC_LLM_HOME/web/ && make -j${NUM_THREADS} && cd -
 elif [[ ${GPU} == ios ]]; then
 	TARGET=ios
 	pip install --pre -U --force-reinstal -f https://mlc.ai/wheels mlc-ai-nightly

--- a/ci/task/test_model_compile.sh
+++ b/ci/task/test_model_compile.sh
@@ -22,6 +22,7 @@ elif [[ ${GPU} == wasm* ]]; then
 	pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 	export TVM_HOME=$(dirname $(python -c 'import tvm; print(tvm.__file__)'))
 	cd $TVM_HOME/web/ && make -j${NUM_THREADS} && cd -
+	cd web/ && make -j${NUM_THREADS} && cd -
 elif [[ ${GPU} == ios ]]; then
 	TARGET=ios
 	pip install --pre -U --force-reinstal -f https://mlc.ai/wheels mlc-ai-nightly

--- a/ci/task/test_model_compile.sh
+++ b/ci/task/test_model_compile.sh
@@ -21,7 +21,7 @@ elif [[ ${GPU} == wasm* ]]; then
 	TARGET=wasm
 	pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 	export TVM_HOME=$(dirname $(python -c 'import tvm; print(tvm.__file__)'))
-	export MLC_LLM_HOME=$(dirname $(python -c 'import mlc_llm; print(mlc_llm.__file__)'))
+	export MLC_LLM_HOME=$(pwd)
 	cd $TVM_HOME/web/ && make -j${NUM_THREADS} && cd -
 	cd $MLC_LLM_HOME/web/ && make -j${NUM_THREADS} && cd -
 elif [[ ${GPU} == ios ]]; then

--- a/docs/install/emcc.rst
+++ b/docs/install/emcc.rst
@@ -21,16 +21,20 @@ Validate that emcc is accessible in shell
 
     emcc --version
 
-Step 2: Set TVM_HOME
---------------------
+Step 2: Set TVM_HOME and MLC_LLM_HOME
+-------------------------------------
 
 We need to set a path to a tvm source in order to build tvm runtime.
 Note that you do not need to build tvm unity from the source. The source here is only used to build the web runtime component.
-Set environment variable in your shell startup profile in to point to ``3rdparty/tvm``
+Set environment variable in your shell startup profile in to point to ``3rdparty/tvm`` (if preferred, you could also
+point to your own TVM address if you installed TVM from source).
+
+Besides, we also need to set ``MLC_LLM_HOME`` so that we can locate ``mlc_wasm_runtime.bc`` when compiling a model library wasm.
 
 .. code:: bash
 
     export TVM_HOME=/path/to/3rdparty/tvm
+    export MLC_LLM_HOME=/path/to/mlc-llm
 
 
 Step 3: Prepare Wasm Runtime

--- a/python/mlc_llm/serve/grammar.py
+++ b/python/mlc_llm/serve/grammar.py
@@ -2,6 +2,7 @@
 
 from typing import List, Optional, Tuple, Union
 
+import tvm
 import tvm._ffi
 from tvm.runtime import Object
 
@@ -255,6 +256,17 @@ class GrammarStateMatcher(Object):
         """
 
         return _ffi_api.GrammarStateMatcherFindNextRejectedTokens(self, verbose)  # type: ignore  # pylint: disable=no-member
+
+    def find_next_token_bitmask_as_ndarray(self) -> tvm.nd.array:
+        """Find the ids of the rejected tokens for the next step.
+
+        Returns
+        -------
+        rejected_token_ids : List[int]
+            A list of rejected token ids.
+        """
+
+        return _ffi_api.GrammarStateMatcherFindNextTokenBitmaskAsNDArray(self)  # type: ignore  # pylint: disable=no-member
 
     def rollback(self, num_tokens: int) -> None:
         """Rollback the matcher to a previous state.

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -227,7 +227,7 @@ def _build_webgpu():
             system_lib=True,
         ).export_library(
             str(output),
-            custom_bc_files=[bc_path],
+            libs=[bc_path],
         )
 
     return build

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -1,6 +1,7 @@
 """Helper functions for target auto-detection."""
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 from tvm import IRModule, relax
@@ -197,6 +198,28 @@ def _build_webgpu():
         output = args.output
         mod = _add_system_lib_prefix(mod, args.system_lib_prefix, is_system_lib=True)
         assert output.suffix == ".wasm"
+
+        # Try to locate `mlc_wasm_runtime.bc`
+        bc_path = None
+        bc_candidates = ["web/dist/wasm/mlc_wasm_runtime.bc"]
+        if os.environ.get("MLC_LLM_HOME", None):
+            mlc_source_home_dir = os.environ["MLC_LLM_HOME"]
+            bc_candidates.append(
+                os.path.join(mlc_source_home_dir, "web", "dist", "wasm", "mlc_wasm_runtime.bc")
+            )
+        error_info = (
+            "Cannot find library: mlc_wasm_runtime.bc\n"
+            + "Make sure you have run `scripts/prep_emcc_deps.sh` and "
+            + "`export MLC_LLM_HOME=/path/to/mlc-llm` so that we can locate the file. "
+            + "We tried to look at candidate paths:\n"
+        )
+        for candidate in bc_candidates:
+            error_info += candidate + "\n"
+            if Path(candidate).exists():
+                bc_path = candidate
+        if not bc_path:
+            raise RuntimeError(error_info)
+
         relax.build(
             mod,
             target=args.target,
@@ -204,6 +227,7 @@ def _build_webgpu():
             system_lib=True,
         ).export_library(
             str(output),
+            custom_bc_files=[bc_path],
         )
 
     return build

--- a/scripts/prep_emcc_deps.sh
+++ b/scripts/prep_emcc_deps.sh
@@ -9,6 +9,11 @@ TVM_HOME_SET="${TVM_HOME:-}"
 
 git submodule update --init --recursive
 
+# Build mlc_wasm_runtime
+cd web && make
+cd -
+
+# Build tvm's web runtime
 if [[ -z ${TVM_HOME_SET} ]]; then
     echo "Do not find TVM_HOME env variable, use 3rdparty/tvm".
     echo "Make sure you set TVM_HOME in your env variable to use emcc build correctly"

--- a/web/Makefile
+++ b/web/Makefile
@@ -30,8 +30,7 @@ all: dist/wasm/mlc_wasm_runtime.wasm
 
 EMCC = emcc
 
-# Pass in COMPILE_MLC_WASM_RUNTIME so unsupported code would not be compiled in to the .bc file
-EMCC_CFLAGS = $(INCLUDE_FLAGS) -O3 -std=c++17 -Wno-ignored-attributes -D COMPILE_MLC_WASM_RUNTIME
+EMCC_CFLAGS = $(INCLUDE_FLAGS) -O3 -std=c++17 -Wno-ignored-attributes
 
 EMCC_LDFLAGS = --no-entry -s WASM_BIGINT=1 -s ALLOW_MEMORY_GROWTH=1 -s STANDALONE_WASM=1\
  -s ERROR_ON_UNDEFINED_SYMBOLS=0

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+TVM_ROOT=$(TVM_HOME)
+MLC_LLM_ROOT=$(shell cd ..; pwd)
+
+INCLUDE_FLAGS = -I$(TVM_ROOT) -I$(TVM_ROOT)/include\
+	-I$(TVM_ROOT)/3rdparty/dlpack/include -I$(TVM_ROOT)/3rdparty/dmlc-core/include\
+	-I$(TVM_ROOT)/3rdparty/compiler-rt -I$(TVM_ROOT)/3rdparty/picojson\
+	-I$(MLC_LLM_ROOT)/3rdparty/tokenizers-cpp\
+	-I$(MLC_LLM_ROOT)/3rdparty/tokenizers-cpp/include -I$(MLC_LLM_ROOT)/cpp
+
+.PHONY: clean all rmtypedep preparetest
+
+all: dist/wasm/mlc_wasm_runtime.wasm
+
+EMCC = emcc
+
+# Pass in COMPILE_MLC_WASM_RUNTIME so unsupported code would not be compiled in to the .bc file
+EMCC_CFLAGS = $(INCLUDE_FLAGS) -O3 -std=c++17 -Wno-ignored-attributes -D COMPILE_MLC_WASM_RUNTIME
+
+EMCC_LDFLAGS = --no-entry -s WASM_BIGINT=1 -s ALLOW_MEMORY_GROWTH=1 -s STANDALONE_WASM=1\
+ -s ERROR_ON_UNDEFINED_SYMBOLS=0
+
+dist/wasm/mlc_wasm_runtime.bc: emcc/mlc_wasm_runtime.cc
+	@mkdir -p $(@D)
+	$(EMCC) $(EMCC_CFLAGS) -c -MM -MT dist/wasm/mlc_wasm_runtime.bc emcc/mlc_wasm_runtime.cc >dist/wasm/mlc_wasm_runtime.d
+	$(EMCC) $(EMCC_CFLAGS) -emit-llvm -c -o dist/wasm/mlc_wasm_runtime.bc emcc/mlc_wasm_runtime.cc
+
+# Compile to wasm here so that errors can be caught earlier (rather than during export_library)
+dist/wasm/mlc_wasm_runtime.wasm: dist/wasm/mlc_wasm_runtime.bc
+	@mkdir -p $(@D)
+	$(EMCC) $(EMCC_CFLAGS) -o dist/wasm/mlc_wasm_runtime.wasm $+ $(EMCC_LDFLAGS)
+
+clean:
+	@rm -rf dist/wasm lib
+
+-include dist/wasm/*.d

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,28 @@
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
+# MLC-LLM WebAssembly Runtime
+
+This folder contains MLC-LLM WebAssembly Runtime.
+
+Please refer to https://llm.mlc.ai/docs/install/emcc.html.
+
+The main step is running `make` under this folder, a step included in `scripts/prep_emcc_deps.sh`.
+
+`make` creates `web/dist/wasm/mlc_wasm_runtime.bc`, which will be included in the model library wasm
+when we compile the model. Thus during runtime, runtimes like WebLLM can directly reuse source
+code from MLC-LLM.

--- a/web/emcc/mlc_wasm_runtime.cc
+++ b/web/emcc/mlc_wasm_runtime.cc
@@ -27,6 +27,9 @@
 #define TVM_LOG_DEBUG 0
 #define TVM_LOG_CUSTOMIZE 1
 
+// Pass in COMPILE_MLC_WASM_RUNTIME so unsupported code would not be compiled in to the .bc file
+#define COMPILE_MLC_WASM_RUNTIME 1
+
 #define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
 
 // Grammar related

--- a/web/emcc/mlc_wasm_runtime.cc
+++ b/web/emcc/mlc_wasm_runtime.cc
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * \file mlc_wasm_runtime.cc
+ * \brief MLC wasm runtime library pack.
+ */
+
+// configurations for tvm logging
+#define TVM_LOG_STACK_TRACE 0
+#define TVM_LOG_DEBUG 0
+#define TVM_LOG_CUSTOMIZE 1
+
+#define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
+
+// Grammar related
+#include "serve/grammar/grammar.cc"
+#include "serve/grammar/grammar_parser.cc"
+#include "serve/grammar/grammar_serializer.cc"
+#include "serve/grammar/grammar_simplifier.cc"
+#include "serve/grammar/grammar_state_matcher.cc"
+#include "support/encoding.cc"


### PR DESCRIPTION
This PR supports wasm runtime in MLC. The main change is a `web` folder, built similarly to [tvm/web](https://github.com/apache/tvm/tree/main/web).

By running `make` under `web`,  we create artifact `mlc_wasm_runtime.bc`, which is passed into the model library's wasm (see changes in `auto_target.py`), so that during runtime, WebLLM can directly use functions defined in MLC-LLM that are registered globally in TVM.

Currently, only global TVM functions in grammar are included in the wasm (see the included list in `web/emcc/mlc_wasm_runtime.cc`). We also define macro `COMPILE_MLC_WASM_RUNTIME` so that dependencies can be minimized (otherwise we need to build the entire `tokenizers-cpp` into the wasm). `FindNextTokenBitmaskAsNDArray()` is defined additionally to help Web runtime deal with bitmask more easily.

For users, there is virtually no difference when compiling wasm, since we update `scripts/prep_emcc_deps.sh`. They may need to define `MLC_LLM_HOME` in addition so that we can look up `mlc_wasm_runtime.bc`. Documentation is updated correspondingly.

Depends on: https://github.com/apache/tvm/pull/16825
On WebLLM side: https://github.com/mlc-ai/web-llm/pull/350