### PR TITLE
[Serving][HotFix] No `std::move()` for disco CallPacked

### DIFF
--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -107,7 +107,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
     this->sess = Session::ProcessSession(num_shards, f_create_process_pool, "mlc_llm.cli.worker");
     this->sess->InitCCL(ccl, ShapeTuple(device_ids));
     this->disco_mod = sess->CallPacked(sess->GetGlobalFunc("runtime.disco.load_vm_module"),
-                                       std::move(reload_lib_path), null_device);
+                                       reload_lib_path, null_device);
     this->mod_get_func = [this,
                           fmodule_get_function = sess->GetGlobalFunc("runtime.ModuleGetFunction")](
                              const std::string& name) -> PackedFunc {


### PR DESCRIPTION
The disco `CallPacked` function cannot handle `std::move()` very well. A previous engine refactor PR introduced a regression that broke our tensor parallelism support. This commit fixes the issue.