### PR TITLE
[Serving] Image support in JSONFFIEngine

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "3rdparty/tvm"]
 	path = 3rdparty/tvm
 	url = https://github.com/mlc-ai/relax.git
+[submodule "3rdparty/stb"]
+	path = 3rdparty/stb
+	url = https://github.com/nothings/stb.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ target_include_directories(mlc_llm_objs PRIVATE ${MLC_LLM_INCLUDES})
 target_compile_definitions(mlc_llm_objs PRIVATE ${MLC_LLM_COMPILE_DEFS})
 target_include_directories(mlc_llm_objs PRIVATE ${TOKENZIER_CPP_PATH}/include)
 target_compile_definitions(mlc_llm_objs PRIVATE -DMLC_LLM_EXPORTS)
+target_include_directories(mlc_llm_objs PRIVATE 3rdparty/stb)
 
 add_library(mlc_llm SHARED $<TARGET_OBJECTS:mlc_llm_objs>)
 add_library(mlc_llm_static STATIC $<TARGET_OBJECTS:mlc_llm_objs>)

--- a/cpp/json_ffi/conv_template.h
+++ b/cpp/json_ffi/conv_template.h
@@ -19,6 +19,43 @@ namespace mlc {
 namespace llm {
 namespace json_ffi {
 
+/****************** Model vision config ******************/
+
+/*! \brief Defines the Vision config of the model (if present) */
+class ModelVisionConfig {
+ public:
+  int hidden_size;
+  int image_size;
+  int intermediate_size;
+  int num_attention_heads;
+  int num_hidden_layers;
+  int patch_size;
+  int projection_dim;
+  int vocab_size;
+  std::string dtype;
+  int num_channels;
+  double layer_norm_eps;
+
+  static ModelVisionConfig FromJSON(const picojson::object& json_obj);
+};
+
+/****************** Model config ******************/
+
+/*! \brief Defines the config of the model.
+Populated from "model_config" field in mlc-chat-config.json */
+class ModelConfig {
+ public:
+  int vocab_size;
+  int context_window_size;
+  int sliding_window_size;
+  int prefill_chunk_size;
+  int tensor_parallel_shards;
+  int max_batch_size;
+  std::optional<ModelVisionConfig> vision_config = std::nullopt;
+
+  static ModelConfig FromJSON(const picojson::object& json_obj);
+};
+
 /****************** Conversation template ******************/
 
 enum class MessagePlaceholders { SYSTEM, USER, ASSISTANT, TOOL, FUNCTION };
@@ -92,7 +129,7 @@ struct Conversation {
   Conversation();
 
   /*! \brief Create the list of prompts from the messages based on the conversation template. */
-  Result<std::vector<Data>> AsPrompt();
+  Result<std::vector<Data>> AsPrompt(ModelConfig config, DLDevice device);
 
   /*! \brief Create a Conversation instance from the given JSON object. */
   static Result<Conversation> FromJSON(const picojson::object& json);

--- a/cpp/json_ffi/image_utils.cc
+++ b/cpp/json_ffi/image_utils.cc
@@ -1,0 +1,156 @@
+#include "image_utils.h"
+
+#include <dmlc/io.h>
+
+#include "../../3rdparty/tvm/src/support/base64.h"
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+namespace mlc {
+namespace llm {
+namespace json_ffi {
+
+using namespace tvm::runtime;
+
+class MemoryBufferStream : public dmlc::Stream {
+ public:
+  MemoryBufferStream(const char* data, size_t size) : data_(data), size_(size), pos_(0) {}
+
+  size_t Read(void* ptr, size_t size) override {
+    size_t remaining = size_ - pos_;
+    if (size > remaining) {
+      size = remaining;
+    }
+    if (size == 0) {
+      return 0;
+    }
+    std::memcpy(ptr, data_ + pos_, size);
+    pos_ += size;
+    return size;
+  }
+
+  void Write(const void* ptr, size_t size) override {
+    LOG(FATAL) << "MemoryBufferStream does not support write";
+  }
+
+ private:
+  const char* data_;
+  size_t size_;
+  size_t pos_;
+};
+
+size_t Base64DecodedSize(const std::string& base64_str) {
+  size_t len = base64_str.size();
+  size_t padding = 0;
+  if (base64_str[len - 1] == '=') {
+    padding++;
+  }
+  if (base64_str[len - 2] == '=') {
+    padding++;
+  }
+  return 3 * len / 4 - padding;
+}
+
+Result<NDArray> LoadImageFromBase64(const std::string& base64_str) {
+  using TResult = Result<NDArray>;
+  MemoryBufferStream stream(base64_str.c_str(), base64_str.size());
+  tvm::support::Base64InStream base64_stream(&stream);
+  size_t decoded_size = Base64DecodedSize(base64_str);
+  std::vector<unsigned char> decoded(decoded_size);
+  base64_stream.InitPosition();
+  base64_stream.Read((void*)decoded.data(), decoded_size);
+  int width, height, num_channels;
+  unsigned char* image_data =
+      stbi_load_from_memory(decoded.data(), decoded_size, &width, &height, &num_channels, 3);
+  if (!image_data) {
+    return TResult::Error(stbi_failure_reason());
+  }
+  auto image_ndarray = NDArray::Empty({height, width, 3}, {kDLUInt, 8, 1}, {kDLCPU, 0});
+  image_ndarray.CopyFromBytes((void*)image_data, width * height * 3);
+  stbi_image_free(image_data);
+  return TResult::Ok(image_ndarray);
+}
+
+NDArray ClipPreprocessor(NDArray image_data, int target_size, DLDevice device) {
+  int height = image_data->shape[0];
+  int width = image_data->shape[1];
+  // Resize
+  const int short_side = width < height ? width : height;
+  const int long_side = width > height ? width : height;
+  const int new_short_side = target_size;
+  const int new_long_side = (int)(new_short_side * (long_side / (float)short_side));
+  const int new_width = width < height ? new_short_side : new_long_side;
+  const int new_height = width > height ? new_short_side : new_long_side;
+
+  std::vector<float> processed_image_data(new_width * new_height * 3);
+
+  // Bilinear Interpolation
+  for (int y = 0; y < new_height; y++) {
+    for (int x = 0; x < new_width; x++) {
+      const float x_ratio = float(width - 1) / new_width;
+      const float y_ratio = float(height - 1) / new_height;
+      const int x1 = int(x_ratio * x);
+      const int y1 = int(y_ratio * y);
+      const int x2 = x1 + 1;
+      const int y2 = y1 + 1;
+      const float x_diff = x_ratio * x - x1;
+      const float y_diff = y_ratio * y - y1;
+      for (int c = 0; c < 3; c++) {
+        const uint8_t top_left = ((uint8_t*)image_data->data)[(y1 * width + x1) * 3 + c];
+        const uint8_t top_right = ((uint8_t*)image_data->data)[(y1 * width + x2) * 3 + c];
+        const uint8_t bottom_left = ((uint8_t*)image_data->data)[(y2 * width + x1) * 3 + c];
+        const uint8_t bottom_right = ((uint8_t*)image_data->data)[(y2 * width + x2) * 3 + c];
+        processed_image_data[(y * new_width + x) * 3 + c] =
+            (float)(int(top_left * (1 - x_diff) * (1 - y_diff) + top_right * x_diff * (1 - y_diff) +
+                        bottom_left * y_diff * (1 - x_diff) + bottom_right * x_diff * y_diff));
+      }
+    }
+  }
+
+  // Center crop
+  const int crop_x = (new_width - target_size) / 2;
+  const int crop_y = (new_height - target_size) / 2;
+  std::vector<float> cropped_image_data(target_size * target_size * 3);
+  for (int y = 0; y < target_size; y++) {
+    for (int x = 0; x < target_size; x++) {
+      for (int c = 0; c < 3; c++) {
+        cropped_image_data[(y * target_size + x) * 3 + c] =
+            processed_image_data[((y + crop_y) * new_width + x + crop_x) * 3 + c];
+      }
+    }
+  }
+
+  // Rescale
+  for (int i = 0; i < target_size * target_size * 3; i++) {
+    cropped_image_data[i] = cropped_image_data[i] / 255.0f;
+  }
+
+  // Normalize
+  const float IMAGE_MEAN[] = {0.48145466f, 0.4578275f, 0.40821073f};
+  const float IMAGE_STD[] = {0.26862954f, 0.26130258f, 0.27577711f};
+  for (int i = 0; i < target_size * target_size * 3; i++) {
+    const int c = i % 3;
+    cropped_image_data[i] = (cropped_image_data[i] - IMAGE_MEAN[c]) / IMAGE_STD[c];
+  }
+
+  std::vector<float> image_data_channel_first(target_size * target_size * 3);
+  for (int y = 0; y < target_size; y++) {
+    for (int x = 0; x < target_size; x++) {
+      for (int c = 0; c < 3; c++) {
+        image_data_channel_first[c * target_size * target_size + y * target_size + x] =
+            cropped_image_data[(y * target_size + x) * 3 + c];
+      }
+    }
+  }
+
+  // Create NDArray
+  auto image_ndarray = NDArray::Empty({1, 3, target_size, target_size}, {kDLFloat, 32, 1}, device);
+  image_ndarray.CopyFromBytes((void*)image_data_channel_first.data(),
+                              target_size * target_size * 3 * sizeof(float));
+
+  return image_ndarray;
+}
+
+}  // namespace json_ffi
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/json_ffi/image_utils.h
+++ b/cpp/json_ffi/image_utils.h
@@ -1,0 +1,31 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file json_ffi/image_utils.h
+ * \brief The header of Image utils for JSON FFI Engine in MLC LLM.
+ */
+#ifndef MLC_LLM_JSON_FFI_IMAGE_UTILS_H_
+#define MLC_LLM_JSON_FFI_IMAGE_UTILS_H_
+
+#include <tvm/runtime/ndarray.h>
+
+#include <optional>
+#include <string>
+
+#include "../support/result.h"
+
+namespace mlc {
+namespace llm {
+namespace json_ffi {
+
+/*! \brief Load a base64 encoded image string into a CPU NDArray of shape {height, width, 3} */
+Result<tvm::runtime::NDArray> LoadImageFromBase64(const std::string& base64_str);
+
+/*! \brief Preprocess the CPU image for CLIP encoder and return an NDArray on the given device */
+tvm::runtime::NDArray ClipPreprocessor(tvm::runtime::NDArray image_data, int target_size,
+                                       DLDevice device);
+
+}  // namespace json_ffi
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_JSON_FFI_IMAGE_UTILS_H_

--- a/cpp/json_ffi/json_ffi_engine.h
+++ b/cpp/json_ffi/json_ffi_engine.h
@@ -50,6 +50,8 @@ class JSONFFIEngine {
   TextStreamer streamer_;  // TODO: Support "n", and support different streamers for each request
   Conversation conv_template_;
   String default_generation_cfg_json_str_;
+  ModelConfig model_config_;
+  DLDevice device_;
 };
 
 }  // namespace json_ffi

--- a/python/mlc_llm/model/llava/llava_model.py
+++ b/python/mlc_llm/model/llava/llava_model.py
@@ -7,7 +7,7 @@ import dataclasses
 import logging
 from typing import Any, Dict, Optional, Tuple
 
-from tvm import relax, te, tir
+from tvm import relax, tir
 from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import Module, Tensor, op
 from tvm.relax.frontend.nn.modules import Conv2D
@@ -375,84 +375,11 @@ class LlavaForCasualLM(Module):
         if dtype is not None:
             self.dtype = dtype
 
-    def _embed_input_ids(self, input_ids: Tensor) -> Tensor:
+    def embed(self, input_ids: Tensor) -> Tensor:
         return self.language_model.embed(input_ids)
 
-    def _embed_pixel_values_and_input_ids(self, pixel_values: Tensor, input_ids: Tensor) -> Tensor:
-        def _index(x, value, batch_size, seq_len):
-            return te.compute(
-                (batch_size, seq_len),
-                lambda i, j: tir.if_then_else(
-                    x[i, j] == value,
-                    j,
-                    tir.IntImm("int32", 0),
-                ),
-                name="index",
-            )
-
-        def _concat(x: Tensor, y: Tensor, new_shape: tuple, insert_index: Tensor):
-            return te.compute(
-                (new_shape),
-                lambda b, i, j: tir.if_then_else(
-                    i < insert_index[0],
-                    x[b, i, j],
-                    tir.if_then_else(
-                        i < insert_index[0] + y.shape[1],
-                        y[b, i - insert_index[0], j],
-                        x[b, i - y.shape[1] + 1, j],
-                    ),
-                ),
-            )
-
-        input_embeddings = self._embed_input_ids(input_ids)
-
-        image_features_all = self.vision_tower.forward(pixel_values)
-        image_features = wrap_nested(
-            strided_slice(
-                image_features_all._expr,  # pylint: disable=protected-access
-                axes=[1],
-                begin=[1],
-                end=[image_features_all.shape[1]],
-            ),
-            name="slice",
-        )
-        image_features = self.multi_modal_projector(image_features)
-        batch_size, seq_len = input_ids.shape
-        image_index_tensor = op.tensor_expr_op(
-            _index,
-            name_hint="index",
-            args=[
-                input_ids,
-                tir.IntImm("int32", self.config.image_token_index),
-                batch_size,
-                seq_len,
-            ],
-        ).astype("int32")
-        ##! Assume only one <IMAGE> token in input
-        ##! Also assume batch_size = 1 for now
-        # TODO: Support image_count > 1 and batch_size > 1 # pylint: disable=fixme
-        insert_index = op.sum(image_index_tensor, axis=1)
-
-        new_shape = (
-            batch_size,
-            seq_len + tir.IntImm("int32", image_features.shape[1] - 1),
-            self.config.text_config.hidden_size,
-        )
-
-        combined_embeddings = op.tensor_expr_op(
-            _concat,
-            name_hint="combined_embeddings",
-            args=[input_embeddings, image_features, new_shape, insert_index],
-        )
-        return combined_embeddings
-
-    def embed(self, input_ids: Tensor) -> Tensor:
-        return self._embed_input_ids(input_ids)
-
-    def embed_with_pixel_values(self, pixel_values: Tensor, input_ids: Tensor) -> Tensor:
-        return self._embed_pixel_values_and_input_ids(pixel_values, input_ids)
-
     def image_embed(self, pixel_values: Tensor) -> Tensor:
+        pixel_values = pixel_values.astype(self.dtype)
         image_features_all = self.vision_tower.forward(pixel_values)
         image_features = wrap_nested(
             strided_slice(
@@ -536,22 +463,6 @@ class LlavaForCasualLM(Module):
                     "effect_mode": "none",
                 },
             },
-            "embed_with_pixel_values": {
-                "pixel_values": nn.spec.Tensor(
-                    [
-                        1,
-                        3,
-                        self.config.vision_config.image_size,
-                        self.config.vision_config.image_size,
-                    ],
-                    self.dtype,
-                ),
-                "input_ids": nn.spec.Tensor([1, "seq_len"], "int32"),
-                "$": {
-                    "param_mode": "packed",
-                    "effect_mode": "none",
-                },
-            },
             "image_embed": {
                 "pixel_values": nn.spec.Tensor(
                     [
@@ -560,7 +471,7 @@ class LlavaForCasualLM(Module):
                         self.config.vision_config.image_size,
                         self.config.vision_config.image_size,
                     ],
-                    self.dtype,
+                    "float32",
                 ),
                 "$": {
                     "param_mode": "packed",

--- a/python/mlc_llm/serve/data.py
+++ b/python/mlc_llm/serve/data.py
@@ -112,11 +112,9 @@ class ImageData(Data):
             size={"shortest_edge": image_input_size},
             crop_size={"height": image_input_size, "width": image_input_size},
         )
-        quantization = config["quantization"]
-        out_dtype = "float16" if "f16" in quantization else "float32"
         image_features = tvm.nd.array(
             image_processor.preprocess(image_tensor, return_tensors="np")["pixel_values"].astype(
-                out_dtype
+                "float32"
             )
         )
         image_data = ImageData(image_features, image_embed_size)

--- a/tests/python/json_ffi/test_json_ffi_engine_image.py
+++ b/tests/python/json_ffi/test_json_ffi_engine_image.py
@@ -1,0 +1,91 @@
+import base64
+from typing import Dict, List, Optional
+
+import requests
+
+from mlc_llm.json_ffi import JSONFFIEngine
+
+
+def base64_encode_image(url: str) -> str:
+    response = requests.get(url)
+    response.raise_for_status()  # Ensure we got a successful response
+    image_data = base64.b64encode(response.content)
+    image_data_str = image_data.decode("utf-8")
+    data_url = f"data:image/jpeg;base64,{image_data_str}"
+    return data_url
+
+
+image_prompts = [
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": f"{base64_encode_image('https://llava-vl.github.io/static/images/view.jpg')}",
+                },
+                {"type": "text", "text": "What does the image represent?"},
+            ],
+        }
+    ]
+]
+
+
+def run_chat_completion(
+    engine: JSONFFIEngine,
+    model: str,
+    prompts: List[List[Dict]] = image_prompts,
+    tools: Optional[List[Dict]] = None,
+):
+    num_requests = 1
+    max_tokens = 64
+    n = 1
+    output_texts: List[List[str]] = [["" for _ in range(n)] for _ in range(num_requests)]
+
+    for rid in range(num_requests):
+        print(f"chat completion for request {rid}")
+        for response in engine.chat_completion(
+            messages=prompts[rid],
+            model=model,
+            max_tokens=max_tokens,
+            n=n,
+            request_id=str(rid),
+            tools=tools,
+        ):
+            for choice in response.choices:
+                assert choice.delta.role == "assistant"
+                assert isinstance(choice.delta.content[0], Dict)
+                assert choice.delta.content[0]["type"] == "text"
+                output_texts[rid][choice.index] += choice.delta.content[0]["text"]
+
+    # Print output.
+    print("Chat completion all finished")
+    for req_id, outputs in enumerate(output_texts):
+        print(f"Prompt {req_id}: {prompts[req_id]}")
+        if len(outputs) == 1:
+            print(f"Output {req_id}:{outputs[0]}\n")
+        else:
+            for i, output in enumerate(outputs):
+                print(f"Output {req_id}({i}):{output}\n")
+
+
+def test_chat_completion():
+    # Create engine.
+    model = "dist/llava-1.5-7b-hf-q4f16_1-MLC"
+    engine = JSONFFIEngine(
+        model,
+        max_total_sequence_length=1024,
+    )
+
+    run_chat_completion(engine, model)
+
+    # Test malformed requests.
+    for response in engine._handle_chat_completion("malformed_string", n=1, request_id="123"):
+        assert len(response.choices) == 1
+        assert response.choices[0].finish_reason == "error"
+
+    engine.terminate()
+
+
+if __name__ == "__main__":
+    test_chat_completion()


### PR DESCRIPTION
This PR adds support for Image input in JSONFFIEngine, so that now LLaVa model can be used. 

The image has to be passed as base64 encoded. See `tests/python/json_ffi/test_json_ffi_engine_image.py` for example usage.

For reading the image in C++, the header-only file `stb_image.h` is being used from the [nothings/stb](https://github.com/nothings/stb/tree/master) repository. This repository has been added as a submodule in `3rdparty/`

The image has to be pre-processed before passing into the LLaVa model (which uses CLIP Vision model). Currently Bilinear interpolation is being used for resizing, instead of [Huggingface CLIPImageProcessor](https://github.com/huggingface/transformers/blob/9fe3f585bb4ea29f209dc705d269fbe292e1128f/src/transformers/models/clip/image_processing_clip.py#L97)'s default Bicubic interpolation
