### PR TITLE
[REFACTOR] Refactor JSONFFI Conv template

### DIFF
--- a/ios/MLCEngineExample/MLCEngineExample/MLCEngineExampleApp.swift
+++ b/ios/MLCEngineExample/MLCEngineExample/MLCEngineExampleApp.swift
@@ -51,7 +51,7 @@ class AppState: ObservableObject {
                 DispatchQueue.main.async {
                     // parse the result content in structured form
                     // and stream back to the display
-                    self.displayText += res.choices[0].delta.content![0]["text"]!
+                    self.displayText += res.choices[0].delta.content!.asText()
                 }
             }
         }

--- a/ios/MLCSwift/Sources/Swift/LLMEngine.swift
+++ b/ios/MLCSwift/Sources/Swift/LLMEngine.swift
@@ -110,7 +110,6 @@ public actor MLCEngine {
         let encoder = JSONEncoder()
         let data = try! encoder.encode(request)
         let jsonRequest = String(data: data, encoding: .utf8)!
-
         // generate a UUID for the request
         let requestID = UUID().uuidString
         let stream = AsyncStream(ChatCompletionStreamResponse.self) { continuation in

--- a/tests/python/json_ffi/test_json_ffi_engine.py
+++ b/tests/python/json_ffi/test_json_ffi_engine.py
@@ -66,9 +66,8 @@ def run_chat_completion(
         ):
             for choice in response.choices:
                 assert choice.delta.role == "assistant"
-                assert isinstance(choice.delta.content[0], Dict)
-                assert choice.delta.content[0]["type"] == "text"
-                output_texts[rid][choice.index] += choice.delta.content[0]["text"]
+                assert isinstance(choice.delta.content, str)
+                output_texts[rid][choice.index] += choice.delta.content
 
     # Print output.
     print("Chat completion all finished")
@@ -83,7 +82,7 @@ def run_chat_completion(
 
 def test_chat_completion():
     # Create engine.
-    model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     engine = JSONFFIEngine(
         model,
         max_total_sequence_length=1024,
@@ -101,7 +100,7 @@ def test_chat_completion():
 
 def test_reload_reset_unload():
     # Create engine.
-    model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     engine = JSONFFIEngine(
         model,
         max_total_sequence_length=1024,
@@ -136,4 +135,4 @@ def test_function_calling():
 if __name__ == "__main__":
     test_chat_completion()
     test_reload_reset_unload()
-    test_function_calling()
+    # test_function_calling()


### PR DESCRIPTION
This PR refactors JSONFFI conv template to use immutable processing. This helps to prevent bugs from multiple requests and concurrent access to the conversation data structure.

It also reduces the need to deep copy the struct.

MISC refactor: allows multiple system prompt processing, allow passing in content as string