### PR TITLE
[Fix] Fix prefix cache reset and forking logic

### DIFF
--- a/cpp/serve/engine_state.cc
+++ b/cpp/serve/engine_state.cc
@@ -57,7 +57,9 @@ void EngineStateObj::Reset() {
   request_states.clear();
   id_manager.Reset();
   stats.Reset();
-  prefix_cache->Reset();
+  if (prefix_cache.defined()) {
+    prefix_cache->Reset();
+  }
 }
 
 RequestState EngineStateObj::GetRequestState(Request request) {

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -108,7 +108,7 @@ class EngineStateObj : public Object {
   /*! \brief Runtime statistics. */
   EngineStats stats;
   /*! \brief The prefix cache. */
-  PrefixCache prefix_cache;
+  PrefixCache prefix_cache{nullptr};
 
   /*! \brief Reset the engine state and clear the statistics. */
   void Reset();

--- a/cpp/serve/prefix_cache.h
+++ b/cpp/serve/prefix_cache.h
@@ -114,7 +114,7 @@ class PrefixCacheObj : public Object {
   /*!
    * \brief Reset the prefix cache to initial status.
    */
-  void Reset(){};
+  virtual void Reset() = 0;
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "mlc.serve.PrefixCache";


### PR DESCRIPTION
This PR refactors the reset logic in prefix cache and disable forking from sequences with sliding windows enabled.