### PR TITLE
[Eagle] Avoid worker - engine transfer for hidden states

### DIFF
--- a/cpp/serve/draft_token_workspace_manager.cc
+++ b/cpp/serve/draft_token_workspace_manager.cc
@@ -45,7 +45,7 @@ void DraftTokenWorkspaceManagerObj::AllocWorkspace(ModelWorkspace* workspace,
       NDArray::Empty({max_num_tokens_, vocab_size_}, DataType::Float(32), device_);
   if (require_hidden_states) {
     workspace->draft_hidden_states_storage =
-        NDArray::Empty({max_num_tokens_, hidden_size_}, hidden_states_dtype_, device_);
+        ft_.Empty({max_num_tokens_, hidden_size_}, hidden_states_dtype_, device_);
   }
 }
 

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -218,7 +218,7 @@ void FunctionTable::_InitFunctions() {
   Module mod = this->use_disco ? this->disco_mod->DebugGetFromRemote(0) : this->local_vm;
   this->get_logits_func_ = mod_get_func("get_logits");
   this->batch_get_logits_func_ = mod_get_func("batch_get_logits");
-  this->batch_select_last_hidden_func_ = mod->GetFunction("batch_select_last_hidden_states", true);
+  this->batch_select_last_hidden_func_ = mod_get_func("batch_select_last_hidden_states");
   this->softmax_func_ = mod->GetFunction("softmax_with_temperature", true);
   this->apply_logit_bias_func_ = mod->GetFunction("apply_logit_bias_inplace", true);
   this->apply_penalty_func_ = mod->GetFunction("apply_penalty_inplace", true);
@@ -259,11 +259,12 @@ void FunctionTable::_InitFunctions() {
   this->nd_get_shape_func_ = get_global_func("vm.builtin.shape_of");
   this->nd_copy_embedding_to_offset_func_ = get_global_func("mlc.copy_embedding_to_offset");
   support_backtracking_kv_ = true;
+  this->tuple_getitem_func_ = get_global_func("vm.builtin.tuple_getitem");
 
   this->gather_probs_func_ = mod->GetFunction("gather_probs", true);
   this->scatter_probs_func_ = mod->GetFunction("scatter_probs", true);
-  this->gather_hidden_states_func_ = mod->GetFunction("gather_hidden_states", true);
-  this->scatter_hidden_states_func_ = mod->GetFunction("scatter_hidden_states", true);
+  this->gather_hidden_states_func_ = mod_get_func("gather_hidden_states");
+  this->scatter_hidden_states_func_ = mod_get_func("scatter_hidden_states");
 }
 
 ObjectRef FunctionTable::Empty(ShapeTuple shape, DataType dtype, Device device) const {

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -120,6 +120,7 @@ struct FunctionTable {
   PackedFunc nd_view_func_;
   PackedFunc nd_get_shape_func_;
   PackedFunc nd_copy_embedding_to_offset_func_;
+  PackedFunc tuple_getitem_func_;
   // Auxiliary functions for speculative decoding.
   PackedFunc gather_probs_func_;
   PackedFunc scatter_probs_func_;

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -7,6 +7,7 @@
 #ifndef MLC_LLM_SERVE_MODEL_H_
 #define MLC_LLM_SERVE_MODEL_H_
 
+#include <picojson.h>
 #include <tvm/runtime/container/string.h>
 #include <tvm/runtime/ndarray.h>
 
@@ -140,35 +141,6 @@ class ModelObj : public Object {
   virtual NDArray GetLogits(const ObjectRef& last_hidden_states, int batch_size, int seq_len) = 0;
 
   /*!
-   * \brief Compute logits for last hidden_states in a batch.
-   * \param last_hidden_states The last hidden_states to compute logits for.
-   * \param seq_ids The id of the sequence in the KV cache.
-   * \param lengths The length of each sequence to prefill.
-   * \return The computed logits.
-   */
-  virtual NDArray BatchGetLogits(const ObjectRef& last_hidden_states,
-                                 const std::vector<int64_t>& seq_ids,
-                                 const std::vector<int>& lengths) = 0;
-
-  /*!
-   * \brief Select desired hidden_states for last hidden_states in a batch.
-   * \param last_hidden_states The last hidden_states to select from.
-   * \param seq_ids The id of the sequence in the KV cache.
-   * \param lengths The length of each sequence to prefill.
-   * \return The last hidden_states for the batch.
-   */
-  virtual NDArray BatchSelectLastHidden(const ObjectRef& last_hidden_states,
-                                        const std::vector<int64_t>& seq_ids,
-                                        const std::vector<int>& lengths) = 0;
-
-  /*!
-   * \brief Concat a list of 1D hidden_states to 2D tensor.
-   * \param hidden_states The hidden_states to concat.
-   * \param dst The copy destination.
-   */
-  virtual NDArray ConcatLastHidden(std::vector<NDArray>& hidden_states, ObjectRef* dst) = 0;
-
-  /*!
    * \brief Batch prefill function. Embedding in, logits out.
    * The embedding order of sequences in `embedding_arr` follows
    * the order of `seq_ids`.
@@ -188,9 +160,9 @@ class ModelObj : public Object {
    * \param lengths The length of each sequence to prefill.
    * \return The hidden_states for the next token.
    */
-  virtual NDArray BatchPrefillToLastHidden(const ObjectRef& hidden_states,
-                                           const std::vector<int64_t>& seq_ids,
-                                           const std::vector<int>& lengths) = 0;
+  virtual ObjectRef BatchPrefillToLastHidden(const ObjectRef& hidden_states,
+                                             const std::vector<int64_t>& seq_ids,
+                                             const std::vector<int>& lengths) = 0;
 
   /*!
    * \brief Batch decode function. Embedding in, logits out.
@@ -209,8 +181,8 @@ class ModelObj : public Object {
    * \param seq_id The id of the sequence in the KV cache.
    * \return The hidden_states for the next token for each sequence in the batch.
    */
-  virtual NDArray BatchDecodeToLastHidden(const ObjectRef& hidden_states,
-                                          const std::vector<int64_t>& seq_ids) = 0;
+  virtual ObjectRef BatchDecodeToLastHidden(const ObjectRef& hidden_states,
+                                            const std::vector<int64_t>& seq_ids) = 0;
 
   /*!
    * \brief Batch verify function. Embedding in, logits out.
@@ -236,9 +208,9 @@ class ModelObj : public Object {
    * That is to say, it does not accept "running a verify step for a subset
    * of the full batch".
    */
-  virtual NDArray BatchVerifyToLastHidden(const ObjectRef& hidden_states,
-                                          const std::vector<int64_t>& seq_ids,
-                                          const std::vector<int>& lengths) = 0;
+  virtual ObjectRef BatchVerifyToLastHidden(const ObjectRef& hidden_states,
+                                            const std::vector<int64_t>& seq_ids,
+                                            const std::vector<int>& lengths) = 0;
 
   /*********************** KV Cache Management  ***********************/
 

--- a/cpp/serve/sampler/gpu_sampler.cc
+++ b/cpp/serve/sampler/gpu_sampler.cc
@@ -74,7 +74,6 @@ class GPUSampler : public SamplerObj {
     sample_indices_device_ = NDArray::Empty({max_num_sample}, dtype_i32_, device);
     top_p_device_ = NDArray::Empty({max_num_sample}, dtype_f32_, device);
     top_prob_offsets_device_ = NDArray::Empty({max_num_sample * 5}, dtype_i32_, device);
-    draft_probs_device_ = NDArray::Empty({max_num_sample, vocab_size}, dtype_f32_, device);
     draft_tokens_device_ = NDArray::Empty({max_num_sample}, dtype_i32_, device);
     token_tree_first_child_device_ = NDArray::Empty({max_num_sample}, dtype_i32_, device);
     token_tree_next_sibling_device_ = NDArray::Empty({max_num_sample}, dtype_i32_, device);
@@ -630,7 +629,6 @@ class GPUSampler : public SamplerObj {
   NDArray sample_indices_device_;
   NDArray top_p_device_;
   NDArray top_prob_offsets_device_;
-  NDArray draft_probs_device_;
   NDArray draft_tokens_device_;
   NDArray token_tree_first_child_device_;
   NDArray token_tree_next_sibling_device_;

--- a/python/mlc_llm/interface/compile.py
+++ b/python/mlc_llm/interface/compile.py
@@ -1,4 +1,5 @@
 """Python entrypoint of compilation."""
+
 import dataclasses
 import math
 from io import StringIO
@@ -162,7 +163,11 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
         logger.info("Running optimizations using TVM Unity")
         additional_tirs = _apply_preproc_to_params(named_params, model_config)
         variable_bounds = _get_variable_bounds(model_config)
-        cuda_graph_symbolic_capture_hints = {"batch_decode": ["batch_size"]}
+        cuda_graph_symbolic_capture_hints = {
+            "batch_decode": ["batch_size"],
+            "batch_decode_to_last_hidden_states": ["batch_size"],
+            "batch_verify_to_last_hidden_states": ["batch_size", "seq_len"],
+        }
         metadata = {
             "model_type": args.model.name,
             "quantization": args.quantization.name,

--- a/python/mlc_llm/model/eagle/eagle_model.py
+++ b/python/mlc_llm/model/eagle/eagle_model.py
@@ -190,8 +190,8 @@ class EagleForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
                 },
             },
             "fuse_embed_hidden_states": {
-                "input_embed": nn.spec.Tensor(["length", self.hidden_size], self.dtype),
-                "hidden_states": nn.spec.Tensor(["length", self.hidden_size], self.dtype),
+                "input_embed": nn.spec.Tensor(["seq_len", self.hidden_size], self.dtype),
+                "hidden_states": nn.spec.Tensor(["seq_len", self.hidden_size], self.dtype),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",


### PR DESCRIPTION
This change `BatchPrefill/DecodeToLastHiden` to return on-worker hidden states which can be used as next input. This avoids transfer between worker and engine.

cc @tqchen 