### PR TITLE
[Test] Use HF model for JIT as much as possible

### DIFF
--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -21,11 +21,9 @@ prompts = [
 
 async def test_engine_generate():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
     )
@@ -78,11 +76,9 @@ async def test_engine_generate():
 
 async def test_chat_completion():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
     )
@@ -130,11 +126,9 @@ async def test_chat_completion():
 
 async def test_chat_completion_non_stream():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
     )
@@ -181,11 +175,9 @@ async def test_chat_completion_non_stream():
 
 async def test_completion():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
     )
@@ -233,11 +225,9 @@ async def test_completion():
 
 async def test_completion_non_stream():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
     )

--- a/tests/python/serve/test_serve_async_engine_spec.py
+++ b/tests/python/serve/test_serve_async_engine_spec.py
@@ -21,15 +21,12 @@ prompts = [
 
 async def test_engine_generate():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    small_model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-    small_model_lib = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
+    small_model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
-        additional_models=[small_model + ":" + small_model_lib],
+        additional_models=[small_model],
         speculative_mode="small_draft",
     )
 

--- a/tests/python/serve/test_serve_engine.py
+++ b/tests/python/serve/test_serve_engine.py
@@ -1,6 +1,6 @@
 # pylint: disable=chained-comparison,line-too-long,missing-docstring,
 # pylint: disable=too-many-arguments,too-many-locals,unused-argument,unused-variable
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -21,8 +21,8 @@ prompts = [
 
 test_models = [
     (
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC",
-        "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so",
+        "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC",
+        None,
     ),
     (
         "dist/rwkv-6-world-1b6-q0f16-MLC",
@@ -31,7 +31,7 @@ test_models = [
 ]
 
 
-def create_engine(model: str, model_lib: str):
+def create_engine(model: str, model_lib: Optional[str]):
     if "rwkv" in model:
         return MLCEngine(
             model=model,
@@ -50,7 +50,7 @@ def create_engine(model: str, model_lib: str):
 
 
 @pytest.mark.parametrize("model,model_lib", test_models)
-def test_engine_generate(model: str, model_lib: str):
+def test_engine_generate(model: str, model_lib: Optional[str]):
     engine = create_engine(model, model_lib)
 
     num_requests = 10

--- a/tests/python/serve/test_serve_engine_grammar.py
+++ b/tests/python/serve/test_serve_engine_grammar.py
@@ -16,13 +16,15 @@ prompts_list = [
     "Generate a JSON containing a non-empty list:",
     "Generate a JSON with 5 elements:",
 ]
-model_path = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-model_lib = "dist/libs/Llama-2-7b-chat-hf-q4f16_1-cuda.so"
+model_path = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
 
 
 def test_batch_generation_with_grammar():
     # Create engine
-    engine = SyncMLCEngine(model=model_path, model_lib=model_lib, mode="server")
+    engine = SyncMLCEngine(
+        model=model_path,
+        mode="server",
+    )
 
     prompt_len = len(prompts_list)
     prompts = prompts_list * 3
@@ -69,7 +71,7 @@ def test_batch_generation_with_grammar():
 
 def test_batch_generation_with_schema():
     # Create engine
-    engine = SyncMLCEngine(model=model_path, model_lib=model_lib, mode="server")
+    engine = SyncMLCEngine(model=model_path, mode="server")
 
     prompt = (
         "Generate a json containing three fields: an integer field named size, a "
@@ -121,7 +123,7 @@ def test_batch_generation_with_schema():
 
 async def run_async_engine():
     # Create engine
-    async_engine = AsyncMLCEngine(model=model_path, model_lib=model_lib, mode="server")
+    async_engine = AsyncMLCEngine(model=model_path, mode="server")
 
     prompts = prompts_list * 20
 

--- a/tests/python/serve/test_serve_engine_prefix_cache.py
+++ b/tests/python/serve/test_serve_engine_prefix_cache.py
@@ -1,16 +1,4 @@
-# pylint: disable=chained-comparison,line-too-long,missing-docstring,
-# pylint: disable=too-many-arguments,too-many-locals
-from typing import Callable, List, Optional
-
-import numpy as np
-
-from mlc_llm.serve import (
-    DebugConfig,
-    GenerationConfig,
-    Request,
-    RequestStreamOutput,
-    data,
-)
+from mlc_llm.serve import DebugConfig, GenerationConfig
 from mlc_llm.serve.sync_engine import SyncMLCEngine
 
 prompts = [
@@ -93,11 +81,9 @@ def test_engine_multi_round(engine):
 
 def test_basic_engine_system_prompt():
     # Create engine
-    model = "dist/q0f16"
-    model_lib = "dist/q0f16/q0f16.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="local",
         max_total_sequence_length=4096,
         prefix_cache_max_num_seqs=5,
@@ -107,11 +93,9 @@ def test_basic_engine_system_prompt():
 
 def test_basic_engine_multi_round():
     # Create engine
-    model = "dist/q0f16"
-    model_lib = "dist/q0f16/q0f16.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
     )
@@ -120,17 +104,14 @@ def test_basic_engine_multi_round():
 
 def test_engine_spec_multi_round():
     # Create engine
-    model = "dist/q0f16"
-    model_lib = "dist/q0f16/q0f16.so"
-    small_model = "dist/q4f16_1"
-    small_model_lib = "dist/q4f16_1/q4f16_1.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
+    small_model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
 
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
+        additional_models=[small_model],
         speculative_mode="small_draft",
     )
 
@@ -139,13 +120,11 @@ def test_engine_spec_multi_round():
 
 def test_engine_eagle_multi_round():
     # Create engine
-    model = "dist/q0f16"
-    model_lib = "dist/q0f16/q0f16.so"
-    small_model = "dist/eagle"
-    small_model_lib = "dist/eagle/eagle.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
+    small_model = "dist/Eagle-llama2-7b-chat-q0f16-MLC"
+    small_model_lib = "dist/Eagle-llama2-7b-chat-q0f16-MLC/Eagle-llama2-7b-chat-q0f16-MLC-cuda.so"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib],

--- a/tests/python/serve/test_serve_engine_spec.py
+++ b/tests/python/serve/test_serve_engine_spec.py
@@ -78,16 +78,13 @@ def test_engine_basic():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    small_model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-    small_model_lib = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
+    small_model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
+        additional_models=[small_model],
         speculative_mode="small_draft",
         request_stream_callback=fcallback,
     )
@@ -144,13 +141,11 @@ def test_engine_eagle_basic():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     small_model = "dist/Eagle-llama2-7b-chat-q0f16-MLC"
     small_model_lib = "dist/Eagle-llama2-7b-chat-q0f16-MLC/Eagle-llama2-7b-chat-q0f16-MLC-cuda.so"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib],
@@ -225,17 +220,14 @@ def test_engine_continuous_batching_1():
             self.timer += 1
 
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    small_model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-    small_model_lib = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
+    small_model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     timer = CallbackTimer()
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
+        additional_models=[small_model],
         speculative_mode="small_draft",
         request_stream_callback=timer.callback_getter(),
     )
