### PR TITLE
[Build] Use TVM_HOME environment variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,11 @@ set(USE_GTEST OFF)
 set(USE_LIBBACKTRACE OFF)
 set(BUILD_DUMMY_LIBTVM ON)
 if (NOT DEFINED TVM_HOME)
-  set(TVM_HOME 3rdparty/tvm)
+  if(DEFINED ENV{TVM_HOME})
+    set(TVM_HOME "$ENV{TVM_HOME}")
+  else()
+    set(TVM_HOME 3rdparty/tvm)
+  endif(DEFINED ENV{TVM_HOME})
 endif (NOT DEFINED TVM_HOME)
 message(STATUS "TVM_HOME: ${TVM_HOME}")
 add_subdirectory(${TVM_HOME} tvm EXCLUDE_FROM_ALL)
@@ -93,7 +97,10 @@ set_target_properties(mlc_llm_static PROPERTIES OUTPUT_NAME mlc_llm)
 target_link_libraries(mlc_llm PUBLIC tvm_runtime)
 target_link_libraries(mlc_llm PRIVATE tokenizers_cpp)
 
-find_library(FLASH_ATTN_LIBRARY flash_attn)
+find_library(
+  FLASH_ATTN_LIBRARY flash_attn
+  HINTS ${TVM_HOME}/*/3rdparty/libflash_attn/src
+)
 
 if (FLASH_ATTN_LIBRARY STREQUAL "FLASH_ATTN_LIBRARY-NOTFOUND")
   message(WARNING "Cannot find libflash_attn. The model must not have been built with --use-flash-attn-mqa option.")


### PR DESCRIPTION
Prior to this commit, the `CMakeLists.txt` file checked a cmake `TVM_HOME` variable, but did not check the usual `TVM_HOME` environment variable.  If this variable is set, it should be used.