### PR TITLE
Allow "mlc_llm --host" option to override host triple the model compi…

### DIFF
--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -41,7 +41,7 @@ def detect_target_and_host(target_hint: str, host_hint: str = "auto") -> Tuple[T
         The hint for the host CPU, default is "auto".
     """
     target, build_func = _detect_target_gpu(target_hint)
-    if target.host is None:
+    if target.host is None or host_hint != "auto":
         target = Target(target, host=_detect_target_host(host_hint))
     if target.kind.name == "cuda":
         # Enable thrust for CUDA


### PR DESCRIPTION
Currently host_hint is ignored when target_hint is in PRESET. This change will allow override of this behavior.