### PR TITLE
[Fix] CUDA architecture detection bug fix

### DIFF
--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 import enum
-import re
 from io import StringIO
 from typing import Optional
 
@@ -96,7 +95,7 @@ class OptimizationFlags:
                 return False
             arch_list = detect_cuda_arch_list(target)
             for arch in arch_list:
-                if int(re.findall(r"\d+", arch)[0]) < 80:
+                if arch < 80:
                     logger.warning("flashinfer is not supported on CUDA arch < 80")
                     return False
             return True

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -293,14 +293,20 @@ def _build_default():
     return build
 
 
-def detect_cuda_arch_list(target: Target) -> List[str]:
+def detect_cuda_arch_list(target: Target) -> List[int]:
     """Detect the CUDA architecture list from the target."""
+
+    def convert_to_num(arch_str):
+        arch_num_str = "".join(filter(str.isdigit, arch_str))
+        assert arch_num_str, f"'{arch_str}' does not contain any digits"
+        return int(arch_num_str)
+
     assert target.kind.name == "cuda", f"Expect target to be CUDA, but got {target}"
     if MLC_MULTI_ARCH is not None:
-        multi_arch = [x.strip() for x in MLC_MULTI_ARCH.split(",")]
+        multi_arch = [convert_to_num(x) for x in MLC_MULTI_ARCH.split(",")]
     else:
         assert target.arch.startswith("sm_")
-        multi_arch = [target.arch[3:]]
+        multi_arch = [convert_to_num(target.arch[3:])]
     multi_arch = list(set(multi_arch))
     return multi_arch
 


### PR DESCRIPTION
In the PR #1976   detect_cuda_arch returned a list of strings, which caused ft_quantization to crash on [call_pure_packed("cutlass.ft_preprocess_weight",](https://github.com/mlc-ai/mlc-llm/blob/main/python/mlc_llm/quantization/ft_quantization.py#L210). This commit returns a list of integers and adds an assert to check that the string of architecture must contain numbers only.

cc @vinx13 @cyx-6 @tqchen 