### PR TITLE
[Serving] Separating ThreadedEngine creation and initialization

### DIFF
--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -26,7 +26,7 @@ using namespace tvm::runtime;
 /*! \brief The implementation of ThreadedEngine. */
 class ThreadedEngineImpl : public ThreadedEngine {
  public:
-  void InitBackgroundEngine(TVMArgs args) {
+  void InitBackgroundEngine(TVMArgs args) final {
     Optional<PackedFunc> request_stream_callback;
     try {
       request_stream_callback = args.At<Optional<PackedFunc>>(4);
@@ -232,9 +232,8 @@ TVM_REGISTER_GLOBAL("mlc.serve.create_threaded_engine").set_body_typed([]() {
   return Module(make_object<ThreadedEngineModule>());
 });
 
-std::unique_ptr<ThreadedEngine> CreateThreadedEnginePacked(TVMArgs args) {
+std::unique_ptr<ThreadedEngine> ThreadedEngine::Create() {
   std::unique_ptr<ThreadedEngineImpl> threaded_engine = std::make_unique<ThreadedEngineImpl>();
-  threaded_engine->InitBackgroundEngine(args);
   return std::move(threaded_engine);
 }
 

--- a/cpp/serve/threaded_engine.h
+++ b/cpp/serve/threaded_engine.h
@@ -28,7 +28,16 @@ using namespace tvm::runtime;
  */
 class ThreadedEngine {
  public:
+  /*! \brief Create a ThreadedEngine. */
+  static std::unique_ptr<ThreadedEngine> Create();
+
   virtual ~ThreadedEngine() = default;
+
+  /*!
+   * \brief Initialize the threaded engine from packed arguments in TVMArgs.
+   * \param args The arguments of engine construction.
+   */
+  virtual void InitBackgroundEngine(TVMArgs args) = 0;
 
   /*! \brief Starts the background request processing loop. */
   virtual void RunBackgroundLoop() = 0;
@@ -49,13 +58,6 @@ class ThreadedEngine {
   /*! \brief Abort the input request (specified by id string) from engine. */
   virtual void AbortRequest(const String& request_id) = 0;
 };
-
-/*!
- * \brief Create a ThreadedEngine from packed arguments in TVMArgs.
- * \param args The arguments of engine construction.
- * \return The constructed threaded engine in unique pointer.
- */
-std::unique_ptr<ThreadedEngine> CreateThreadedEnginePacked(TVMArgs args);
 
 }  // namespace serve
 }  // namespace llm


### PR DESCRIPTION
This PR separates the creation and initialization of ThreadedEngine for multi-threading use cases. So we can make sure that the ThreadedEngine instance is created before any other operations (such as initialization, running background loop, etc.).