### PR TITLE
[Docs] Update quick start to mention Llama 3 8B

### DIFF
--- a/docs/get_started/quick_start.rst
+++ b/docs/get_started/quick_start.rst
@@ -6,7 +6,7 @@ Quick Start
 Examples
 --------
 
-To begin with, try out MLC LLM support for int4-quantized Llama2 7B.
+To begin with, try out MLC LLM support for int4-quantized Llama3 8B.
 It is recommended to have at least 6GB free VRAM to run it.
 
 .. tabs::
@@ -133,7 +133,7 @@ It is recommended to have at least 6GB free VRAM to run it.
 
     |
 
-    **Requirement**. Llama2-7B model needs an iOS device with a minimum of 6GB RAM, whereas the RedPajama-3B model runs with at least 4GB RAM.
+    **Requirement**. Llama3-8B model needs an iOS device with a minimum of 6GB RAM, whereas the RedPajama-3B model runs with at least 4GB RAM.
 
     **Tutorial and source code**. The source code of the iOS app is fully `open source <https://github.com/mlc-ai/mlc-llm/tree/main/ios>`__,
     and a :ref:`tutorial <deploy-ios>` is included in documentation.
@@ -154,7 +154,7 @@ It is recommended to have at least 6GB free VRAM to run it.
 
     |
 
-    **Requirement**. Llama2-7B model needs a device with a minimum of 6GB RAM, whereas the RedPajama-3B model runs with at least 4GB RAM.
+    **Requirement**. Llama3-8B model needs a device with a minimum of 6GB RAM, whereas the RedPajama-3B model runs with at least 4GB RAM.
     The demo is tested on
 
     - Samsung S23 with Snapdragon 8 Gen 2 chip


### PR DESCRIPTION
This commit updates the quick start to mention Llama 3 8B instead of Llama 2 7B. The code blocks where already updated in #2169.

Docs changes only, no code changes.

A few notes:
- Do we need to update the VRAM recommendation, considering the model is slightly larger (and goes up to 8K context)?
- Do we need to retest this guide on different devices?
- Is the Android APK up-to-date enough to run Llama 3?
   (see also #2194)