### PR TITLE
[Fix] Use static_cast for `.size()` for safety

### DIFF
--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -117,19 +117,19 @@ void UpdatePrefixCache(Array<Request> requests, EngineState estate) {
           rsentry->mstates[0]->prefilled_inputs.clear();
         }
         if (rsentry->mstates[0]->cached_committed_tokens <
-            rsentry->mstates[0]->committed_tokens.size() - 1) {
+            static_cast<int64_t>(rsentry->mstates[0]->committed_tokens.size()) - 1) {
           // Notify the prefix cache of the newly decoded data, except the last token as it is not
           // in KVCache yet.
           std::vector<int64_t> tokens;
-          tokens.reserve((rsentry->mstates[0]->committed_tokens.size() -
+          tokens.reserve((static_cast<int64_t>(rsentry->mstates[0]->committed_tokens.size()) -
                           rsentry->mstates[0]->cached_committed_tokens));
           for (int i = rsentry->mstates[0]->cached_committed_tokens;
-               i < rsentry->mstates[0]->committed_tokens.size() - 1; ++i) {
+               i < static_cast<int64_t>(rsentry->mstates[0]->committed_tokens.size()) - 1; ++i) {
             tokens.push_back(rsentry->mstates[0]->committed_tokens[i].sampled_token_id.first);
           }
           estate->prefix_cache->ExtendSequence(rsentry->mstates[0]->internal_id, IntTuple(tokens));
           rsentry->mstates[0]->cached_committed_tokens =
-              rsentry->mstates[0]->committed_tokens.size() - 1;
+              static_cast<int64_t>(rsentry->mstates[0]->committed_tokens.size()) - 1;
         }
       }
     }
@@ -260,7 +260,7 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
         std::vector<int> token_ids{token_input->token_ids->data,
                                    token_input->token_ids->data + token_input->token_ids.size()};
         token_ids.insert(token_ids.end(), committed_token_ids.begin(), committed_token_ids.end());
-        inputs.Set(inputs.size() - 1, TokenData(token_ids));
+        inputs.Set(static_cast<int64_t>(inputs.size()) - 1, TokenData(token_ids));
       } else if (!committed_token_ids.empty()) {
         inputs.push_back(TokenData(committed_token_ids));
       }

--- a/cpp/serve/grammar/grammar_state_matcher_preproc.h
+++ b/cpp/serve/grammar/grammar_state_matcher_preproc.h
@@ -316,7 +316,7 @@ inline std::shared_ptr<GrammarStateInitContext> GrammarStateMatcher::CreateInitC
     if (token == "</s>" || token == "<|end_of_text|>" || token == "<|eot_id|>" ||
         token == "<|endoftext|>" || token == "<eos>" || token == "<end_of_turn>") {
       ptr->stop_token_ids.push_back(i);
-    } else if ((token[0] == '<' && token[token.size() - 1] == '>' && token.size() >= 3) ||
+    } else if ((token[0] == '<' && token.back() == '>' && token.size() >= 3) ||
                token == "[@BOS@]") {
       // gemma treats [@BOS@] as a special token
       ptr->special_token_ids.insert(i);

--- a/cpp/serve/grammar/grammar_state_matcher_state.h
+++ b/cpp/serve/grammar/grammar_state_matcher_state.h
@@ -72,7 +72,7 @@ class RulePositionBuffer {
     int32_t id;
     if (free_nodes_.empty()) {
       buffer_.emplace_back();
-      id = buffer_.size() - 1;
+      id = static_cast<int32_t>(buffer_.size()) - 1;
     } else {
       id = free_nodes_.back();
       DCHECK(buffer_[id].IsInvalid());
@@ -419,8 +419,8 @@ inline void RulePositionTree::CheckWellFormed(const std::vector<int32_t>& outsid
 }
 
 inline std::string StackTopsHistory::PrintHistory(int history_position_to_latest) const {
-  const auto& latest_tops =
-      stack_tops_history_[stack_tops_history_.size() - 1 - history_position_to_latest];
+  const auto& latest_tops = stack_tops_history_[static_cast<int64_t>(stack_tops_history_.size()) -
+                                                1 - history_position_to_latest];
   std::stringstream ss;
   ss << "Stacks tops size: " << latest_tops.size() << std::endl;
   int cnt = 0;

--- a/cpp/serve/grammar/json_schema_converter.cc
+++ b/cpp/serve/grammar/json_schema_converter.cc
@@ -786,7 +786,8 @@ std::string JSONSchemaToEBNFConverter::GetPartialRuleForPropertiesAllOptional(
     additional_prop_pattern =
         GetOtherPropertyPattern(kBasicString, additional, rule_name, additional_suffix);
     std::string last_rule_body = "(" + mid_sep + " " + additional_prop_pattern + ")*";
-    std::string last_rule_name = rule_name + "_part_" + std::to_string(properties.size() - 1);
+    std::string last_rule_name =
+        rule_name + "_part_" + std::to_string(static_cast<int>(properties.size()) - 1);
     rules_.push_back(std::make_pair(last_rule_name, last_rule_body));
     rule_names.back() = last_rule_name;
   } else {

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -55,7 +55,7 @@ class RequestModelStateNode : public Object {
   /*! \brief The list of prefilled input data, used to notify prefix cache. */
   Array<Data> prefilled_inputs;
   /*! \brief The number of tokens already cached in prefix cache. */
-  size_t cached_committed_tokens = 0;
+  int64_t cached_committed_tokens = 0;
 
   // NOTE: The following fields are reserved for future speculative inference
   // settings, and are produced by the speculative small models.

--- a/cpp/serve/sampler/cpu_sampler.cc
+++ b/cpp/serve/sampler/cpu_sampler.cc
@@ -142,8 +142,8 @@ TokenProbPair SampleTopPFromProb(NDArray prob, int unit_offset, int input_prob_o
       }
       last_cum_sum_prob = it->first;
     }
-    return std::make_pair(data[data.size() - 1].first - last_cum_sum_prob,
-                          data[data.size() - 1].second);
+    return std::make_pair(data[static_cast<int64_t>(data.size()) - 1].first - last_cum_sum_prob,
+                          data[static_cast<int64_t>(data.size()) - 1].second);
   };
 
   if (top_p < 1) {


### PR DESCRIPTION
This PR updates the occurences of `.size() - 1` with static_cast to avoid the integer underflow.