### PR TITLE
[Serving] EngineConfig refactor

### DIFF
--- a/cpp/llm_chat.cc
+++ b/cpp/llm_chat.cc
@@ -1618,8 +1618,6 @@ class LLMChat {
   NDArray logits_on_cpu_{nullptr};
   // pre-allocated ndarray for decode function's input tokens
   DRef input_tokens_decode_{nullptr};
-  // KV cache config
-  serve::KVCacheConfig kv_cache_config_{nullptr};
 };
 
 /*!

--- a/cpp/serve/engine.h
+++ b/cpp/serve/engine.h
@@ -50,26 +50,14 @@ class Engine {
 
   /*!
    * \brief Create an engine in unique pointer.
-   * \param max_single_sequence_length The maximum allowed single
-   * sequence length supported by the engine.
-   * \param tokenizer_path The tokenizer path on disk.
-   * \param kv_cache_config_json_str The KV cache config in JSON string.
-   * \param engine_config_json_str The Engine execution configuration in JSON string.
-   * \param request_stream_callback The request stream callback function to
-   * stream back generated output for requests.
+   * \param engine_config The engine config.
+   * \param request_stream_callback The request stream callback function to.
    * \param trace_recorder Event trace recorder for requests.
-   * \param model_infos The model info tuples. Each tuple contains
-   * - the model library, which might be a path to the binary file or
-   * an executable module that is pre-loaded,
-   * - the path to the model weight parameters,
-   * - the device to run the model on.
    * \return The created Engine in pointer.
    */
-  static std::unique_ptr<Engine> Create(
-      int max_single_sequence_length, const String& tokenizer_path,
-      const String& kv_cache_config_json_str, const String& engine_config_json_str,
-      Optional<PackedFunc> request_stream_callback, Optional<EventTraceRecorder> trace_recorder,
-      const std::vector<std::tuple<TVMArgValue, String, DLDevice>>& model_infos);
+  static std::unique_ptr<Engine> Create(EngineConfig engine_config,
+                                        Optional<PackedFunc> request_stream_callback,
+                                        Optional<EventTraceRecorder> trace_recorder);
 
   /*! \brief Reset the engine, clean up all running data and statistics. */
   virtual void Reset() = 0;
@@ -113,30 +101,6 @@ class Engine {
   /*! \brief Call the given global function on all workers. Only for debug purpose. */
   virtual void DebugCallFuncOnAllAllWorker(const String& func_name) = 0;
 };
