### PR TITLE
[Pass] Attach non-negative TIR var attributes

### DIFF
--- a/python/mlc_llm/compiler_pass/attach_sampler.py
+++ b/python/mlc_llm/compiler_pass/attach_sampler.py
@@ -20,6 +20,7 @@ class AttachGPUSamplingFunc:  # pylint: disable=too-few-public-methods
             "num_samples": max_batch_size,
             "num_positions": 6 * max_batch_size,
         }
+        self.non_negative_var = ["vocab_size"]
         self.target = target
 
     def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:
@@ -50,7 +51,11 @@ class AttachGPUSamplingFunc:  # pylint: disable=too-few-public-methods
 
         mod = bb.finalize()
         for gv_name in gv_names:
-            mod[gv_name] = mod[gv_name].with_attr("tir_var_upper_bound", self.variable_bounds)
+            mod[gv_name] = (
+                mod[gv_name]
+                .with_attr("tir_var_upper_bound", self.variable_bounds)
+                .with_attr("tir_non_negative_var", self.non_negative_var)
+            )
         return mod
 
 

--- a/python/mlc_llm/compiler_pass/attach_support_info.py
+++ b/python/mlc_llm/compiler_pass/attach_support_info.py
@@ -13,12 +13,15 @@ class AttachVariableBounds:  # pylint: disable=too-few-public-methods
     def __init__(self, variable_bounds: Dict[str, int]):
         # Specifically for RWKV workloads, which contains -1 max_seq_len
         self.variable_bounds = {k: v for k, v in variable_bounds.items() if v > 0}
+        self.non_negative_var = ["vocab_size"]
 
     def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:
         """Entrypoint"""
         for g_var, func in mod.functions_items():
             if isinstance(func, relax.Function):
-                mod[g_var] = func.with_attr("tir_var_upper_bound", self.variable_bounds)
+                mod[g_var] = func.with_attr("tir_var_upper_bound", self.variable_bounds).with_attr(
+                    "tir_non_negative_var", self.non_negative_var
+                )
         return mod
 
 


### PR DESCRIPTION
This PR attaches the attributes of `tir.non_negative_var` for memory planning.