### PR TITLE
[CMAKE][BUILD] Add config option to enable OpenCL Host ptr

### DIFF
--- a/cmake/gen_cmake_config.py
+++ b/cmake/gen_cmake_config.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
             "USE_OPENCL",
             "Use OpenCL? (y/n) ",
         ),
+        Backend("OpenCLHostPtr", "USE_OPENCL_ENABLE_HOST_PTR", "Use OpenCLHostPtr? (y/n): "),
     ]
 
     enabled_backends = set()


### PR DESCRIPTION
Added config option to enable OpenCL host pointer flag for MLC-TVM build.