### PR TITLE
[PREFIX-CACHE] Fix some issues with prefix cache

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -383,7 +383,7 @@ String EngineConfigNode::AsJSONString() const {
   config["prefill_chunk_size"] = picojson::value(static_cast<int64_t>(this->prefill_chunk_size));
   config["max_history_size"] = picojson::value(static_cast<int64_t>(this->max_history_size));
   config["prefix_cache_mode"] = picojson::value(PrefixCacheModeToString(this->prefix_cache_mode));
-  config["prefix_cache_max_recycling_seqs"] =
+  config["prefix_cache_max_num_recycling_seqs"] =
       picojson::value(static_cast<int64_t>(this->prefix_cache_max_num_recycling_seqs));
   config["speculative_mode"] = picojson::value(SpeculativeModeToString(this->speculative_mode));
   config["spec_draft_length"] = picojson::value(static_cast<int64_t>(this->spec_draft_length));

--- a/cpp/serve/prefix_cache.cc
+++ b/cpp/serve/prefix_cache.cc
@@ -168,7 +168,7 @@ class PrefixCacheImpl : public PrefixCacheObj {
   void RecycleSequence(int64_t seq_id, bool lazy = true) final {
     CHECK(seq_states_.at(seq_id) == SequenceState::kActive);
     CHECK(recycling_seq_lrus_.find(seq_id) == recycling_seq_lrus_.end());
-    if (lazy) {
+    if (lazy && max_num_recycling_seqs_ != 0) {
       // Remove the sequence lazily.
       if (recycling_seq_lrus_.size() == max_num_recycling_seqs_) {
         // If prefix cache has reached maximum number of recycling sequences, try to pop one


### PR DESCRIPTION
This PR fixes issues with prefix cache when used together with MLCEngine. It also fixes an issue when prefix_cache_max_num_recycling_seqs == 0