### PR TITLE
Increase the timeout in PopenServer

### DIFF
--- a/python/mlc_llm/help.py
+++ b/python/mlc_llm/help.py
@@ -210,7 +210,7 @@ The number of draft tokens to generate in speculative proposal. The default valu
     "engine_config_serve": """
 The MLCEngine execution configuration.
 Currently speculative decoding mode is specified via engine config.
-For example, you can use "--engine-config='spec_draft_length=4;speculative_mode=EAGLE'" to
+For example, you can use "--engine-config='spec_draft_length=4;speculative_mode=eagle'" to
 specify the eagle-style speculative decoding.
 Check out class `EngineConfig` in mlc_llm/serve/config.py for detailed specification.
 """,

--- a/python/mlc_llm/serve/server/popen_server.py
+++ b/python/mlc_llm/serve/server/popen_server.py
@@ -95,7 +95,7 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         # Try to query the server until it is ready.
         openai_v1_models_url = f"http://{self.host}:{str(self.port)}/v1/models"
         query_result = None
-        timeout = 60
+        timeout = 120
         attempts = 0.0
         while query_result is None and attempts < timeout:
             try:


### PR DESCRIPTION
The current 60-second timeout in PopenServer is insufficient for the small_draft speculative mode on an 8-GPU setup.

cc: @tqchen @vinx13 