### PR TITLE
[Sampler] Use pivot-based renormalization for top-p sampling

### DIFF
--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -114,8 +114,10 @@ class BatchDecodeActionObj : public EngineActionObj {
     // Fill range [0, num_rsentries) into `sample_indices`.
     std::vector<int> sample_indices(num_rsentries);
     std::iota(sample_indices.begin(), sample_indices.end(), 0);
-    std::vector<SampleResult> sample_results = sampler_->BatchSampleTokensWithProbBeforeTopP(
-        probs_on_device, sample_indices, request_ids, generation_cfg, rngs);
+    NDArray renormalized_probs = sampler_->BatchRenormalizeProbsByTopP(
+        probs_on_device, sample_indices, request_ids, generation_cfg);
+    std::vector<SampleResult> sample_results = sampler_->BatchSampleTokensWithProbAfterTopP(
+        renormalized_probs, sample_indices, request_ids, generation_cfg, rngs);
     ICHECK_EQ(sample_results.size(), num_rsentries);
 
     // - Update the committed tokens of states.

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -229,8 +229,10 @@ class NewRequestPrefillActionObj : public EngineActionObj {
         rsentry_activated.push_back(true);
       }
     }
-    std::vector<SampleResult> sample_results = sampler_->BatchSampleTokensWithProbBeforeTopP(
-        probs_on_device, sample_indices, request_ids, generation_cfg, rngs);
+    NDArray renormalized_probs = sampler_->BatchRenormalizeProbsByTopP(
+        probs_on_device, sample_indices, request_ids, generation_cfg);
+    std::vector<SampleResult> sample_results = sampler_->BatchSampleTokensWithProbAfterTopP(
+        renormalized_probs, sample_indices, request_ids, generation_cfg, rngs);
     ICHECK_EQ(sample_results.size(), rsentries_for_sample.size());
 
     // - Update the committed tokens of states.

--- a/python/mlc_llm/compiler_pass/attach_sampler.py
+++ b/python/mlc_llm/compiler_pass/attach_sampler.py
@@ -7,7 +7,8 @@ from tvm import IRModule, relax, te, tir
 from tvm.relax.frontend import nn
 from tvm.script import tir as T
 
-from ..op.batch_spec_verify import batch_spec_verify
+from mlc_llm.op.batch_spec_verify import batch_spec_verify
+from mlc_llm.op.top_p_pivot import top_p_pivot, top_p_renorm
 
 
 @tvm.transform.module_pass(opt_level=0, name="AttachGPUSamplingFunc")
@@ -49,7 +50,7 @@ class AttachGPUSamplingFunc:  # pylint: disable=too-few-public-methods
                 _attach_sample_with_top_p(bb, vocab_size),
                 _attach_take_probs_func(bb, vocab_size),
                 _attach_batch_verifier(bb, vocab_size),
-                _attach_renormalize_by_top_p(bb, vocab_size),
+                _attach_renormalize_by_top_p(bb, vocab_size, self.target),
             ]
         ]
 
@@ -227,41 +228,36 @@ def _attach_sample_with_top_p(  # pylint: disable=too-many-locals
     return gv
 
 
-def _attach_renormalize_by_top_p(bb: relax.BlockBuilder, vocab_size: tir.PrimExpr):
+def _attach_renormalize_by_top_p(
+    bb: relax.BlockBuilder, vocab_size: tir.PrimExpr, target: tvm.target.Target
+):
     batch_size = tir.Var("batch_size", "int64")
+    num_pivots = 3
     probs = relax.Var("probs", relax.TensorStructInfo((batch_size, vocab_size), "float32"))
-    sorted_probs = relax.Var(
-        "sorted_probs", relax.TensorStructInfo((batch_size, vocab_size), "float32")
-    )
     top_p = relax.Var("top_p", relax.TensorStructInfo((batch_size,), "float32"))
-    with bb.function("renormalize_by_top_p", [probs, sorted_probs, top_p]):
+    init_pivots = relax.Var(
+        "init_pivots", relax.TensorStructInfo((batch_size, num_pivots), "float32")
+    )
+    with bb.function("renormalize_by_top_p", [probs, top_p, init_pivots]):
         with bb.dataflow():
-            probs_tensor = nn.wrap_nested(probs, name="probs")
-            sorted_probs_tensor = nn.wrap_nested(sorted_probs, name="sorted_probs")
-            top_p_shape = relax.ShapeExpr([batch_size, 1])
-            top_p_tensor = nn.wrap_nested(
-                relax.call_pure_packed(
-                    "vm.builtin.reshape",
-                    top_p,
-                    top_p_shape,
-                    sinfo_args=relax.TensorStructInfo(top_p_shape, "float32"),
-                ),
-                name="sample_indices",
+            cutoff_output = bb.emit(
+                relax.call_tir(
+                    bb.add_func(top_p_pivot(num_pivots, target), "top_p_pivot_cutoff"),
+                    args=[probs, top_p, init_pivots],
+                    out_sinfo=[top_p.struct_info, top_p.struct_info],  # pylint: disable=no-member
+                )
             )
-            top_k_tensor = nn.tensor_ir_op(
-                full,
-                name_hint="full",
-                args=[vocab_size],
-                out=nn.Tensor.placeholder(
-                    [batch_size, 1],
-                    "int32",
-                ),
+            final_pivot = cutoff_output[0]
+            renorm_sum = cutoff_output[1]
+            renormalized_probs = bb.emit(
+                relax.call_tir(
+                    bb.add_func(top_p_renorm(target), "top_p_renorm_after_cutoff"),
+                    args=[probs, final_pivot, renorm_sum],
+                    out_sinfo=probs.struct_info,  # pylint: disable=no-member
+                )
             )
-            renormalized_probs = nn.renormalize_top_p_top_k_prob(
-                probs_tensor, sorted_probs_tensor, top_p_tensor, top_k_tensor
-            )
-            bb.emit_output(renormalized_probs._expr)  # pylint: disable=protected-access
-        gv = bb.emit_func_output(renormalized_probs._expr)  # pylint: disable=protected-access
+            bb.emit_output(renormalized_probs)
+        gv = bb.emit_func_output(renormalized_probs)
     return gv
 
 

--- a/python/mlc_llm/compiler_pass/rewrite_softmax.py
+++ b/python/mlc_llm/compiler_pass/rewrite_softmax.py
@@ -79,6 +79,15 @@ class _Rewriter(PyExprMutator):  # pylint: disable=abstract-method
 def _get_lse_and_softmax_func(  # pylint: disable=too-many-locals,too-many-statements
     target: tvm.target.Target, chunk_size: int
 ):
+    # NOTE: A quick note on the softmax implementation.
+    # We once tried to multiply every element by log2e which can be computed
+    # potentially more efficiently on hardware.
+    # However, when the input values are large, multiplying by the factor of log2e
+    # causes numerical issue in float32 dtype.
+    # This leads to the softmax output not summing up to 1.
+    # For numerical stability, we removed the log2e factor and switched back
+    # to the standard log/exp computation.
+
     # pylint: disable=invalid-name
     @T.prim_func
     def chunk_lse(var_A: T.handle, var_chunked_lse: T.handle):  # pylint: disable=too-many-locals


### PR DESCRIPTION
This PR integrates the pivot-based prob renormalization for top-p sampling, whose performance is a few times faster than the current sort-based top-p sampling on CUDA.