@@ -309,8 +301,7 @@ def test_engine_eagle_continuous_batching_1():
             self.timer += 1
 
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     small_model = "dist/Eagle-llama2-7b-chat-q4f16_1-MLC"
     small_model_lib = (
         "dist/Eagle-llama2-7b-chat-q4f16_1-MLC/Eagle-llama2-7b-chat-q4f16_1-MLC-cuda.so"
@@ -318,7 +309,6 @@ def test_engine_eagle_continuous_batching_1():
     timer = CallbackTimer()
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib],
@@ -366,17 +356,14 @@ def compare_output_text(output_text1, output_text2):
 
 def test_engine_generate(compare_precision=False):
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
-    small_model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-    small_model_lib = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
+    small_model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
 
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
+        additional_models=[small_model],
         speculative_mode="small_draft",
     )
 
@@ -426,15 +413,13 @@ def test_engine_generate(compare_precision=False):
 
 def test_engine_eagle_generate():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     small_model = "dist/Eagle-llama2-7b-chat-q4f16_1-MLC"
     small_model_lib = (
         "dist/Eagle-llama2-7b-chat-q4f16_1-MLC/Eagle-llama2-7b-chat-q4f16_1-MLC-cuda.so"
     )
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib],
@@ -478,11 +463,9 @@ def test_engine_efficiency():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    model = "dist/Llama-2-13b-chat-hf-q4f16_1-MLC"
-    model_lib = "dist/Llama-2-13b-chat-hf-q4f16_1-MLC/Llama-2-13b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-13b-chat-hf-q4f16_1-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
         request_stream_callback=fcallback,
