### PR TITLE
[Serve] Fork sequence at specified positions

### DIFF
--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -340,8 +340,8 @@ class ModelImpl : public ModelObj {
 
   void AddNewSequence(int64_t seq_id) final { ft_.kv_cache_add_sequence_func_(kv_cache_, seq_id); }
 
-  void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id) final {
-    ft_.kv_cache_fork_sequence_func_(kv_cache_, parent_seq_id, child_seq_id);
+  void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id, int64_t fork_pos) final {
+    ft_.kv_cache_fork_sequence_func_(kv_cache_, parent_seq_id, child_seq_id, fork_pos);
   }
 
   void RemoveSequence(int64_t seq_id) final {

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -138,7 +138,7 @@ class ModelObj : public Object {
   virtual void AddNewSequence(int64_t seq_id) = 0;
 
   /*! \brief Fork a sequence from a given parent sequence. */
-  virtual void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id) = 0;
+  virtual void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id, int64_t fork_pos = -1) = 0;
 
   /*! \brief Remove the given sequence from the KV cache in the model. */
   virtual void RemoveSequence(int64_t seq_id) = 0;


### PR DESCRIPTION
With PagedKVCache supporting fork at a specified position, this PR updates `Model` interface accordingly. The fork position defaults to -1, which means the last position.