### PR TITLE
[WASM] Support grammar schema in wasm

### DIFF
--- a/cpp/serve/grammar/grammar_state_matcher.cc
+++ b/cpp/serve/grammar/grammar_state_matcher.cc
@@ -469,9 +469,10 @@ TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFromTokenizer")
 TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFromTokenTable")
     .set_body([](TVMArgs args, TVMRetValue* rv) {
       BNFGrammar grammar = args[0];
+      Array<String> token_table_arr = args[1];
       std::vector<std::string> token_table;
-      for (int i = 1; i < args.size() - 1; ++i) {
-        token_table.push_back(args[i]);
+      for (int i = 0; i < token_table_arr.size(); ++i) {
+        token_table.push_back(token_table_arr[i]);
       }
       int max_rollback_steps = args[args.size() - 1];
       auto init_ctx = GrammarStateMatcher::CreateInitContext(grammar, token_table);

--- a/cpp/serve/grammar/json_schema_converter.cc
+++ b/cpp/serve/grammar/json_schema_converter.cc
@@ -23,6 +23,14 @@ namespace serve {
 
 using namespace tvm::runtime;
 
+// EMCC somehow cannot pickup operator overload from picojson.h, so we copy here.
+#ifdef COMPILE_MLC_WASM_RUNTIME
+inline std::ostream& operator<<(std::ostream& os, const picojson::value& x) {
+  x.serialize(std::ostream_iterator<char>(os));
+  return os;
+}
+#endif
+
 /*!
  * \brief Manage the indent and separator for the generation of EBNF grammar.
  * \param indent The number of spaces for each indent. If it is std::nullopt, there will be no

--- a/python/mlc_llm/serve/grammar.py
+++ b/python/mlc_llm/serve/grammar.py
@@ -247,7 +247,7 @@ class GrammarStateMatcher(Object):
             self.__init_handle_by_constructor__(
                 _ffi_api.GrammarStateMatcherFromTokenTable,  # type: ignore  # pylint: disable=no-member
                 grammar,
-                *tokenizer,
+                tokenizer,
                 max_rollback_steps,
             )
         else:

--- a/web/emcc/mlc_wasm_runtime.cc
+++ b/web/emcc/mlc_wasm_runtime.cc
@@ -29,6 +29,8 @@
 
 // Pass in COMPILE_MLC_WASM_RUNTIME so unsupported code would not be compiled in to the .bc file
 #define COMPILE_MLC_WASM_RUNTIME 1
+#define __STDC_FORMAT_MACROS 1
+#define PICOJSON_USE_INT64
 
 #define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
 
@@ -38,4 +40,5 @@
 #include "serve/grammar/grammar_serializer.cc"
 #include "serve/grammar/grammar_simplifier.cc"
 #include "serve/grammar/grammar_state_matcher.cc"
+#include "serve/grammar/json_schema_converter.cc"
 #include "support/encoding.cc"


### PR DESCRIPTION
Update `web/emcc/mlc_wasm_runtime.cc` to include the recent grammar schema implementation.

Change `GrammarStateMatcherFromTokenTable()` to take in a list of string rather than unpacking them so that each string is an element. This is to avoid error `RangeError: Maximum call stack size exceeded` in platforms like Javascript, especially with the recent 128000 vocab size of Llama 3.

Made sure `test_grammar_state_matcher_json.py` still passes.