@@ -541,10 +524,8 @@ def test_engine_spec_efficiency():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    model = "dist/Llama-2-13b-chat-hf-q4f16_1-MLC"
-    model_lib = "dist/Llama-2-13b-chat-hf-q4f16_1-MLC/Llama-2-13b-chat-hf-q4f16_1-MLC-cuda.so"
-    small_model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-    small_model_lib = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-13b-chat-hf-q4f16_1-MLC"
+    small_model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     # If Flashinfer allows head_dim < 128, we can test this model
     # small_model = "dist/TinyLlama-1.1B-Chat-v1.0-q0f16-MLC"
     # small_model_lib = (
@@ -552,10 +533,9 @@ def test_engine_spec_efficiency():
     # )
     spec_engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
+        additional_models=[small_model],
         spec_draft_length=6,
         speculative_mode="small_draft",
         request_stream_callback=fcallback,
@@ -614,13 +594,11 @@ def test_engine_eagle_spec_efficiency():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q4f16_1-MLC/Llama-2-7b-chat-hf-q4f16_1-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
     small_model = "dist/Eagle-llama2-7b-chat-q0f16-MLC"
     small_model_lib = "dist/Eagle-llama2-7b-chat-q0f16-MLC/Eagle-llama2-7b-chat-q0f16-MLC-cuda.so"
     spec_engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
         additional_models=[small_model + ":" + small_model_lib],

--- a/tests/python/serve/test_serve_sync_engine.py
+++ b/tests/python/serve/test_serve_sync_engine.py
@@ -78,11 +78,9 @@ def test_engine_basic():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         request_stream_callback=fcallback,
     )
@@ -154,11 +152,9 @@ def test_engine_continuous_batching_1():
 
     # Create engine
     timer = CallbackTimer()
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         request_stream_callback=timer.callback_getter(),
     )
@@ -235,11 +231,9 @@ def test_engine_continuous_batching_2():
 
     # Create engine
     timer = CallbackTimer()
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         request_stream_callback=timer.callback_getter(),
     )
@@ -321,11 +315,9 @@ def test_engine_continuous_batching_3():
 
     # Create engine
     timer = CallbackTimer()
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         request_stream_callback=timer.callback_getter(),
     )
@@ -363,11 +355,9 @@ def test_engine_continuous_batching_3():
 
 def test_engine_generate():
     # Create engine
-    model = "dist/Llama-2-7b-chat-hf-q0f16-MLC"
-    model_lib = "dist/Llama-2-7b-chat-hf-q0f16-MLC/Llama-2-7b-chat-hf-q0f16-MLC-cuda.so"
+    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
-        model_lib=model_lib,
         mode="server",
         max_total_sequence_length=4096,
     )


### PR DESCRIPTION
This PR updates the test files to use JIT by default as much as possible, in order to make tests runnable out of the box.

Of course, they can be locally tweaked to use local models.

For Eagle/Llava/rwkv, given we don't have them delivered yet, they are kept as using local model lib now.