### PR TITLE
[SLM] Support BERT architecture. Implement a text embedding module

### DIFF
--- a/python/mlc_llm/embeddings/embeddings.py
+++ b/python/mlc_llm/embeddings/embeddings.py
@@ -1,0 +1,182 @@
+"""The Python API for MLC Embeddings."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import tvm
+from tvm import relax
+from tvm.contrib import tvmjs
+from tvm.runtime import Device, Module
+from tvm.runtime.relax_vm import VirtualMachine
+
+from mlc_llm.chat_module import _get_model_path
+from mlc_llm.serve import engine_utils
+from mlc_llm.support.auto_device import detect_device
+from mlc_llm.tokenizer import Tokenizer
+
+
+def _extract_metadata(mod: Module):
+    return json.loads(VirtualMachine(mod, tvm.runtime.device("cpu"))["_metadata"]())
+
+
+def _load_params(
+    model_weight_path: str, device: Device, model_metadata: Dict[str, Any]
+) -> List[tvm.nd.NDArray]:
+    params, meta = tvmjs.load_ndarray_cache(model_weight_path, device)
+    param_names = [param["name"] for param in model_metadata["params"]]
+    assert len(param_names) == meta["ParamSize"]
+
+    plist = []
+    for param_name in param_names:
+        plist.append(params[param_name])
+    return plist
+
+
+def _get_tvm_module(
+    model_weight_path: str, lib_path: str, device: Device, instrument: tvm.runtime.PackedFunc = None
+):
+    ex = tvm.runtime.load_module(lib_path)
+    vm = relax.VirtualMachine(ex, device)
+    if instrument:
+        vm.set_instrument(instrument)
+    metadata = _extract_metadata(ex)
+    params = _load_params(model_weight_path, device, metadata)
+    return vm.module, params, metadata
+
+
+class DefaultDebugInstrument:
+    """The default debug instrument to use if users don't specify
+    a customized one.
+
+    This debug instrument will dump the arguments and output of each
+    VM Call instruction into a .npz file. It will also alert the user
+    if any function outputs are NaN or INF.
+    """
+
+    def __init__(self, debug_out: Path):
+        """Constructor
+
+        Parameters
+        ----------
+        debug_out : Path
+            the directory to dump the .npz files
+        """
+        self.counter = 0
+        self.first_nan_occurred = False
+        self.first_inf_occurred = False
+        self.debug_out = debug_out
+        debug_out.mkdir(exist_ok=True, parents=True)
+
+    def reset(self, debug_out: Path):
+        """Reset the state of the Instrument class
+
+        Parameters
+        ----------
+        debug_out : Path
+            the directory to dump the .npz files
+        """
+        self.counter = 0
+        self.first_nan_occurred = False
+        self.first_inf_occurred = False
+        self.debug_out = debug_out
+        debug_out.mkdir(exist_ok=True, parents=True)
+
+    def __call__(self, func, name, before_run, ret_val, *args):
+        # Determine what functions to look at
+        if before_run:  # Whether before the function is called or after
+            return
+        if name.startswith("vm.builtin.") and "attention_with_fused_qkv" not in name:
+            return
+
+        # Decide what to print or save about the function's arguments (where args[-1] is the
+        # buffer we write the result to)
+        func_name = f"f{self.counter}_{name}"
+
+        # Save the arguments to npz
+        arg_dict = {}
+        for i, arg in enumerate(args):
+            if isinstance(arg, tvm.nd.NDArray):
+                arg_dict[f"arg_{i}"] = arg.numpy()
+
+        np.savez(self.debug_out / f"{func_name}.npz", **arg_dict)
+
+        self.counter += 1
+
+
+class MLCEmbeddings:  # pylint: disable=too-few-public-methods
+    """A class to embed queries using MLC LLM encoder models.
+
+    Parameters
+    ----------
+    model: str
+        The model folder after compiling with MLC-LLM build process. The parameter
+        can either be the model name with its quantization scheme
+        (e.g. ``Llama-2-7b-chat-hf-q4f16_1``), or a full path to the model
+        folder. In the former case, we will use the provided name to search
+        for the model folder over possible paths.
+
+    model_lib_path : str
+        The full path to the model library file to use (e.g. a ``.so`` file).
+
+    device : Optional[str]
+        The description of the device to run on. User should provide a string in the
+        form of 'device_name:device_id' or 'device_name', where 'device_name' is one of
+        'cuda', 'metal', 'vulkan', 'rocm', 'opencl', 'auto' (automatically detect the
+        local device), and 'device_id' is the device id to run on. If no 'device_id'
+        is provided, it will be set to 0 by default.
+
+    debug_dir: Path
+        The output folder to store the dumped debug files. If None, will not dump any debug files.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        model: str,
+        model_lib_path: str,
+        device: Optional[str] = "auto",
+        debug_dir: Optional[str] = None,
+    ):
+
+        self.device = detect_device(device)
+        instrument = DefaultDebugInstrument(Path(debug_dir)) if debug_dir else None
+        self.mod, self.params, self.metadata = _get_tvm_module(
+            model, model_lib_path, self.device, instrument
+        )
+        self.model_path, _ = _get_model_path(model)
+        self.tokenizer = Tokenizer(self.model_path)
+        self.prefill_func = self.mod["prefill"]
+
+    def embed(self, queries: List[str]) -> tvm.runtime.NDArray:
+        """
+        Embeds a list of queries in a single batch.
+
+        Parameters
+        ----------
+        queries : List[str]
+            A list of queries to embed.
+
+        Returns
+        -------
+        List[float]
+            A list of embeddings for the queries.
+        """
+        tokens, attention_mask = self._tokenize_queries(queries)
+        tokens_tvm = tvm.nd.array(tokens.astype("int32"), device=self.device)
+        attention_mask_tvm = tvm.nd.array(attention_mask.astype("int32"), device=self.device)
+        output = self.prefill_func(tokens_tvm, attention_mask_tvm, self.params)
+        return output
+
+    def _tokenize_queries(self, queries: List[str]) -> Tuple[np.ndarray, np.ndarray]:
+        tokens = engine_utils.process_prompts(queries, self.tokenizer.encode)
+        max_query_length = max(len(token_seq) for token_seq in tokens)
+
+        token_inputs = np.zeros((len(tokens), max_query_length), dtype=np.int32)
+        attention_mask = np.zeros((len(tokens), max_query_length), dtype=np.int32)
+
+        for i, token_seq in enumerate(tokens):
+            token_inputs[i, : len(token_seq)] = token_seq
+            attention_mask[i, : len(token_seq)] = 1
+
+        return token_inputs, attention_mask

