### PR TITLE
[Serving][Spec] Fix normal mode verification for extra draft token

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -90,7 +90,7 @@ class EngineImpl : public Engine {
 
     int max_num_tokens = engine_config->max_num_sequence;
     if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
-      max_num_tokens *= engine_config->spec_draft_length;
+      max_num_tokens *= engine_config->spec_draft_length + 1;
     }
     LogitProcessor logit_processor =
         this->models_[0]->CreateLogitProcessor(max_num_tokens, trace_recorder);

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -459,7 +459,7 @@ class EagleNewRequestPrefillActionObj : public EngineActionObj {
     // No exceeding of the maximum allowed requests that can
     // run simultaneously.
     int spec_factor = engine_config_->speculative_mode != SpeculativeMode::kDisable
-                          ? engine_config_->spec_draft_length
+                          ? (engine_config_->spec_draft_length + 1)
                           : 1;
     if ((num_running_rsentries + num_prefill_rsentries) * spec_factor >
         std::min(engine_config_->max_num_sequence, engine_config_->prefill_chunk_size)) {

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -399,7 +399,7 @@ class NewRequestPrefillActionObj : public EngineActionObj {
     // No exceeding of the maximum allowed requests that can
     // run simultaneously.
     int spec_factor = engine_config_->speculative_mode != SpeculativeMode::kDisable
-                          ? engine_config_->spec_draft_length
+                          ? (engine_config_->spec_draft_length + 1)
                           : 1;
     if ((num_running_rsentries + num_prefill_rsentries) * spec_factor >
         std::min(engine_config_->max_num_sequence, engine_config_->prefill_chunk_size)) {

--- a/cpp/serve/sampler/gpu_sampler.cc
+++ b/cpp/serve/sampler/gpu_sampler.cc
@@ -142,6 +142,7 @@ class GPUSampler : public SamplerObj {
       const std::vector<RandomGenerator*>& rngs,
       const std::vector<std::vector<SampleResult>>& draft_output_tokens,
       const std::vector<std::vector<NDArray>>& draft_output_prob_dist) final {
+    NVTXScopedRange nvtx_scope("BatchVerifyDraftTokensWithProbAfterTopP");
     std::vector<std::vector<SampleResult>> sample_results;
     // probs_on_device: (n, v)
     RECORD_EVENT(trace_recorder_, request_ids, "start draft verification");


### PR DESCRIPTION
This PR updates the draft verification of the normal mode speculative decoding. Prior to this PR, we did not effectively leverage all the draft tokens, and this PR fixes the issue.