### PR TITLE
[Serving] Support input chunking

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -146,12 +146,13 @@ class EngineImpl : public Engine {
     request = Request::FromUntokenized(request, tokenizer_);
     ICHECK_NE(request->input_total_length, -1);
 
-    if (request->input_total_length >= kv_cache_config_->prefill_chunk_size) {
-      // If the request input length exceeds the prefill chunk size,
+    if (request->input_total_length >= max_single_sequence_length_) {
+      // If the request input length exceeds the maximum allowed single sequence length,
       // invoke callback and do not process the request.
-      // Todo(mlc-team): Use "maximum single sequence length" after impl input chunking.
       Array<RequestStreamOutput> output{RequestStreamOutput(
-          request->id, {}, Optional<Array<Array<String>>>(), {String("length")})};
+          request->id, std::vector<IntTuple>(request->generation_cfg->n),
+          Optional<Array<Array<String>>>(),
+          std::vector<Optional<String>>(request->generation_cfg->n, String("length")))};
       request_stream_callback_.value()(std::move(output));
       return;
     }

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -395,7 +395,7 @@ class ModelImpl : public ModelObj {
       embedding_shape = embedding_nd.Shape();
     }
     ICHECK_EQ(embedding_shape.size(), 2);
-    ICHECK_EQ(embedding_shape[0], prefill_chunk_size_);
+    ICHECK_GE(embedding_shape[0], prefill_chunk_size_);
     this->hidden_size_ = embedding_shape[1];
     return embedding;
   }

--- a/python/mlc_llm/serve/async_engine.py
+++ b/python/mlc_llm/serve/async_engine.py
@@ -278,8 +278,7 @@ class AsyncThreadedEngine:  # pylint: disable=too-many-instance-attributes
             # [model_lib_path, model_path, device.device_type, device.device_id] * N
             model.model_lib_path = model_args[i * (len(model_args) // len(models))]
 
-        # Todo(mlc-team): use `max_single_sequence_length` only after impl input chunking.
-        self.max_input_sequence_length = min(max_single_sequence_length, prefill_chunk_size)
+        self.max_input_sequence_length = max_single_sequence_length
         self.state = _AsyncThreadedEngineState(enable_tracing)
 
         if kv_cache_config.max_total_sequence_length is None:

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -338,8 +338,7 @@ class Engine:
             ],
         )
         self.trace_recorder = EventTraceRecorder() if enable_tracing else None
-        # Todo(mlc-team): use `max_single_sequence_length` only after impl input chunking.
-        self.max_input_sequence_length = min(max_single_sequence_length, prefill_chunk_size)
+        self.max_input_sequence_length = max_single_sequence_length
 
         if kv_cache_config.max_total_sequence_length is None:
             kv_cache_config.max_total_sequence_length = _estimate_max_total_sequence_length(


### PR DESCRIPTION
This PR supports input chunking with regard to customized "prefill chunk size" (field `prefill_chunk_size` in `mlc-chat-config.json`). With this PR, we can now chunk a long input into multiples when there is an upper limit on the prefill chunk size. Only `TokenData` is supported for now.