### PR TITLE
[Quantization] Introduce PerTensor and F8 quantization

### DIFF
--- a/python/mlc_llm/compiler_pass/fuse_dequantize_matmul_ewise.py
+++ b/python/mlc_llm/compiler_pass/fuse_dequantize_matmul_ewise.py
@@ -15,7 +15,7 @@ class FuseDequantizeMatmulEwise:  # pylint: disable=too-few-public-methods
     ) -> IRModule:
         """IRModule-level transformation"""
         seq = []
-        for n_aux_tensor in [1, 2, 3, 4]:
+        for n_aux_tensor in [0, 1, 2, 3, 4]:
             for match_ewise in [0, 1, 2, 6]:
                 if match_ewise == 6 and n_aux_tensor != 4:
                     continue

--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -103,7 +103,13 @@ class OptimizationFlags:
 
         def _cublas_gemm(target, quantization) -> bool:
             """correct cublas_gemm flag"""
-            if not (target.kind.name == "cuda" and quantization.name in ["q0f16", "q0f32"]):
+            if not target.kind.name == "cuda":
+                return False
+            if not (
+                quantization.name in ["q0f16", "q0f32"]
+                or "e4m3" in quantization.name
+                or "e5m2" in quantization.name
+            ):
                 return False
             return self.cublas_gemm
 

--- a/python/mlc_llm/model/llama/llama_quantization.py
+++ b/python/mlc_llm/model/llama/llama_quantization.py
@@ -5,7 +5,13 @@ from typing import Tuple
 from tvm.relax.frontend import nn
 
 from mlc_llm.loader import QuantizeMapping
-from mlc_llm.quantization import AWQQuantize, FTQuantize, GroupQuantize, NoQuantize
+from mlc_llm.quantization import (
+    AWQQuantize,
+    FTQuantize,
+    GroupQuantize,
+    NoQuantize,
+    PerTensorQuantize,
+)
 
 from .llama_model import LlamaConfig, LlamaForCasualLM
 
@@ -66,4 +72,20 @@ def no_quant(
     model: nn.Module = LlamaForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})
