### PR TITLE
[DOC] Improve Install via environment variable

### DIFF
--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -214,7 +214,9 @@ There are two ways to do so:
 
        .. code-tab :: bash Install via environment variable
 
-          export PYTHONPATH=/path-to-mlc-llm/python:$PYTHONPATH
+          export MLC_LLM_HOME=/path-to-mlc-llm
+          export PYTHONPATH=$MLC_LLM_HOME/python:$PYTHONPATH
+          alias mlc_llm="python -m mlc_llm"
 
        .. code-tab :: bash Install via pip local project
 


### PR DESCRIPTION
This PR adds alias `mlc_llm="python -m mlc_llm"` to allow users instal mlc_llm python package via environment variable
and user can directly use command `mlc_llm` in bash