-
-/*!
- * \brief Create an Engine from packed arguments in TVMArgs.
- * \param args The arguments of engine construction.
- * \return The constructed engine in unique pointer.
- */
-std::unique_ptr<Engine> CreateEnginePacked(TVMArgs args);
-
-constexpr const char* kEngineCreationErrorMessage =
-    "With `n` models, engine initialization "
-    "takes (6 + 4 * n) arguments. The first 6 arguments should be: "
-    "1) (int) maximum length of a sequence, which must be equal or smaller than the context "
-    "window size of each model; "
-    "2) (string) path to tokenizer configuration files, which in MLC LLM, usually in a model "
-    "weights directory; "
-    "3) (string) JSON configuration for the KVCache; "
-    "4) (string) JSON mode for Engine;"
-    "5) (packed function, optional) global request stream callback function. "
-    "6) (EventTraceRecorder, optional) the event trace recorder for requests."
-    "The following (4 * n) arguments, 4 for each model, should be: "
-    "1) (tvm.runtime.Module) The model library loaded into TVM's RelaxVM; "
-    "2) (string) Model path which includes weights and mlc-chat-config.json; "
-    "3) (int, enum DLDeviceType) Device type, e.g. CUDA, ROCm, etc; "
-    "4) (int) Device id, i.e. the ordinal index of the device that exists locally.";
 
 }  // namespace serve
 }  // namespace llm

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -56,15 +56,14 @@ class EngineAction : public ObjectRef {
    * \param logit_processor The logit processor.
    * \param sampler The sampler to sample new tokens.
    * \param model_workspaces The workspace of each model.
-   * \param kv_cache_config The KV cache config to help decide prefill is doable.
-   * \param engine_config The engine operation mode.
+   * \param engine_config The engine config.
    * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction NewRequestPrefill(Array<Model> models, LogitProcessor logit_processor,
                                         Sampler sampler,
                                         std::vector<ModelWorkspace> model_workspaces,
-                                        KVCacheConfig kv_cache_config, EngineConfig engine_config,
+                                        EngineConfig engine_config,
                                         Optional<EventTraceRecorder> trace_recorder);
   /*!
    * \brief Create the action that prefills requests in the `waiting_queue`
@@ -73,15 +72,13 @@ class EngineAction : public ObjectRef {
    * \param logit_processor The logit processor.
    * \param sampler The sampler to sample new tokens.
    * \param model_workspaces The workspace of each model.
-   * \param kv_cache_config The KV cache config to help decide prefill is doable.
-   * \param engine_config The engine operation mode.
+   * \param engine_config The engine config.
    * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction EagleNewRequestPrefill(Array<Model> models, LogitProcessor logit_processor,
                                              Sampler sampler,
                                              std::vector<ModelWorkspace> model_workspaces,
-                                             KVCacheConfig kv_cache_config,
                                              EngineConfig engine_config,
                                              Optional<EventTraceRecorder> trace_recorder);
   /*!
@@ -139,12 +136,12 @@ class EngineAction : public ObjectRef {
    * \param models The model to run decode in. When there are multiple
    * models, the `Step` function of the created action will not take effect.
    * \param sampler The sampler to sample new tokens.
-   * \param kv_cache_config The KV cache config to help decide verify is doable.
+   * \param engine_config The engine config.
    * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction BatchVerify(Array<Model> models, LogitProcessor logit_processor,
-                                  Sampler sampler, KVCacheConfig kv_cache_config,
+                                  Sampler sampler, EngineConfig engine_config,
                                   Optional<EventTraceRecorder> trace_recorder);
 
   /*!
@@ -155,14 +152,14 @@ class EngineAction : public ObjectRef {
    * models, the `Step` function of the created action will not take effect.
    * \param sampler The sampler to sample new tokens.
    * \param model_workspaces The workspace of each model.
-   * \param kv_cache_config The KV cache config to help decide verify is doable.
+   * \param engine_config The engine config.
    * \param trace_recorder The event trace recorder for requests.
    * \return The created action object.
    */
   static EngineAction EagleBatchVerify(Array<Model> models, LogitProcessor logit_processor,
                                        Sampler sampler,
                                        std::vector<ModelWorkspace> model_workspaces,
-                                       KVCacheConfig kv_cache_config,
+                                       EngineConfig engine_config,
                                        Optional<EventTraceRecorder> trace_recorder);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(EngineAction, ObjectRef, EngineActionObj);

--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -27,12 +27,12 @@ namespace serve {
 class BatchVerifyActionObj : public EngineActionObj {
  public:
   explicit BatchVerifyActionObj(Array<Model> models, LogitProcessor logit_processor,
-                                Sampler sampler, KVCacheConfig kv_cache_config,
+                                Sampler sampler, EngineConfig engine_config,
                                 Optional<EventTraceRecorder> trace_recorder)
       : models_(std::move(models)),
         logit_processor_(std::move(logit_processor)),
         sampler_(std::move(sampler)),
-        kv_cache_config_(std::move(kv_cache_config)),
+        engine_config_(std::move(engine_config)),
         trace_recorder_(std::move(trace_recorder)),
         rng_(RandomGenerator::GetInstance()) {}
 
@@ -182,8 +182,8 @@ class BatchVerifyActionObj : public EngineActionObj {
     num_page_requirement.reserve(running_rsentries.size());
     for (const RequestStateEntry& rsentry : running_rsentries) {
       int draft_length = rsentry->mstates[draft_model_id_]->draft_output_tokens.size();
-      int num_require_pages =
-          (draft_length + kv_cache_config_->page_size - 1) / kv_cache_config_->page_size;
+      int num_require_pages = (draft_length + engine_config_->kv_cache_page_size - 1) /
+                              engine_config_->kv_cache_page_size;
       draft_lengths.push_back(draft_length);
       num_page_requirement.push_back(num_require_pages);
       total_draft_length += draft_length;
@@ -218,8 +218,8 @@ class BatchVerifyActionObj : public EngineActionObj {
   LogitProcessor logit_processor_;
   /*! \brief The sampler to sample new tokens. */
   Sampler sampler_;
-  /*! \brief The kv cache config. */
-  KVCacheConfig kv_cache_config_;
+  /*! \brief The engine config. */
+  EngineConfig engine_config_;
   /*! \brief Event trace recorder. */
   Optional<EventTraceRecorder> trace_recorder_;
   /*! \brief Random number generator. */
@@ -231,10 +231,10 @@ class BatchVerifyActionObj : public EngineActionObj {
 };
 
 EngineAction EngineAction::BatchVerify(Array<Model> models, LogitProcessor logit_processor,
-                                       Sampler sampler, KVCacheConfig kv_cache_config,
+                                       Sampler sampler, EngineConfig engine_config,
                                        Optional<EventTraceRecorder> trace_recorder) {
   return EngineAction(make_object<BatchVerifyActionObj>(
-      std::move(models), std::move(logit_processor), std::move(sampler), std::move(kv_cache_config),
+      std::move(models), std::move(logit_processor), std::move(sampler), std::move(engine_config),
       std::move(trace_recorder)));
 }
 

--- a/cpp/serve/engine_actions/eagle_batch_verify.cc
+++ b/cpp/serve/engine_actions/eagle_batch_verify.cc
@@ -29,13 +29,13 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
  public:
   explicit EagleBatchVerifyActionObj(Array<Model> models, LogitProcessor logit_processor,
                                      Sampler sampler, std::vector<ModelWorkspace> model_workspaces,
-                                     KVCacheConfig kv_cache_config,
+                                     EngineConfig engine_config,
                                      Optional<EventTraceRecorder> trace_recorder)
       : models_(std::move(models)),
         logit_processor_(std::move(logit_processor)),
         sampler_(std::move(sampler)),
         model_workspaces_(std::move(model_workspaces)),
-        kv_cache_config_(std::move(kv_cache_config)),
+        engine_config_(std::move(engine_config)),
         trace_recorder_(std::move(trace_recorder)),
         rng_(RandomGenerator::GetInstance()) {}
 
@@ -279,8 +279,8 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
     num_page_requirement.reserve(running_rsentries.size());
     for (const RequestStateEntry& rsentry : running_rsentries) {
       int draft_length = rsentry->mstates[draft_model_id_]->draft_output_tokens.size();
-      int num_require_pages =
-          (draft_length + kv_cache_config_->page_size - 1) / kv_cache_config_->page_size;
+      int num_require_pages = (draft_length + engine_config_->kv_cache_page_size - 1) /
+                              engine_config_->kv_cache_page_size;
       draft_lengths.push_back(draft_length);
       num_page_requirement.push_back(num_require_pages);
       total_draft_length += draft_length;
@@ -337,8 +337,8 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
   Sampler sampler_;
   /*! \brief Workspace of each model. */
   std::vector<ModelWorkspace> model_workspaces_;
-  /*! \brief The kv cache config. */
-  KVCacheConfig kv_cache_config_;
+  /*! \brief The engine config. */
+  EngineConfig engine_config_;
   /*! \brief Event trace recorder. */
   Optional<EventTraceRecorder> trace_recorder_;
   /*! \brief Random number generator. */
@@ -352,11 +352,11 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
 EngineAction EngineAction::EagleBatchVerify(Array<Model> models, LogitProcessor logit_processor,
                                             Sampler sampler,
                                             std::vector<ModelWorkspace> model_workspaces,
-                                            KVCacheConfig kv_cache_config,
+                                            EngineConfig engine_config,
                                             Optional<EventTraceRecorder> trace_recorder) {
   return EngineAction(make_object<EagleBatchVerifyActionObj>(
       std::move(models), std::move(logit_processor), std::move(sampler),
-      std::move(model_workspaces), std::move(kv_cache_config), std::move(trace_recorder)));
+      std::move(model_workspaces), std::move(engine_config), std::move(trace_recorder)));
 }
 
 }  // namespace serve

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -23,13 +23,12 @@ class NewRequestPrefillActionObj : public EngineActionObj {
  public:
   explicit NewRequestPrefillActionObj(Array<Model> models, LogitProcessor logit_processor,
                                       Sampler sampler, std::vector<ModelWorkspace> model_workspaces,
-                                      KVCacheConfig kv_cache_config, EngineConfig engine_config,
+                                      EngineConfig engine_config,
                                       Optional<EventTraceRecorder> trace_recorder)
       : models_(std::move(models)),
         logit_processor_(std::move(logit_processor)),
         sampler_(std::move(sampler)),
         model_workspaces_(std::move(model_workspaces)),
-        kv_cache_config_(std::move(kv_cache_config)),
         engine_config_(std::move(engine_config)),
         trace_recorder_(std::move(trace_recorder)) {}
 
@@ -332,8 +331,8 @@ class NewRequestPrefillActionObj : public EngineActionObj {
         }
 
         int input_length = rsentry->mstates[0]->GetInputLength();
-        int num_require_pages =
-            (input_length + kv_cache_config_->page_size - 1) / kv_cache_config_->page_size;
+        int num_require_pages = (input_length + engine_config_->kv_cache_page_size - 1) /
+                                engine_config_->kv_cache_page_size;
         total_input_length += input_length;
         total_required_pages += num_require_pages;
         // - Attempt 1. Check if the entire request state entry can fit for prefill.
@@ -356,9 +355,9 @@ class NewRequestPrefillActionObj : public EngineActionObj {
         total_required_pages -= num_require_pages;
 
         // - Attempt 2. Check if the request state entry can partially fit by input chunking.
-        ICHECK_LE(total_input_length, kv_cache_config_->prefill_chunk_size);
-        if (kv_cache_config_->prefill_chunk_size - total_input_length >= input_length ||
-            kv_cache_config_->prefill_chunk_size == total_input_length) {
+        ICHECK_LE(total_input_length, engine_config_->prefill_chunk_size);
+        if (engine_config_->prefill_chunk_size - total_input_length >= input_length ||
+            engine_config_->prefill_chunk_size == total_input_length) {
           // 1. If the input length can fit the remaining prefill chunk size,
           // it means the failure of attempt 1 is not because of the input
           // length being too long, and thus chunking does not help.
@@ -368,9 +367,9 @@ class NewRequestPrefillActionObj : public EngineActionObj {
           prefill_stops = true;
           break;
         }
-        input_length = kv_cache_config_->prefill_chunk_size - total_input_length;
-        num_require_pages =
-            (input_length + kv_cache_config_->page_size - 1) / kv_cache_config_->page_size;
+        input_length = engine_config_->prefill_chunk_size - total_input_length;
+        num_require_pages = (input_length + engine_config_->kv_cache_page_size - 1) /
+                            engine_config_->kv_cache_page_size;
         total_input_length += input_length;
         total_required_pages += num_require_pages;
         if (CanPrefill(estate, num_prefill_rsentries + 1, total_input_length, total_required_pages,
@@ -395,7 +394,7 @@ class NewRequestPrefillActionObj : public EngineActionObj {
   bool CanPrefill(EngineState estate, int num_prefill_rsentries, int total_input_length,
                   int num_required_pages, int num_available_pages, int current_total_seq_len,
                   int num_running_rsentries) {
-    ICHECK_LE(num_running_rsentries, kv_cache_config_->max_num_sequence);
+    ICHECK_LE(num_running_rsentries, engine_config_->max_num_sequence);
 
     // No exceeding of the maximum allowed requests that can
     // run simultaneously.
@@ -403,7 +402,7 @@ class NewRequestPrefillActionObj : public EngineActionObj {
                           ? engine_config_->spec_draft_length
                           : 1;
     if ((num_running_rsentries + num_prefill_rsentries) * spec_factor >
-        std::min(kv_cache_config_->max_num_sequence, kv_cache_config_->prefill_chunk_size)) {
+        std::min(engine_config_->max_num_sequence, engine_config_->prefill_chunk_size)) {
       return false;
     }
 
@@ -414,10 +413,10 @@ class NewRequestPrefillActionObj : public EngineActionObj {
     // exceed the limit, where 8 is a watermark number can
     // be configured and adjusted in the future.
     int new_batch_size = num_running_rsentries + num_prefill_rsentries;
-    return total_input_length <= kv_cache_config_->prefill_chunk_size &&
+    return total_input_length <= engine_config_->prefill_chunk_size &&
            num_required_pages + new_batch_size <= num_available_pages &&
            current_total_seq_len + total_input_length + 8 * new_batch_size <=
-               kv_cache_config_->max_total_sequence_length;
+               engine_config_->max_total_sequence_length;
   }
 
   /*!
@@ -501,9 +500,7 @@ class NewRequestPrefillActionObj : public EngineActionObj {
   Sampler sampler_;
   /*! \brief Workspace of each model. */
   std::vector<ModelWorkspace> model_workspaces_;
-  /*! \brief The KV cache config to help decide prefill is doable. */
-  KVCacheConfig kv_cache_config_;
-  /*! \brief The engine operation mode. */
+  /*! \brief The engine config. */
   EngineConfig engine_config_;
   /*! \brief Event trace recorder. */
   Optional<EventTraceRecorder> trace_recorder_;
@@ -512,13 +509,11 @@ class NewRequestPrefillActionObj : public EngineActionObj {
 EngineAction EngineAction::NewRequestPrefill(Array<Model> models, LogitProcessor logit_processor,
                                              Sampler sampler,
                                              std::vector<ModelWorkspace> model_workspaces,
-                                             KVCacheConfig kv_cache_config,
                                              EngineConfig engine_config,
                                              Optional<EventTraceRecorder> trace_recorder) {
   return EngineAction(make_object<NewRequestPrefillActionObj>(
       std::move(models), std::move(logit_processor), std::move(sampler),
-      std::move(model_workspaces), std::move(kv_cache_config), std::move(engine_config),
-      std::move(trace_recorder)));
+      std::move(model_workspaces), std::move(engine_config), std::move(trace_recorder)));
 }
 
 }  // namespace serve

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -41,7 +41,7 @@ using namespace tvm::runtime;
 struct FunctionTable {
   static PackedFunc SessionFuncAsPackedFunc(Session sess, DRef sess_func, String name);
 
-  void Init(TVMArgValue reload_lib, Device device, picojson::object model_config);
+  void Init(String reload_lib_path, Device device, picojson::object model_config);
 
   ObjectRef LoadParams(const std::string& model_path, Device device);
 

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -227,9 +227,16 @@ class ModelObj : public Object {
 
   /*!
    * \brief Create the KV cache inside the model with regard to the input config.
-   * \param kv_cache_config The configuration of KV cache.
+   * \param page_size The number of consecutive tokens handled in each page in paged KV cache.
+   * \param max_num_sequence The maximum number of sequences that are allowed to be
+   * processed by the KV cache at any time.
+   * \param max_total_sequence_length The maximum length allowed for a single sequence
+   * in the engine.
+   * \param prefill_chunk_size The maximum total number of tokens whose KV data
+   * are allowed to exist in the KV cache at any time.
    */
-  virtual void CreateKVCache(KVCacheConfig kv_cache_config) = 0;
+  virtual void CreateKVCache(int page_size, int max_num_sequence, int max_total_sequence_length,
+                             int prefill_chunk_size) = 0;
 
   /*! \brief Add a new sequence with the given sequence id to the KV cache. */
   virtual void AddNewSequence(int64_t seq_id) = 0;
@@ -306,15 +313,14 @@ class Model : public ObjectRef {
  public:
   /*!
    * \brief Create the runtime module for LLM functions.
-   * \param reload_lib The model library. It might be a path to the binary
-   * file or an executable module that is pre-loaded.
+   * \param reload_lib_path The model library path.
    * \param model_path The path to the model weight parameters.
    * \param device The device to run the model on.
    * \param max_num_sequence The maximum number of sequences to be processed
    * \param trace_enabled A boolean indicating whether tracing is enabled.
    * \return The created runtime module.
    */
-  TVM_DLL static Model Create(TVMArgValue reload_lib, String model_path, DLDevice device,
+  TVM_DLL static Model Create(String reload_lib_path, String model_path, DLDevice device,
                               int max_num_sequence, bool trace_enabled);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Model, ObjectRef, ModelObj);

--- a/cpp/serve/threaded_engine.h
+++ b/cpp/serve/threaded_engine.h
@@ -35,9 +35,13 @@ class ThreadedEngine {
 
   /*!
    * \brief Initialize the threaded engine from packed arguments in TVMArgs.
-   * \param args The arguments of engine construction.
+   * \param engine_config The engine config.
+   * \param request_stream_callback The request stream callback function to.
+   * \param trace_recorder Event trace recorder for requests.
    */
-  virtual void InitBackgroundEngine(TVMArgs args) = 0;
+  virtual void InitBackgroundEngine(EngineConfig engine_config,
+                                    Optional<PackedFunc> request_stream_callback,
+                                    Optional<EventTraceRecorder> trace_recorder) = 0;
 
   /*! \brief Starts the background request processing loop. */
   virtual void RunBackgroundLoop() = 0;

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -4,7 +4,7 @@ import json
 
 from mlc_llm.help import HELP
 from mlc_llm.interface.serve import serve
-from mlc_llm.serve.config import EngineConfig
+from mlc_llm.serve.config import SpeculativeMode
 from mlc_llm.support.argparse import ArgumentParser
 
 
@@ -48,9 +48,14 @@ def main(argv):
         "--gpu-memory-utilization", type=float, help=HELP["gpu_memory_utilization_serve"]
     )
     parser.add_argument(
-        "--engine-config",
-        type=EngineConfig.from_str,
-        help=HELP["engine_config_serve"] + ' (default: "%(default)s")',
+        "--speculative-mode",
+        type=str,
+        choices=["DISABLE", "SMALL_DRAFT", "EAGLE"],
+        default="DISABLE",
+        help=HELP["speculative_mode_serve"],
+    )
+    parser.add_argument(
+        "--spec-draft-length", type=int, default=4, help=HELP["spec_draft_length_serve"]
     )
     parser.add_argument("--enable-tracing", action="store_true", help=HELP["enable_tracing_serve"])
     parser.add_argument(
@@ -96,7 +101,8 @@ def main(argv):
         max_total_sequence_length=parsed.max_total_seq_length,
         prefill_chunk_size=parsed.prefill_chunk_size,
         gpu_memory_utilization=parsed.gpu_memory_utilization,
-        engine_config=parsed.engine_config,
+        speculative_mode=SpeculativeMode[parsed.speculative_mode],
+        spec_draft_length=parsed.spec_draft_length,
         enable_tracing=parsed.enable_tracing,
         host=parsed.host,
         port=parsed.port,

--- a/python/mlc_llm/help.py
+++ b/python/mlc_llm/help.py
@@ -192,6 +192,16 @@ When it is unspecified, it defaults to 0.90.
 Under mode "local" or "interactive", the actual memory usage may be significantly smaller than
 this number. Under mode "server", the actual memory usage may be slightly larger than this number.
 """,
+    "speculative_mode_serve": """
+The speculative decoding mode. Right now three options are supported:
+ - DISABLE, where speculative decoding is not enabled,
+ - SMALL_DRAFT, denoting the normal speculative decoding (small draft) style,
+ - EAGLE, denoting the eagle-style speculative decoding.
+The default mode is "DISABLE".
+""",
+    "spec_draft_length_serve": """
+The number of draft tokens to generate in speculative proposal. The default values is 4.
+""",
     "engine_config_serve": """
 The LLMEngine execution configuration.
 Currently speculative decoding mode is specified via engine config.

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from mlc_llm.protocol import error_protocol
 from mlc_llm.serve import engine
-from mlc_llm.serve.config import EngineConfig
+from mlc_llm.serve.config import SpeculativeMode
 from mlc_llm.serve.entrypoints import debug_entrypoints, openai_entrypoints
 from mlc_llm.serve.server import ServerContext
 
@@ -23,7 +23,8 @@ def serve(
     max_total_sequence_length: Optional[int],
     prefill_chunk_size: Optional[int],
     gpu_memory_utilization: Optional[float],
-    engine_config: Optional[EngineConfig],
+    speculative_mode: SpeculativeMode,
+    spec_draft_length: int,
     enable_tracing: bool,
     host: str,
     port: int,
@@ -44,7 +45,8 @@ def serve(
         max_total_sequence_length=max_total_sequence_length,
         prefill_chunk_size=prefill_chunk_size,
         gpu_memory_utilization=gpu_memory_utilization,
-        engine_config=engine_config,
+        speculative_mode=speculative_mode,
+        spec_draft_length=spec_draft_length,
         enable_tracing=enable_tracing,
     )
 

--- a/python/mlc_llm/serve/__init__.py
+++ b/python/mlc_llm/serve/__init__.py
@@ -2,7 +2,7 @@
 
 # Load MLC LLM library by importing base
 from .. import base
-from .config import EngineConfig, GenerationConfig, KVCacheConfig, SpeculativeMode
+from .config import EngineConfig, GenerationConfig, SpeculativeMode
 from .data import Data, ImageData, RequestStreamOutput, TextData, TokenData
 from .engine import AsyncLLMEngine, LLMEngine
 from .grammar import BNFGrammar, GrammarStateMatcher

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -22,7 +22,7 @@ from tvm.runtime import Device
 
 from mlc_llm.protocol import openai_api_protocol
 from mlc_llm.serve import data, engine_utils
-from mlc_llm.serve.config import EngineConfig, GenerationConfig
+from mlc_llm.serve.config import GenerationConfig, SpeculativeMode
 from mlc_llm.serve.request import Request
 from mlc_llm.streamer import TextStreamer
 from mlc_llm.support import logging
@@ -847,7 +847,8 @@ class AsyncLLMEngine(engine_base.LLMEngineBase):
         max_total_sequence_length: Optional[int] = None,
         prefill_chunk_size: Optional[int] = None,
         gpu_memory_utilization: Optional[float] = None,
-        engine_config: Optional[EngineConfig] = None,
+        speculative_mode: SpeculativeMode = SpeculativeMode.DISABLE,
+        spec_draft_length: int = 4,
         enable_tracing: bool = False,
     ) -> None:
         super().__init__(
@@ -861,7 +862,8 @@ class AsyncLLMEngine(engine_base.LLMEngineBase):
             max_total_sequence_length=max_total_sequence_length,
             prefill_chunk_size=prefill_chunk_size,
             gpu_memory_utilization=gpu_memory_utilization,
-            engine_config=engine_config,
+            speculative_mode=speculative_mode,
+            spec_draft_length=spec_draft_length,
             enable_tracing=enable_tracing,
         )
         self.chat = Chat(weakref.ref(self))
@@ -1390,7 +1392,8 @@ class LLMEngine(engine_base.LLMEngineBase):
         max_total_sequence_length: Optional[int] = None,
         prefill_chunk_size: Optional[int] = None,
         gpu_memory_utilization: Optional[float] = None,
-        engine_config: Optional[EngineConfig] = None,
+        speculative_mode: SpeculativeMode = SpeculativeMode.DISABLE,
+        spec_draft_length: int = 4,
         enable_tracing: bool = False,
     ) -> None:
         super().__init__(
@@ -1404,7 +1407,8 @@ class LLMEngine(engine_base.LLMEngineBase):
             max_total_sequence_length=max_total_sequence_length,
             prefill_chunk_size=prefill_chunk_size,
             gpu_memory_utilization=gpu_memory_utilization,
-            engine_config=engine_config,
+            speculative_mode=speculative_mode,
+            spec_draft_length=spec_draft_length,
             enable_tracing=enable_tracing,
         )
         self.chat = Chat(weakref.ref(self))

--- a/python/mlc_llm/serve/server/popen_server.py
+++ b/python/mlc_llm/serve/server/popen_server.py
@@ -11,7 +11,7 @@ import psutil
 import requests
 from tvm.runtime import Device
 
-from mlc_llm.serve.config import EngineConfig
+from mlc_llm.serve.config import SpeculativeMode
 
 
 class PopenServer:  # pylint: disable=too-many-instance-attributes
@@ -30,7 +30,8 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         max_total_sequence_length: Optional[int] = None,
         prefill_chunk_size: Optional[int] = None,
         gpu_memory_utilization: Optional[float] = None,
-        engine_config: Optional[EngineConfig] = None,
+        speculative_mode: SpeculativeMode = SpeculativeMode.DISABLE,
+        spec_draft_length: int = 4,
         enable_tracing: bool = False,
         host: str = "127.0.0.1",
         port: int = 8000,
@@ -45,7 +46,8 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         self.max_total_sequence_length = max_total_sequence_length
         self.prefill_chunk_size = prefill_chunk_size
         self.gpu_memory_utilization = gpu_memory_utilization
-        self.engine_config = engine_config
+        self.speculative_mode = speculative_mode
+        self.spec_draft_length = spec_draft_length
         self.enable_tracing = enable_tracing
         self.host = host
         self.port = port
@@ -70,8 +72,13 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
             cmd += ["--max-total-seq-length", str(self.max_total_sequence_length)]
         if self.prefill_chunk_size is not None:
             cmd += ["--prefill-chunk-size", str(self.prefill_chunk_size)]
-        if self.engine_config is not None:
-            cmd += ["--engine-config", str(self.engine_config)]
+        if self.speculative_mode != SpeculativeMode.DISABLE:
+            cmd += [
+                "--speculative-mode",
+                self.speculative_mode.name,
+                "--spec-draft-length",
+                str(self.spec_draft_length),
+            ]
         if self.gpu_memory_utilization is not None:
             cmd += ["--gpu-memory-utilization", str(self.gpu_memory_utilization)]
         if self.enable_tracing:

--- a/tests/python/serve/test_serve_async_engine_spec.py
+++ b/tests/python/serve/test_serve_async_engine_spec.py
@@ -1,14 +1,9 @@
 # pylint: disable=chained-comparison,line-too-long,missing-docstring,
-# pylint: disable=too-many-arguments,too-many-locals,unused-argument,unused-variable
+# pylint: disable=too-many-arguments,too-many-locals
 import asyncio
 from typing import List
 
-from mlc_llm.serve import (
-    AsyncLLMEngine,
-    EngineConfig,
-    GenerationConfig,
-    SpeculativeMode,
-)
+from mlc_llm.serve import AsyncLLMEngine, GenerationConfig, SpeculativeMode
 
 prompts = [
     "What is the meaning of life?",
@@ -37,7 +32,7 @@ async def test_engine_generate():
         model_lib_path=model_lib_path,
         mode="server",
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(speculative_mode=SpeculativeMode.SMALL_DRAFT),
+        speculative_mode=SpeculativeMode.SMALL_DRAFT,
     )
 
     num_requests = 10

--- a/tests/python/serve/test_serve_engine_spec.py
+++ b/tests/python/serve/test_serve_engine_spec.py
@@ -1,19 +1,16 @@
 # pylint: disable=chained-comparison,line-too-long,missing-docstring,
-# pylint: disable=too-many-arguments,too-many-locals,unused-argument,unused-variable
+# pylint: disable=too-many-arguments,too-many-locals
 from typing import Callable, List, Optional
 
 import numpy as np
 
 from mlc_llm.serve import (
-    EngineConfig,
     GenerationConfig,
-    KVCacheConfig,
     Request,
     RequestStreamOutput,
     SpeculativeMode,
     data,
 )
-from mlc_llm.serve.engine_base import ModelInfo
 from mlc_llm.serve.sync_engine import SyncLLMEngine
 
 prompts = [
@@ -99,7 +96,7 @@ def test_engine_basic():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(speculative_mode=SpeculativeMode.SMALL_DRAFT),
+        speculative_mode=SpeculativeMode.SMALL_DRAFT,
         request_stream_callback=fcallback,
     )
 
@@ -167,7 +164,8 @@ def test_engine_eagle_basic():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(spec_draft_length=2, speculative_mode=SpeculativeMode.EAGLE),
+        speculative_mode=SpeculativeMode.EAGLE,
+        spec_draft_length=2,
         request_stream_callback=fcallback,
     )
 
@@ -250,7 +248,7 @@ def test_engine_continuous_batching_1():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(speculative_mode=SpeculativeMode.SMALL_DRAFT),
+        speculative_mode=SpeculativeMode.SMALL_DRAFT,
         request_stream_callback=timer.callback_getter(),
     )
 
@@ -336,7 +334,7 @@ def test_engine_eagle_continuous_batching_1():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(speculative_mode=SpeculativeMode.EAGLE),
+        speculative_mode=SpeculativeMode.EAGLE,
         request_stream_callback=timer.callback_getter(),
     )
 
@@ -380,7 +378,7 @@ def test_engine_generate():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(speculative_mode=SpeculativeMode.SMALL_DRAFT),
+        speculative_mode=SpeculativeMode.SMALL_DRAFT,
     )
 
     num_requests = 10
@@ -413,7 +411,7 @@ def test_engine_eagle_generate():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(speculative_mode=SpeculativeMode.EAGLE),
+        speculative_mode=SpeculativeMode.EAGLE,
     )
 
     num_requests = 10
@@ -533,9 +531,8 @@ def test_engine_spec_efficiency():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(
-            spec_draft_length=6, speculative_mode=SpeculativeMode.SMALL_DRAFT
-        ),
+        spec_draft_length=6,
+        speculative_mode=SpeculativeMode.SMALL_DRAFT,
         request_stream_callback=fcallback,
     )
 
@@ -604,7 +601,8 @@ def test_engine_eagle_spec_efficiency():
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib_path],
-        engine_config=EngineConfig(spec_draft_length=6, speculative_mode=SpeculativeMode.EAGLE),
+        spec_draft_length=6,
+        speculative_mode=SpeculativeMode.EAGLE,
         request_stream_callback=fcallback,
     )
 


### PR DESCRIPTION
This PR refactors EngineConfig for a cleaner interface of internal Engine constructor in MLC serve. This is a preparation step towards the engine reload/unload which will be introduced in follow-up PRs for JSONFFIEngine functionality on mobile and other platforms.