### PR TITLE
[Serving] Support ThreadedEngine Reload/Unload/Reset

### DIFF
--- a/cpp/json_ffi/json_ffi_engine.cc
+++ b/cpp/json_ffi/json_ffi_engine.cc
@@ -103,6 +103,9 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ModuleNode {
  public:
   TVM_MODULE_VTABLE_BEGIN("mlc.json_ffi");
   TVM_MODULE_VTABLE_ENTRY("init_background_engine", &JSONFFIEngineImpl::InitBackgroundEngine);
+  TVM_MODULE_VTABLE_ENTRY("reload", &JSONFFIEngineImpl::Reload);
+  TVM_MODULE_VTABLE_ENTRY("unload", &JSONFFIEngineImpl::Unload);
+  TVM_MODULE_VTABLE_ENTRY("reset", &JSONFFIEngineImpl::Reset);
   TVM_MODULE_VTABLE_ENTRY("chat_completion", &JSONFFIEngineImpl::ChatCompletion);
   TVM_MODULE_VTABLE_ENTRY("abort", &JSONFFIEngineImpl::Abort);
   TVM_MODULE_VTABLE_ENTRY("get_last_error", &JSONFFIEngineImpl::GetLastError);
@@ -132,6 +135,12 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ModuleNode {
     this->engine_->InitBackgroundEngine(
         std::move(engine_config), std::move(request_stream_callback), std::move(trace_recorder));
   }
+
+  void Reload(EngineConfig engine_config) { this->engine_->Reload(std::move(engine_config)); }
+
+  void Unload() { this->engine_->Unload(); }
+
+  void Reset() { this->engine_->Reset(); }
 
   void RunBackgroundLoop() { this->engine_->RunBackgroundLoop(); }
 

--- a/cpp/serve/engine.h
+++ b/cpp/serve/engine.h
@@ -82,6 +82,9 @@ class Engine {
   /*! \brief Abort the input request (specified by id string) from engine. */
   virtual void AbortRequest(const String& request_id) = 0;
 
+  /*! \brief Abort all requests from the engine. */
+  virtual void AbortAllRequests() = 0;
+
   /*********************** Engine Action ***********************/
 
   /*!

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -29,7 +29,8 @@ enum class InstructionKind : int {
   kAbortRequest = 1,
   kUnloadEngine = 2,
   kReloadEngine = 3,
-  kDebugCallFuncOnAllAllWorker = 4,
+  kResetEngine = 4,
+  kDebugCallFuncOnAllAllWorker = 5,
 };
 
 /*! \brief The implementation of ThreadedEngine. */
@@ -41,6 +42,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
     CHECK(request_stream_callback.defined())
         << "ThreadedEngine requires request stream callback function, but it is not given.";
     request_stream_callback_ = request_stream_callback.value();
+    trace_recorder_ = trace_recorder;
 
     auto frequest_stream_callback_wrapper = [this](TVMArgs args, TVMRetValue* ret) {
       ICHECK_EQ(args.size(), 1);
@@ -60,6 +62,45 @@ class ThreadedEngineImpl : public ThreadedEngine {
     request_stream_callback = PackedFunc(frequest_stream_callback_wrapper);
     background_engine_ = Engine::Create(
         std::move(engine_config), std::move(request_stream_callback), std::move(trace_recorder));
+  }
+
+  void Reload(EngineConfig engine_config) final {
+    bool need_notify = false;
+    {
+      std::lock_guard<std::mutex> lock(background_loop_mutex_);
+      instruction_queue_.emplace_back(InstructionKind::kReloadEngine, std::move(engine_config));
+      ++pending_request_operation_cnt_;
+      need_notify = engine_waiting_;
+    }
+    if (need_notify) {
+      background_loop_cv_.notify_one();
+    }
+  }
+
+  void Unload() final {
+    bool need_notify = false;
+    {
+      std::lock_guard<std::mutex> lock(background_loop_mutex_);
+      instruction_queue_.emplace_back(InstructionKind::kUnloadEngine, ObjectRef(nullptr));
+      ++pending_request_operation_cnt_;
+      need_notify = engine_waiting_;
+    }
+    if (need_notify) {
+      background_loop_cv_.notify_one();
+    }
+  }
+
+  void Reset() final {
+    bool need_notify = false;
+    {
+      std::lock_guard<std::mutex> lock(background_loop_mutex_);
+      instruction_queue_.emplace_back(InstructionKind::kResetEngine, ObjectRef(nullptr));
+      ++pending_request_operation_cnt_;
+      need_notify = engine_waiting_;
+    }
+    if (need_notify) {
+      background_loop_cv_.notify_one();
+    }
   }
 
   void AddRequest(Request request) final {
@@ -97,7 +138,8 @@ class ThreadedEngineImpl : public ThreadedEngine {
         std::unique_lock<std::mutex> lock(background_loop_mutex_);
         engine_waiting_ = true;
         background_loop_cv_.wait(lock, [this] {
-          return !background_engine_->Empty() || pending_request_operation_cnt_.load() > 0 ||
+          return (background_engine_ != nullptr && !background_engine_->Empty()) ||
+                 pending_request_operation_cnt_.load() > 0 ||
                  exit_now_.load(std::memory_order_relaxed);
         });
         engine_waiting_ = false;
@@ -108,22 +150,31 @@ class ThreadedEngineImpl : public ThreadedEngine {
       }
       for (const auto& [kind, arg] : local_instruction_queue) {
         if (kind == InstructionKind::kAddRequest) {
+          CHECK(background_engine_ != nullptr) << "Background engine is not loaded.";
           background_engine_->AddRequest(Downcast<Request>(arg));
         } else if (kind == InstructionKind::kAbortRequest) {
+          CHECK(background_engine_ != nullptr) << "Background engine is not loaded.";
           background_engine_->AbortRequest(Downcast<String>(arg));
         } else if (kind == InstructionKind::kUnloadEngine) {
-          // Todo(mlc-team): implement engine unload
-          LOG(FATAL) << "Not implemented yet.";
+          EngineUnloadImpl();
         } else if (kind == InstructionKind::kReloadEngine) {
-          // Todo(mlc-team): implement engine reload
-          LOG(FATAL) << "Not implemented yet.";
+          EngineUnloadImpl();
+          InitBackgroundEngine(Downcast<EngineConfig>(arg), request_stream_callback_,
+                               trace_recorder_);
+        } else if (kind == InstructionKind::kResetEngine) {
+          if (background_engine_ != nullptr) {
+            background_engine_->Reset();
+          }
         } else if (kind == InstructionKind::kDebugCallFuncOnAllAllWorker) {
+          CHECK(background_engine_ != nullptr) << "Background engine is not loaded.";
           background_engine_->DebugCallFuncOnAllAllWorker(Downcast<String>(arg));
         } else {
           LOG(FATAL) << "Cannot reach here";
         }
       }
-      background_engine_->Step();
+      if (background_engine_ != nullptr) {
+        background_engine_->Step();
+      }
     }
   }
 
@@ -184,10 +235,24 @@ class ThreadedEngineImpl : public ThreadedEngine {
   }
 
  private:
+  void EngineUnloadImpl() {
+    if (background_engine_ != nullptr) {
+      background_engine_->AbortAllRequests();
+      background_engine_ = nullptr;
+      // Clear the allocated memory in cached memory pool.
+      const PackedFunc* fclear_memory_manager =
+          tvm::runtime::Registry::Get("vm.builtin.memory_manager.clear");
+      ICHECK(fclear_memory_manager) << "Cannot find env function vm.builtin.memory_manager.clear";
+      (*fclear_memory_manager)();
+    }
+  }
+
   /*! \brief The background normal engine for request processing. */
   std::unique_ptr<Engine> background_engine_;
   /*! \brief The request stream callback. */
   PackedFunc request_stream_callback_;
+  /*! \brief Event trace recorder. */
+  Optional<EventTraceRecorder> trace_recorder_;
 
   /*! \brief The mutex ensuring only one thread can access critical regions. */
   std::mutex background_loop_mutex_;

--- a/cpp/serve/threaded_engine.h
+++ b/cpp/serve/threaded_engine.h
@@ -43,6 +43,15 @@ class ThreadedEngine {
                                     Optional<PackedFunc> request_stream_callback,
                                     Optional<EventTraceRecorder> trace_recorder) = 0;
 
+  /*! \brief Reload the engine with the new engine config. */
+  virtual void Reload(EngineConfig engine_config) = 0;
+
+  /*! \brief Unload the background engine. */
+  virtual void Unload() = 0;
+
+  /*! \brief Reset the engine to the initial state. */
+  virtual void Reset() = 0;
+
   /*! \brief Starts the background request processing loop. */
   virtual void RunBackgroundLoop() = 0;
 

--- a/tests/python/json_ffi/test_json_ffi_engine.py
+++ b/tests/python/json_ffi/test_json_ffi_engine.py
@@ -111,6 +111,9 @@ class JSONFFIEngine:
             key: module[key]
             for key in [
                 "init_background_engine",
+                "reload",
+                "unload",
+                "reset",
                 "chat_completion",
                 "abort",
                 "get_last_error",
@@ -121,22 +124,24 @@ class JSONFFIEngine:
         }
         self.tokenizer = Tokenizer(model_args[0][0])
 
+        self.engine_config = EngineConfig(
+            model=model_args[0][0],
+            model_lib_path=model_args[0][1],
+            additional_models=[model_arg[0] for model_arg in model_args[1:]],
+            additional_model_lib_paths=[model_arg[1] for model_arg in model_args[1:]],
+            device=device,
+            kv_cache_page_size=16,
+            max_num_sequence=max_batch_size,
+            max_total_sequence_length=max_total_sequence_length,
+            max_single_sequence_length=max_single_sequence_length,
+            prefill_chunk_size=prefill_chunk_size,
+            speculative_mode=speculative_mode,
+            spec_draft_length=spec_draft_length,
+        )
+
         def _background_loop():
             self._ffi["init_background_engine"](
-                EngineConfig(
-                    model=model_args[0][0],
-                    model_lib_path=model_args[0][1],
-                    additional_models=[model_arg[0] for model_arg in model_args[1:]],
-                    additional_model_lib_paths=[model_arg[1] for model_arg in model_args[1:]],
-                    device=device,
-                    kv_cache_page_size=16,
-                    max_num_sequence=max_batch_size,
-                    max_total_sequence_length=max_total_sequence_length,
-                    max_single_sequence_length=max_single_sequence_length,
-                    prefill_chunk_size=prefill_chunk_size,
-                    speculative_mode=speculative_mode,
-                    spec_draft_length=spec_draft_length,
-                ),
+                self.engine_config,
                 self.state.get_request_stream_callback(),
                 None,
             )
@@ -251,8 +256,17 @@ class JSONFFIEngine:
             self._ffi["abort"](request_id)
             raise exception
 
+    def _test_reload(self):
+        self._ffi["reload"](self.engine_config)
 
-def test_chat_completion(engine: JSONFFIEngine):
+    def _test_reset(self):
+        self._ffi["reset"]()
+
+    def _test_unload(self):
+        self._ffi["unload"]()
+
+
+def run_chat_completion(engine: JSONFFIEngine, model: str):
     num_requests = 2
     max_tokens = 64
     n = 1
@@ -284,13 +298,7 @@ def test_chat_completion(engine: JSONFFIEngine):
                 print(f"Output {req_id}({i}):{output}\n")
 
 
-def test_malformed_request(engine: JSONFFIEngine):
-    for response in engine._handle_chat_completion("malformed_string", n=1, request_id="123"):
-        assert len(response.choices) == 1
-        assert response.choices[0].finish_reason == "error"
-
-
-if __name__ == "__main__":
+def test_chat_completion():
     # Create engine.
     model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
     model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
@@ -300,8 +308,37 @@ if __name__ == "__main__":
         max_total_sequence_length=1024,
     )
 
-    test_chat_completion(engine)
-    test_malformed_request(engine)
+    run_chat_completion(engine, model)
+
+    # Test malformed requests.
+    for response in engine._handle_chat_completion("malformed_string", n=1, request_id="123"):
+        assert len(response.choices) == 1
+        assert response.choices[0].finish_reason == "error"
 
     engine.terminate()
-    del engine
+
+
+def test_reload_reset_unload():
+    # Create engine.
+    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
+    model_lib_path = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    engine = JSONFFIEngine(
+        model,
+        model_lib_path=model_lib_path,
+        max_total_sequence_length=1024,
+    )
+
+    # Run chat completion before and after reload/reset.
+    run_chat_completion(engine, model)
+    engine._test_reload()
+    run_chat_completion(engine, model)
+    engine._test_reset()
+    run_chat_completion(engine, model)
+    engine._test_unload()
+
+    engine.terminate()
+
+
+if __name__ == "__main__":
+    test_chat_completion()
+    test_reload_reset_unload()


### PR DESCRIPTION
This PR brings the support of reload (reload the engine with a new model), unload (unload the current running model) and reset (reset the engine to the initial states without unloading) to ThreadedEngine and JSONFFIEngine.

These functions are useful for app bindings for iOS/Android.