### PR TITLE
[Minor][SpecInfer] Fix Optional FC Bias for Mixtral Eagle Model

### DIFF
--- a/python/mlc_llm/model/eagle/eagle_model.py
+++ b/python/mlc_llm/model/eagle/eagle_model.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @dataclasses.dataclass
 class EagleConfig(LlamaConfig):
     """Configuration of the Eagle model."""
-
+    bias: bool = True # Whether to use bias in the fc layers
 
 # pylint: disable=invalid-name,missing-docstring
 
@@ -77,7 +77,7 @@ class EagleForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
             [EagleDecoderLayer(config, i) for i in range(config.num_hidden_layers)]
         )
         self.fc = nn.Linear(
-            in_features=2 * config.hidden_size, out_features=config.hidden_size, bias=True
+            in_features=2 * config.hidden_size, out_features=config.hidden_size, bias=config.bias
         )
 
         self.num_hidden_layers = config.num_hidden_layers

--- a/python/mlc_llm/model/eagle/eagle_model.py
+++ b/python/mlc_llm/model/eagle/eagle_model.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 @dataclasses.dataclass
 class EagleConfig(LlamaConfig):
     """Configuration of the Eagle model."""
-    bias: bool = True # Whether to use bias in the fc layers
+
+    bias: bool = True  # Whether to use bias in the fc layers
+
 
 # pylint: disable=invalid-name,missing-docstring
 


### PR DESCRIPTION
This PR added an optional fc bias option so that mixtral eagle model could be loaded.
Fix referenced from https://github.com/SafeAILab/EAGLE/blob/08dc06ccb428f2d3cf8380933ea50ed3e4178168/eagle/model/ea_model.py#L42

CC: @KnowingNothing @tqchen 