### PR TITLE
[Serving][Python] Rename Engine to LLMEngine

### DIFF
--- a/docs/deploy/python_engine.rst
+++ b/docs/deploy/python_engine.rst
@@ -4,7 +4,7 @@ Python API
 ==========
 
 .. note::
-   This page introduces the Python API with Engine in MLC LLM.
+   This page introduces the Python API with LLMEngine in MLC LLM.
    If you want to check out the old Python API which uses :class:`mlc_llm.ChatModule`,
    please go to :ref:`deploy-python-chat-module`
 

--- a/docs/get_started/introduction.rst
+++ b/docs/get_started/introduction.rst
@@ -88,11 +88,11 @@ You can save the code below into a Python file and run it.
 
 .. code:: python
 
-  from mlc_llm import Engine
+  from mlc_llm import LLMEngine
 
   # Create engine
   model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
-  engine = Engine(model)
+  engine = LLMEngine(model)
 
   # Run chat completion in OpenAI API.
   for response in engine.chat.completions.create(
@@ -112,9 +112,9 @@ You can save the code below into a Python file and run it.
 
   MLC LLM Python API
 
-This code example first creates an :class:`mlc_llm.Engine` instance with the the 4-bit quantized Llama-2 model.
-**We design the Python API** :class:`mlc_llm.Engine` **to align with OpenAI API**,
-which means you can use :class:`mlc_llm.Engine` in the same way of using
+This code example first creates an :class:`mlc_llm.LLMEngine` instance with the the 4-bit quantized Llama-2 model.
+**We design the Python API** :class:`mlc_llm.LLMEngine` **to align with OpenAI API**,
+which means you can use :class:`mlc_llm.LLMEngine` in the same way of using
 `OpenAI's Python package <https://github.com/openai/openai-python?tab=readme-ov-file#usage>`_
 for both synchronous and asynchronous generation.
 
@@ -132,7 +132,7 @@ If you want to run without streaming, you can run
   print(response)
 
 You can also try different arguments supported in `OpenAI chat completion API <https://platform.openai.com/docs/api-reference/chat/create>`_.
-If you would like to do concurrent asynchronous generation, you can use :class:`mlc_llm.AsyncEngine` instead.
+If you would like to do concurrent asynchronous generation, you can use :class:`mlc_llm.AsyncLLMEngine` instead.
 
 REST Server
 -----------
@@ -226,7 +226,7 @@ You can also use this model in Python API, MLC serve and other use scenarios.
 (Optional) Compile Model Library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In previous sections, model libraries are compiled when the :class:`mlc_llm.Engine` launches,
+In previous sections, model libraries are compiled when the :class:`mlc_llm.LLMEngine` launches,
 which is what we call "JIT (Just-in-Time) model compilation".
 In some cases, it is beneficial to explicitly compile the model libraries.
 We can deploy LLMs with reduced dependencies by shipping the library for deployment without going through compilation.
@@ -254,12 +254,12 @@ At runtime, we need to specify this model library path to use it. For example,
 
 .. code:: python
 
-  from mlc_llm import Engine
+  from mlc_llm import LLMEngine
 
   # For Python API
   model = "models/phi-2"
   model_lib_path = "models/phi-2/lib.so"
-  engine = Engine(model, model_lib_path=model_lib_path)
+  engine = LLMEngine(model, model_lib_path=model_lib_path)
 
 :ref:`compile-model-libraries` introduces the model compilation command in detail,
 where you can find instructions and example commands to compile model to different

--- a/docs/get_started/quick_start.rst
+++ b/docs/get_started/quick_start.rst
@@ -20,11 +20,11 @@ It is recommended to have at least 6GB free VRAM to run it.
 
     .. code:: python
 
-      from mlc_llm import Engine
+      from mlc_llm import LLMEngine
 
       # Create engine
       model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
-      engine = Engine(model)
+      engine = LLMEngine(model)
 
       # Run chat completion in OpenAI API.
       for response in engine.chat.completions.create(

--- a/examples/python/sample_mlc_engine.py
+++ b/examples/python/sample_mlc_engine.py
@@ -1,8 +1,8 @@
-from mlc_llm import Engine
+from mlc_llm import LLMEngine
 
 # Create engine
 model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
-engine = Engine(model)
+engine = LLMEngine(model)
 
 # Run chat completion in OpenAI API.
 for response in engine.chat.completions.create(

--- a/python/mlc_llm/__init__.py
+++ b/python/mlc_llm/__init__.py
@@ -6,4 +6,4 @@ MLC Chat is the app runtime of MLC LLM.
 from . import protocol, serve
 from .chat_module import ChatConfig, ChatModule, ConvConfig, GenerationConfig
 from .libinfo import __version__
-from .serve import AsyncEngine, Engine
+from .serve import AsyncLLMEngine, LLMEngine

--- a/python/mlc_llm/help.py
+++ b/python/mlc_llm/help.py
@@ -193,7 +193,7 @@ Under mode "local" or "interactive", the actual memory usage may be significantl
 this number. Under mode "server", the actual memory usage may be slightly larger than this number.
 """,
     "engine_config_serve": """
-The Engine execution configuration.
+The LLMEngine execution configuration.
 Currently speculative decoding mode is specified via engine config.
 For example, you can use "--engine-config='spec_draft_length=4;speculative_mode=EAGLE'" to
 specify the eagle-style speculative decoding.

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -34,7 +34,7 @@ def serve(
 ):  # pylint: disable=too-many-arguments, too-many-locals
     """Serve the model with the specified configuration."""
     # Create engine and start the background loop
-    async_engine = engine.AsyncEngine(
+    async_engine = engine.AsyncLLMEngine(
         model=model,
         device=device,
         model_lib_path=model_lib_path,

--- a/python/mlc_llm/serve/__init__.py
+++ b/python/mlc_llm/serve/__init__.py
@@ -4,7 +4,7 @@
 from .. import base
 from .config import EngineConfig, GenerationConfig, KVCacheConfig, SpeculativeMode
 from .data import Data, ImageData, RequestStreamOutput, TextData, TokenData
-from .engine import AsyncEngine, Engine
+from .engine import AsyncLLMEngine, LLMEngine
 from .grammar import BNFGrammar, GrammarStateMatcher
 from .request import Request
 from .server import PopenServer

--- a/python/mlc_llm/serve/config.py
+++ b/python/mlc_llm/serve/config.py
@@ -175,7 +175,7 @@ class SpeculativeMode(enum.IntEnum):
 
 @dataclass
 class EngineConfig:
-    """The class of Engine execution configuration.
+    """The class of LLMEngine execution configuration.
 
     Parameters
     ----------

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -37,10 +37,10 @@ class Chat:  # pylint: disable=too-few-public-methods
     """The proxy class to direct to chat completions."""
 
     def __init__(self, engine: weakref.ReferenceType) -> None:
-        assert isinstance(engine(), (AsyncEngine, Engine))
+        assert isinstance(engine(), (AsyncLLMEngine, LLMEngine))
         self.completions = (
             AsyncChatCompletion(engine)  # type: ignore
-            if isinstance(engine(), AsyncEngine)
+            if isinstance(engine(), AsyncLLMEngine)
             else ChatCompletion(engine)  # type: ignore
         )
 
@@ -49,7 +49,7 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
     """The proxy class to direct to async chat completions."""
 
     if sys.version_info >= (3, 9):
-        engine: weakref.ReferenceType["AsyncEngine"]
+        engine: weakref.ReferenceType["AsyncLLMEngine"]
     else:
         engine: weakref.ReferenceType
 
@@ -226,7 +226,7 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
     """The proxy class to direct to chat completions."""
 
     if sys.version_info >= (3, 9):
-        engine: weakref.ReferenceType["Engine"]
+        engine: weakref.ReferenceType["LLMEngine"]
     else:
         engine: weakref.ReferenceType
 
@@ -401,7 +401,7 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
     """The proxy class to direct to async completions."""
 
     if sys.version_info >= (3, 9):
-        engine: weakref.ReferenceType["AsyncEngine"]
+        engine: weakref.ReferenceType["AsyncLLMEngine"]
     else:
         engine: weakref.ReferenceType
 
@@ -580,7 +580,7 @@ class Completion:  # pylint: disable=too-few-public-methods
     """The proxy class to direct to completions."""
 
     if sys.version_info >= (3, 9):
-        engine: weakref.ReferenceType["Engine"]
+        engine: weakref.ReferenceType["LLMEngine"]
     else:
         engine: weakref.ReferenceType
 
@@ -752,8 +752,8 @@ class Completion:  # pylint: disable=too-few-public-methods
         )
 
 
-class AsyncEngine(engine_base.EngineBase):
-    """The AsyncEngine in MLC LLM that provides the asynchronous
+class AsyncLLMEngine(engine_base.LLMEngineBase):
+    """The AsyncLLMEngine in MLC LLM that provides the asynchronous
     interfaces with regard to OpenAI API.
 
     Parameters
@@ -825,7 +825,7 @@ class AsyncEngine(engine_base.EngineBase):
         memory usage may be slightly larger than this number.
 
     engine_config : Optional[EngineConfig]
-        The Engine execution configuration.
+        The LLMEngine execution configuration.
         Currently speculative decoding mode is specified via engine config.
         For example, you can use "--engine-config='spec_draft_length=4;speculative_mode=EAGLE'"
         to specify the eagle-style speculative decoding.
@@ -1225,7 +1225,7 @@ class AsyncEngine(engine_base.EngineBase):
         generation_config: GenerationConfig,
         request_id: str,
     ) -> AsyncGenerator[List[engine_base.CallbackStreamOutput], Any]:
-        """Internal asynchronous text generation interface of AsyncEngine.
+        """Internal asynchronous text generation interface of AsyncLLMEngine.
         The method is a coroutine that streams a list of CallbackStreamOutput
         at a time via yield. The returned list length is the number of
         parallel generations specified by `generation_config.n`.
@@ -1295,8 +1295,8 @@ class AsyncEngine(engine_base.EngineBase):
         self._ffi["abort_request"](request_id)
 
 
-class Engine(engine_base.EngineBase):
-    """The Engine in MLC LLM that provides the synchronous
+class LLMEngine(engine_base.LLMEngineBase):
+    """The LLMEngine in MLC LLM that provides the synchronous
     interfaces with regard to OpenAI API.
 
     Parameters
@@ -1368,7 +1368,7 @@ class Engine(engine_base.EngineBase):
         memory usage may be slightly larger than this number.
 
     engine_config : Optional[EngineConfig]
-        The Engine execution configuration.
+        The LLMEngine execution configuration.
         Currently speculative decoding mode is specified via engine config.
         For example, you can use "--engine-config='spec_draft_length=4;speculative_mode=EAGLE'"
         to specify the eagle-style speculative decoding.
@@ -1761,7 +1761,7 @@ class Engine(engine_base.EngineBase):
         generation_config: GenerationConfig,
         request_id: str,
     ) -> Iterator[List[engine_base.CallbackStreamOutput]]:
-        """Internal synchronous text generation interface of AsyncEngine.
+        """Internal synchronous text generation interface of AsyncLLMEngine.
         The method is a coroutine that streams a list of CallbackStreamOutput
         at a time via yield. The returned list length is the number of
         parallel generations specified by `generation_config.n`.
@@ -1815,7 +1815,7 @@ class Engine(engine_base.EngineBase):
     def _request_stream_callback_impl(
         self, delta_outputs: List[data.RequestStreamOutput]
     ) -> List[List[engine_base.CallbackStreamOutput]]:
-        """The underlying implementation of request stream callback of Engine."""
+        """The underlying implementation of request stream callback of LLMEngine."""
         batch_outputs: List[List[engine_base.CallbackStreamOutput]] = []
         for delta_output in delta_outputs:
             request_id, stream_outputs = delta_output.unpack()

--- a/python/mlc_llm/serve/server/server_context.py
+++ b/python/mlc_llm/serve/server/server_context.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Optional
 
-from ..engine import AsyncEngine
+from ..engine import AsyncLLMEngine
 
 
 class ServerContext:
@@ -13,7 +13,7 @@ class ServerContext:
     server_context: Optional["ServerContext"] = None
 
     def __init__(self):
-        self._models: Dict[str, AsyncEngine] = {}
+        self._models: Dict[str, AsyncLLMEngine] = {}
 
     def __enter__(self):
         if ServerContext.server_context is not None:
@@ -31,13 +31,13 @@ class ServerContext:
         """Returns the current ServerContext."""
         return ServerContext.server_context
 
-    def add_model(self, hosted_model: str, engine: AsyncEngine) -> None:
+    def add_model(self, hosted_model: str, engine: AsyncLLMEngine) -> None:
         """Add a new model to the server context together with the engine."""
         if hosted_model in self._models:
             raise RuntimeError(f"Model {hosted_model} already running.")
         self._models[hosted_model] = engine
 
-    def get_engine(self, model: str) -> Optional[AsyncEngine]:
+    def get_engine(self, model: str) -> Optional[AsyncLLMEngine]:
         """Get the async engine of the requested model."""
         return self._models.get(model, None)
 

--- a/python/mlc_llm/serve/sync_engine.py
+++ b/python/mlc_llm/serve/sync_engine.py
@@ -41,7 +41,7 @@ def _create_tvm_module(
     return {key: module[key] for key in ffi_funcs}
 
 
-class SyncEngine:
+class SyncLLMEngine:
     """The Python interface of synchronize request serving engine for MLC LLM.
 
     The engine receives requests from the "add_request" method. For

--- a/tests/python/serve/evaluate_engine.py
+++ b/tests/python/serve/evaluate_engine.py
@@ -5,7 +5,7 @@ import random
 from typing import List, Tuple
 
 from mlc_llm.serve import GenerationConfig
-from mlc_llm.serve.sync_engine import SyncEngine
+from mlc_llm.serve.sync_engine import SyncLLMEngine
 
 
 def _parse_args():
@@ -41,7 +41,7 @@ def benchmark(args: argparse.Namespace):
     random.seed(args.seed)
 
     # Create engine
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=args.model,
         device=args.device,
         model_lib_path=args.model_lib_path,

--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import List
 
-from mlc_llm.serve import AsyncEngine, GenerationConfig
+from mlc_llm.serve import AsyncLLMEngine, GenerationConfig
 
 prompts = [
     "What is the meaning of life?",
@@ -23,7 +23,7 @@ async def test_engine_generate():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    async_engine = AsyncEngine(
+    async_engine = AsyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -39,7 +39,7 @@ async def test_engine_generate():
     ]
 
     async def generate_task(
-        async_engine: AsyncEngine,
+        async_engine: AsyncLLMEngine,
         prompt: str,
         generation_cfg: GenerationConfig,
         request_id: str,
@@ -80,7 +80,7 @@ async def test_chat_completion():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    async_engine = AsyncEngine(
+    async_engine = AsyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -132,7 +132,7 @@ async def test_chat_completion_non_stream():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    async_engine = AsyncEngine(
+    async_engine = AsyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -183,7 +183,7 @@ async def test_completion():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    async_engine = AsyncEngine(
+    async_engine = AsyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -235,7 +235,7 @@ async def test_completion_non_stream():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    async_engine = AsyncEngine(
+    async_engine = AsyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",

--- a/tests/python/serve/test_serve_async_engine_spec.py
+++ b/tests/python/serve/test_serve_async_engine_spec.py
@@ -3,7 +3,12 @@
 import asyncio
 from typing import List
 
-from mlc_llm.serve import AsyncEngine, EngineConfig, GenerationConfig, SpeculativeMode
+from mlc_llm.serve import (
+    AsyncLLMEngine,
+    EngineConfig,
+    GenerationConfig,
+    SpeculativeMode,
+)
 
 prompts = [
     "What is the meaning of life?",
@@ -27,7 +32,7 @@ async def test_engine_generate():
     small_model_lib_path = (
         "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
     )
-    async_engine = AsyncEngine(
+    async_engine = AsyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -44,7 +49,7 @@ async def test_engine_generate():
     ]
 
     async def generate_task(
-        async_engine: AsyncEngine,
+        async_engine: AsyncLLMEngine,
         prompt: str,
         generation_cfg: GenerationConfig,
         request_id: str,

--- a/tests/python/serve/test_serve_engine.py
+++ b/tests/python/serve/test_serve_engine.py
@@ -2,7 +2,7 @@
 # pylint: disable=too-many-arguments,too-many-locals,unused-argument,unused-variable
 from typing import List
 
-from mlc_llm.serve import Engine, GenerationConfig
+from mlc_llm.serve import GenerationConfig, LLMEngine
 
 prompts = [
     "What is the meaning of life?",
@@ -22,7 +22,7 @@ def test_engine_generate():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = Engine(
+    engine = LLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -61,7 +61,7 @@ def test_chat_completion():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = Engine(
+    engine = LLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -105,7 +105,7 @@ def test_chat_completion_non_stream():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = Engine(
+    engine = LLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -148,7 +148,7 @@ def test_completion():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = Engine(
+    engine = LLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -192,7 +192,7 @@ def test_completion_non_stream():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = Engine(
+    engine = LLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",

--- a/tests/python/serve/test_serve_engine_grammar.py
+++ b/tests/python/serve/test_serve_engine_grammar.py
@@ -7,9 +7,9 @@ from typing import List
 import pytest
 from pydantic import BaseModel
 
-from mlc_llm.serve import AsyncEngine, GenerationConfig
+from mlc_llm.serve import AsyncLLMEngine, GenerationConfig
 from mlc_llm.serve.config import ResponseFormat
-from mlc_llm.serve.sync_engine import SyncEngine
+from mlc_llm.serve.sync_engine import SyncLLMEngine
 
 prompts_list = [
     "Generate a JSON string containing 20 objects:",
@@ -22,7 +22,7 @@ model_lib_path = "dist/libs/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
 
 def test_batch_generation_with_grammar():
     # Create engine
-    engine = SyncEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
+    engine = SyncLLMEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
 
     prompt_len = len(prompts_list)
     prompts = prompts_list * 3
@@ -69,7 +69,7 @@ def test_batch_generation_with_grammar():
 
 def test_batch_generation_with_schema():
     # Create engine
-    engine = SyncEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
+    engine = SyncLLMEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
 
     prompt = (
         "Generate a json containing three fields: an integer field named size, a "
@@ -121,7 +121,7 @@ def test_batch_generation_with_schema():
 
 async def run_async_engine():
     # Create engine
-    async_engine = AsyncEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
+    async_engine = AsyncLLMEngine(model=model_path, model_lib_path=model_lib_path, mode="server")
 
     prompts = prompts_list * 20
 
@@ -142,7 +142,7 @@ async def run_async_engine():
     ]
 
     async def generate_task(
-        async_engine: AsyncEngine,
+        async_engine: AsyncLLMEngine,
         prompt: str,
         generation_cfg: GenerationConfig,
         request_id: str,

--- a/tests/python/serve/test_serve_engine_image.py
+++ b/tests/python/serve/test_serve_engine_image.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from mlc_llm.serve import GenerationConfig, data
-from mlc_llm.serve.sync_engine import SyncEngine
+from mlc_llm.serve.sync_engine import SyncLLMEngine
 
 
 def get_test_image(config) -> data.ImageData:
@@ -13,7 +13,7 @@ def test_engine_generate():
     # Create engine
     model = "dist/llava-1.5-7b-hf-q4f16_1-MLC/params"
     model_lib_path = "dist/llava-1.5-7b-hf-q4f16_1-MLC/llava-1.5-7b-hf-q4f16_1-MLC.so"
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",

--- a/tests/python/serve/test_serve_engine_spec.py
+++ b/tests/python/serve/test_serve_engine_spec.py
@@ -14,7 +14,7 @@ from mlc_llm.serve import (
     data,
 )
 from mlc_llm.serve.engine_base import ModelInfo
-from mlc_llm.serve.sync_engine import SyncEngine
+from mlc_llm.serve.sync_engine import SyncLLMEngine
 
 prompts = [
     "What is the meaning of life?",
@@ -93,7 +93,7 @@ def test_engine_basic():
     small_model_lib_path = (
         "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
     )
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -161,7 +161,7 @@ def test_engine_eagle_basic():
     small_model_lib_path = (
         "dist/Eagle-llama2-7b-chat-q0f16-MLC/Eagle-llama2-7b-chat-q0f16-MLC-cuda.so"
     )
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -244,7 +244,7 @@ def test_engine_continuous_batching_1():
         "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
     )
     timer = CallbackTimer()
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -330,7 +330,7 @@ def test_engine_eagle_continuous_batching_1():
         "dist/Eagle-llama2-7b-chat-q4f16_1-MLC/Eagle-llama2-7b-chat-q4f16_1-MLC-cuda.so"
     )
     timer = CallbackTimer()
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -374,7 +374,7 @@ def test_engine_generate():
     small_model_lib_path = (
         "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
     )
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -407,7 +407,7 @@ def test_engine_eagle_generate():
     small_model_lib_path = (
         "dist/Eagle-llama2-7b-chat-q4f16_1-MLC/Eagle-llama2-7b-chat-q4f16_1-MLC-cuda.so"
     )
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -455,7 +455,7 @@ def test_engine_efficiency():
     # Create engine
     model = "dist/Llama-2-13b-chat-hf-q4f16_1-MLC"
     model_lib_path = "dist/Llama-2-13b-chat-hf-q4f16_1-MLC/Llama-2-13b-chat-hf-q4f16_1-MLC-cuda.so"
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -527,7 +527,7 @@ def test_engine_spec_efficiency():
     # small_model_lib_path = (
     #     "dist/TinyLlama-1.1B-Chat-v1.0-q0f16-MLC/TinyLlama-1.1B-Chat-v1.0-q0f16-MLC-cuda.so"
     # )
-    spec_engine = SyncEngine(
+    spec_engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -598,7 +598,7 @@ def test_engine_eagle_spec_efficiency():
     small_model_lib_path = (
         "dist/Eagle-llama2-7b-chat-q0f16-MLC/Eagle-llama2-7b-chat-q0f16-MLC-cuda.so"
     )
-    spec_engine = SyncEngine(
+    spec_engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",

--- a/tests/python/serve/test_serve_sync_engine.py
+++ b/tests/python/serve/test_serve_sync_engine.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional
 import numpy as np
 
 from mlc_llm.serve import GenerationConfig, Request, RequestStreamOutput, data
-from mlc_llm.serve.sync_engine import SyncEngine
+from mlc_llm.serve.sync_engine import SyncLLMEngine
 
 prompts = [
     "What is the meaning of life?",
@@ -80,7 +80,7 @@ def test_engine_basic():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -156,7 +156,7 @@ def test_engine_continuous_batching_1():
     timer = CallbackTimer()
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -237,7 +237,7 @@ def test_engine_continuous_batching_2():
     timer = CallbackTimer()
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -323,7 +323,7 @@ def test_engine_continuous_batching_3():
     timer = CallbackTimer()
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",
@@ -365,7 +365,7 @@ def test_engine_generate():
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    engine = SyncEngine(
+    engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
         mode="server",


### PR DESCRIPTION
We rename the public Python serve interface from `Engine` to `LLMEngine` (and from `AsyncEngine` to `AsyncLLMEngine` accordingly) for better class name clarity.

This is because in cases people do wildcard import, in which case the name `Engine` itself does not convey enough meaning.