### PR TITLE
[Fix] Fix metric names in tests and static PrefixCacheModes

### DIFF
--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -364,7 +364,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
    */
   void MatchPrefixCache(EngineState estate, PrefillInput* input) final {
     RequestStateEntry rsentry = input->rsentry;
-    if (estate->prefix_cache->mode == PrefixCacheMode::kDisable) {
+    if (estate->prefix_cache->Mode() == PrefixCacheMode::kDisable) {
       return;
     }
     if (rsentry->parent_idx == -1 && rsentry->status == RequestStateStatus::kPending &&

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -250,7 +250,7 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
    */
   void MatchPrefixCache(EngineState estate, PrefillInput* input) final {
     RequestStateEntry rsentry = input->rsentry;
-    if (estate->prefix_cache->mode == PrefixCacheMode::kDisable) {
+    if (estate->prefix_cache->Mode() == PrefixCacheMode::kDisable) {
       return;
     }
     if (rsentry->parent_idx == -1 && rsentry->status == RequestStateStatus::kPending &&

--- a/cpp/serve/metrics.h
+++ b/cpp/serve/metrics.h
@@ -8,6 +8,7 @@
 
 #include <picojson.h>
 
+#include <chrono>
 #include <string>
 
 namespace mlc {

--- a/cpp/serve/prefix_cache.cc
+++ b/cpp/serve/prefix_cache.cc
@@ -237,10 +237,7 @@ class PrefixCacheImpl : public PrefixCacheObj {
     lru_counter_ = 0;
   }
 
-  /*!
-   * \brief The prefix cache mode.
-   */
-  static const PrefixCacheMode mode = PrefixCacheMode::kRadix;
+  PrefixCacheMode Mode() final { return PrefixCacheMode::kRadix; }
 
  private:
   void ReuseRecyclingSequence(int64_t seq_id) {
@@ -389,10 +386,7 @@ class NoPrefixCache : public PrefixCacheObj {
    */
   void Reset() final {}
 
-  /*!
-   * \brief The prefix cache mode.
-   */
-  static const PrefixCacheMode mode = PrefixCacheMode::kDisable;
+  PrefixCacheMode Mode() final { return PrefixCacheMode::kDisable; }
 };
 
 TVM_REGISTER_OBJECT_TYPE(NoPrefixCache);

--- a/cpp/serve/prefix_cache.h
+++ b/cpp/serve/prefix_cache.h
@@ -116,10 +116,8 @@ class PrefixCacheObj : public Object {
    */
   virtual void Reset() = 0;
 
-  /*!
-   * \brief The prefix cache mode.
-   */
-  static const PrefixCacheMode mode = PrefixCacheMode::kDisable;
+  /*! \brief Return the prefix cache mode. */
+  virtual PrefixCacheMode Mode() = 0;
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "mlc.serve.PrefixCache";

--- a/tests/python/serve/test_serve_engine_prefix_cache.py
+++ b/tests/python/serve/test_serve_engine_prefix_cache.py
@@ -28,7 +28,7 @@ def test_engine_system_prompt(engine):
         ),
     )
     metrics = engine.metrics()
-    assert metrics["sum_num_prefill_tokens"] == system_prompt_tokens
+    assert metrics["num_prefill_tokens_sum"] == system_prompt_tokens
     sum_prefill_tokens = system_prompt_tokens
 
     input_token_lens = [len(engine.tokenizer.encode(prompt)) for prompt in prompts]
@@ -36,19 +36,19 @@ def test_engine_system_prompt(engine):
     generation_config = GenerationConfig(temperature=0, max_tokens=max_tokens)
     _, _ = engine.generate(prompts, generation_config)
     metrics = engine.metrics()
-    assert metrics["sum_num_prefill_tokens"] == sum_prefill_tokens + sum(input_token_lens)
-    sum_prefill_tokens = metrics["sum_num_prefill_tokens"]
+    assert metrics["num_prefill_tokens_sum"] == sum_prefill_tokens + sum(input_token_lens)
+    sum_prefill_tokens = metrics["num_prefill_tokens_sum"]
 
     _, _ = engine.generate(system_prompt + " and why ?", generation_config)
     metrics = engine.metrics()
     # system prompt is reused entirely
-    assert metrics["sum_num_prefill_tokens"] == sum_prefill_tokens + 3
-    sum_prefill_tokens = metrics["sum_num_prefill_tokens"]
+    assert metrics["num_prefill_tokens_sum"] == sum_prefill_tokens + 3
+    sum_prefill_tokens = metrics["num_prefill_tokens_sum"]
 
     _, _ = engine.generate(prompts[:4], generation_config)
     metrics = engine.metrics()
     # first 4 prompts are removed and need to prefill again
-    assert metrics["sum_num_prefill_tokens"] == sum_prefill_tokens + sum(input_token_lens[:4])
+    assert metrics["num_prefill_tokens_sum"] == sum_prefill_tokens + sum(input_token_lens[:4])
 
 
 def test_engine_multi_round(engine):
@@ -59,14 +59,14 @@ def test_engine_multi_round(engine):
 
     output_texts, _ = engine.generate(prompts[:num_requests], generation_config)
     metrics = engine.metrics()
-    assert metrics["sum_num_prefill_tokens"] == sum(input_token_lens)
-    sum_prefill_tokens = metrics["sum_num_prefill_tokens"]
+    assert metrics["num_prefill_tokens_sum"] == sum(input_token_lens)
+    sum_prefill_tokens = metrics["num_prefill_tokens_sum"]
     concat_prompt = []
     for i, output in enumerate(output_texts):
         concat_prompt.append(prompts[i] + " " + output[0] + " ?")
     output_texts, _ = engine.generate(concat_prompt[:num_requests], generation_config)
     metrics = engine.metrics()
-    assert metrics["sum_num_prefill_tokens"] == sum_prefill_tokens + 2 * num_requests
+    assert metrics["num_prefill_tokens_sum"] == sum_prefill_tokens + 2 * num_requests
 
 
 def test_basic_engine_system_prompt():

--- a/tests/python/serve/test_serve_engine_spec.py
+++ b/tests/python/serve/test_serve_engine_spec.py
@@ -507,7 +507,7 @@ def test_engine_efficiency():
         print("engine name:", name)
         if name == "Speculative Decoding":
             print("spec decode metrics:", metrics["spec_decode"])
-        print("engine total decode time:", metrics["sum_engine_decode_time"])
+        print("engine total decode time:", metrics["engine_decode_time_sum"])
         print()
 
 
@@ -579,7 +579,7 @@ def test_engine_spec_efficiency():
                 "Accept rate:",
                 metrics["sum_num_accepted_tokens"] / (1e-10 + metrics["sum_num_draft_tokens"]),
             )
-        print("engine total decode time:", metrics["sum_engine_decode_time"])
+        print("engine total decode time:", metrics["engine_decode_time_sum"])
         print()
 
 
@@ -642,7 +642,7 @@ def test_engine_eagle_spec_efficiency():
         print("engine name:", name)
         if name == "Speculative Decoding":
             print("spec decode:", metrics["spec_decode"])
-        print("engine total decode time:", metrics["sum_engine_decode_time"])
+        print("engine total decode time:", metrics["engine_decode_time_sum"])
         print()
 
 


### PR DESCRIPTION
* This PR fixes the metric names referenced in tests which were not updated together with previous PRs.

* This PR fixes the static PrefixCacheMode member introduced in #2397. The way of fix using the static class members is not correct, which essentially disables PrefixCache forever. This is because when checking the `mode` member of a PrefixCache instance, it is always the base class mode (which is `kDisabled`) being returned.

* This PR also adds a missing header for chrono.