### PR TITLE
[Bugfix] Make sequence_length dtype int64 in EngineConfig. Fix Mistral engine serving issue

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -392,9 +392,9 @@ Result<ModelConfigLimits> GetModelConfigLimits(const std::vector<picojson::objec
         json::Lookup<picojson::object>(model_configs[i], "model_config");
     // - The maximum single sequence length is the minimum context window size among all models.
     int64_t runtime_context_window_size =
-        json::Lookup<int64_t>(model_configs[i], "context_window_size");
+        json::LookupOptional<int64_t>(model_configs[i], "context_window_size").value_or(-1);
     int64_t compile_time_context_window_size =
-        json::Lookup<int64_t>(compile_time_model_config, "context_window_size");
+        json::LookupOptional<int64_t>(compile_time_model_config, "context_window_size").value_or(-1);
     if (runtime_context_window_size > compile_time_context_window_size) {
       return Result<ModelConfigLimits>::Error(
           "Model " + std::to_string(i) + "'s runtime context window size (" +
@@ -458,7 +458,7 @@ Result<MemUsageEstimationResult> EstimateMemoryUsageOnMode(
     InferrableEngineConfig init_config, bool verbose) {
   std::ostringstream os;
   InferrableEngineConfig inferred_config = init_config;
-  // - 1. max_mum_sequence
+  // - 1. max_num_sequence
   if (!init_config.max_num_sequence.has_value()) {
     if (mode == EngineMode::kLocal) {
       inferred_config.max_num_sequence =

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -394,7 +394,8 @@ Result<ModelConfigLimits> GetModelConfigLimits(const std::vector<picojson::objec
     int64_t runtime_context_window_size =
         json::LookupOptional<int64_t>(model_configs[i], "context_window_size").value_or(-1);
     int64_t compile_time_context_window_size =
-        json::LookupOptional<int64_t>(compile_time_model_config, "context_window_size").value_or(-1);
+        json::LookupOptional<int64_t>(compile_time_model_config, "context_window_size")
+            .value_or(-1);
     if (runtime_context_window_size > compile_time_context_window_size) {
       return Result<ModelConfigLimits>::Error(
           "Model " + std::to_string(i) + "'s runtime context window size (" +

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -158,14 +158,14 @@ class EngineConfigNode : public Object {
    */
   int max_num_sequence = 4;
   /*! \brief The maximum length allowed for a single sequence in the engine. */
-  int max_total_sequence_length = 4096;
+  int64_t max_total_sequence_length = 4096;
   /*!
    * \brief The maximum total number of tokens whose KV data are allowed
    * to exist in the KV cache at any time.
    */
-  int max_single_sequence_length = 4096;
+  int64_t max_single_sequence_length = 4096;
   /*! \brief The maximum total sequence length in a prefill. */
-  int prefill_chunk_size = 1024;
+  int64_t prefill_chunk_size = 1024;
   /*! \brief The maximum history size for RNN state. KV cache does not need this. */
   int max_history_size = 0;
 

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -85,7 +85,7 @@ void ProcessFinishedRequestStateEntries(std::vector<RequestStateEntry> finished_
 void ActionStepPostProcess(Array<Request> requests, EngineState estate, Array<Model> models,
                            const Tokenizer& tokenizer,
                            FRequestStreamCallback request_stream_callback,
-                           int max_single_sequence_length) {
+                           int64_t max_single_sequence_length) {
   NVTXScopedRange nvtx_scope("EngineAction postproc");
   std::vector<RequestStateEntry> finished_rsentries;
   finished_rsentries.reserve(requests.size());

--- a/cpp/serve/engine_actions/action_commons.h
+++ b/cpp/serve/engine_actions/action_commons.h
@@ -44,7 +44,7 @@ void RemoveRequestFromModel(EngineState estate, int64_t req_internal_id, Array<M
 void ActionStepPostProcess(Array<Request> requests, EngineState estate, Array<Model> models,
                            const Tokenizer& tokenizer,
                            FRequestStreamCallback request_stream_callback,
-                           int max_single_sequence_length);
+                           int64_t max_single_sequence_length);
 
 /*!
  * \brief Preempt the last running request state entry from `running_queue`.

--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -130,7 +130,8 @@ bool BatchPrefillBaseActionObj::CanPrefill(EngineState estate, int num_prefill_r
                         ? (engine_config_->spec_draft_length + 1)
                         : 1;
   if ((num_running_rsentries + num_prefill_rsentries) * spec_factor >
-      std::min(engine_config_->max_num_sequence, engine_config_->prefill_chunk_size)) {
+      std::min(static_cast<int64_t>(engine_config_->max_num_sequence),
+               engine_config_->prefill_chunk_size)) {
     return false;
   }
 

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -573,8 +573,8 @@ class ModelImpl : public ModelObj {
 
   /*********************** KV Cache Management  ***********************/
 
-  void CreateKVCache(int page_size, int max_num_sequence, int max_total_sequence_length,
-                     int prefill_chunk_size, int max_history_size) final {
+  void CreateKVCache(int page_size, int max_num_sequence, int64_t max_total_sequence_length,
+                     int64_t prefill_chunk_size, int max_history_size) final {
     //  KVStateKind kv_state_kind) final {
     KVStateKind kv_state_kind = GetMetadata().kv_state_kind;
     if (kv_state_kind == KVStateKind::kKVCache) {

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -227,8 +227,8 @@ class ModelObj : public Object {
    * \param max_history_size The maximum history size for RNN state to roll back.
    * The KV cache does not need this.
    */
-  virtual void CreateKVCache(int page_size, int max_num_sequence, int max_total_sequence_length,
-                             int prefill_chunk_size, int max_history_size) = 0;
+  virtual void CreateKVCache(int page_size, int max_num_sequence, int64_t max_total_sequence_length,
+                             int64_t prefill_chunk_size, int max_history_size) = 0;
 
   /*! \brief Add a new sequence with the given sequence id to the KV cache. */
   virtual void AddNewSequence(int64_t seq_id) = 0;

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -118,7 +118,7 @@ RequestStateEntry::RequestStateEntry(
 }
 
 DeltaRequestReturn RequestStateEntryNode::GetReturnTokenIds(const Tokenizer& tokenizer,
-                                                            int max_single_sequence_length) {
+                                                            int64_t max_single_sequence_length) {
   std::vector<int32_t> return_token_ids;
   std::vector<String> logprob_json_strs;
   Optional<String> finish_reason;

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -202,7 +202,8 @@ class RequestStateEntryNode : public Object {
    * \return The delta token ids to return, the logprob JSON strings of each delta token id, and
    * the optional finish reason.
    */
-  DeltaRequestReturn GetReturnTokenIds(const Tokenizer& tokenizer, int64_t max_single_sequence_length);
+  DeltaRequestReturn GetReturnTokenIds(const Tokenizer& tokenizer,
+                                       int64_t max_single_sequence_length);
 
   static constexpr const char* _type_key = "mlc.serve.RequestStateEntry";
   static constexpr const bool _type_has_method_sequal_reduce = false;

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -202,7 +202,7 @@ class RequestStateEntryNode : public Object {
    * \return The delta token ids to return, the logprob JSON strings of each delta token id, and
    * the optional finish reason.
    */
-  DeltaRequestReturn GetReturnTokenIds(const Tokenizer& tokenizer, int max_single_sequence_length);
+  DeltaRequestReturn GetReturnTokenIds(const Tokenizer& tokenizer, int64_t max_single_sequence_length);
 
   static constexpr const char* _type_key = "mlc.serve.RequestStateEntry";
   static constexpr const bool _type_has_method_sequal_reduce = false;

--- a/python/mlc_llm/serve/config.py
+++ b/python/mlc_llm/serve/config.py
@@ -179,11 +179,11 @@ class EngineConfig:  # pylint: disable=too-many-instance-attributes
         processed by the KV cache at any time.
 
     max_total_sequence_length : Optional[int]
-        The maximum length allowed for a single sequence in the engine.
-
-    max_single_sequence_length : Optional[int]
         The maximum total number of tokens whose KV data are allowed
         to exist in the KV cache at any time.
+
+    max_single_sequence_length : Optional[int]
+        The maximum length allowed for a single sequence in the engine.
 
     prefill_chunk_size : Optional[int]
         The maximum total sequence length in a prefill.


### PR DESCRIPTION
Mistral now works on `Engine` serving:

```
mlc-llm-head % python -m mlc_llm serve HF://mlc-ai/OpenHermes-2.5-Mistral-7B-q4f16_1-MLC
```

```
import requests

# Get a response using a prompt without streaming
payload = {
   "model": "HF://mlc-ai/OpenHermes-2.5-Mistral-7B-q4f16_1-MLC",
   "messages": [
      {"role": "user", "content": "Write a haiku about apples."},
   ],
   "stream": False
}
r = requests.post("http://127.0.0.1:8000/v1/chat/completions", json=payload)
choices = r.json()["choices"]
for choice in choices:
   print(f"{choice['message']['content']}\n")
```

Output:
```
Crimson fruit, ripe and sweet,
Nature's bounty, a treasure trove,
Graceful in their fall.
```