### PR TITLE
[Serving] Support loading system library

### DIFF
--- a/cpp/json_ffi/json_ffi_engine.cc
+++ b/cpp/json_ffi/json_ffi_engine.cc
@@ -118,6 +118,9 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ModuleNode {
   void InitBackgroundEngine(EngineConfig engine_config,
                             Optional<PackedFunc> request_stream_callback,
                             Optional<EventTraceRecorder> trace_recorder) {
+    // Todo(mlc-team): decouple InitBackgroundEngine into two functions
+    // by removing `engine_config` from arguments, after properly handling
+    // streamers.
     this->streamer_ = TextStreamer(Tokenizer::FromPath(engine_config->model));
 
     CHECK(request_stream_callback.defined())
@@ -132,8 +135,9 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ModuleNode {
     };
 
     request_stream_callback = PackedFunc(frequest_stream_callback_wrapper);
-    this->engine_->InitBackgroundEngine(
-        std::move(engine_config), std::move(request_stream_callback), std::move(trace_recorder));
+    this->engine_->InitBackgroundEngine(std::move(request_stream_callback),
+                                        std::move(trace_recorder));
+    this->engine_->Reload(std::move(engine_config));
   }
 
   void Reload(EngineConfig engine_config) { this->engine_->Reload(std::move(engine_config)); }

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -36,32 +36,12 @@ enum class InstructionKind : int {
 /*! \brief The implementation of ThreadedEngine. */
 class ThreadedEngineImpl : public ThreadedEngine {
  public:
-  void InitBackgroundEngine(EngineConfig engine_config,
-                            Optional<PackedFunc> request_stream_callback,
+  void InitBackgroundEngine(Optional<PackedFunc> request_stream_callback,
                             Optional<EventTraceRecorder> trace_recorder) final {
     CHECK(request_stream_callback.defined())
         << "ThreadedEngine requires request stream callback function, but it is not given.";
     request_stream_callback_ = request_stream_callback.value();
     trace_recorder_ = trace_recorder;
-
-    auto frequest_stream_callback_wrapper = [this](TVMArgs args, TVMRetValue* ret) {
-      ICHECK_EQ(args.size(), 1);
-      Array<RequestStreamOutput> delta_outputs = args[0];
-      bool need_notify = false;
-      {
-        std::lock_guard<std::mutex> lock(request_stream_callback_mutex_);
-        request_stream_callback_inputs_.push_back(std::move(delta_outputs));
-        ++pending_request_stream_callback_cnt_;
-        need_notify = stream_callback_waiting_;
-      }
-      if (need_notify) {
-        request_stream_callback_cv_.notify_one();
-      }
-    };
-
-    request_stream_callback = PackedFunc(frequest_stream_callback_wrapper);
-    background_engine_ = Engine::Create(
-        std::move(engine_config), std::move(request_stream_callback), std::move(trace_recorder));
   }
 
   void Reload(EngineConfig engine_config) final {
@@ -159,8 +139,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
           EngineUnloadImpl();
         } else if (kind == InstructionKind::kReloadEngine) {
           EngineUnloadImpl();
-          InitBackgroundEngine(Downcast<EngineConfig>(arg), request_stream_callback_,
-                               trace_recorder_);
+          EngineReloadImpl(Downcast<EngineConfig>(arg));
         } else if (kind == InstructionKind::kResetEngine) {
           if (background_engine_ != nullptr) {
             background_engine_->Reset();
@@ -235,6 +214,27 @@ class ThreadedEngineImpl : public ThreadedEngine {
   }
 
  private:
+  void EngineReloadImpl(EngineConfig engine_config) {
+    auto frequest_stream_callback_wrapper = [this](TVMArgs args, TVMRetValue* ret) {
+      ICHECK_EQ(args.size(), 1);
+      Array<RequestStreamOutput> delta_outputs = args[0];
+      bool need_notify = false;
+      {
+        std::lock_guard<std::mutex> lock(request_stream_callback_mutex_);
+        request_stream_callback_inputs_.push_back(std::move(delta_outputs));
+        ++pending_request_stream_callback_cnt_;
+        need_notify = stream_callback_waiting_;
+      }
+      if (need_notify) {
+        request_stream_callback_cv_.notify_one();
+      }
+    };
+
+    Optional<PackedFunc> request_stream_callback = PackedFunc(frequest_stream_callback_wrapper);
+    background_engine_ = Engine::Create(std::move(engine_config),
+                                        std::move(request_stream_callback), trace_recorder_);
+  }
+
   void EngineUnloadImpl() {
     if (background_engine_ != nullptr) {
       background_engine_->AbortAllRequests();
@@ -302,6 +302,7 @@ class ThreadedEngineModule : public ThreadedEngineImpl, public ModuleNode {
  public:
   TVM_MODULE_VTABLE_BEGIN("mlc.serve.async_threaded_engine");
   TVM_MODULE_VTABLE_ENTRY("init_background_engine", &ThreadedEngineImpl::InitBackgroundEngine);
+  TVM_MODULE_VTABLE_ENTRY("reload", &ThreadedEngineImpl::Reload);
   TVM_MODULE_VTABLE_ENTRY("add_request", &ThreadedEngineImpl::AddRequest);
   TVM_MODULE_VTABLE_ENTRY("abort_request", &ThreadedEngineImpl::AbortRequest);
   TVM_MODULE_VTABLE_ENTRY("run_background_loop", &ThreadedEngineImpl::RunBackgroundLoop);

--- a/cpp/serve/threaded_engine.h
+++ b/cpp/serve/threaded_engine.h
@@ -35,15 +35,16 @@ class ThreadedEngine {
 
   /*!
    * \brief Initialize the threaded engine from packed arguments in TVMArgs.
-   * \param engine_config The engine config.
    * \param request_stream_callback The request stream callback function to.
    * \param trace_recorder Event trace recorder for requests.
    */
-  virtual void InitBackgroundEngine(EngineConfig engine_config,
-                                    Optional<PackedFunc> request_stream_callback,
+  virtual void InitBackgroundEngine(Optional<PackedFunc> request_stream_callback,
                                     Optional<EventTraceRecorder> trace_recorder) = 0;
 
-  /*! \brief Reload the engine with the new engine config. */
+  /*!
+   * \brief Reload the engine with the new engine config.
+   * \param engine_config The engine config.
+   */
   virtual void Reload(EngineConfig engine_config) = 0;
 
   /*! \brief Unload the background engine. */

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -10,6 +10,7 @@
 namespace mlc {
 namespace llm {
 
+/*! \brief Split the input string by the given delimiter character. */
 inline std::vector<std::string> Split(const std::string& str, char delim) {
   std::string item;
   std::istringstream is(str);
@@ -18,6 +19,22 @@ inline std::vector<std::string> Split(const std::string& str, char delim) {
     ret.push_back(item);
   }
   return ret;
+}
+
+/*!
+ * \brief Check whether the string starts with a given prefix.
+ * \param str The given string.
+ * \param prefix The given prefix.
+ * \return Whether the prefix matched.
+ */
+inline bool StartsWith(const std::string& str, const char* prefix) {
+  size_t n = str.length();
+  for (size_t i = 0; i < n; i++) {
+    if (prefix[i] == '\0') return true;
+    if (str.data()[i] != prefix[i]) return false;
+  }
+  // return true if the str is equal to the prefix
+  return prefix[n] == '\0';
 }
 
 }  // namespace llm

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -776,32 +776,35 @@ class LLMEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
                 "abort_request",
                 "run_background_loop",
                 "run_background_stream_back_loop",
+                "reload",
                 "init_background_engine",
                 "exit_background_loop",
                 "debug_call_func_on_all_worker",
             ]
         }
         self.tokenizer = Tokenizer(model_args[0][0])
+        self._ffi["init_background_engine"](
+            self.state.get_request_stream_callback(kind),
+            self.state.trace_recorder,
+        )
+        self._ffi["reload"](
+            EngineConfig(
+                model=model_args[0][0],
+                model_lib_path=model_args[0][1],
+                additional_models=[model_arg[0] for model_arg in model_args[1:]],
+                additional_model_lib_paths=[model_arg[1] for model_arg in model_args[1:]],
+                device=device,
+                kv_cache_page_size=16,
+                max_num_sequence=max_batch_size,
+                max_total_sequence_length=max_total_sequence_length,
+                max_single_sequence_length=max_single_sequence_length,
+                prefill_chunk_size=prefill_chunk_size,
+                speculative_mode=speculative_mode,
+                spec_draft_length=spec_draft_length,
+            )
+        )
 
         def _background_loop():
-            self._ffi["init_background_engine"](
-                EngineConfig(
-                    model=model_args[0][0],
-                    model_lib_path=model_args[0][1],
-                    additional_models=[model_arg[0] for model_arg in model_args[1:]],
-                    additional_model_lib_paths=[model_arg[1] for model_arg in model_args[1:]],
-                    device=device,
-                    kv_cache_page_size=16,
-                    max_num_sequence=max_batch_size,
-                    max_total_sequence_length=max_total_sequence_length,
-                    max_single_sequence_length=max_single_sequence_length,
-                    prefill_chunk_size=prefill_chunk_size,
-                    speculative_mode=speculative_mode,
-                    spec_draft_length=spec_draft_length,
-                ),
-                self.state.get_request_stream_callback(kind),
-                self.state.trace_recorder,
-            )
             self._ffi["run_background_loop"]()
 
         def _background_stream_back_loop():

--- a/tests/python/json_ffi/test_json_ffi_engine.py
+++ b/tests/python/json_ffi/test_json_ffi_engine.py
@@ -138,13 +138,13 @@ class JSONFFIEngine:
             speculative_mode=speculative_mode,
             spec_draft_length=spec_draft_length,
         )
+        self._ffi["init_background_engine"](
+            self.engine_config,
+            self.state.get_request_stream_callback(),
+            None,
+        )
 
         def _background_loop():
-            self._ffi["init_background_engine"](
-                self.engine_config,
-                self.state.get_request_stream_callback(),
-                None,
-            )
             self._ffi["run_background_loop"]()
 
         def _background_stream_back_loop():


### PR DESCRIPTION
This PR introduces the support of loading system libraries. Now in engine reload, when the given library path starts with `"system://"`, we recognize this as a system library and will try to load the the library from the path after the `"system://"` prefix.

This PR also decouples the InitBackgroundEngine of ThreadedEngine into two parts, where the reload is now called explicitly when initializing the engine. This can be also done for the JSONFFIEngine. However, we need to move the construction of streamers in JSONFFIEngine before doing the same thing for JSONFFIEngine. So this is marked as a TODO item.