--- a/python/mlc_llm/embeddings/embeddings.py
+++ b/python/mlc_llm/embeddings/embeddings.py
@@ -138,7 +138,6 @@ class MLCEmbeddings:  # pylint: disable=too-few-public-methods
         device: Optional[str] = "auto",
         debug_dir: Optional[str] = None,
     ):
-
         self.device = detect_device(device)
         instrument = DefaultDebugInstrument(Path(debug_dir)) if debug_dir else None
         self.mod, self.params, self.metadata = _get_tvm_module(
@@ -169,7 +168,7 @@ class MLCEmbeddings:  # pylint: disable=too-few-public-methods
         return output
 
     def _tokenize_queries(self, queries: List[str]) -> Tuple[np.ndarray, np.ndarray]:
-        tokens = engine_utils.process_prompts(queries, self.tokenizer.encode)
+        tokens = engine_utils.process_prompts(queries, self.tokenizer.encode)  # type: ignore
         max_query_length = max(len(token_seq) for token_seq in tokens)
 
         token_inputs = np.zeros((len(tokens), max_query_length), dtype=np.int32)

--- a/python/mlc_llm/model/bert/bert_loader.py
+++ b/python/mlc_llm/model/bert/bert_loader.py
@@ -1,0 +1,86 @@
+"""
+This file specifies how MLC's BERT parameter maps from other formats, for example HuggingFace
+PyTorch, HuggingFace safetensors.
+"""
+import functools
+
+import numpy as np
+
+from mlc_llm.loader import ExternMapping
+from mlc_llm.quantization import Quantization
+
+from .bert_model import BertConfig, BertModel
+
+
+def huggingface(model_config: BertConfig, quantization: Quantization) -> ExternMapping:
+    """Returns a parameter mapping that maps from the names of MLC LLM parameters to
+    the names of HuggingFace PyTorch parameters.
+
+    Parameters
+    ----------
+    model_config : BertConfig
+        The configuration of the BERT model.
+
+    quantization : Quantization
+        The quantization configuration.
+
+    Returns
+    -------
+    param_map : ExternMapping
+        The parameter mapping from MLC to HuggingFace PyTorch.
+    """
+    model = BertModel(model_config)
+    if quantization is not None:
+        model.to(quantization.model_dtype)
+    _, _named_params, _ = model.export_tvm(  # type: ignore[misc]
+        spec=model.get_default_spec(),
+        allow_extern=True,
+    )
+    named_parameters = dict(_named_params)
+
+    mapping = ExternMapping()
+
+    for i in range(model_config.num_hidden_layers):
+        attn = f"encoder.layer.{i}.attention.self"
+        mlc_name = f"{attn}.qkv.weight"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [
+                f"{attn}.query.weight",
+                f"{attn}.key.weight",
+                f"{attn}.value.weight",
+            ],
+            functools.partial(
+                lambda q, k, v, dtype: np.concatenate([q, k, v], axis=0).astype(dtype),
+                dtype=mlc_param.dtype,
+            ),
+        )
+
+        mlc_name = f"{attn}.qkv.bias"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [
+                f"{attn}.query.bias",
+                f"{attn}.key.bias",
+                f"{attn}.value.bias",
+            ],
+            functools.partial(
+                lambda q, k, v, dtype: np.concatenate([q, k, v], axis=0).astype(dtype),
+                dtype=mlc_param.dtype,
+            ),
+        )
+
+    for mlc_name, mlc_param in named_parameters.items():
+        if mlc_name not in mapping.param_map:
+            mapping.add_mapping(
+                mlc_name,
+                [mlc_name],
+                functools.partial(
+                    lambda x, dtype: x.astype(dtype),
+                    dtype=mlc_param.dtype,
+                ),
+            )
+
+    return mapping

