### PR TITLE
[JIT] Better organize JIT and AOT handling

### DIFF
--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -118,6 +118,13 @@ Select your operating system/compute platform and run the command in your termin
                     python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly mlc-ai-nightly
 
         .. note::
+            Make sure you also install vulkan loader and clang to avoid vulkan
+            not found error or clang not found(needed for jit compile)
+
+            .. code-block:: bash
+
+                conda install -c conda-forge clang libvulkan-loader
+
             If encountering the error below:
 
             .. code-block:: bash

--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -112,6 +112,13 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
               python3 -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly
 
       .. note::
+        Make sure you also install vulkan loader and clang to avoid vulkan
+        not found error or clang not found(needed for jit compile)
+
+        .. code-block:: bash
+
+            conda install -c conda-forge clang libvulkan-loader
+
         If encountering the error below:
 
         .. code-block:: bash
@@ -213,7 +220,7 @@ While it is generally recommended to always use the prebuilt TVM Unity, if you r
         If you are using CUDA and your compute capability is above 80, then it is require to build with
         ``set(USE_FLASHINFER ON)``. Otherwise, you may run into ``Cannot find PackedFunc`` issue during
         runtime.
-        
+
         To check your CUDA compute capability, you can use ``nvidia-smi --query-gpu=compute_cap --format=csv``.
 
     Once ``config.cmake`` is edited accordingly, kick off build with the commands below:

--- a/python/mlc_llm/chat_module.py
+++ b/python/mlc_llm/chat_module.py
@@ -768,7 +768,7 @@ class ChatModule:  # pylint: disable=too-many-instance-attributes
         self.chat_config = _get_chat_config(self.config_file_path, chat_config)
 
         # 4. Look up model library
-        try:
+        if model_lib_path is not None:
             self.model_lib_path = _get_lib_module_path(
                 model,
                 self.model_path,
@@ -777,8 +777,8 @@ class ChatModule:  # pylint: disable=too-many-instance-attributes
                 self.device.MASK2STR[self.device.device_type],
                 self.config_file_path,
             )
-        except FileNotFoundError:
-            logger.info("Model lib not found. Now compiling model lib on device...")
+        else:
+            logger.info("Now compiling model lib on device...")
             from mlc_llm.interface import jit  # pylint: disable=import-outside-toplevel
 
             self.model_lib_path = str(

--- a/python/mlc_llm/interface/jit.py
+++ b/python/mlc_llm/interface/jit.py
@@ -93,7 +93,11 @@ def jit(model_path: Path, chat_config: Dict[str, Any], device: Device) -> Path:
             ]
             logger.info("Compiling using commands below:")
             logger.info("%s", blue(shlex.join(cmd)))
-            subprocess.run(cmd, check=True, env=os.environ)
+            subprocess.run(cmd, check=False, env=os.environ)
+            # note on windows: compilation can succeed but return code is still nonzero
+            # check whether file exists instead
+            if not os.path.isfile(dso_path):
+                raise RuntimeError("Cannot find compilation output, compilation failed")
             shutil.move(dso_path, dst)
             logger.info("Using compiled model lib: %s", bold(dst))
 

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -89,8 +89,10 @@ def _process_model_args(
         if conversation is None:
             assert isinstance(chat_config.conv_template, Conversation)
             conversation = chat_config.conv_template
-        # Try look up model library, and do JIT compile if model library not found.
-        try:
+
+        if model.model_lib_path is not None:
+            # do model lib search if the model lib path is provided
+            # error out if file not found
             model_lib_path = _get_lib_module_path(
                 model=model.model,
                 model_path=model_path,
@@ -99,7 +101,9 @@ def _process_model_args(
                 device_name=device.MASK2STR[device.device_type],
                 config_file_path=config_file_path,
             )
-        except FileNotFoundError:
+        else:
+            # TODO(mlc-team) add logging information
+            # Run jit if model_lib_path is not provided
             from mlc_llm.interface import jit  # pylint: disable=import-outside-toplevel
 
             model_lib_path = str(


### PR DESCRIPTION
Previously we do JIT when AOT lib lookup failed.
The error message can become cryptic when JIT also fails, it will show up as cannot find None-vulkan.dll.

This PR changes the behavior to only to lookup when model_lib_path is provided, or only to JIT when it is not. This will leads to cleaner error message overall.