+    return model, quant_map
+
+
+def per_tensor_quant(
+    model_config: LlamaConfig,
+    quantization: PerTensorQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a Llama-architecture model using per-tensor quantization."""
+    model: nn.Module = LlamaForCasualLM(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    model = quantization.quantize_model(
+        model,
+        quant_map,
+        "",
+    )
     return model, quant_map

--- a/python/mlc_llm/model/mixtral/mixtral_model.py
+++ b/python/mlc_llm/model/mixtral/mixtral_model.py
@@ -49,11 +49,13 @@ class MixtralMoE(nn.Module):
             self.num_local_experts,
             in_features=config.hidden_size,
             out_features=2 * self.intermediate_size,
+            tensor_parallel_shards=config.tensor_parallel_shards,
         )
         self.e2 = MixtralExperts(
             self.num_local_experts,
             in_features=self.intermediate_size,
             out_features=config.hidden_size,
+            tensor_parallel_shards=config.tensor_parallel_shards,
         )
         self.dtype = "float32"
 

--- a/python/mlc_llm/model/mixtral/mixtral_quantization.py
+++ b/python/mlc_llm/model/mixtral/mixtral_quantization.py
@@ -5,7 +5,13 @@ from typing import Tuple
 from tvm.relax.frontend import nn
 
 from mlc_llm.loader import QuantizeMapping
-from mlc_llm.quantization import AWQQuantize, FTQuantize, GroupQuantize, NoQuantize
+from mlc_llm.quantization import (
+    AWQQuantize,
+    FTQuantize,
+    GroupQuantize,
+    NoQuantize,
+    PerTensorQuantize,
+)
 
 from .mixtral_model import MixtralConfig, MixtralForCasualLM
 
@@ -58,4 +64,20 @@ def no_quant(
     model: nn.Module = MixtralForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})
+    return model, quant_map
+
+
+def per_tensor_quant(
+    model_config: MixtralConfig,
+    quantization: PerTensorQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a Mixtral model using per-tensor quantization."""
+    model: nn.Module = MixtralForCasualLM(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    model = quantization.quantize_model(
+        model,
+        quant_map,
+        "",
+    )
     return model, quant_map

--- a/python/mlc_llm/model/model.py
+++ b/python/mlc_llm/model/model.py
@@ -83,6 +83,7 @@ MODELS: Dict[str, Model] = {
             "group-quant": llama_quantization.group_quant,
             "ft-quant": llama_quantization.ft_quant,
             "awq": llama_quantization.awq_quant,
+            "per-tensor-quant": llama_quantization.per_tensor_quant,
         },
     ),
     "mistral": Model(
@@ -139,6 +140,7 @@ MODELS: Dict[str, Model] = {
             "no-quant": mixtral_quantization.no_quant,
             "group-quant": mixtral_quantization.group_quant,
             "ft-quant": mixtral_quantization.ft_quant,
+            "per-tensor-quant": mixtral_quantization.per_tensor_quant,
         },
     ),
     "gpt_neox": Model(

--- a/python/mlc_llm/nn/expert.py
+++ b/python/mlc_llm/nn/expert.py
@@ -8,12 +8,13 @@ from mlc_llm.op import cutlass, extern, ft_gemm, moe_matmul
 class MixtralExperts(nn.Module):
     """Mixtral experts"""
 
-    def __init__(self, num_local_experts, in_features, out_features):
+    def __init__(self, num_local_experts, in_features, out_features, tensor_parallel_shards=1):
         self.num_local_experts = num_local_experts
         self.in_features = in_features
         self.out_features = out_features
         self.weight = nn.Parameter((num_local_experts, out_features, in_features))
         self.dtype = "float32"
+        self.tensor_parallel_shards = tensor_parallel_shards
 
     def forward(self, x: Tensor, indptr: Tensor):  # pylint: disable=invalid-name,missing-docstring
         assert x.ndim == 2

--- a/python/mlc_llm/op/cutlass.py
+++ b/python/mlc_llm/op/cutlass.py
@@ -45,23 +45,22 @@ def group_gemm(
     assert x.ndim == 2
     assert weight.ndim == 3
     assert indptr.ndim == 1
-    assert weight.shape[2] == x.shape[1]
     assert weight.shape[0] == indptr.shape[0]
     assert indptr.dtype == "int64"
     out_dtype = out_dtype if out_dtype else x.dtype
     weight_dtype = weight_dtype if weight_dtype else weight.dtype
 
-    if x.dtype == "e5m2_float8" and weight.dtype == "e5m2_float8" and out_dtype == "float16":
+    if x.dtype == "e5m2_float8" and weight_dtype == "e5m2_float8" and out_dtype == "float16":
         func_name = "cutlass.group_gemm_e5m2_e5m2_fp16"
-    elif x.dtype == "e4m3_float8" and weight.dtype == "e5m2_float8" and out_dtype == "float16":
+    elif x.dtype == "e4m3_float8" and weight_dtype == "e5m2_float8" and out_dtype == "float16":
         func_name = "cutlass.group_gemm_e4m3_e5m2_fp16"
-    elif x.dtype == "e4m3_float8" and weight.dtype == "e4m3_float8" and out_dtype == "float16":
+    elif x.dtype == "e4m3_float8" and weight_dtype == "e4m3_float8" and out_dtype == "float16":
         func_name = "cutlass.group_gemm_e4m3_e4m3_fp16"
-    elif x.dtype == "float16" and weight.dtype == "float16" and out_dtype == "float16":
+    elif x.dtype == "float16" and weight_dtype == "float16" and out_dtype == "float16":
         func_name = "cutlass.group_gemm_fp16_sm90"
     else:
         raise NotImplementedError(
-            f"Unsupported data type: x={x.dtype}, weight={weight.dtype}, out={out_dtype}"
+            f"Unsupported data type: x={x.dtype}, weight={weight_dtype}, out={out_dtype}"
         )
 
     if "float8" in x.dtype:

--- a/python/mlc_llm/op/moe_matmul.py
+++ b/python/mlc_llm/op/moe_matmul.py
@@ -1,6 +1,6 @@
 """Mixture of Experts operators"""
 
-from typing import Optional
+from typing import Optional, Literal
 
 from tvm import DataType, tir
 from tvm.relax.frontend.nn import Tensor, op
@@ -182,9 +182,9 @@ def dequantize_float8_gemv(
     w: Tensor,
     scale: Optional[Tensor],
     indptr: Tensor,
-    quantize_dtype: Literal["e5m2_float8", "e4m3_float8"]
+    quantize_dtype: Literal["e5m2_float8", "e4m3_float8"],
 ) -> Tensor:
-    """GEMV for project-in (e1-e3) or project-out (e2) in MLP but the weight is quantized in 
+    """GEMV for project-in (e1-e3) or project-out (e2) in MLP but the weight is quantized in
     fp8 e5m2 or e4m3. It needs to be dequantized before the GEMV computation.
 
     Parameters
@@ -287,13 +287,12 @@ def dequantize_float8_gemv(
             args=[x, w, scale, indptr],
             out=Tensor.placeholder([experts_per_tok, out_features], model_dtype),
         )
-    else:
-        return op.tensor_ir_op(
-            _func_without_scale,
-            "moe_dequantize_gemv",
-            args=[x, w, indptr],
-            out=Tensor.placeholder([experts_per_tok, out_features], model_dtype),
-        )
+    return op.tensor_ir_op(
+        _func_without_scale,
+        "moe_dequantize_gemv",
+        args=[x, w, indptr],
+        out=Tensor.placeholder([experts_per_tok, out_features], model_dtype),
+    )
 
 
 def group_gemm(x: Tensor, w: Tensor, indptr: Tensor):  # pylint: disable=too-many-statements

--- a/python/mlc_llm/op/moe_matmul.py
+++ b/python/mlc_llm/op/moe_matmul.py
@@ -1,6 +1,6 @@
 """Mixture of Experts operators"""
 
-from typing import Optional, Literal
+from typing import Literal, Optional
 
 from tvm import DataType, tir
 from tvm.relax.frontend.nn import Tensor, op

--- a/python/mlc_llm/quantization/__init__.py
+++ b/python/mlc_llm/quantization/__init__.py
@@ -3,4 +3,5 @@ from .awq_quantization import AWQQuantize
 from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize
 from .no_quantization import NoQuantize
+from .per_tensor_quantization import PerTensorQuantize
 from .quantization import QUANTIZATION, Quantization

--- a/python/mlc_llm/quantization/__init__.py
+++ b/python/mlc_llm/quantization/__init__.py
@@ -1,5 +1,6 @@
 """A subpackage for quantization and dequantization algorithms"""
 from .awq_quantization import AWQQuantize
+from .fp8_quantization import FP8PerTensorQuantizeMixtralExperts
 from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize
 from .no_quantization import NoQuantize

--- a/python/mlc_llm/quantization/fp8_quantization.py
+++ b/python/mlc_llm/quantization/fp8_quantization.py
@@ -1,0 +1,88 @@
+""" Quantization techniques for FP8 """
+import numpy as np
+from tvm import nd, relax
+from tvm.relax.frontend import nn
+
+from mlc_llm.nn import MixtralExperts
+
+from ..op import cutlass, extern, moe_matmul
+from . import per_tensor_quantization as ptq
+from .utils import apply_sharding
+
+
+class FP8PerTensorQuantizeMixtralExperts(
+    ptq.PerTensorQuantizeMixtralExperts
+):  # pylint: disable=too-many-instance-attributes
+    """ MixtralExperts with per-tensor quantization in FP8. """
+    def __init__(
+        self,
+        num_local_experts,
+        in_features,
+        out_features,
+        config: ptq.PerTensorQuantize,
+        tensor_parallel_shards=1,
+    ):  # pylint: disable=too-many-arguments
+        super().__init__(num_local_experts, in_features, out_features, config)
+        self.tensor_parallel_shards = tensor_parallel_shards
+
+    @staticmethod
+    def from_mixtral_experts(
+        src: "MixtralExperts",
+        config: ptq.PerTensorQuantize,
+    ) -> "FP8PerTensorQuantizeMixtralExperts":
+        """
+        Converts a non-quantized MixtralExperts to a per-tensor quantized MixtralExperts.
+
+        Parameters
+        ----------
+        src : MixtralExperts
+            The non-quantized MixtralExperts
+
+        weight_config : GroupQuantize
+            The group quantization weight_config.
+
+        Returns
+        -------
+        ret : MixtralExpertsFP8
+            The per-tensor quantized MixtralExperts.
+        """
+        quantized_mistral_experts = FP8PerTensorQuantizeMixtralExperts(
+            num_local_experts=src.num_local_experts,
+            in_features=src.in_features,
+            out_features=src.out_features,
+            config=config,
+            tensor_parallel_shards=src.tensor_parallel_shards,
+        )
+
+        if "shard_strategy" in src.weight.attrs:
+            shard = src.weight.attrs["shard_strategy"]
+            apply_sharding(shard, f"{shard.name}_q_weight", quantized_mistral_experts.q_weight)
+            # scale doesn't need to be sharded since it's the same for all shards
+
+        return quantized_mistral_experts
+
+    def forward(self, x: nn.Tensor, indptr: nn.Tensor) -> nn.Tensor:  # pylint: disable=invalid-name
+        w = self.q_weight
+        if indptr.ndim == 2:
+            assert indptr.shape[0] == 1
+            return moe_matmul.dequantize_float8_gemv(
+                x, w, self.q_scale, indptr, self.config.weight_dtype
+            )
+
+        if extern.get_store().cutlass_group_gemm:
+            # TODO: calibration scale should be used to convert x to fp8
+            x = nn.op.astype(x, dtype=self.config.activation_dtype)
+            scale = (
+                self.q_scale.astype("float32")
+                if self.q_scale is not None
+                else nn.wrap_nested(
+                    relax.Constant(nd.array(np.array([1.0]).astype("float32"))), "scale"
+                )
+            )
+            return cutlass.group_gemm(
+                x, w, indptr, scale, self.config.weight_dtype, self.config.model_dtype
+            )
+        else:
+            # Note: convert_weight is target agnostic, so a fallback must be provided
+            w =nn.tensor_expr_op(self.config.dequantize_float8, "dequantize", args=[w, self.q_scale, self.config.weight_dtype])
+            return moe_matmul.group_gemm(x, w, indptr)

--- a/python/mlc_llm/quantization/fp8_quantization.py
+++ b/python/mlc_llm/quantization/fp8_quantization.py
@@ -1,4 +1,5 @@
 """ Quantization techniques for FP8 """
+
 import numpy as np
 from tvm import nd, relax
 from tvm.relax.frontend import nn
@@ -90,3 +91,7 @@ class FP8PerTensorQuantizeMixtralExperts(
             args=[w, self.q_scale, self.config.weight_dtype],
         )
         return moe_matmul.group_gemm(x, w, indptr)
+
+
+# pylint: disable=protected-access
+ptq.PerTensorQuantizeMixtralExperts._IMPL["fp8"] = FP8PerTensorQuantizeMixtralExperts

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -1,7 +1,7 @@
 """The per-tensor quantization config"""
 
 from dataclasses import dataclass
-from typing import Any, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 from tvm import DataType, DataTypeCode, IRModule, te, tir, topi
 from tvm.relax.frontend import nn
@@ -481,6 +481,8 @@ class PerTensorQuantizeEmbedding(nn.Module):
 class PerTensorQuantizeMixtralExperts(nn.Module):  # pylint: disable=too-many-instance-attributes
     """An MixtralExperts module with group quantization"""
 
+    _IMPL: Dict[str, PerTensorQuantizeMixtralExperts] = {}
+
     def __init__(
         self,
         num_local_experts,
@@ -531,16 +533,8 @@ class PerTensorQuantizeMixtralExperts(nn.Module):  # pylint: disable=too-many-in
             DataTypeCode.E4M3Float,
             DataTypeCode.E5M2Float,
         ]:
-            # pylint: disable=import-outside-toplevel
-            from .fp8_quantization import FP8PerTensorQuantizeMixtralExperts
-
-            quantized_mixtral_experts = FP8PerTensorQuantizeMixtralExperts.from_mixtral_experts(
-                src,
-                config,
-            )
-        else:
-            raise NotImplementedError()
-        return quantized_mixtral_experts
+            return PerTensorQuantizeMixtralExperts._IMPL["fp8"].from_mixtral_experts(src, config)
+        raise NotImplementedError()
 
     def forward(self, x: nn.Tensor, indptr: nn.Tensor) -> nn.Tensor:  # pylint: disable=invalid-name
         """Forward method for per-tensor quantized mistral experts.

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -1,7 +1,7 @@
 """The per-tensor quantization config"""
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union, Type
 
 from tvm import DataType, DataTypeCode, IRModule, te, tir, topi
 from tvm.relax.frontend import nn
@@ -481,7 +481,7 @@ class PerTensorQuantizeEmbedding(nn.Module):
 class PerTensorQuantizeMixtralExperts(nn.Module):  # pylint: disable=too-many-instance-attributes
     """An MixtralExperts module with group quantization"""
 
-    _IMPL: Dict[str, PerTensorQuantizeMixtralExperts] = {}
+    _IMPL: Dict[str, Type["PerTensorQuantizeMixtralExperts"]] = {}
 
     def __init__(
         self,

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -1,7 +1,7 @@
 """The per-tensor quantization config"""
 
 from dataclasses import dataclass
-from typing import Any, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, List, Literal, Optional, Sequence, Tuple, Union
 
 from tvm import DataType, DataTypeCode, IRModule, te, tir, topi
 from tvm.relax.frontend import nn
@@ -122,7 +122,7 @@ class PerTensorQuantize:  # pylint: disable=too-many-instance-attributes
         model = mutator.visit(name_prefix, model)
         return model
 
-    def quantize_weight(self, weight) -> Union[Tuple[NDArray, NDArray], NDArray]:
+    def quantize_weight(self, weight) -> List[NDArray]:
         """
         Quantize weight with per-tensor quantization.
 
@@ -133,7 +133,7 @@ class PerTensorQuantize:  # pylint: disable=too-many-instance-attributes
 
         Returns
         -------
-        ret : Union[Tuple[NDArray, NDArray], NDArray]
+        ret : List[NDArray]
             The quantized weight and the scale if use_scale is True.
         """
         device = weight.device

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -1,7 +1,7 @@
 """The per-tensor quantization config"""
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union, Type
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Type, Union
 
 from tvm import DataType, DataTypeCode, IRModule, te, tir, topi
 from tvm.relax.frontend import nn

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -3,8 +3,7 @@
 from dataclasses import dataclass
 from typing import Any, Literal, Optional, Sequence, Tuple, Union
 
-from tvm import DataType, DataTypeCode, IRModule
-from tvm import te, tir, topi
+from tvm import DataType, DataTypeCode, IRModule, te, tir, topi
 from tvm.relax.frontend import nn
 from tvm.runtime import NDArray
 

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -1,0 +1,562 @@
+"""The per-tensor quantization config"""
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional, Sequence, Tuple, Union
+
+from tvm import DataType, DataTypeCode, IRModule
+from tvm import te, tir, topi
+from tvm.relax.frontend import nn
+from tvm.runtime import NDArray
+
+from mlc_llm.loader import QuantizeMapping
+from mlc_llm.nn import MixtralExperts
+from mlc_llm.support import logging
+
+from .utils import (
+    apply_sharding,
+    compile_quantize_func,
+    convert_uint_packed_fp8_to_float,
+    is_final_fc,
+    pack_weight,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PerTensorQuantize:  # pylint: disable=too-many-instance-attributes
+    """Configuration for per-tensor quantization"""
+
+    name: str
+    kind: str
+    activation_dtype: Literal["e4m3_float8", "e5m2_float8"]
+    weight_dtype: Literal["e4m3_float8", "e5m2_float8"]
+    storage_dtype: Literal["uint32"]
+    model_dtype: Literal["float16"]
+    quantize_embedding: bool = True
+    quantize_final_fc: bool = True
+
+    num_elem_per_storage: int = 0
+    max_int_value: int = 0
+    use_scale: bool = True
+
+    def __post_init__(self):
+        assert self.kind == "per-tensor-quant"
+        self.num_elem_per_storage = (
+            DataType(self.storage_dtype).bits // DataType(self.weight_dtype).bits
+        )
+        self.max_int_value = int(tir.max_value(self.weight_dtype).value)
+        self._quantize_func_cache = {}
+
+    def quantize_model(
+        self, model: nn.Module, quant_map: QuantizeMapping, name_prefix: str
+    ) -> nn.Module:
+        """
+        Quantize model with per-tensor quantization
+
+        Parameters
+        ----------
+        model : nn.Module
+            The non-quantized nn.Module.
+
+        quant_map : QuantizeMapping
+            The quantize mapping with name mapping and func mapping.
+
+        name_prefix : str
+            The name prefix for visited weight.
+
+        Returns
+        -------
+        ret : nn.Module
+            The quantized nn.Module.
+        """
+
+        class _Mutator(nn.Mutator):
+            def __init__(self, config: PerTensorQuantize, quant_map: QuantizeMapping) -> None:
+                super().__init__()
+                self.config = config
+                self.quant_map = quant_map
+
+            def visit_module(self, name: str, node: nn.Module) -> Any:
+                """
+                The visiting method for per-tensor quantization of nn.Module nodes.
+
+                Parameters
+                ----------
+                name : str
+                    The name of the current node.
+
+                node : nn.Module
+                    The current node of nn.Module to mutate.
+
+                Returns
+                ------
+                ret_node: Any
+                    The new node to replace current node.
+                """
+                weight_name = f"{name}.weight"
+                param_names = (
+                    [f"{name}.q_weight", f"{name}.q_scale"]
+                    if self.config.use_scale
+                    else [
+                        f"{name}.q_weight",
+                    ]
+                )
+                if isinstance(node, nn.Linear) and (
+                    not is_final_fc(name) or self.config.quantize_final_fc
+                ):
+                    self.quant_map.param_map[weight_name] = param_names
+                    self.quant_map.map_func[weight_name] = self.config.quantize_weight
+                    return PerTensorQuantizeLinear.from_linear(node, self.config)
+                if isinstance(node, nn.Embedding) and self.config.quantize_embedding:
+                    self.quant_map.param_map[weight_name] = param_names
+                    self.quant_map.map_func[weight_name] = self.config.quantize_weight
+                    return PerTensorQuantizeEmbedding.from_embedding(node, self.config)
+                if isinstance(node, MixtralExperts):
+                    self.quant_map.param_map[weight_name] = param_names
+                    self.quant_map.map_func[weight_name] = self.config.quantize_weight
+                    return PerTensorQuantizeMixtralExperts.from_mixtral_experts(node, self.config)
+                return self.visit(name, node)
+
+        model.to(dtype=self.model_dtype)
+        mutator = _Mutator(self, quant_map)
+        model = mutator.visit(name_prefix, model)
+        return model
+
+    def quantize_weight(self, weight) -> Union[Tuple[NDArray, NDArray], NDArray]:
+        """
+        Quantize weight with per-tensor quantization.
+
+        Parameters
+        ----------
+        weight : NDArray
+            The weight to quantize.
+
+        Returns
+        -------
+        ret : Union[Tuple[NDArray, NDArray], NDArray]
+            The quantized weight and the scale if use_scale is True.
+        """
+        device = weight.device
+        device_type = device.MASK2STR[device.device_type]
+
+        def _create_quantize_func() -> IRModule:
+            if DataType(self.weight_dtype).type_code in [
+                DataTypeCode.E4M3Float,
+                DataTypeCode.E5M2Float,
+            ]:
+                quantize_func = self._quantize_float8
+            else:
+                assert NotImplementedError()
+
+            class Quantizer(nn.Module):
+                """Quantizer module for per-tensor quantization."""
+
+                def main(self, weight: nn.Tensor):  # pylint: disable=missing-function-docstring
+                    return quantize_func(weight)
+
+            mod = Quantizer()
+            mod, _ = mod.export_tvm(  # pylint: disable=unbalanced-tuple-unpacking
+                spec={"main": {"weight": nn.spec.Tensor(weight.shape, weight.dtype)}}
+            )
+            return mod
+
+        key = f"({weight.shape}, {weight.dtype}, {device_type}"
+        quantize_func = self._quantize_func_cache.get(key, None)
+        if quantize_func is None:
+            logger.info("Compiling quantize function for key: %s", key)
+            quantize_func = compile_quantize_func(_create_quantize_func(), device)
+            self._quantize_func_cache[key] = quantize_func
+        return quantize_func(weight)
+
+    def _quantize_float8(  # pylint: disable=too-many-locals
+        self,
+        weight: nn.Tensor,
+    ) -> Union[Tuple[nn.Tensor], Tuple[nn.Tensor, nn.Tensor]]:
+        """Per-tensor quantization for weight tensor, defined in tensor expression."""
+
+        quantize_dtype = DataType(self.weight_dtype)
+
+        if self.use_scale:
+            # min_scaling_factor taken from TRT-LLM
+            def _compute_scale(x: te.Tensor) -> te.Tensor:
+                max_abs = topi.max(topi.abs(x))
+                min_scaling_factor = tir.const(1.0 / (self.max_int_value * 512.0), self.model_dtype)
+                scale = topi.maximum(
+                    max_abs.astype(self.model_dtype) / self.max_int_value, min_scaling_factor
+                )
+                scale = topi.expand_dims(scale, axis=0)
+                return scale
+
+            scale = nn.tensor_expr_op(_compute_scale, "compute_scale", args=[weight])
+        else:
+            scale = None
+
+        def _compute_quantized_weight(weight: te.Tensor, scale: Optional[te.Tensor]) -> te.Tensor:
+            elem_storage_dtype = f"uint{quantize_dtype.bits}"
+            scaled_weight = te.compute(
+                shape=weight.shape,
+                fcompute=lambda *idx: tir.Cast(
+                    self.storage_dtype,
+                    tir.reinterpret(
+                        elem_storage_dtype,
+                        tir.Cast(
+                            quantize_dtype,
+                            weight(*idx) / scale(0) if scale is not None else weight(*idx),
+                        ),
+                    ),
+                ),
+            )
+
+            packed_weight = pack_weight(
+                scaled_weight,
+                axis=-1,
+                num_elem_per_storage=self.num_elem_per_storage,
+                weight_dtype=self.weight_dtype,
+                storage_dtype=self.storage_dtype,
+            )
+
+            return packed_weight
+
+        quantized_weight = nn.tensor_expr_op(
+            _compute_quantized_weight, "compute_quantized_weight", args=[weight, scale]
+        )
+
+        if self.use_scale:
+            return quantized_weight, scale
+        return (quantized_weight,)
+
+    def _dequantize(
+        self,
+        q_weight: te.Tensor,
+        scale: Optional[te.Tensor] = None,
+        out_shape: Optional[Sequence[tir.PrimExpr]] = None,
+    ) -> te.Tensor:
+        if self.use_scale:
+            assert scale is not None
+        if DataType(self.weight_dtype).type_code in [
+            DataTypeCode.E4M3Float,
+            DataTypeCode.E5M2Float,
+        ]:
+            return self.dequantize_float8(q_weight, scale, self.weight_dtype, out_shape)
+        raise NotImplementedError()
+
+    def dequantize_float8(
+        self,
+        q_weight: te.Tensor,
+        scale: Optional[te.Tensor],
+        quantize_dtype: str,
+        out_shape: Optional[Sequence[tir.PrimExpr]] = None,
+    ) -> te.Tensor:
+        """Dequantize a fp8 tensor to higher-precision float."""
+        weight = convert_uint_packed_fp8_to_float(
+            q_weight,
+            self.num_elem_per_storage,
+            self.storage_dtype,
+            self.model_dtype,
+            quantize_dtype,
+            axis=-1,
+            out_shape=out_shape,
+        )
+        if scale is not None:
+            weight = weight * scale
+        return weight
+
+
+class PerTensorQuantizeLinear(nn.Module):  # pylint: disable=too-many-instance-attributes
+    """An nn.Linear module with per-tensor quantization."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        in_features: int,
+        out_features: Union[int, tir.Var],
+        config: PerTensorQuantize,
+        bias: bool = True,
+        out_dtype: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.out_dtype = out_dtype
+        self.config = config
+        self.q_weight = nn.Parameter(
+            (out_features, tir.ceildiv(in_features, config.num_elem_per_storage)),
+            config.storage_dtype,
+        )
+        if config.use_scale:
+            self.q_scale = nn.Parameter((1,), config.model_dtype)
+        else:
+            self.q_scale = None
+        if bias:
+            self.bias = nn.Parameter(
+                (out_features,), config.model_dtype if out_dtype is None else out_dtype
+            )
+        else:
+            self.bias = None
+
+    @classmethod
+    def from_linear(cls, src: nn.Linear, config: PerTensorQuantize) -> "PerTensorQuantizeLinear":
+        """
+        Converts a non-quantized nn.Linear to a per-tensor quantized PerTensorQuantizeLinear
+
+        Parameters
+        ----------
+        src : nn.Linear
+            The non-quantized nn.Linear.
+
+        config : PerTensorQuantize
+            The per-tensor quantization config.
+
+        Returns
+        -------
+        ret : PerTensorQuantizeLinear
+            The per-tensor quantized PerTensorQuantizeLinear layer.
+        """
+        out_features, in_features = src.weight.shape
+        quantized_linear = cls(
+            in_features=in_features,
+            out_features=out_features,
+            config=config,
+            bias=getattr(src, "bias", None) is not None,
+            out_dtype=src.out_dtype,
+        )
+        if quantized_linear.bias is not None:
+            quantized_linear.bias.attrs = src.bias.attrs
+        if "shard_strategy" in src.weight.attrs:
+            shard = src.weight.attrs["shard_strategy"]
+            apply_sharding(shard, f"{shard.name}_q_weight", quantized_linear.q_weight)
+            # scale doesn't need to be sharded since it's the same for all shards
+        return quantized_linear
+
+    def forward(self, x: nn.Tensor) -> nn.Tensor:  # pylint: disable=invalid-name
+        """
+        Forward method for per-tensor quantized linear layer.
+
+        Parameters
+        ----------
+        x : nn.Tensor
+            The input tensor.
+
+        Returns
+        -------
+        ret : nn.Tensor
+            The output tensor for the per-tensor quantized linear layer.
+        """
+        w = nn.op.tensor_expr_op(
+            lambda weight, scale: self.config._dequantize(  # pylint: disable=protected-access
+                weight,
+                scale,
+                out_shape=[
+                    (
+                        tir.IntImm("int64", self.out_features)
+                        if isinstance(self.out_features, int)
+                        else weight.shape[0]
+                    ),
+                    tir.IntImm("int64", self.in_features),
+                ],
+            ),
+            "dequantize",
+            args=[self.q_weight, self.q_scale],
+        )
+        w = nn.op.permute_dims(w)
+        x = nn.op.matmul(x, w, out_dtype=self.out_dtype)
+        if self.bias is not None:
+            x = x + self.bias
+        return x
+
+    def to(self, dtype: Optional[str] = None) -> None:
+        """
+        Override to() such that we do not convert bias if there is an out_dtype.
+        Otherwise, we might run into dtype mismatch when computing x + self.bias.
+        """
+        self.q_weight.to(dtype=dtype)
+        if self.q_scale:
+            self.q_scale.to(dtype=dtype)
+        if self.bias is not None and self.out_dtype is None:
+            self.bias.to(dtype=dtype)
+        if dtype is not None and isinstance(getattr(self, "dtype", None), str):
+            self.dtype = dtype  # pylint: disable=attribute-defined-outside-init
+
+
+class PerTensorQuantizeEmbedding(nn.Module):
+    """An nn.Embedding module with group quantization"""
+
+    def __init__(self, num: Union[int, tir.Var], dim: int, config: PerTensorQuantize):
+        self.num = num
+        self.dim = dim
+        self.config = config
+        self.q_weight = nn.Parameter(
+            (num, tir.ceildiv(dim, config.num_elem_per_storage)), config.storage_dtype
+        )
+        if self.config.use_scale:
+            self.q_scale = nn.Parameter((1,), config.model_dtype)
+        else:
+            self.q_scale = None
+
+    @staticmethod
+    def from_embedding(
+        embedding: nn.Embedding, config: PerTensorQuantize
+    ) -> "PerTensorQuantizeEmbedding":
+        """
+        Converts a non-quantized nn.Embedding to a per-tensor quantized PerTensorQuantizeEmbedding
+
+        Parameters
+        ----------
+        linear : nn.Embedding
+            The non-quantized nn.Embedding.
+
+        config : PerTensorQuantize
+            The per-tensor quantization config.
+
+        Returns
+        -------
+        ret : PerTensorQuantizeEmbedding
+            The per-tensor quantized embedding layer.
+        """
+        num, dim = embedding.weight.shape
+        return PerTensorQuantizeEmbedding(num, dim, config)
+
+    def forward(self, x: nn.Tensor):  # pylint: disable=invalid-name
+        """
+        Forward method for per-tensor quantized embedding layer.
+
+        Parameters
+        ----------
+        x : nn.Tensor
+            The input tensor.
+
+        Returns
+        -------
+        ret : nn.Tensor
+            The output tensor for the embedding layer.
+        """
+        w = nn.op.tensor_expr_op(
+            lambda weight, scale: self.config._dequantize(  # pylint: disable=protected-access
+                weight,
+                scale,
+                out_shape=[
+                    tir.IntImm("int64", self.num) if isinstance(self.num, int) else weight.shape[0],
+                    tir.IntImm("int64", self.dim),
+                ],
+            ),
+            "dequantize",
+            args=[self.q_weight, self.q_scale],
+        )
+        if x.ndim == 1:
+            return nn.op.take(w, x, axis=0)
+        return nn.op.reshape(
+            nn.op.take(w, nn.op.reshape(x, shape=[-1]), axis=0),
+            shape=[*x.shape, self.dim],
+        )
+
+    def lm_head_forward(self, x: nn.Tensor):
+        """The lm_head forwarding, which dequantizes the weight
+        and multiplies it with the input tensor.
+
+        Parameters
+        ----------
+        x : nn.Tensor
+            The input tensor.
+
+        Returns
+        -------
+        ret : nn.Tensor
+            The output tensor for the lm_head layer.
+        """
+        w = nn.op.tensor_expr_op(
+            lambda weight, scale: self.config._dequantize(  # pylint: disable=protected-access
+                weight,
+                scale,
+                out_shape=[
+                    tir.IntImm("int64", self.num) if isinstance(self.num, int) else weight.shape[0],
+                    tir.IntImm("int64", self.dim),
+                ],
+            ),
+            "dequantize",
+            args=[self.q_weight, self.q_scale],
+        )
+        w = nn.op.permute_dims(w)
+        return nn.op.matmul(x, w, out_dtype="float32")
+
+
+class PerTensorQuantizeMixtralExperts(nn.Module):  # pylint: disable=too-many-instance-attributes
+    """An MixtralExperts module with group quantization"""
+
+    def __init__(
+        self,
+        num_local_experts,
+        in_features,
+        out_features,
+        config: PerTensorQuantize,
+    ):  # pylint: disable=too-many-arguments
+        self.num_local_experts = num_local_experts
+        self.in_features = in_features
+        self.out_features = out_features
+        self.config = config
+        self.q_weight = nn.Parameter(
+            (
+                num_local_experts,
+                out_features,
+                tir.ceildiv(in_features, config.num_elem_per_storage),
+            ),
+            config.storage_dtype,
+        )
+        if config.use_scale:
+            self.q_scale = nn.Parameter((1,), config.model_dtype)
+        else:
+            self.q_scale = None
+
+    @staticmethod
+    def from_mixtral_experts(
+        src: "MixtralExperts",
+        config: PerTensorQuantize,
+    ) -> "PerTensorQuantizeMixtralExperts":
+        """
+        Converts a non-quantized MixtralExperts to a per-tensor quantized
+        PerTensorQuantizeMixtralExperts
+
+        Parameters
+        ----------
+        src : MixtralExperts
+            The non-quantized MixtralExperts
+
+        config : PerTensorQuantize
+            The per-tensor quantization config
+
+        Returns
+        -------
+        ret : PerTensorQuantizeMixtralExperts
+            The per-tensor quantized MixtralExperts layer
+        """
+        if DataType(config.weight_dtype).type_code in [
+            DataTypeCode.E4M3Float,
+            DataTypeCode.E5M2Float,
+        ]:
+            # pylint: disable=import-outside-toplevel
+            from .fp8_quantization import FP8PerTensorQuantizeMixtralExperts
+
+            quantized_mixtral_experts = FP8PerTensorQuantizeMixtralExperts.from_mixtral_experts(
+                src,
+                config,
+            )
+        else:
+            raise NotImplementedError()
+        return quantized_mixtral_experts
+
+    def forward(self, x: nn.Tensor, indptr: nn.Tensor) -> nn.Tensor:  # pylint: disable=invalid-name
+        """Forward method for per-tensor quantized mistral experts.
+
+        Parameters
+        ----------
+        x : nn.Tensor
+            The input tensor.
+
+        indptr: nn.Tensor
+            The indptr tensor
+
+        Returns
+        -------
+        ret : nn.Tensor
+            The output tensor for the per-tensor quantized mistral experts layer.
+        """
+        raise NotImplementedError()

--- a/python/mlc_llm/quantization/quantization.py
+++ b/python/mlc_llm/quantization/quantization.py
@@ -5,6 +5,7 @@ from .awq_quantization import AWQQuantize
 from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize
 from .no_quantization import NoQuantize
+from .per_tensor_quantization import PerTensorQuantize
 
 Quantization = Any
 """Quantization is an object that represents an quantization algorithm. It is required to
@@ -116,5 +117,16 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_dtype="int4",
         storage_dtype="int8",
         model_dtype="float16",
+    ),
+    "e5m2_e5m2_f16": PerTensorQuantize(
+        name="e5m2_e5m2_f16",
+        kind="per-tensor-quant",
+        activation_dtype="e5m2_float8",
+        weight_dtype="e5m2_float8",
+        storage_dtype="uint32",
+        model_dtype="float16",
+        quantize_final_fc=True,
+        quantize_embedding=False,
+        use_scale=False,
     ),
 }


### PR DESCRIPTION
This introduces a new quantization mode FP8 per-tensor quantization that quantizes both weight and activation. `e5m2_e5m2_float16` uses `e5m2_float8` for both inputs and weights, the outputs and the un-quantized parts are in fp16. Calibration is not supported in this PR.

Co-authored-by: Chris Sullivan \<csullivan@octo.ai\>
Co-authored-by: Joseph McMahan \<jmcmahan@octoml.ai\>

cc @tqchen @csullivan @JosephTheOctonaut @MasterJH5574 