### PR TITLE
[Refactor] Expose EngineConfig in engine constructor

### DIFF
--- a/docs/install/emcc.rst
+++ b/docs/install/emcc.rst
@@ -22,7 +22,7 @@ Validate that emcc is accessible in shell
     emcc --version
 
 Step 2: Set TVM_SOURCE_DIR and MLC_LLM_SOURCE_DIR
--------------------------------------
+-------------------------------------------------
 
 We need to set a path to a tvm source in order to build tvm runtime.
 Note that you do not need to build tvm unity from the source. The source here is only used to build the web runtime component.

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -1,10 +1,65 @@
 """Command line entrypoint of serve."""
 
+import dataclasses
 import json
+from io import StringIO
+from typing import Optional
 
 from mlc_llm.interface.help import HELP
 from mlc_llm.interface.serve import serve
+from mlc_llm.support import argparse
 from mlc_llm.support.argparse import ArgumentParser
+
+
+@dataclasses.dataclass
+class EngineConfigOverride:
+    """Arguments for overriding engine config."""
+
+    max_num_sequence: Optional[int] = None
+    max_total_seq_length: Optional[int] = None
+    prefill_chunk_size: Optional[int] = None
+    max_history_size: Optional[int] = None
+    gpu_memory_utilization: Optional[float] = None
+    spec_draft_length: Optional[int] = None
+    prefix_cache_max_num_recycling_seqs: Optional[int] = None
+
+    def __repr__(self) -> str:
+        out = StringIO()
+        print(f"max_num_sequence={self.max_num_sequence}", file=out, end="")
+        print(f";max_total_seq_length={self.max_total_seq_length}", file=out, end="")
+        print(f";prefill_chunk_size={self.prefill_chunk_size}", file=out, end="")
+        print(f";max_history_size={self.max_history_size}", file=out, end="")
+        print(f";gpu_memory_utilization={self.gpu_memory_utilization}", file=out, end="")
+        print(f";spec_draft_length={self.spec_draft_length}", file=out, end="")
+        print(
+            f";prefix_cache_max_num_recycling_seqs={self.prefix_cache_max_num_recycling_seqs}",
+            file=out,
+            end="",
+        )
+        return out.getvalue().rstrip()
+
+    @staticmethod
+    def from_str(source: str) -> "EngineConfigOverride":
+        """Parse engine config override values from a string."""
+        parser = argparse.ArgumentParser(description="Engine config override values")
+
+        parser.add_argument("--max_num_sequence", type=int, default=None)
+        parser.add_argument("--max_total_seq_length", type=int, default=None)
+        parser.add_argument("--prefill_chunk_size", type=int, default=None)
+        parser.add_argument("--max_history_size", type=int, default=None)
+        parser.add_argument("--gpu_memory_utilization", type=float, default=None)
+        parser.add_argument("--spec_draft_length", type=int, default=None)
+        parser.add_argument("--prefix_cache_max_num_recycling_seqs", type=int, default=None)
+        results = parser.parse_args([f"--{i}" for i in source.split(";") if i])
+        return EngineConfigOverride(
+            max_num_sequence=results.max_num_sequence,
+            max_total_seq_length=results.max_total_seq_length,
+            prefill_chunk_size=results.prefill_chunk_size,
+            max_history_size=results.max_history_size,
+            gpu_memory_utilization=results.gpu_memory_utilization,
+            spec_draft_length=results.spec_draft_length,
+            prefix_cache_max_num_recycling_seqs=results.prefix_cache_max_num_recycling_seqs,
+        )
 
 
 def main(argv):
@@ -38,24 +93,12 @@ def main(argv):
     parser.add_argument(
         "--additional-models", type=str, nargs="*", help=HELP["additional_models_serve"]
     )
