### PR TITLE
[REFACTOR][ENV] MLC_CACHE_DIR to MLC_LLM_HOME

### DIFF
--- a/python/mlc_llm/interface/jit.py
+++ b/python/mlc_llm/interface/jit.py
@@ -18,9 +18,9 @@ from mlc_llm.model import MODELS
 from mlc_llm.support import logging
 from mlc_llm.support.auto_device import device2str
 from mlc_llm.support.constants import (
-    MLC_CACHE_DIR,
     MLC_DSO_SUFFIX,
     MLC_JIT_POLICY,
+    MLC_LLM_HOME,
     MLC_TEMP_DIR,
 )
 from mlc_llm.support.style import blue, bold
@@ -155,7 +155,7 @@ def jit(  # pylint: disable=too-many-locals,too-many-statements
             indent=2,
         ).encode("utf-8")
     ).hexdigest()
-    dst = MLC_CACHE_DIR / "model_lib" / f"{hash_value}.{lib_suffix}"
+    dst = MLC_LLM_HOME / "model_lib" / f"{hash_value}.{lib_suffix}"
     if dst.is_file() and MLC_JIT_POLICY in ["ON", "READONLY"]:
         logger.info("Using cached model lib: %s", bold(str(dst)))
         return JITResult(str(dst), system_lib_prefix)

--- a/python/mlc_llm/support/constants.py
+++ b/python/mlc_llm/support/constants.py
@@ -14,8 +14,8 @@ def _check():
 
 
 def _get_cache_dir() -> Path:
-    if "MLC_CACHE_DIR" in os.environ:
-        result = Path(os.environ["MLC_CACHE_DIR"])
+    if "MLC_LLM_HOME" in os.environ:
+        result = Path(os.environ["MLC_LLM_HOME"])
     elif sys.platform == "win32":
         result = Path(os.environ["LOCALAPPDATA"])
         result = result / "mlc_llm"
@@ -29,7 +29,7 @@ def _get_cache_dir() -> Path:
     if not result.is_dir():
         raise ValueError(
             f"The default cache directory is not a directory: {result}. "
-            "Use environment variable MLC_CACHE_DIR to specify a valid cache directory."
+            "Use environment variable MLC_LLM_HOME to specify a valid cache directory."
         )
     (result / "model_weights").mkdir(parents=True, exist_ok=True)
     (result / "model_lib").mkdir(parents=True, exist_ok=True)
@@ -57,7 +57,7 @@ def _get_test_model_path() -> List[Path]:
 
 MLC_TEMP_DIR = os.getenv("MLC_TEMP_DIR", None)
 MLC_MULTI_ARCH = os.environ.get("MLC_MULTI_ARCH", None)
-MLC_CACHE_DIR: Path = _get_cache_dir()
+MLC_LLM_HOME: Path = _get_cache_dir()
 MLC_JIT_POLICY = os.environ.get("MLC_JIT_POLICY", "ON")
 MLC_DSO_SUFFIX = _get_dso_suffix()
 MLC_TEST_MODEL_PATH: List[Path] = _get_test_model_path()

--- a/python/mlc_llm/support/download.py
+++ b/python/mlc_llm/support/download.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple
 import requests  # pylint: disable=import-error
 
 from . import logging, tqdm
-from .constants import MLC_CACHE_DIR, MLC_TEMP_DIR
+from .constants import MLC_LLM_HOME, MLC_TEMP_DIR
 from .style import bold
 
 logger = logging.getLogger(__name__)
@@ -126,7 +126,7 @@ def download_mlc_weights(  # pylint: disable=too-many-locals
     if model_url.count("/") != 1 + mlc_prefix.count("/") or not model_url.startswith(mlc_prefix):
         raise ValueError(f"Invalid model URL: {model_url}")
     user, repo = model_url[len(mlc_prefix) :].split("/")
-    git_dir = MLC_CACHE_DIR / "model_weights" / user / repo
+    git_dir = MLC_LLM_HOME / "model_weights" / user / repo
     try:
         _ensure_directory_not_exist(git_dir, force_redo=force_redo)
     except ValueError:

--- a/rust/README.md
+++ b/rust/README.md
@@ -10,7 +10,7 @@ To set up the MLC-LLM Rust package, please follow these steps:
 **Step 2:** Define the environment variables for TVM and MLC-LLM by running the following commands in your terminal:
 ```bash
 export TVM_SOURCE_DIR=/path/to/tvm
-export MLC_HOME=/path/to/mlc-llm
+export MLC_LLM_HOME=/path/to/mlc-llm
 ```
 
 **Step 3:** Update your `LD_LIBRARY_PATH` to include the `libtvm_runtime` and `libmlc_llm_module` libraries. These can typically be found within the build directories of your TVM and MLC-LLM installations.

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let mlc_home = env!("MLC_HOME");
+    let mlc_home = env!("MLC_LLM_HOME");
 
     println!("cargo:rustc-link-lib=dylib=mlc_llm_module");
     println!("cargo:rustc-link-search=native={}/build", mlc_home);


### PR DESCRIPTION
This PR changes the MLC_CACHE_DIR env to MLC_LLM_HOME. This change aligns with most of the packages.