### PR TITLE
[Serving][Fix] Pass draft length when constructing draft action

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -170,7 +170,8 @@ class EngineImpl : public Engine {
                                               engine_config,         //
                                               n->trace_recorder_),
               EngineAction::BatchDraft(n->models_, logit_processor, sampler, n->model_workspaces_,
-                                       draft_token_workspace_manager, n->trace_recorder_),
+                                       draft_token_workspace_manager, n->trace_recorder_,
+                                       engine_config->spec_draft_length),
               EngineAction::BatchVerify(n->models_, logit_processor, sampler, n->model_workspaces_,
                                         draft_token_workspace_manager, engine_config,
                                         n->trace_recorder_)};

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -115,7 +115,7 @@ class EngineAction : public ObjectRef {
   static EngineAction BatchDraft(Array<Model> models, LogitProcessor logit_processor,
                                  Sampler sampler, std::vector<ModelWorkspace> model_workspaces,
                                  DraftTokenWorkspaceManager draft_token_workspace_manager,
-                                 Optional<EventTraceRecorder> trace_recorder, int draft_length = 4);
+                                 Optional<EventTraceRecorder> trace_recorder, int draft_length);
 
   /*!
    * \brief Create the action that runs one-step speculative draft proposal for


### PR DESCRIPTION
This PR fixes a bug which does not pass the speculative decoding draft length to the draft generation stage.