-    parser.add_argument("--max-batch-size", type=int, help=HELP["max_batch_size"])
-    parser.add_argument(
-        "--max-total-seq-length", type=int, help=HELP["max_total_sequence_length_serve"]
-    )
-    parser.add_argument("--prefill-chunk-size", type=int, help=HELP["prefill_chunk_size_serve"])
-    parser.add_argument("--max-history-size", type=int, help=HELP["max_history_size_serve"])
-    parser.add_argument(
-        "--gpu-memory-utilization", type=float, help=HELP["gpu_memory_utilization_serve"]
-    )
     parser.add_argument(
         "--speculative-mode",
         type=str,
         choices=["disable", "small_draft", "eagle", "medusa"],
         default="disable",
         help=HELP["speculative_mode_serve"] + ' (default: "%(default)s")',
-    )
-    parser.add_argument(
-        "--spec-draft-length", type=int, default=4, help=HELP["spec_draft_length_serve"]
     )
     parser.add_argument(
         "--prefix-cache-mode",
@@ -65,9 +108,10 @@ def main(argv):
         help=HELP["prefix_cache_mode_serve"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
-        "--prefix-cache-max-num-recycling-seqs",
-        type=int,
-        help=HELP["prefix_cache_max_num_recycling_seqs_serve"],
+        "--overrides",
+        type=EngineConfigOverride.from_str,
+        default="",
+        help=HELP["overrides_serve"],
     )
     parser.add_argument("--enable-tracing", action="store_true", help=HELP["enable_tracing_serve"])
     parser.add_argument(
@@ -103,21 +147,30 @@ def main(argv):
     )
     parsed = parser.parse_args(argv)
 
+    additional_models = []
+    if parsed.additional_models is not None:
+        for additional_model in parsed.additional_models:
+            splits = additional_model.split(",", maxsplit=1)
+            if len(splits) == 2:
+                additional_models.append((splits[0], splits[1]))
+            else:
+                additional_models.append(splits[0])
+
     serve(
         model=parsed.model,
         device=parsed.device,
         model_lib=parsed.model_lib,
         mode=parsed.mode,
-        additional_models=parsed.additional_models,
-        max_batch_size=parsed.max_batch_size,
-        max_total_sequence_length=parsed.max_total_seq_length,
-        prefill_chunk_size=parsed.prefill_chunk_size,
-        max_history_size=parsed.max_history_size,
-        gpu_memory_utilization=parsed.gpu_memory_utilization,
+        additional_models=additional_models,
         speculative_mode=parsed.speculative_mode,
-        spec_draft_length=parsed.spec_draft_length,
         prefix_cache_mode=parsed.prefix_cache_mode,
-        prefix_cache_max_num_recycling_seqs=parsed.prefix_cache_max_num_recycling_seqs,
+        max_num_sequence=parsed.overrides.max_num_sequence,
+        max_total_sequence_length=parsed.overrides.max_total_seq_length,
+        prefill_chunk_size=parsed.overrides.prefill_chunk_size,
+        max_history_size=parsed.overrides.max_history_size,
+        gpu_memory_utilization=parsed.overrides.gpu_memory_utilization,
+        spec_draft_length=parsed.overrides.spec_draft_length,
+        prefix_cache_max_num_recycling_seqs=parsed.overrides.prefix_cache_max_num_recycling_seqs,
         enable_tracing=parsed.enable_tracing,
         host=parsed.host,
         port=parsed.port,

--- a/python/mlc_llm/interface/help.py
+++ b/python/mlc_llm/interface/help.py
@@ -167,8 +167,8 @@ to get the Chrome Trace. For example,
     "mode_serve": """
 The engine mode in MLC LLM. We provide three preset modes: "local", "interactive" and "server".
 The default mode is "local".
-The choice of mode decides the values of "--max-batch-size", "--max-total-seq-length" and
-"--prefill-chunk-size" when they are not explicitly specified.
+The choice of mode decides the values of "max_num_sequence", "max_total_seq_length" and
+"prefill_chunk_size" when they are not explicitly specified.
 1. Mode "local" refers to the local server deployment which has low request concurrency.
    So the max batch size will be set to 4, and max total sequence length and prefill chunk size
    are set to the context window size (or sliding window size) of the model.
@@ -178,15 +178,16 @@ The choice of mode decides the values of "--max-batch-size", "--max-total-seq-le
 3. Mode "server" refers to the large server use case which may handle many concurrent request
    and want to use GPU memory as much as possible. In this mode, we will automatically infer
    the largest possible max batch size and max total sequence length.
-You can manually specify arguments "--max-batch-size", "--max-total-seq-length" and
-"--prefill-chunk-size" to override the automatic inferred values.
+You can manually specify arguments "max_num_sequence", "max_total_seq_length" and
+"prefill_chunk_size" via "--overrides" to override the automatic inferred values.
+For example: --overrides "max_num_sequence=32;max_total_seq_length=4096"
 """.strip(),
     "additional_models_serve": """
 The model paths and (optional) model library paths of additional models (other than the main model).
 When engine is enabled with speculative decoding, additional models are needed.
 The way of specifying additional models is:
 "--additional-models model_path_1 model_path_2 ..." or
-"--additional-models model_path_1:model_lib_1 model_path_2 ...".
+"--additional-models model_path_1,model_lib_1 model_path_2 ...".
 When the model lib of a model is not given, JIT model compilation will be activated
 to compile the model automatically.
 """.strip(),
@@ -198,10 +199,11 @@ Under mode "local" or "interactive", the actual memory usage may be significantl
 this number. Under mode "server", the actual memory usage may be slightly larger than this number.
 """.strip(),
     "speculative_mode_serve": """
-The speculative decoding mode. Right now three options are supported:
+The speculative decoding mode. Right now four options are supported:
  - "disable", where speculative decoding is not enabled,
  - "small_draft", denoting the normal speculative decoding (small draft) style,
  - "eagle", denoting the eagle-style speculative decoding.
+ - "medusa", denoting the medusa-style speculative decoding.
 The default mode is "disable".
 """.strip(),
     "spec_draft_length_serve": """
@@ -217,12 +219,14 @@ The default mode is "radix".
 The maximum number of sequences in prefix cache, default as max_batch_size.
 And set 0 to disable prefix cache, set -1 to have infinite capacity prefix cache.
 """.strip(),
-    "engine_config_serve": """
-The MLCEngine execution configuration.
-Currently speculative decoding mode is specified via engine config.
-For example, you can use "--engine-config='spec_draft_length=4;speculative_mode=eagle'" to
-specify the eagle-style speculative decoding.
-Check out class `EngineConfig` in mlc_llm/serve/config.py for detailed specification.
+    "overrides_serve": """
+Overriding extra configurable fields of EngineConfig.
+Supporting fields that can be be overridden: "max_num_sequence", "max_total_seq_length",
+"prefill_chunk_size", "max_history_size", "gpu_memory_utilization", "spec_draft_length",
+"prefix_cache_max_num_recycling_seqs".
+Please check out the documentation of EngineConfig in mlc_llm/serve/config.py for detailed docstring
+of each field.
+Example: --overrides "max_num_sequence=32;max_total_seq_length=4096;gpu_memory_utilization=0.8"
 """.strip(),
     "config_package": """
 The path to "mlc-package-config.json" which is used for package build.

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -1,6 +1,6 @@
 """Python entrypoint of serve."""
 
-from typing import Any, List, Literal, Optional
+from typing import Any, List, Literal, Optional, Tuple, Union
 
 import fastapi
 import uvicorn
@@ -17,14 +17,14 @@ def serve(
     device: str,
     model_lib: Optional[str],
     mode: Literal["local", "interactive", "server"],
-    additional_models: List[str],
-    max_batch_size: Optional[int],
+    additional_models: List[Union[str, Tuple[str, str]]],
+    max_num_sequence: Optional[int],
     max_total_sequence_length: Optional[int],
     prefill_chunk_size: Optional[int],
     max_history_size: Optional[int],
     gpu_memory_utilization: Optional[float],
     speculative_mode: Literal["disable", "small_draft", "eagle", "medusa"],
-    spec_draft_length: int,
+    spec_draft_length: Optional[int],
     prefix_cache_mode: Literal["disable", "radix"],
     prefix_cache_max_num_recycling_seqs: Optional[int],
     enable_tracing: bool,
@@ -42,16 +42,18 @@ def serve(
         device=device,
         model_lib=model_lib,
         mode=mode,
-        additional_models=additional_models,
-        max_batch_size=max_batch_size,
-        max_total_sequence_length=max_total_sequence_length,
-        prefill_chunk_size=prefill_chunk_size,
-        max_history_size=max_history_size,
-        gpu_memory_utilization=gpu_memory_utilization,
-        speculative_mode=speculative_mode,
-        spec_draft_length=spec_draft_length,
-        prefix_cache_mode=prefix_cache_mode,
-        prefix_cache_max_num_recycling_seqs=prefix_cache_max_num_recycling_seqs,
+        engine_config=engine.EngineConfig(
+            additional_models=additional_models,
+            max_num_sequence=max_num_sequence,
+            max_total_sequence_length=max_total_sequence_length,
+            prefill_chunk_size=prefill_chunk_size,
+            max_history_size=max_history_size,
+            gpu_memory_utilization=gpu_memory_utilization,
+            speculative_mode=speculative_mode,
+            spec_draft_length=spec_draft_length,
+            prefix_cache_mode=prefix_cache_mode,
+            prefix_cache_max_num_recycling_seqs=prefix_cache_max_num_recycling_seqs,
+        ),
         enable_tracing=enable_tracing,
     )
 

--- a/python/mlc_llm/serve/config.py
+++ b/python/mlc_llm/serve/config.py
@@ -2,7 +2,7 @@
 
 import json
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 
 @dataclass
@@ -154,17 +154,16 @@ class EngineConfig:  # pylint: disable=too-many-instance-attributes
     model_lib : str
         The path to the model library.
 
-    additional_models : List[str]
-        The path to the additional models' directories.
-
-    additional_model_libs : List[str]
-        The path to the additional models' libraries.
+    additional_models : List[Union[str, Tuple[str, str]]]
+        The paths to the additional models' directories (and model libraries).
+        Each element is a single string (denoting the model directory)
+        or a tuple of two strings (denoting the model directory and model lib path).
 
     mode : Literal["local", "interactive", "server"]
         The engine mode in MLC LLM.
         We provide three preset modes: "local", "interactive" and "server".
         The default mode is "local".
-        The choice of mode decides the values of "max_batch_size", "max_total_sequence_length"
+        The choice of mode decides the values of "max_num_sequence", "max_total_sequence_length"
         and "prefill_chunk_size" when they are not explicitly specified.
         1. Mode "local" refers to the local server deployment which has low
         request concurrency. So the max batch size will be set to 4, and max
@@ -179,7 +178,7 @@ class EngineConfig:  # pylint: disable=too-many-instance-attributes
         In this mode, we will automatically infer the largest possible max batch
         size and max total sequence length.
 
-        You can manually specify arguments "max_batch_size", "max_total_sequence_length" and
+        You can manually specify arguments "max_num_sequence", "max_total_sequence_length" and
         "prefill_chunk_size" to override the automatic inferred values.
 
     gpu_memory_utilization : float
@@ -236,11 +235,10 @@ class EngineConfig:  # pylint: disable=too-many-instance-attributes
         A boolean indicating whether to print logging info in engine.
     """
 
-    model: str
-    model_lib: str
-    additional_models: List[str] = field(default_factory=list)
-    additional_model_libs: List[str] = field(default_factory=list)
-    mode: Literal["local", "interactive", "server"] = "local"
+    model: Optional[str] = None
+    model_lib: Optional[str] = None
+    additional_models: List[Union[str, Tuple[str, str]]] = field(default_factory=list)
+    mode: Optional[Literal["local", "interactive", "server"]] = None
     gpu_memory_utilization: Optional[float] = None
     kv_cache_page_size: int = 16
     max_num_sequence: Optional[int] = None

--- a/python/mlc_llm/serve/sync_engine.py
+++ b/python/mlc_llm/serve/sync_engine.py
@@ -16,6 +16,7 @@ import tvm
 from mlc_llm.serve import data
 from mlc_llm.serve.config import EngineConfig, GenerationConfig
 from mlc_llm.serve.engine_base import (
+    _check_engine_config,
     _parse_models,
     _print_engine_mode_logging_msg,
     _process_model_args,
@@ -58,6 +59,13 @@ class SyncMLCEngine:
 
     Parameters
     ----------
+    engine_config : Optional[EngineConfig]
+        Additional configurable arguments of MLC engine.
+        See class "EngineConfig" for more detail.
+
+    enable_tracing : bool
+        A boolean indicating if to enable event logging for requests.
+
     request_stream_callback : Optional[Callable[[str, data.TokenData, Optional[str]], None]]
         The provided callback function to handle the generation
         output. It has the signature of `(str, data.TokenData, bool) -> None`,
@@ -72,12 +80,6 @@ class SyncMLCEngine:
         be set before the engine executing requests. This can be done via
         the `set_request_stream_callback` method. Otherwise, the engine will raise
         exception.
-
-    enable_tracing : bool
-        A boolean indicating if to enable event logging for requests.
-
-    verbose : bool
-        A boolean indicating whether to print logging info in engine.
     """
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-locals
@@ -87,22 +89,17 @@ class SyncMLCEngine:
         *,
         model_lib: Optional[str] = None,
         mode: Literal["local", "interactive", "server"] = "local",
-        additional_models: Optional[List[str]] = None,
-        max_batch_size: Optional[int] = None,
-        max_total_sequence_length: Optional[int] = None,
-        prefill_chunk_size: Optional[int] = None,
-        max_history_size: Optional[int] = None,
-        gpu_memory_utilization: Optional[float] = None,
+        engine_config: Optional[EngineConfig] = None,
         enable_tracing: bool = False,
-        speculative_mode: Literal["disable", "small_draft", "eagle"] = "disable",
-        spec_draft_length: int = 4,
-        prefix_cache_mode: Literal["disable", "radix"] = "radix",
-        prefix_cache_max_num_recycling_seqs: Optional[int] = None,
-        verbose: bool = True,
         request_stream_callback: Optional[Callable[[List[data.RequestStreamOutput]], None]] = None,
     ):
+        # - Check the fields fields of `engine_config`.
+        if engine_config is None:
+            engine_config = EngineConfig()
+        _check_engine_config(model, model_lib, mode, engine_config)
+
         # - Initialize model loading info.
-        models = _parse_models(model, model_lib, additional_models)
+        models = _parse_models(model, model_lib, engine_config.additional_models)
         if isinstance(device, str):
             device = detect_device(device)
         assert isinstance(device, tvm.runtime.Device)
@@ -120,7 +117,7 @@ class SyncMLCEngine:
                 self.model_config_dicts.append(json.load(file))
 
         # - Print logging info for regarding the mode selection.
-        if verbose:
+        if engine_config.verbose:
             _print_engine_mode_logging_msg(mode)
 
         self._ffi = _create_tvm_module(
@@ -139,25 +136,12 @@ class SyncMLCEngine:
         )
         self.trace_recorder = EventTraceRecorder() if enable_tracing else None
 
+        engine_config.model = model_args[0][0]
+        engine_config.model_lib = model_args[0][1]
+        engine_config.additional_models = model_args[1:]  # type: ignore
+        engine_config.mode = mode
         self._ffi["init"](
-            EngineConfig(
-                model=model_args[0][0],
-                model_lib=model_args[0][1],
-                additional_models=[model_arg[0] for model_arg in model_args[1:]],
-                additional_model_libs=[model_arg[1] for model_arg in model_args[1:]],
-                mode=mode,
-                gpu_memory_utilization=gpu_memory_utilization,
-                kv_cache_page_size=16,
-                max_num_sequence=max_batch_size,
-                max_total_sequence_length=max_total_sequence_length,
-                prefill_chunk_size=prefill_chunk_size,
-                max_history_size=max_history_size,
-                speculative_mode=speculative_mode,
-                spec_draft_length=spec_draft_length,
-                prefix_cache_mode=prefix_cache_mode,
-                prefix_cache_max_num_recycling_seqs=prefix_cache_max_num_recycling_seqs,
-                verbose=verbose,
-            ).asjson(),
+            engine_config.asjson(),
             device,
             request_stream_callback,
             self.trace_recorder,

--- a/tests/python/serve/evaluate_engine.py
+++ b/tests/python/serve/evaluate_engine.py
@@ -5,7 +5,7 @@ import random
 from typing import List, Tuple
 
 from mlc_llm.serve import GenerationConfig
-from mlc_llm.serve.sync_engine import SyncMLCEngine
+from mlc_llm.serve.sync_engine import EngineConfig, SyncMLCEngine
 
 
 def _parse_args():
@@ -46,8 +46,10 @@ def benchmark(args: argparse.Namespace):
         device=args.device,
         model_lib=args.model_lib,
         mode="server",
-        max_batch_size=args.batch_size,
-        max_total_sequence_length=args.max_total_seq_length,
+        engine_config=EngineConfig(
+            max_num_sequence=args.batch_size,
+            max_total_sequence_length=args.max_total_seq_length,
+        ),
     )
 
     print(args)

--- a/tests/python/serve/server/conftest.py
+++ b/tests/python/serve/server/conftest.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import pytest
 
-from mlc_llm.serve import PopenServer
+from mlc_llm.serve import EngineConfig, PopenServer
 
 
 @pytest.fixture(scope="session")

--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import List
 
-from mlc_llm.serve import AsyncMLCEngine, GenerationConfig
+from mlc_llm.serve import AsyncMLCEngine, EngineConfig, GenerationConfig
 
 prompts = [
     "What is the meaning of life?",
@@ -25,7 +25,7 @@ async def test_engine_generate():
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
 
     num_requests = 10
@@ -80,7 +80,7 @@ async def test_chat_completion():
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
 
     num_requests = 2
@@ -130,7 +130,7 @@ async def test_chat_completion_non_stream():
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
 
     num_requests = 2
@@ -179,7 +179,7 @@ async def test_completion():
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
 
     num_requests = 2
@@ -229,7 +229,7 @@ async def test_completion_non_stream():
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
 
     num_requests = 2

--- a/tests/python/serve/test_serve_async_engine_spec.py
+++ b/tests/python/serve/test_serve_async_engine_spec.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import List
 
-from mlc_llm.serve import AsyncMLCEngine, GenerationConfig
+from mlc_llm.serve import AsyncMLCEngine, EngineConfig, GenerationConfig
 
 prompts = [
     "What is the meaning of life?",
@@ -26,8 +26,10 @@ async def test_engine_generate():
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
-        additional_models=[small_model],
-        speculative_mode="small_draft",
+        engine_config=EngineConfig(
+            additional_models=[small_model],
+            speculative_mode="small_draft",
+        ),
     )
 
     num_requests = 10

--- a/tests/python/serve/test_serve_engine.py
+++ b/tests/python/serve/test_serve_engine.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import pytest
 
-from mlc_llm.serve import GenerationConfig, MLCEngine
+from mlc_llm.serve import EngineConfig, GenerationConfig, MLCEngine
 
 prompts = [
     "What is the meaning of life?",
@@ -37,15 +37,19 @@ def create_engine(model: str, model_lib: Optional[str]):
             model=model,
             model_lib=model_lib,
             mode="server",
-            max_batch_size=8,
-            max_history_size=1,
+            engine_config=EngineConfig(
+                max_num_sequence=8,
+                max_history_size=1,
+            ),
         )
     else:
         return MLCEngine(
             model=model,
             model_lib=model_lib,
             mode="server",
-            max_total_sequence_length=4096,
+            engine_config=EngineConfig(
+                max_total_sequence_length=4096,
+            ),
         )
 
 

--- a/tests/python/serve/test_serve_engine_image.py
+++ b/tests/python/serve/test_serve_engine_image.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from mlc_llm.serve import GenerationConfig, data
-from mlc_llm.serve.sync_engine import SyncMLCEngine
+from mlc_llm.serve.sync_engine import EngineConfig, SyncMLCEngine
 
 
 def get_test_image(config) -> data.ImageData:
@@ -17,7 +17,7 @@ def test_engine_generate():
         model=model,
         model_lib=model_lib,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
     max_tokens = 256
 

--- a/tests/python/serve/test_serve_engine_prefix_cache.py
+++ b/tests/python/serve/test_serve_engine_prefix_cache.py
@@ -1,5 +1,5 @@
 from mlc_llm.serve import DebugConfig, GenerationConfig
-from mlc_llm.serve.sync_engine import SyncMLCEngine
+from mlc_llm.serve.sync_engine import EngineConfig, SyncMLCEngine
 
 prompts = [
     "The meaning of life is",
@@ -75,8 +75,10 @@ def test_basic_engine_system_prompt():
     engine = SyncMLCEngine(
         model=model,
         mode="local",
-        max_total_sequence_length=4096,
-        prefix_cache_max_num_recycling_seqs=5,
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            prefix_cache_max_num_recycling_seqs=5,
+        ),
     )
     test_engine_system_prompt(engine)
 
@@ -87,7 +89,7 @@ def test_basic_engine_multi_round():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
     test_engine_multi_round(engine)
 
@@ -100,9 +102,11 @@ def test_engine_spec_multi_round():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model],
-        speculative_mode="small_draft",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[small_model],
+            speculative_mode="small_draft",
+        ),
     )
 
     test_engine_multi_round(engine)
@@ -116,10 +120,12 @@ def test_engine_eagle_multi_round():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
-        speculative_mode="eagle",
-        max_batch_size=80,
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[(small_model, small_model_lib)],
+            speculative_mode="eagle",
+            max_num_sequence=80,
+        ),
     )
 
     test_engine_multi_round(engine)

--- a/tests/python/serve/test_serve_engine_spec.py
+++ b/tests/python/serve/test_serve_engine_spec.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional
 import numpy as np
 
 from mlc_llm.serve import GenerationConfig, Request, RequestStreamOutput, data
-from mlc_llm.serve.sync_engine import SyncMLCEngine
+from mlc_llm.serve.sync_engine import EngineConfig, SyncMLCEngine
 
 prompts = [
     "What is the meaning of life?",
@@ -83,9 +83,11 @@ def test_engine_basic():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model],
-        speculative_mode="small_draft",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[small_model],
+            speculative_mode="small_draft",
+        ),
         request_stream_callback=fcallback,
     )
 
@@ -147,10 +149,12 @@ def test_engine_eagle_basic():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
-        speculative_mode="eagle",
-        spec_draft_length=2,
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[(small_model, small_model_lib)],
+            speculative_mode="eagle",
+            spec_draft_length=2,
+        ),
         request_stream_callback=fcallback,
     )
 
@@ -226,9 +230,11 @@ def test_engine_continuous_batching_1():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model],
-        speculative_mode="small_draft",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[small_model],
+            speculative_mode="small_draft",
+        ),
         request_stream_callback=timer.callback_getter(),
     )
 
@@ -310,9 +316,11 @@ def test_engine_eagle_continuous_batching_1():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
-        speculative_mode="eagle",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[(small_model, small_model_lib)],
+            speculative_mode="eagle",
+        ),
         request_stream_callback=timer.callback_getter(),
     )
 
@@ -362,9 +370,11 @@ def test_engine_generate(compare_precision=False):
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model],
-        speculative_mode="small_draft",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[small_model],
+            speculative_mode="small_draft",
+        ),
     )
 
     num_requests = 10
@@ -379,7 +389,9 @@ def test_engine_generate(compare_precision=False):
         engine_single_model = SyncMLCEngine(
             model=model,
             mode="server",
-            max_total_sequence_length=4096,
+            engine_config=EngineConfig(
+                max_total_sequence_length=4096,
+            ),
         )
         output_texts_single_model, _ = engine_single_model.generate(
             prompts[:num_requests], generation_config
@@ -420,9 +432,11 @@ def test_engine_eagle_generate():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
-        speculative_mode="eagle",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[(small_model, small_model_lib)],
+            speculative_mode="eagle",
+        ),
     )
 
     num_requests = 10
@@ -528,10 +542,12 @@ def test_engine_spec_efficiency():
     spec_engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model],
-        spec_draft_length=6,
-        speculative_mode="small_draft",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[small_model],
+            spec_draft_length=6,
+            speculative_mode="small_draft",
+        ),
         request_stream_callback=fcallback,
     )
 
@@ -594,10 +610,12 @@ def test_engine_eagle_spec_efficiency():
     spec_engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
-        additional_models=[small_model + ":" + small_model_lib],
-        spec_draft_length=6,
-        speculative_mode="eagle",
+        engine_config=EngineConfig(
+            max_total_sequence_length=4096,
+            additional_models=[(small_model, small_model_lib)],
+            spec_draft_length=6,
+            speculative_mode="eagle",
+        ),
         request_stream_callback=fcallback,
     )
 

--- a/tests/python/serve/test_serve_sync_engine.py
+++ b/tests/python/serve/test_serve_sync_engine.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional
 import numpy as np
 
 from mlc_llm.serve import GenerationConfig, Request, RequestStreamOutput, data
-from mlc_llm.serve.sync_engine import SyncMLCEngine
+from mlc_llm.serve.sync_engine import EngineConfig, SyncMLCEngine
 
 prompts = [
     "What is the meaning of life?",
@@ -359,7 +359,7 @@ def test_engine_generate():
     engine = SyncMLCEngine(
         model=model,
         mode="server",
-        max_total_sequence_length=4096,
+        engine_config=EngineConfig(max_total_sequence_length=4096),
     )
 
     num_requests = 10


### PR DESCRIPTION
This PR lifts the EngineConfig as one engine constructor, so that we can hide most less important arguments in EngineConfig, and thus focus the user attention to the few key arguments.

`mlc_llm serve` CLI and PopenServer are updated accordingly. Documentation is updated accordingly.