--- a/python/mlc_llm/model/bert/bert_model.py
+++ b/python/mlc_llm/model/bert/bert_model.py
@@ -248,9 +248,6 @@ class BertModel(nn.Module):
         )
         return self.forward(inputs, attention_mask_2d)
 
-    def softmax_with_temperature(self, logits: Tensor, temperature: Tensor):
-        return op.softmax(logits / op.reshape(temperature, (temperature.shape[0], 1, 1)), axis=-1)
-
     def get_default_spec(self):
         mod_spec = {
             "prefill": {
@@ -258,14 +255,6 @@ class BertModel(nn.Module):
                 "attention_mask": nn.spec.Tensor(["batch_size", "seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
-                    "effect_mode": "none",
-                },
-            },
-            "softmax_with_temperature": {
-                "logits": nn.spec.Tensor(["batch_size", 1, "vocab_size"], "float32"),
-                "temperature": nn.spec.Tensor(["batch_size"], "float32"),
-                "$": {
-                    "param_mode": "none",
                     "effect_mode": "none",
                 },
             },

--- a/python/mlc_llm/model/bert/bert_model.py
+++ b/python/mlc_llm/model/bert/bert_model.py
@@ -1,0 +1,273 @@
+"""
+Implementation for BERT architecture.
+"""
+
+import dataclasses
+from functools import partial
+from typing import Any, Dict, Optional
+
+from tvm import te, tir
+from tvm.relax.frontend import nn
+from tvm.relax.frontend.nn import Tensor, op
+
+from mlc_llm import op as op_ext
+from mlc_llm.support import logging
+from mlc_llm.support.config import ConfigBase
+from mlc_llm.support.style import bold
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class BertConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
+    """Configuration of the BERT model."""
+
+    vocab_size: int
+    hidden_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    intermediate_size: int
+    hidden_act: str
+    layer_norm_eps: float
+    context_window_size: int = 0
+    prefill_chunk_size: int = 0
+    tensor_parallel_shards: int = 1
+    head_dim: int = 0
+    max_batch_size: int = 1
+    kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.intermediate_size is None or self.intermediate_size == -1:
+            self.intermediate_size = 4 * self.hidden_size
+        if self.context_window_size == 0:
+            for name in ["max_position_embeddings", "max_sequence_length"]:
+                if name in self.kwargs:
+                    self.context_window_size = self.kwargs.pop(name)
+                    logger.info(
+                        "%s not found in config.json. Falling back to %s (%d)",
+                        bold("context_window_size"),
+                        bold(name),
+                        self.context_window_size,
+                    )
+                    break
+            else:
+                raise ValueError(
+                    "Unable to determine the maxmimum sequence length, because none of "
+                    "`context_window_size`, `max_position_embeddings` or `max_sequence_length` is "
+                    "provided in `config.json`."
+                )
+        if self.head_dim == 0:
+            self.head_dim = self.hidden_size // self.num_attention_heads
+        assert self.head_dim * self.num_attention_heads == self.hidden_size
+        if self.prefill_chunk_size == 0:
+            logger.info(
+                "%s defaults to %s (%d)",
+                bold("prefill_chunk_size"),
+                bold("context_window_size"),
+                self.context_window_size,
+            )
+            self.prefill_chunk_size = self.context_window_size
+        elif self.prefill_chunk_size > self.context_window_size:
+            logger.info(
+                "Overriding %s from %d to %d (%s)",
+                bold("prefill_chunk_size"),
+                self.prefill_chunk_size,
+                self.context_window_size,
+                bold("context_window_size"),
+            )
+            self.prefill_chunk_size = self.context_window_size
+
+
+# pylint: disable=invalid-name,missing-docstring,too-many-locals
+
+
+class BertSelfAttention(nn.Module):  # pylint: disable=too-many-instance-attributes
+    def __init__(self, config: BertConfig):
+        self.num_heads = config.num_attention_heads // config.tensor_parallel_shards
+        self.head_dim = config.head_dim
+
+        self.qkv = nn.Linear(
+            in_features=config.hidden_size,
+            out_features=3 * self.num_heads * self.head_dim,
+            bias=True,
+        )
+
+    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
+        d, h = self.head_dim, self.num_heads
+        b, s, _ = hidden_states.shape
+
+        qkv = self.qkv(hidden_states)
+        qkv = op.reshape(qkv, (b, s, 3 * h, d))
+        q, k, v = op.split(qkv, 3, axis=2)
+
+        # Attention
+        output = op_ext.attention(q, k, v, attention_mask)
+        return output
+
+
+class BertSelfOutput(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def forward(self, hidden_states: Tensor, input_tensor: Tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class BertAttention(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.self = BertSelfAttention(config)
+        self.output = BertSelfOutput(config)
+
+    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
+        self_output = self.self(hidden_states, attention_mask)
+        attention_output = self.output(self_output, hidden_states)
+        return attention_output
+
+
+ACT2FN = {
+    "gelu": partial(nn.gelu, approximate=False),
+    "relu": nn.relu,
+    "silu": nn.silu,
+    "swish": nn.silu,
+    "gelu_new": partial(nn.gelu, approximate=True),
+}
+
+
+class BertIntermediate(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.dense = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.intermediate_act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_states: Tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
+        return hidden_states
+
+
+class BertOutput(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def forward(self, hidden_states: Tensor, input_tensor: Tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class BertLayer(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.attention = BertAttention(config)
+        self.intermediate = BertIntermediate(config)
+        self.output = BertOutput(config)
+
+    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
+        attention_output = self.attention(hidden_states, attention_mask)
+        intermediate_output = self.intermediate(attention_output)
+        layer_output = self.output(intermediate_output, attention_output)
+        return layer_output
+
+
+class BertEncoder(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.layer = nn.ModuleList([BertLayer(config) for _ in range(config.num_hidden_layers)])
+
+    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
+        for layer in self.layer:
+            hidden_states = layer(hidden_states, attention_mask)
+        return hidden_states
+
+
+class BertEmbeddings(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size, dtype="float32")
+        self.position_embeddings = nn.Embedding(
+            config.context_window_size, config.hidden_size, dtype="float32"
+        )
+        self.token_type_embeddings = nn.Embedding(2, config.hidden_size, dtype="float32")
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def forward(self, input_ids: Tensor, token_type_ids: Tensor, position_ids: Tensor):
+        words_embeddings = self.word_embeddings(input_ids)
+        position_embeddings = self.position_embeddings(position_ids)
+        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        embeddings = words_embeddings + position_embeddings + token_type_embeddings
+        embeddings = self.LayerNorm(embeddings)
+        return embeddings
+
+
+class BertModel(nn.Module):
+    def __init__(self, config: BertConfig):
+        self.embeddings = BertEmbeddings(config)
+        self.encoder = BertEncoder(config)
+        self.dtype = "float32"
+
+    def to(self, dtype: Optional[str] = None):
+        super().to(dtype=dtype)
+        if dtype is not None:
+            self.dtype = dtype
+
+    def forward(self, inputs: Tensor, attention_mask: Tensor):
+        def _input_positions(inputs: te.Tensor):
+            b, s = inputs.shape
+            return te.compute((b, s), lambda _, j: j.astype("int32"), name="input_positions")
+
+        input_positions = op.tensor_expr_op(
+            _input_positions,
+            name_hint="input_positions",
+            args=[inputs],
+        )
+
+        token_type_ids = op.zeros(inputs.shape, dtype="int32")
+
+        embeddings = self.embeddings(inputs, token_type_ids, input_positions)
+        encoder_output = self.encoder(embeddings, attention_mask)
+        return encoder_output
+
+    def prefill(self, inputs: Tensor, attention_mask: Tensor):
+        def _attention_mask(mask: te.Tensor, zero, batch_size, seq_len):
+            return te.compute(
+                (batch_size, 1, seq_len, seq_len),
+                lambda b, _, i, j: tir.if_then_else(
+                    tir.any(mask[b, i] == zero, mask[b, j] == zero),
+                    tir.min_value(self.dtype),
+                    tir.max_value(self.dtype),
+                ),
+                name="attention_mask_prefill",
+            )
+
+        batch_size, seq_len = inputs.shape
+        attention_mask_2d = op.tensor_expr_op(
+            _attention_mask,
+            name_hint="attention_mask_prefill",
+            args=[attention_mask, tir.IntImm("int32", 0), batch_size, seq_len],
+        )
+        return self.forward(inputs, attention_mask_2d)
+
+    def softmax_with_temperature(self, logits: Tensor, temperature: Tensor):
+        return op.softmax(logits / op.reshape(temperature, (temperature.shape[0], 1, 1)), axis=-1)
+
+    def get_default_spec(self):
+        mod_spec = {
+            "prefill": {
+                "inputs": nn.spec.Tensor(["batch_size", "seq_len"], "int32"),
+                "attention_mask": nn.spec.Tensor(["batch_size", "seq_len"], "int32"),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "softmax_with_temperature": {
+                "logits": nn.spec.Tensor(["batch_size", 1, "vocab_size"], "float32"),
+                "temperature": nn.spec.Tensor(["batch_size"], "float32"),
+                "$": {
+                    "param_mode": "none",
+                    "effect_mode": "none",
+                },
+            },
+        }
+        return nn.spec.ModuleSpec.from_raw(mod_spec, self)

--- a/python/mlc_llm/model/bert/bert_quantization.py
+++ b/python/mlc_llm/model/bert/bert_quantization.py
@@ -1,0 +1,53 @@
+"""This file specifies how MLC's BERT parameters are quantized using group quantization
+or other formats."""
+from typing import Tuple
+
+from tvm.relax.frontend import nn
+
+from mlc_llm.loader import QuantizeMapping
+from mlc_llm.quantization import FTQuantize, GroupQuantize, NoQuantize
+
+from .bert_model import BertConfig, BertModel
+
+
+def group_quant(
+    model_config: BertConfig,
+    quantization: GroupQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a BERT-architecture model using group quantization."""
+    model: nn.Module = BertModel(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    model = quantization.quantize_model(
+        model,
+        quant_map,
+        "",
+    )
+    return model, quant_map
+
+
+def ft_quant(
+    model_config: BertConfig,
+    quantization: FTQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a BERT-architecture model using FasterTransformer quantization."""
+    model: nn.Module = BertModel(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    model = quantization.quantize_model(
+        model,
+        quant_map,
+        "",
+    )
+    return model, quant_map
+
+
+def no_quant(
+    model_config: BertConfig,
+    quantization: NoQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a BERT model without quantization."""
+    model: nn.Module = BertModel(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    return model, quant_map

--- a/python/mlc_llm/model/gpt2/gpt2_model.py
+++ b/python/mlc_llm/model/gpt2/gpt2_model.py
@@ -28,7 +28,7 @@ class GPT2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     n_embd: int
     n_layer: int
     n_head: int
-    layer_norm_epsilon: int
+    layer_norm_epsilon: float
     n_inner: int = -1
     context_window_size: int = 0
     prefill_chunk_size: int = 0

--- a/python/mlc_llm/model/model.py
+++ b/python/mlc_llm/model/model.py
@@ -9,6 +9,7 @@ from mlc_llm.loader import ExternMapping, QuantizeMapping
 from mlc_llm.quantization.quantization import Quantization
 
 from .baichuan import baichuan_loader, baichuan_model, baichuan_quantization
+from .bert import bert_loader, bert_model, bert_quantization
 from .chatglm3 import chatglm3_loader, chatglm3_model, chatglm3_quantization
 from .eagle import eagle_loader, eagle_model, eagle_quantization
 from .gemma import gemma_loader, gemma_model, gemma_quantization
@@ -27,7 +28,6 @@ from .qwen2 import qwen2_loader, qwen2_model, qwen2_quantization
 from .rwkv5 import rwkv5_loader, rwkv5_model, rwkv5_quantization
 from .rwkv6 import rwkv6_loader, rwkv6_model, rwkv6_quantization
 from .stable_lm import stablelm_loader, stablelm_model, stablelm_quantization
-from .bert import bert_loader, bert_model, bert_quantization
 
 ModelConfig = Any
 """A ModelConfig is an object that represents a model architecture. It is required to have
@@ -369,5 +369,5 @@ MODELS: Dict[str, Model] = {
             "group-quant": bert_quantization.group_quant,
             "ft-quant": bert_quantization.ft_quant,
         },
-    )
+    ),
 }

--- a/python/mlc_llm/model/model.py
+++ b/python/mlc_llm/model/model.py
@@ -27,6 +27,7 @@ from .qwen2 import qwen2_loader, qwen2_model, qwen2_quantization
 from .rwkv5 import rwkv5_loader, rwkv5_model, rwkv5_quantization
 from .rwkv6 import rwkv6_loader, rwkv6_model, rwkv6_quantization
 from .stable_lm import stablelm_loader, stablelm_model, stablelm_quantization
+from .bert import bert_loader, bert_model, bert_quantization
 
 ModelConfig = Any
 """A ModelConfig is an object that represents a model architecture. It is required to have
@@ -355,4 +356,18 @@ MODELS: Dict[str, Model] = {
             "awq": eagle_quantization.awq_quant,
         },
     ),
+    "bert": Model(
+        name="bert",
+        model=bert_model.BertModel,
+        config=bert_model.BertConfig,
+        source={
+            "huggingface-torch": bert_loader.huggingface,
+            "huggingface-safetensor": bert_loader.huggingface,
+        },
+        quantize={
+            "no-quant": bert_quantization.no_quant,
+            "group-quant": bert_quantization.group_quant,
+            "ft-quant": bert_quantization.ft_quant,
+        },
+    )
 }

--- a/python/mlc_llm/model/model_preset.py
+++ b/python/mlc_llm/model/model_preset.py
@@ -728,6 +728,6 @@ MODEL_PRESETS: Dict[str, Any] = {
         "position_embedding_type": "absolute",
         "transformers_version": "4.6.0.dev0",
         "type_vocab_size": 2,
-        "vocab_size": 30522
-    }
+        "vocab_size": 30522,
+    },
 }

--- a/python/mlc_llm/model/model_preset.py
+++ b/python/mlc_llm/model/model_preset.py
@@ -710,4 +710,24 @@ MODEL_PRESETS: Dict[str, Any] = {
         "use_cache": True,
         "vocab_size": 128256,
     },
+    "bert": {
+        "architectures": ["BertModel"],
+        "attention_probs_dropout_prob": 0.1,
+        "gradient_checkpointing": False,
+        "hidden_act": "gelu",
+        "hidden_dropout_prob": 0.1,
+        "hidden_size": 768,
+        "initializer_range": 0.02,
+        "intermediate_size": 3072,
+        "layer_norm_eps": 1e-12,
+        "max_position_embeddings": 512,
+        "model_type": "bert",
+        "num_attention_heads": 12,
+        "num_hidden_layers": 12,
+        "pad_token_id": 0,
+        "position_embedding_type": "absolute",
+        "transformers_version": "4.6.0.dev0",
+        "type_vocab_size": 2,
+        "vocab_size": 30522
+    }
 }

--- a/python/mlc_llm/op/attention.py
+++ b/python/mlc_llm/op/attention.py
@@ -62,7 +62,6 @@ def attention(  # pylint: disable=invalid-name,too-many-locals,too-many-statemen
     b, s, h_q, d = q.shape
     t, h_kv, _ = k.shape[-3:]
     group_size = h_q // h_kv
-    assert b == 1, "batch size must be 1"
 
     def _fallback():
         nonlocal q, k, v, qk_dtype


### PR DESCRIPTION
This PR supports text embedding in MLC-LLM with a BERT encoder-only model.

Example usage: https://github.com/rickzx/mlc-llm/blob/18aa7ee378b826a61ce4baa98e4bab1bf3d64038/python/mlc_llm/embeddings/embeddings.ipynb