### PR TITLE
[DOC] fix small python env install error

### DIFF
--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -160,7 +160,8 @@ While it is generally recommended to always use the prebuilt TVM Unity, if you r
         conda create -n tvm-build-venv -c conda-forge \
             "llvmdev>=15" \
             "cmake>=3.24" \
-            git
+            git \
+            python=3.11
         # enter the build environment
         conda activate tvm-build-venv
 


### PR DESCRIPTION
Fixed one slight issue of tvm install: would require specify python=3.11 on the platform otherwise will encounter python not found error on 4090 Linux issue.