### PR TITLE
[Misc] Pass env along when calling `subprocess.run`

### DIFF
--- a/python/mlc_llm/chat_module.py
+++ b/python/mlc_llm/chat_module.py
@@ -664,7 +664,7 @@ def _inspect_model_lib_metadata_memory_usage(model_lib_path, config_file_path):
         "--mlc-chat-config",
         config_file_path,
     ]
-    subprocess.run(cmd, check=False)
+    subprocess.run(cmd, check=False, env=os.environ)
 
 
 class ChatModule:  # pylint: disable=too-many-instance-attributes

--- a/python/mlc_llm/cli/delivery.py
+++ b/python/mlc_llm/cli/delivery.py
@@ -1,7 +1,9 @@
 """Continuous model delivery for MLC LLM models."""
+
 import argparse
 import dataclasses
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -131,7 +133,9 @@ def _run_quantization(
                     cmd += ["--" + optional_arg.replace("_", "-"), str(optional_arg_val)]
 
             print(" ".join(cmd), file=log_file, flush=True)
-            subprocess.run(cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT)
+            subprocess.run(
+                cmd, check=True, stdout=log_file, stderr=subprocess.STDOUT, env=os.environ
+            )
             cmd = [
                 sys.executable,
                 "-m",
@@ -146,7 +150,9 @@ def _run_quantization(
                 output_dir,
             ]
             print(" ".join(cmd), file=log_file, flush=True)
-            subprocess.run(cmd, check=False, stdout=log_file, stderr=subprocess.STDOUT)
+            subprocess.run(
+                cmd, check=False, stdout=log_file, stderr=subprocess.STDOUT, env=os.environ
+            )
             logger.info("[MLC] Complete!")
         if not (Path(output_dir) / "ndarray-cache.json").exists():
             logger.error(

--- a/python/mlc_llm/interface/jit.py
+++ b/python/mlc_llm/interface/jit.py
@@ -93,7 +93,7 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
             ]
             logger.info("Compiling using commands below:")
             logger.info("%s", blue(shlex.join(cmd)))
-            subprocess.run(cmd, check=True)
+            subprocess.run(cmd, check=True, env=os.environ)
             shutil.move(dso_path, dst)
             logger.info("Using compiled model lib: %s", bold(dst))
 

--- a/python/mlc_llm/support/auto_device.py
+++ b/python/mlc_llm/support/auto_device.py
@@ -1,4 +1,6 @@
 """Automatic detection of the device available on the local machine."""
+
+import os
 import subprocess
 import sys
 from typing import Dict, Optional
@@ -65,6 +67,7 @@ def _device_exists(device: Device) -> bool:
             capture_output=True,
             text=True,
             check=False,
+            env=os.environ,
         )
         .stdout.strip()
         .splitlines()

--- a/python/mlc_llm/support/download.py
+++ b/python/mlc_llm/support/download.py
@@ -36,11 +36,13 @@ def git_clone(url: str, destination: Path, ignore_lfs: bool) -> None:
     command = ["git", "clone", url, repo_name]
     _ensure_directory_not_exist(destination, force_redo=False)
     try:
+        env = os.environ.copy()
+        env["GIT_LFS_SKIP_SMUDGE"] = "1"
         with tempfile.TemporaryDirectory(dir=MLC_TEMP_DIR) as tmp_dir:
             logger.info("[Git] Cloning %s to %s", bold(url), destination)
             subprocess.run(
                 command,
-                env={"GIT_LFS_SKIP_SMUDGE": "1"},
+                env=env,
                 cwd=tmp_dir,
                 check=True,
                 stdout=subprocess.DEVNULL,


### PR DESCRIPTION
The uses of `subprocess.run` in the codebase did not pass the environment, which may cause some issues in cases.