### PR TITLE
[Serving] Add reset_engine in debug_entrypoints

### DIFF
--- a/cpp/serve/engine_state.cc
+++ b/cpp/serve/engine_state.cc
@@ -43,6 +43,8 @@ void EngineStats::Reset() {
   total_decode_length = 0;
   total_accepted_length = 0;
   total_draft_length = 0;
+  accept_count.clear();
+  draft_count.clear();
 }
 
 TVM_REGISTER_OBJECT_TYPE(EngineStateObj);

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -374,6 +374,7 @@ class ThreadedEngineModule : public ThreadedEngineImpl, public ModuleNode {
   TVM_MODULE_VTABLE_ENTRY("get_complete_engine_config",
                           &ThreadedEngineImpl::GetCompleteEngineConfigJSONString);
   TVM_MODULE_VTABLE_ENTRY("stats", &ThreadedEngineImpl::Stats);
+  TVM_MODULE_VTABLE_ENTRY("reset", &ThreadedEngineImpl::Reset);
   TVM_MODULE_VTABLE_ENTRY("debug_call_func_on_all_worker",
                           &ThreadedEngineImpl::DebugCallFuncOnAllAllWorker);
   TVM_MODULE_VTABLE_END();

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -468,6 +468,7 @@ class MLCEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
                 "get_default_generation_config",
                 "get_complete_engine_config",
                 "stats",
+                "reset",
                 "debug_call_func_on_all_worker",
             ]
         }
@@ -532,6 +533,10 @@ class MLCEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
     def stats(self):
         """Get the engine stats."""
         return self._ffi["stats"]()
+
+    def reset(self):
+        """Reset the engine, clear the running data and statistics."""
+        return self._ffi["reset"]()
 
 
 def process_chat_completion_request(  # pylint: disable=too-many-arguments

--- a/python/mlc_llm/serve/entrypoints/debug_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/debug_entrypoints.py
@@ -34,7 +34,7 @@ async def debug_dump_event_trace(request: fastapi.Request):
             HTTPStatus.BAD_REQUEST, message=f"Invalid request {request_json_str}"
         )
 
-    # - Check the requested model.
+    # Check the requested model.
     model = request_dict["model"]
 
     server_context: ServerContext = ServerContext.current()
@@ -99,7 +99,7 @@ async def debug_dump_engine_stats(request: fastapi.Request):
             HTTPStatus.BAD_REQUEST, message=f"Invalid request {request_json_str}"
         )
 
-    # - Check the requested model.
+    # Check the requested model.
     model = request_dict["model"]
 
     server_context: ServerContext = ServerContext.current()
@@ -107,3 +107,29 @@ async def debug_dump_engine_stats(request: fastapi.Request):
     res = async_engine.stats()
     print(res)
     return json.loads(res)
+
+
+@app.post("/debug/reset_engine")
+async def debug_reset_engine_stats(request: fastapi.Request):
+    """Reset the engine, clean up all running data and statistics."""
+    # Get the raw request body as bytes
+    request_raw_data = await request.body()
+    request_json_str = request_raw_data.decode("utf-8")
+    try:
+        # Parse the JSON string
+        request_dict = json.loads(request_json_str)
+    except json.JSONDecodeError:
+        return error_protocol.create_error_response(
+            HTTPStatus.BAD_REQUEST, message=f"Invalid request {request_json_str}"
+        )
+    if "model" not in request_dict:
+        return error_protocol.create_error_response(
+            HTTPStatus.BAD_REQUEST, message=f"Invalid request {request_json_str}"
+        )
+
+    # Check the requested model.
+    model = request_dict["model"]
+
+    server_context: ServerContext = ServerContext.current()
+    async_engine = server_context.get_engine(model)
+    async_engine.reset()


### PR DESCRIPTION
Expose the Reset in engine to debug_entrypoints, will use it (instead of re-deploying) to help measure the acceptance rate.

cc: @vinx13 @tqchen 