### PR TITLE
[Serving][Refactor] Engine constructor interface refactor

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -295,18 +295,18 @@ String KVCacheConfigNode::AsJSONString() const {
   return picojson::value(config).serialize(true);
 }
 
-/****************** EngineMode ******************/
+/****************** EngineConfig ******************/
 
-TVM_REGISTER_OBJECT_TYPE(EngineModeNode);
+TVM_REGISTER_OBJECT_TYPE(EngineConfigNode);
 
-EngineMode::EngineMode(int spec_draft_length, int speculative_mode) {
-  ObjectPtr<EngineModeNode> n = make_object<EngineModeNode>();
+EngineConfig::EngineConfig(int spec_draft_length, int speculative_mode) {
+  ObjectPtr<EngineConfigNode> n = make_object<EngineConfigNode>();
   n->spec_draft_length = spec_draft_length;
   n->speculative_mode = SpeculativeMode(speculative_mode);
   data_ = std::move(n);
 }
 
-EngineMode::EngineMode(const std::string& config_str) {
+EngineConfig::EngineConfig(const std::string& config_str) {
   int spec_draft_length = 4;
   int speculative_mode = 0;
 
@@ -327,13 +327,13 @@ EngineMode::EngineMode(const std::string& config_str) {
     speculative_mode = config["speculative_mode"].get<int64_t>();
   }
 
-  ObjectPtr<EngineModeNode> n = make_object<EngineModeNode>();
+  ObjectPtr<EngineConfigNode> n = make_object<EngineConfigNode>();
   n->spec_draft_length = spec_draft_length;
   n->speculative_mode = SpeculativeMode(speculative_mode);
   data_ = std::move(n);
 }
 
-String EngineModeNode::AsJSONString() const {
+String EngineConfigNode::AsJSONString() const {
   picojson::object config;
   config["spec_draft_length"] = picojson::value(static_cast<int64_t>(this->spec_draft_length));
   config["speculative_mode"] = picojson::value(static_cast<int64_t>(this->speculative_mode));

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -105,8 +105,8 @@ enum class SpeculativeMode : int {
   kEagle = 2,
 };
 
-/*! \brief The configuration of engine execution mode. */
-class EngineModeNode : public Object {
+/*! \brief The configuration of engine execution config. */
+class EngineConfigNode : public Object {
  public:
   /* The number of tokens to generate in speculative proposal (draft) */
   int spec_draft_length;
@@ -115,19 +115,19 @@ class EngineModeNode : public Object {
 
   String AsJSONString() const;
 
-  static constexpr const char* _type_key = "mlc.serve.EngineMode";
+  static constexpr const char* _type_key = "mlc.serve.EngineConfig";
   static constexpr const bool _type_has_method_sequal_reduce = false;
   static constexpr const bool _type_has_method_shash_reduce = false;
-  TVM_DECLARE_BASE_OBJECT_INFO(EngineModeNode, Object);
+  TVM_DECLARE_BASE_OBJECT_INFO(EngineConfigNode, Object);
 };
 
-class EngineMode : public ObjectRef {
+class EngineConfig : public ObjectRef {
  public:
-  explicit EngineMode(int spec_draft_length, int speculative_mode);
+  explicit EngineConfig(int spec_draft_length, int speculative_mode);
 
-  explicit EngineMode(const std::string& config_str);
+  explicit EngineConfig(const std::string& config_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(EngineMode, ObjectRef, EngineModeNode);
+  TVM_DEFINE_OBJECT_REF_METHODS(EngineConfig, ObjectRef, EngineConfigNode);
 };
 
 }  // namespace serve

--- a/cpp/serve/engine.h
+++ b/cpp/serve/engine.h
@@ -54,7 +54,7 @@ class Engine {
    * sequence length supported by the engine.
    * \param tokenizer_path The tokenizer path on disk.
    * \param kv_cache_config_json_str The KV cache config in JSON string.
-   * \param engine_mode_json_str The Engine execution mode in JSON string.
+   * \param engine_config_json_str The Engine execution configuration in JSON string.
    * \param request_stream_callback The request stream callback function to
    * stream back generated output for requests.
    * \param trace_recorder Event trace recorder for requests.
@@ -67,7 +67,7 @@ class Engine {
    */
   static std::unique_ptr<Engine> Create(
       int max_single_sequence_length, const String& tokenizer_path,
-      const String& kv_cache_config_json_str, const String& engine_mode_json_str,
+      const String& kv_cache_config_json_str, const String& engine_config_json_str,
       Optional<PackedFunc> request_stream_callback, Optional<EventTraceRecorder> trace_recorder,
       const std::vector<std::tuple<TVMArgValue, String, DLDevice>>& model_infos);
 

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -57,14 +57,14 @@ class EngineAction : public ObjectRef {
    * \param sampler The sampler to sample new tokens.
    * \param model_workspaces The workspace of each model.
    * \param kv_cache_config The KV cache config to help decide prefill is doable.
-   * \param engine_mode The engine operation mode.
+   * \param engine_config The engine operation mode.
    * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction NewRequestPrefill(Array<Model> models, LogitProcessor logit_processor,
                                         Sampler sampler,
                                         std::vector<ModelWorkspace> model_workspaces,
-                                        KVCacheConfig kv_cache_config, EngineMode engine_mode,
+                                        KVCacheConfig kv_cache_config, EngineConfig engine_config,
                                         Optional<EventTraceRecorder> trace_recorder);
   /*!
    * \brief Create the action that prefills requests in the `waiting_queue`
@@ -74,14 +74,15 @@ class EngineAction : public ObjectRef {
    * \param sampler The sampler to sample new tokens.
    * \param model_workspaces The workspace of each model.
    * \param kv_cache_config The KV cache config to help decide prefill is doable.
-   * \param engine_mode The engine operation mode.
+   * \param engine_config The engine operation mode.
    * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction EagleNewRequestPrefill(Array<Model> models, LogitProcessor logit_processor,
                                              Sampler sampler,
                                              std::vector<ModelWorkspace> model_workspaces,
-                                             KVCacheConfig kv_cache_config, EngineMode engine_mode,
+                                             KVCacheConfig kv_cache_config,
+                                             EngineConfig engine_config,
                                              Optional<EventTraceRecorder> trace_recorder);
   /*!
    * \brief Create the action that runs one-step decode for requests in the

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -24,14 +24,15 @@ class EagleNewRequestPrefillActionObj : public EngineActionObj {
   explicit EagleNewRequestPrefillActionObj(Array<Model> models, LogitProcessor logit_processor,
                                            Sampler sampler,
                                            std::vector<ModelWorkspace> model_workspaces,
-                                           KVCacheConfig kv_cache_config, EngineMode engine_mode,
+                                           KVCacheConfig kv_cache_config,
+                                           EngineConfig engine_config,
                                            Optional<EventTraceRecorder> trace_recorder)
       : models_(std::move(models)),
         logit_processor_(std::move(logit_processor)),
         sampler_(std::move(sampler)),
         model_workspaces_(std::move(model_workspaces)),
         kv_cache_config_(std::move(kv_cache_config)),
-        engine_mode_(std::move(engine_mode)),
+        engine_config_(std::move(engine_config)),
         trace_recorder_(std::move(trace_recorder)) {}
 
   Array<Request> Step(EngineState estate) final {
@@ -421,8 +422,8 @@ class EagleNewRequestPrefillActionObj : public EngineActionObj {
 
     // No exceeding of the maximum allowed requests that can
     // run simultaneously.
-    int spec_factor = engine_mode_->speculative_mode != SpeculativeMode::kDisable
-                          ? engine_mode_->spec_draft_length
+    int spec_factor = engine_config_->speculative_mode != SpeculativeMode::kDisable
+                          ? engine_config_->spec_draft_length
                           : 1;
     if ((num_running_rsentries + num_prefill_rsentries) * spec_factor >
         std::min(kv_cache_config_->max_num_sequence, kv_cache_config_->prefill_chunk_size)) {
@@ -546,7 +547,7 @@ class EagleNewRequestPrefillActionObj : public EngineActionObj {
   /*! \brief The KV cache config to help decide prefill is doable. */
   KVCacheConfig kv_cache_config_;
   /*! \brief The engine operation mode. */
-  EngineMode engine_mode_;
+  EngineConfig engine_config_;
   /*! \brief Event trace recorder. */
   Optional<EventTraceRecorder> trace_recorder_;
 };
@@ -555,11 +556,11 @@ EngineAction EngineAction::EagleNewRequestPrefill(Array<Model> models,
                                                   LogitProcessor logit_processor, Sampler sampler,
                                                   std::vector<ModelWorkspace> model_workspaces,
                                                   KVCacheConfig kv_cache_config,
-                                                  EngineMode engine_mode,
+                                                  EngineConfig engine_config,
                                                   Optional<EventTraceRecorder> trace_recorder) {
   return EngineAction(make_object<EagleNewRequestPrefillActionObj>(
       std::move(models), std::move(logit_processor), std::move(sampler),
-      std::move(model_workspaces), std::move(kv_cache_config), std::move(engine_mode),
+      std::move(model_workspaces), std::move(kv_cache_config), std::move(engine_config),
       std::move(trace_recorder)));
 }
 

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -23,14 +23,14 @@ class NewRequestPrefillActionObj : public EngineActionObj {
  public:
   explicit NewRequestPrefillActionObj(Array<Model> models, LogitProcessor logit_processor,
                                       Sampler sampler, std::vector<ModelWorkspace> model_workspaces,
-                                      KVCacheConfig kv_cache_config, EngineMode engine_mode,
+                                      KVCacheConfig kv_cache_config, EngineConfig engine_config,
                                       Optional<EventTraceRecorder> trace_recorder)
       : models_(std::move(models)),
         logit_processor_(std::move(logit_processor)),
         sampler_(std::move(sampler)),
         model_workspaces_(std::move(model_workspaces)),
         kv_cache_config_(std::move(kv_cache_config)),
-        engine_mode_(std::move(engine_mode)),
+        engine_config_(std::move(engine_config)),
         trace_recorder_(std::move(trace_recorder)) {}
 
   Array<Request> Step(EngineState estate) final {
@@ -360,8 +360,8 @@ class NewRequestPrefillActionObj : public EngineActionObj {
 
     // No exceeding of the maximum allowed requests that can
     // run simultaneously.
-    int spec_factor = engine_mode_->speculative_mode != SpeculativeMode::kDisable
-                          ? engine_mode_->spec_draft_length
+    int spec_factor = engine_config_->speculative_mode != SpeculativeMode::kDisable
+                          ? engine_config_->spec_draft_length
                           : 1;
     if ((num_running_rsentries + num_prefill_rsentries) * spec_factor >
         std::min(kv_cache_config_->max_num_sequence, kv_cache_config_->prefill_chunk_size)) {
@@ -465,7 +465,7 @@ class NewRequestPrefillActionObj : public EngineActionObj {
   /*! \brief The KV cache config to help decide prefill is doable. */
   KVCacheConfig kv_cache_config_;
   /*! \brief The engine operation mode. */
-  EngineMode engine_mode_;
+  EngineConfig engine_config_;
   /*! \brief Event trace recorder. */
   Optional<EventTraceRecorder> trace_recorder_;
 };
@@ -473,11 +473,12 @@ class NewRequestPrefillActionObj : public EngineActionObj {
 EngineAction EngineAction::NewRequestPrefill(Array<Model> models, LogitProcessor logit_processor,
                                              Sampler sampler,
                                              std::vector<ModelWorkspace> model_workspaces,
-                                             KVCacheConfig kv_cache_config, EngineMode engine_mode,
+                                             KVCacheConfig kv_cache_config,
+                                             EngineConfig engine_config,
                                              Optional<EventTraceRecorder> trace_recorder) {
   return EngineAction(make_object<NewRequestPrefillActionObj>(
       std::move(models), std::move(logit_processor), std::move(sampler),
-      std::move(model_workspaces), std::move(kv_cache_config), std::move(engine_mode),
+      std::move(model_workspaces), std::move(kv_cache_config), std::move(engine_config),
       std::move(trace_recorder)));
 }
 

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -4,6 +4,7 @@ import json
 
 from mlc_llm.help import HELP
 from mlc_llm.interface.serve import serve
+from mlc_llm.serve.config import EngineConfig
 from mlc_llm.support.argparse import ArgumentParser
 
 
@@ -29,15 +30,28 @@ def main(argv):
         help=HELP["model_lib_path"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
-        "--max-batch-size",
-        type=int,
-        default=80,
-        help=HELP["max_batch_size"] + ' (default: "%(default)s")',
+        "--mode",
+        type=str,
+        choices=["local", "interactive", "server"],
+        default="local",
+        help=HELP["mode_serve"] + ' (default: "%(default)s")',
     )
+    parser.add_argument(
+        "--additional-models", type=str, nargs="*", help=HELP["additional_models_serve"]
+    )
+    parser.add_argument("--max-batch-size", type=int, help=HELP["max_batch_size"])
     parser.add_argument(
         "--max-total-seq-length", type=int, help=HELP["max_total_sequence_length_serve"]
     )
     parser.add_argument("--prefill-chunk-size", type=int, help=HELP["prefill_chunk_size_serve"])
+    parser.add_argument(
+        "--gpu-memory-utilization", type=float, help=HELP["gpu_memory_utilization_serve"]
+    )
+    parser.add_argument(
+        "--engine-config",
+        type=EngineConfig.from_str,
+        help=HELP["engine_config_serve"] + ' (default: "%(default)s")',
+    )
     parser.add_argument("--enable-tracing", action="store_true", help=HELP["enable_tracing_serve"])
     parser.add_argument(
         "--host",
@@ -76,9 +90,13 @@ def main(argv):
         model=parsed.model,
         device=parsed.device,
         model_lib_path=parsed.model_lib_path,
+        mode=parsed.mode,
+        additional_models=parsed.additional_models,
         max_batch_size=parsed.max_batch_size,
         max_total_sequence_length=parsed.max_total_seq_length,
         prefill_chunk_size=parsed.prefill_chunk_size,
+        gpu_memory_utilization=parsed.gpu_memory_utilization,
+        engine_config=parsed.engine_config,
         enable_tracing=parsed.enable_tracing,
         host=parsed.host,
         port=parsed.port,

--- a/python/mlc_llm/help.py
+++ b/python/mlc_llm/help.py
@@ -159,4 +159,44 @@ After enabling, you can send POST request to the "debug/dump_event_trace" entryp
 to get the Chrome Trace. For example,
 "curl -X POST http://127.0.0.1:8000/debug/dump_event_trace -H "Content-Type: application/json" -d '{"model": "dist/llama"}'"
 """.strip(),
+    "mode_serve": """
+The engine mode in MLC LLM. We provide three preset modes: "local", "interactive" and "server".
+The default mode is "local".
+The choice of mode decides the values of "--max-batch-size", "--max-total-seq-length" and
+"--prefill-chunk-size" when they are not explicitly specified.
+1. Mode "local" refers to the local server deployment which has low request concurrency.
+   So the max batch size will be set to 4, and max total sequence length and prefill chunk size
+   are set to the context window size (or sliding window size) of the model.
+2. Mode "interactive" refers to the interactive use of server, which has at most 1 concurrent
+   request. So the max batch size will be set to 1, and max total sequence length and prefill
+   chunk size are set to the context window size (or sliding window size) of the model.
+3. Mode "server" refers to the large server use case which may handle many concurrent request
+   and want to use GPU memory as much as possible. In this mode, we will automatically infer
+   the largest possible max batch size and max total sequence length.
+You can manually specify arguments "--max-batch-size", "--max-total-seq-length" and
+"--prefill-chunk-size" to override the automatic inferred values.
+""".strip(),
+    "additional_models_serve": """
+The model paths and (optional) model library paths of additional models (other than the main model).
+When engine is enabled with speculative decoding, additional models are needed.
+The way of specifying additional models is:
+"--additional-models model_path_1 model_path_2 ..." or
+"--additional-models model_path_1:model_lib_path_1 model_path_2 ...".
+When the model lib path of a model is not given, JIT model compilation will be activated
+to compile the model automatically.
+""",
+    "gpu_memory_utilization_serve": """
+A number in (0, 1) denoting the fraction of GPU memory used by the server in total.
+It is used to infer to maximum possible KV cache capacity.
+When it is unspecified, it defaults to 0.90.
+Under mode "local" or "interactive", the actual memory usage may be significantly smaller than
+this number. Under mode "server", the actual memory usage may be slightly larger than this number.
+""",
+    "engine_config_serve": """
+The Engine execution configuration.
+Currently speculative decoding mode is specified via engine config.
+For example, you can use "--engine-config='spec_draft_length=4;speculative_mode=EAGLE'" to
+specify the eagle-style speculative decoding.
+Check out class `EngineConfig` in mlc_llm/serve/config.py for detailed specification.
+""",
 }

--- a/python/mlc_llm/serve/__init__.py
+++ b/python/mlc_llm/serve/__init__.py
@@ -2,7 +2,7 @@
 
 # Load MLC LLM library by importing base
 from .. import base
-from .config import EngineMode, GenerationConfig, KVCacheConfig, SpeculativeMode
+from .config import EngineConfig, GenerationConfig, KVCacheConfig, SpeculativeMode
 from .data import Data, ImageData, RequestStreamOutput, TextData, TokenData
 from .engine import AsyncEngine, Engine
 from .grammar import BNFGrammar, GrammarStateMatcher

--- a/python/mlc_llm/serve/server/popen_server.py
+++ b/python/mlc_llm/serve/server/popen_server.py
@@ -4,10 +4,13 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import List, Literal, Optional, Union
 
 import psutil
 import requests
+from tvm.runtime import Device
+
+from mlc_llm.serve.config import EngineConfig
 
 
 class PopenServer:  # pylint: disable=too-many-instance-attributes
@@ -17,11 +20,16 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
         model: str,
-        device: str = "auto",
+        device: Union[str, Device] = "auto",
         *,
         model_lib_path: Optional[str] = None,
-        max_batch_size: int = 80,
+        mode: Literal["local", "interactive", "server"] = "local",
+        additional_models: Optional[List[str]] = None,
+        max_batch_size: Optional[int] = None,
         max_total_sequence_length: Optional[int] = None,
+        prefill_chunk_size: Optional[int] = None,
+        gpu_memory_utilization: Optional[float] = None,
+        engine_config: Optional[EngineConfig] = None,
         enable_tracing: bool = False,
         host: str = "127.0.0.1",
         port: int = 8000,
@@ -30,14 +38,19 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         self.model = model
         self.model_lib_path = model_lib_path
         self.device = device
+        self.mode = mode
+        self.additional_models = additional_models
         self.max_batch_size = max_batch_size
         self.max_total_sequence_length = max_total_sequence_length
+        self.prefill_chunk_size = prefill_chunk_size
+        self.gpu_memory_utilization = gpu_memory_utilization
+        self.engine_config = engine_config
         self.enable_tracing = enable_tracing
         self.host = host
         self.port = port
         self._proc: Optional[subprocess.Popen] = None
 
-    def start(self) -> None:
+    def start(self) -> None:  # pylint: disable=too-many-branches
         """Launch the server in a popen subprocess.
         Wait until the server becomes ready before return.
         """
@@ -46,9 +59,20 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         if self.model_lib_path is not None:
             cmd += ["--model-lib-path", self.model_lib_path]
         cmd += ["--device", self.device]
-        cmd += ["--max-batch-size", str(self.max_batch_size)]
+        if self.mode is not None:
+            cmd += ["--mode", self.mode]
+        if self.additional_models is not None:
+            cmd += ["--additional-models", *self.additional_models]
+        if self.max_batch_size is not None:
+            cmd += ["--max-batch-size", str(self.max_batch_size)]
         if self.max_total_sequence_length is not None:
             cmd += ["--max-total-seq-length", str(self.max_total_sequence_length)]
+        if self.prefill_chunk_size is not None:
+            cmd += ["--prefill-chunk-size", str(self.prefill_chunk_size)]
+        if self.engine_config is not None:
+            cmd += ["--engine-config", str(self.engine_config)]
+        if self.gpu_memory_utilization is not None:
+            cmd += ["--gpu-memory-utilization", str(self.gpu_memory_utilization)]
         if self.enable_tracing:
             cmd += ["--enable-tracing"]
 

--- a/tests/python/serve/evaluate_engine.py
+++ b/tests/python/serve/evaluate_engine.py
@@ -4,8 +4,7 @@ import os
 import random
 from typing import List, Tuple
 
-from mlc_llm.serve import GenerationConfig, KVCacheConfig
-from mlc_llm.serve.engine_base import ModelInfo
+from mlc_llm.serve import GenerationConfig
 from mlc_llm.serve.sync_engine import SyncEngine
 
 
@@ -14,14 +13,12 @@ def _parse_args():
     args.add_argument("--model-lib-path", type=str)
     args.add_argument("--device", type=str, default="auto")
     args.add_argument("--batch-size", type=int, default=80)
-    args.add_argument("--page-size", type=int, default=16)
     args.add_argument("--max-total-seq-length", type=int)
     args.add_argument("--seed", type=int, default=0)
 
     parsed = args.parse_args()
     parsed.model = os.path.dirname(parsed.model_lib_path)
     assert parsed.batch_size % 16 == 0
-    assert parsed.page_size == 16
     return parsed
 
 
@@ -43,16 +40,15 @@ def generate_requests(
 def benchmark(args: argparse.Namespace):
     random.seed(args.seed)
 
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(args.model, args.model_lib_path, args.device)
-    kv_cache_config = KVCacheConfig(
-        page_size=args.page_size,
-        max_num_sequence=args.batch_size,
+    # Create engine
+    engine = SyncEngine(
+        model=args.model,
+        device=args.device,
+        model_lib_path=args.model_lib_path,
+        mode="server",
+        max_batch_size=args.batch_size,
         max_total_sequence_length=args.max_total_seq_length,
     )
-
-    # Create engine
-    engine = SyncEngine(model, kv_cache_config)
 
     print(args)
     for num_requests in [1, 2, 4, 8, 16, 32, 64]:

--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -3,8 +3,7 @@
 import asyncio
 from typing import List
 
-from mlc_llm.serve import AsyncEngine, GenerationConfig, KVCacheConfig
-from mlc_llm.serve.engine_base import ModelInfo
+from mlc_llm.serve import AsyncEngine, GenerationConfig
 
 prompts = [
     "What is the meaning of life?",
@@ -21,14 +20,15 @@ prompts = [
 
 
 async def test_engine_generate():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    async_engine = AsyncEngine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    async_engine = AsyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 10
     max_tokens = 256
@@ -77,14 +77,15 @@ async def test_engine_generate():
 
 
 async def test_chat_completion():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    async_engine = AsyncEngine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    async_engine = AsyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 32
@@ -96,7 +97,7 @@ async def test_chat_completion():
         rid = int(request_id)
         async for response in await async_engine.chat.completions.create(
             messages=[{"role": "user", "content": prompt}],
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             request_id=request_id,
@@ -128,14 +129,15 @@ async def test_chat_completion():
 
 
 async def test_chat_completion_non_stream():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    async_engine = AsyncEngine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    async_engine = AsyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 32
@@ -147,7 +149,7 @@ async def test_chat_completion_non_stream():
         rid = int(request_id)
         response = await async_engine.chat.completions.create(
             messages=[{"role": "user", "content": prompt}],
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             request_id=request_id,
@@ -178,14 +180,15 @@ async def test_chat_completion_non_stream():
 
 
 async def test_completion():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    async_engine = AsyncEngine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    async_engine = AsyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 128
@@ -197,7 +200,7 @@ async def test_completion():
         rid = int(request_id)
         async for response in await async_engine.completions.create(
             prompt=prompt,
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             ignore_eos=True,
@@ -229,14 +232,15 @@ async def test_completion():
 
 
 async def test_completion_non_stream():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    async_engine = AsyncEngine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    async_engine = AsyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 128
@@ -248,7 +252,7 @@ async def test_completion_non_stream():
         rid = int(request_id)
         response = await async_engine.completions.create(
             prompt=prompt,
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             ignore_eos=True,

--- a/tests/python/serve/test_serve_async_engine_spec.py
+++ b/tests/python/serve/test_serve_async_engine_spec.py
@@ -3,14 +3,7 @@
 import asyncio
 from typing import List
 
-from mlc_llm.serve import (
-    AsyncEngine,
-    EngineMode,
-    GenerationConfig,
-    KVCacheConfig,
-    SpeculativeMode,
-)
-from mlc_llm.serve.engine_base import ModelInfo
+from mlc_llm.serve import AsyncEngine, EngineConfig, GenerationConfig, SpeculativeMode
 
 prompts = [
     "What is the meaning of life?",
@@ -27,19 +20,20 @@ prompts = [
 
 
 async def test_engine_generate():
-    # Initialize model loading info and KV cache config
-    ssm = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so",
-    )
-    llm = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16)
-    engine_mode = EngineMode(speculative_mode=SpeculativeMode.SMALL_DRAFT)
     # Create engine
-    async_engine = AsyncEngine([llm, ssm], kv_cache_config, engine_mode)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    small_model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
+    small_model_lib_path = (
+        "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    )
+    async_engine = AsyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        additional_models=[small_model + ":" + small_model_lib_path],
+        engine_config=EngineConfig(speculative_mode=SpeculativeMode.SMALL_DRAFT),
+    )
 
     num_requests = 10
     max_tokens = 256

--- a/tests/python/serve/test_serve_engine.py
+++ b/tests/python/serve/test_serve_engine.py
@@ -2,8 +2,7 @@
 # pylint: disable=too-many-arguments,too-many-locals,unused-argument,unused-variable
 from typing import List
 
-from mlc_llm.serve import Engine, GenerationConfig, KVCacheConfig
-from mlc_llm.serve.engine_base import ModelInfo
+from mlc_llm.serve import Engine, GenerationConfig
 
 prompts = [
     "What is the meaning of life?",
@@ -20,14 +19,15 @@ prompts = [
 
 
 def test_engine_generate():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    engine = Engine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = Engine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 10
     max_tokens = 256
@@ -58,14 +58,15 @@ def test_engine_generate():
 
 
 def test_chat_completion():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    engine = Engine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = Engine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 64
@@ -76,7 +77,7 @@ def test_chat_completion():
         print(f"chat completion for request {rid}")
         for response in engine.chat.completions.create(
             messages=[{"role": "user", "content": prompts[rid]}],
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             request_id=str(rid),
@@ -101,14 +102,15 @@ def test_chat_completion():
 
 
 def test_chat_completion_non_stream():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    engine = Engine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = Engine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 64
@@ -119,7 +121,7 @@ def test_chat_completion_non_stream():
         print(f"chat completion for request {rid}")
         response = engine.chat.completions.create(
             messages=[{"role": "user", "content": prompts[rid]}],
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             request_id=str(rid),
@@ -143,14 +145,15 @@ def test_chat_completion_non_stream():
 
 
 def test_completion():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    engine = Engine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = Engine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 128
@@ -161,7 +164,7 @@ def test_completion():
         print(f"completion for request {rid}")
         for response in engine.completions.create(
             prompt=prompts[rid],
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             ignore_eos=True,
@@ -186,14 +189,15 @@ def test_completion():
 
 
 def test_completion_non_stream():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    engine = Engine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = Engine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 2
     max_tokens = 128
@@ -204,7 +208,7 @@ def test_completion_non_stream():
         print(f"completion for request {rid}")
         response = engine.completions.create(
             prompt=prompts[rid],
-            model=model.model,
+            model=model,
             max_tokens=max_tokens,
             n=n,
             ignore_eos=True,

--- a/tests/python/serve/test_serve_engine_grammar.py
+++ b/tests/python/serve/test_serve_engine_grammar.py
@@ -7,9 +7,8 @@ from typing import List
 import pytest
 from pydantic import BaseModel
 
-from mlc_llm.serve import AsyncEngine, GenerationConfig, KVCacheConfig
+from mlc_llm.serve import AsyncEngine, GenerationConfig
 from mlc_llm.serve.config import ResponseFormat
-from mlc_llm.serve.engine_base import ModelInfo
 from mlc_llm.serve.sync_engine import SyncEngine
 
 prompts_list = [
@@ -22,11 +21,8 @@ model_lib_path = "dist/libs/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
 
 
 def test_batch_generation_with_grammar():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(model_path, model_lib_path=model_lib_path)
-    kv_cache_config = KVCacheConfig(page_size=16)
     # Create engine
-    engine = SyncEngine(model, kv_cache_config)
+    engine = SyncEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
 
     prompt_len = len(prompts_list)
     prompts = prompts_list * 3
@@ -72,11 +68,8 @@ def test_batch_generation_with_grammar():
 
 
 def test_batch_generation_with_schema():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(model_path, model_lib_path=model_lib_path)
-    kv_cache_config = KVCacheConfig(page_size=16)
     # Create engine
-    engine = SyncEngine(model, kv_cache_config)
+    engine = SyncEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
 
     prompt = (
         "Generate a json containing three fields: an integer field named size, a "
@@ -127,11 +120,8 @@ def test_batch_generation_with_schema():
 
 
 async def run_async_engine():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(model_path, model_lib_path=model_lib_path)
-    kv_cache_config = KVCacheConfig(page_size=16)
     # Create engine
-    async_engine = AsyncEngine(model, kv_cache_config, enable_tracing=True)
+    async_engine = AsyncEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
 
     prompts = prompts_list * 20
 
@@ -184,8 +174,6 @@ async def run_async_engine():
         else:
             for i, output in enumerate(outputs):
                 print(f"Output {req_id}({i}):{output}\n")
-
-    print(async_engine.state.trace_recorder.dump_json(), file=open("tmpfiles/tmp.json", "w"))
 
     async_engine.terminate()
 

--- a/tests/python/serve/test_serve_engine_image.py
+++ b/tests/python/serve/test_serve_engine_image.py
@@ -1,8 +1,7 @@
 import json
 from pathlib import Path
 
-from mlc_llm.serve import GenerationConfig, KVCacheConfig, data
-from mlc_llm.serve.engine_base import ModelInfo
+from mlc_llm.serve import GenerationConfig, data
 from mlc_llm.serve.sync_engine import SyncEngine
 
 
@@ -11,17 +10,18 @@ def get_test_image(config) -> data.ImageData:
 
 
 def test_engine_generate():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/llava-1.5-7b-hf-q4f16_1-MLC/params",
-        model_lib_path="dist/llava-1.5-7b-hf-q4f16_1-MLC/llava-1.5-7b-hf-q4f16_1-MLC.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    engine = SyncEngine(model, kv_cache_config)
+    model = "dist/llava-1.5-7b-hf-q4f16_1-MLC/params"
+    model_lib_path = "dist/llava-1.5-7b-hf-q4f16_1-MLC/llava-1.5-7b-hf-q4f16_1-MLC.so"
+    engine = SyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
     max_tokens = 256
 
-    with open(Path(model.model) / "mlc-chat-config.json", "r", encoding="utf-8") as file:
+    with open(Path(model) / "mlc-chat-config.json", "r", encoding="utf-8") as file:
         model_config = json.load(file)
 
     prompts = [

--- a/tests/python/serve/test_serve_sync_engine.py
+++ b/tests/python/serve/test_serve_sync_engine.py
@@ -4,14 +4,7 @@ from typing import Callable, List, Optional
 
 import numpy as np
 
-from mlc_llm.serve import (
-    GenerationConfig,
-    KVCacheConfig,
-    Request,
-    RequestStreamOutput,
-    data,
-)
-from mlc_llm.serve.engine_base import ModelInfo
+from mlc_llm.serve import GenerationConfig, Request, RequestStreamOutput, data
 from mlc_llm.serve.sync_engine import SyncEngine
 
 prompts = [
@@ -67,13 +60,6 @@ def test_engine_basic():
     requests + max_tokens - 1). Then check the output of each request.
     """
 
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16)
-
     # Hyperparameters for tests (you can try different combinations).
     num_requests = 10  # [4, 8, 10]
     temperature = 0.9  # [0, 0.8, 0.9, 1.0, 1.1]
@@ -92,7 +78,14 @@ def test_engine_basic():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    engine = SyncEngine(model, kv_cache_config, request_stream_callback=fcallback)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = SyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        request_stream_callback=fcallback,
+    )
 
     # Create requests
     requests = create_requests(
@@ -128,13 +121,6 @@ def test_engine_continuous_batching_1():
     of each request.
     """
 
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16)
-
     # Hyperparameters for tests (you can try different combinations)
     num_requests = 10  # [4, 8, 10]
     temperature = 0.9  # [0.8, 0.9, 1.0, 1.1]
@@ -168,7 +154,14 @@ def test_engine_continuous_batching_1():
 
     # Create engine
     timer = CallbackTimer()
-    engine = SyncEngine(model, kv_cache_config, request_stream_callback=timer.callback_getter())
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = SyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        request_stream_callback=timer.callback_getter(),
+    )
 
     # Create requests
     requests = create_requests(
@@ -209,13 +202,6 @@ def test_engine_continuous_batching_2():
     of each request.
     """
 
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16)
-
     # Hyperparameters for tests (you can try different combinations)
     num_requests = 10  # [4, 8, 10]
     temperature = 0.9  # [0.8, 0.9, 1.0, 1.1]
@@ -249,7 +235,14 @@ def test_engine_continuous_batching_2():
 
     # Create engine
     timer = CallbackTimer()
-    engine = SyncEngine(model, kv_cache_config, request_stream_callback=timer.callback_getter())
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = SyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        request_stream_callback=timer.callback_getter(),
+    )
 
     # Create requests
     requests = create_requests(
@@ -288,13 +281,6 @@ def test_engine_continuous_batching_3():
     - Engine keeps running `step` until all requests finish.
     Then check the output of each request.
     """
-
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16)
 
     # Hyperparameters for tests (you can try different combinations)
     num_requests = 10  # [4, 8, 10]
@@ -335,7 +321,14 @@ def test_engine_continuous_batching_3():
 
     # Create engine
     timer = CallbackTimer()
-    engine = SyncEngine(model, kv_cache_config, request_stream_callback=timer.callback_getter())
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = SyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        request_stream_callback=timer.callback_getter(),
+    )
 
     # Create requests
     requests = create_requests(
@@ -369,14 +362,15 @@ def test_engine_continuous_batching_3():
 
 
 def test_engine_generate():
-    # Initialize model loading info and KV cache config
-    model = ModelInfo(
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        model_lib_path="dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
-    )
-    kv_cache_config = KVCacheConfig(page_size=16, max_total_sequence_length=4096)
     # Create engine
-    engine = SyncEngine(model, kv_cache_config)
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = SyncEngine(
+        model=model,
+        model_lib_path=model_lib_path,
+        mode="server",
+        max_total_sequence_length=4096,
+    )
 
     num_requests = 10
     max_tokens = 256


### PR DESCRIPTION
This PR is a refactor of the engine's contructor interface and the serve CLI interface.

This PR introduces the "mode" argument for engine, which has options "local", "interactive" and "server". The choice of mode will affect the automatically inferred value of `max_batch_size`, `max_total_sequence_length` and `prefill_chunk_size` (only effective when arguements are not specified. Once an argument is specified, we will not override it). For detailed specification of the mode, please check out the CLI help messages in `mlc_llm/help.py` or the engine constructor in `mlc_llm/serve/engine.py`.

No matter which mode is chosen, we will print out the current mode and the values of these arguments, for peopple to understand the settings of the engine. We also provide hints on how to adjust the mode. For example,

```
[2024-04-12 16:12:26] INFO chat_module.py:379: Using model folder: /home/ruihang/Workspace/mlc-llm/dist/Llama-2-7b-chat-hf-q0f16-MLC
[2024-04-12 16:12:26] INFO chat_module.py:380: Using mlc chat config: /home/ruihang/Workspace/mlc-llm/dist/Llama-2-7b-chat-hf-q0f16-MLC/mlc-chat-config.json
[2024-04-12 16:12:26] INFO chat_module.py:529: Using library model: dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so
[2024-04-12 16:12:26] INFO chat_module.py:379: Using model folder: /home/ruihang/Workspace/mlc-llm/dist/Llama-2-7b-chat-hf-q4f16_1-MLC
[2024-04-12 16:12:26] INFO chat_module.py:380: Using mlc chat config: /home/ruihang/Workspace/mlc-llm/dist/Llama-2-7b-chat-hf-q4f16_1-MLC/mlc-chat-config.json
[2024-04-12 16:12:26] INFO chat_module.py:529: Using library model: dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so
[2024-04-12 16:12:29] INFO engine_base.py:382: Engine mode is "local". Max batch size is set to 4. Max KV cache token capacity is set to 4096. Prefill chunk size is set to 4096.
[2024-04-12 16:12:29] INFO engine_base.py:387: Estimated total single GPU memory usage: 21543.74 MB (Parameters: 16467.64 MB. KVCache: 4450.07 MB. Temporary buffer: 626.03 MB). The actual usage might be slightly larger than the estimated number.
[2024-04-12 16:12:29] INFO engine_base.py:398: Please switch to mode "server" if you want to use more GPU memory and support more concurrent requests.
```

After the refactor, we bring the speculative decoding to the serve CLI so that people can use multiple models and run speculative decoding with the server launched in CLI (which was not doable before).