### PR TITLE
[Model] Remove redundant space in llama2 tokenizer

### DIFF
--- a/cpp/conv_templates.cc
+++ b/cpp/conv_templates.cc
@@ -97,12 +97,12 @@ Conversation Llama2() {
   Conversation conv;
   conv.name = "llama-2";
   conv.system =
-      ("[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n ");
+      ("[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n");
   conv.roles = {"[INST]", "[/INST]"};
   conv.messages = {};
   conv.offset = 0;
   conv.separator_style = SeparatorStyle::kSepRoleMsg;
-  conv.seps = {" "};
+  conv.seps = {"", " "};
   conv.role_msg_sep = " ";
   conv.role_empty_sep = " ";
   conv.stop_tokens = {2};

--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -64,7 +64,7 @@ ConvTemplateRegistry.register_conv_template(
         system_template=f"[INST] <<SYS>>\n{MessagePlaceholders.SYSTEM.value}\n<</SYS>>\n\n",
         system_message="You are a helpful, respectful and honest assistant.",
         roles={"user": "[INST]", "assistant": "[/INST]", "tool": "[INST]"},
-        seps=[" "],
+        seps=["", " "],
         role_content_sep=" ",
         role_empty_sep=" ",
         stop_str=["[INST]"],


### PR DESCRIPTION
Llama-2 chat template has system prompt directly followed by the user message after `\n\n`

cc @MasterJH5574 @tqchen 