### PR TITLE
Fix mismatch of metadata func and global symbol

### DIFF
--- a/python/mlc_llm/compiler_pass/estimate_memory_usage.py
+++ b/python/mlc_llm/compiler_pass/estimate_memory_usage.py
@@ -22,14 +22,15 @@ class AttachMetadataWithMemoryUsage:  # pylint: disable=too-few-public-methods
     def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:
         """Entrypoint"""
 
+        func_name = "_metadata"
         def _emit_metadata(metadata):
             bb = relax.BlockBuilder()  # pylint: disable=invalid-name
-            with bb.function("main", params=[]):
+            with bb.function(func_name, params=[]):
                 bb.emit_func_output(relax.StringImm(json.dumps(metadata)))
-            return bb.finalize()["main"]
+            return bb.finalize()[func_name]
 
         self.metadata["memory_usage"] = _MemoryEstimator().run(mod)
-        mod["_metadata"] = _emit_metadata(self.metadata)
+        mod[func_name] = _emit_metadata(self.metadata)
         return mod
 
 

--- a/python/mlc_llm/compiler_pass/estimate_memory_usage.py
+++ b/python/mlc_llm/compiler_pass/estimate_memory_usage.py
@@ -23,6 +23,7 @@ class AttachMetadataWithMemoryUsage:  # pylint: disable=too-few-public-methods
         """Entrypoint"""
 
         func_name = "_metadata"
+
         def _emit_metadata(metadata):
             bb = relax.BlockBuilder()  # pylint: disable=invalid-name
             with bb.function(func_name, params=[]):


### PR DESCRIPTION
The function for metadata has global symbol `main` that is inconsistent with the function name

cc @MasterJH5574 