### PR TITLE
Fix the output inconsistent bug of q0f32 spec decoding

### DIFF
--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -128,8 +128,6 @@ class BatchVerifyActionObj : public EngineActionObj {
         rsentries[i]->mstates[draft_model_id_]->CommitToken(sample_result);
       }
       estate->stats.total_accepted_length += accept_length;
-      // - Minus one because the last draft token has no kv cache entry
-      // - Take max with 0 in case of all accepted.
       int rollback_length =
           std::max(cum_verify_lengths[i + 1] - cum_verify_lengths[i] - accept_length, 0);
       // rollback kv cache

--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -131,7 +131,7 @@ class BatchVerifyActionObj : public EngineActionObj {
       // - Minus one because the last draft token has no kv cache entry
       // - Take max with 0 in case of all accepted.
       int rollback_length =
-          std::max(cum_verify_lengths[i + 1] - cum_verify_lengths[i] - accept_length - 1, 0);
+          std::max(cum_verify_lengths[i + 1] - cum_verify_lengths[i] - accept_length, 0);
       // rollback kv cache
       // NOTE: when number of small models is more than 1 (in the future),
       // it is possible to re-compute prefill for the small models.

--- a/tests/python/serve/test_serve_engine_spec.py
+++ b/tests/python/serve/test_serve_engine_spec.py
@@ -364,7 +364,19 @@ def test_engine_eagle_continuous_batching_1():
         # assert fin_time == request.generation_config.max_tokens - 1
 
 
-def test_engine_generate():
+def compare_output_text(output_text1, output_text2):
+    if isinstance(output_text1, list) and isinstance(output_text2, list):
+        for item1, item2 in zip(output_text1, output_text2):
+            if not compare_output_text(item1, item2):
+                return False
+    elif output_text1 != output_text2:
+        print(output_text1)
+        print(output_text2)
+        return False
+    return True
+
+
+def test_engine_generate(compare_precision=False):
     # Create engine
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
@@ -372,6 +384,7 @@ def test_engine_generate():
     small_model_lib_path = (
         "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
     )
+
     engine = SyncLLMEngine(
         model=model,
         model_lib_path=model_lib_path,
@@ -385,9 +398,31 @@ def test_engine_generate():
     max_tokens = 256
 
     # Generate output.
-    output_texts, _ = engine.generate(
-        prompts[:num_requests], GenerationConfig(max_tokens=max_tokens, n=3)
-    )
+    if compare_precision:
+        print("compare precision")
+        generation_config = GenerationConfig(
+            temperature=0.0, top_p=0, max_tokens=1024, stop_token_ids=[2], n=1
+        )
+        engine_single_model = SyncLLMEngine(
+            model=model,
+            model_lib_path=model_lib_path,
+            mode="server",
+            max_total_sequence_length=4096,
+        )
+        output_texts_single_model, _ = engine_single_model.generate(
+            prompts[:num_requests], generation_config
+        )
+        for req_id, outputs in enumerate(output_texts_single_model):
+            print(f"Prompt {req_id}: {prompts[req_id]}")
+            if len(outputs) == 1:
+                print(f"Output {req_id}:{outputs[0]}\n")
+            else:
+                for i, output in enumerate(outputs):
+                    print(f"Output {req_id}({i}):{output}\n")
+        # TODO: Add pytorch precision
+    else:
+        generation_config = GenerationConfig(max_tokens=max_tokens, n=3)
+    output_texts, _ = engine.generate(prompts[:num_requests], generation_config)
     for req_id, outputs in enumerate(output_texts):
         print(f"Prompt {req_id}: {prompts[req_id]}")
         if len(outputs) == 1:
@@ -395,6 +430,12 @@ def test_engine_generate():
         else:
             for i, output in enumerate(outputs):
                 print(f"Output {req_id}({i}):{output}\n")
+    if compare_precision:
+        precision_flag = compare_output_text(output_texts, output_texts_single_model)
+        if precision_flag:
+            print(f"Accuracy verification succeed\n")
+        else:
+            print(f"Accuracy verification failed\n")
 
 
 def test_engine_eagle_generate():
@@ -643,7 +684,7 @@ if __name__ == "__main__":
     test_engine_eagle_basic()
     test_engine_continuous_batching_1()
     test_engine_eagle_continuous_batching_1()
-    test_engine_generate()
+    test_engine_generate(compare_precision=True)
     test_engine_eagle_generate()
     test_engine_efficiency()
     test_engine_spec_efficiency()


### PR DESCRIPTION
- According to https://github.com/mlc-ai/mlc-llm/issues/2167 ， the problem that the output of spec decoding in q0f32 is inconsistent with the single model of q0f32 has been fixed. 
- Modified the test_engine_generate function located in [tests/python/serve/test_serve_engine_spec.py](https://github.com/mlc-ai/mlc-llm/blob/main/tests/python/serve/test_serve_engine_spec.py) to support comparison of the output of a single model and the output of spec decoding
- The accuracy comparison with hugging face is left (because the current version of llama-2-7b of q0f32 cannot be consistent with the output of hugging face model)
- The output of spec decoding for q0f16 cannot be consistent with the output of a single model of q0f16, but this may be due to floating point errors.   