### PR TITLE
[Fix][Serving] Fix prefill chunk in interactive mode

### DIFF
--- a/cpp/serve/engine_actions/action_commons.h
+++ b/cpp/serve/engine_actions/action_commons.h
@@ -67,7 +67,10 @@ inline std::vector<RequestStateEntry> GetRunningRequestStateEntries(const Engine
   std::vector<RequestStateEntry> rsentries;
   for (const Request& request : estate->running_queue) {
     for (const RequestStateEntry& rsentry : estate->GetRequestState(request)->entries) {
-      if (rsentry->status == RequestStateStatus::kAlive && rsentry->child_indices.empty()) {
+      // One request entry is considered as running for decode if it is a leaf and has
+      // finished all input prefill.
+      if (rsentry->status == RequestStateStatus::kAlive && rsentry->child_indices.empty() &&
+          rsentry->mstates[0]->inputs.empty()) {
         rsentries.push_back(rsentry);
       }
     }

--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -93,11 +93,10 @@ BatchPrefillBaseActionObj::GetRequestStateEntriesToPrefill(EngineState estate) {
                           engine_config_->kv_cache_page_size;
       total_input_length += input_length;
       total_required_pages += num_require_pages;
-      if (CanPrefill(estate, num_prefill_rsentries + 1, total_input_length, total_required_pages,
+      if (CanPrefill(estate, num_prefill_rsentries, total_input_length, total_required_pages,
                      num_available_pages, current_total_seq_len, num_running_rsentries,
                      kv_state_kind)) {
         prefill_inputs.push_back({rsentry, input_length, 0});
-        num_prefill_rsentries += 1;
       }
 
       // - Prefill stops here.


### PR DESCRIPTION
This PR fixes a bug of prefill chunking in the interactive mode. The bug counts requests with remaining inputs as running requests which turns out disabling the prefill of the remaining inputs.

This PR fixes by no longer counting requests with unfinished inputs as running requests for decode.