### PR TITLE
[REFACTOR] Reorganize GenerationConfig DebugConfig and FFI

### DIFF
--- a/cpp/json_ffi/json_ffi_engine.h
+++ b/cpp/json_ffi/json_ffi_engine.h
@@ -51,7 +51,7 @@ class JSONFFIEngine {
   PackedFunc request_stream_callback_;
   TextStreamer streamer_;  // TODO: Support "n", and support different streamers for each request
   Conversation conv_template_;
-  String default_generation_cfg_json_str_;
+  GenerationConfig default_generation_config_;
   ModelConfig model_config_;
   DLDevice device_;
 };

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -33,9 +33,8 @@ struct ResponseFormat {
 /*! \brief The debug configuration of a request. */
 class DebugConfig {
  public:
+  bool ignore_eos = false;
   bool pinned_system_prompt = false;
-
-  DebugConfig(bool pinned_system_prompt) : pinned_system_prompt(pinned_system_prompt) {}
 };
 
 /*! \brief The generation configuration of a request. */
@@ -51,14 +50,13 @@ class GenerationConfigNode : public Object {
   int top_logprobs = 0;
   std::vector<std::pair<int, float>> logit_bias;
   int seed;
-  bool ignore_eos = false;
 
   int max_tokens = 128;
   Array<String> stop_strs;
   std::vector<int> stop_token_ids;
 
   ResponseFormat response_format;
-  std::optional<DebugConfig> debug_config = std::nullopt;
+  DebugConfig debug_config;
 
   String AsJSONString() const;
 
@@ -70,21 +68,10 @@ class GenerationConfigNode : public Object {
 
 class GenerationConfig : public ObjectRef {
  public:
-  TVM_DLL explicit GenerationConfig(
-      std::optional<int> n, std::optional<double> temperature, std::optional<double> top_p,
-      std::optional<double> frequency_penalty, std::optional<double> presense_penalty,
-      std::optional<double> repetition_penalty, std::optional<bool> logprobs,
-      std::optional<int> top_logprobs, std::optional<std::vector<std::pair<int, float>>> logit_bias,
-      std::optional<int> seed, std::optional<bool> ignore_eos, std::optional<int> max_tokens,
-      std::optional<Array<String>> stop_strs, std::optional<std::vector<int>> stop_token_ids,
-      std::optional<ResponseFormat> response_format, std::optional<DebugConfig> debug_config,
-      Optional<String> default_config_json_str);
-
-  TVM_DLL explicit GenerationConfig(String config_json_str,
-                                    Optional<String> default_config_json_str);
+  explicit GenerationConfig(String config_json_str, const GenerationConfig& default_config);
 
   /*! \brief Get the default generation config from the model config. */
-  TVM_DLL static GenerationConfig GetDefaultFromModelConfig(const picojson::object& json);
+  static GenerationConfig GetDefaultFromModelConfig(const picojson::object& json);
 
   TVM_DEFINE_OBJECT_REF_METHODS(GenerationConfig, ObjectRef, GenerationConfigNode);
 };

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -27,8 +27,7 @@ void RemoveRequestFromModel(EngineState estate, int64_t req_internal_id, Array<M
 void RemoveRequestStateEntry(EngineState estate, Array<Model> models, RequestStateEntry rsentry) {
   if (estate->prefix_cache->HasSequence(rsentry->mstates[0]->internal_id)) {
     // If the sequence is stored in prefix cache, call prefix cache to remove.
-    if (!(rsentry->request->generation_cfg->debug_config.has_value() &&
-          rsentry->request->generation_cfg->debug_config.value().pinned_system_prompt)) {
+    if (!(rsentry->request->generation_cfg->debug_config.pinned_system_prompt)) {
       // If the request is not pinned, recycle the request.
       estate->prefix_cache->RecycleSequence(rsentry->mstates[0]->internal_id, /*lazy=*/true);
     }

--- a/cpp/serve/request.cc
+++ b/cpp/serve/request.cc
@@ -66,14 +66,6 @@ Request Request::FromUntokenized(const Request& request, const Tokenizer& tokeni
   }
 }
 
-TVM_REGISTER_GLOBAL("mlc.serve.Request")
-    .set_body_typed([](String id, Array<Data> inputs, String generation_cfg_json_str,
-                       Optional<String> default_generation_cfg_json_str) {
-      return Request(std::move(id), std::move(inputs),
-                     GenerationConfig(std::move(generation_cfg_json_str),
-                                      std::move(default_generation_cfg_json_str)));
-    });
-
 TVM_REGISTER_GLOBAL("mlc.serve.RequestGetInputs").set_body_typed([](Request request) {
   return request->inputs;
 });

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -106,9 +106,10 @@ RequestStateEntry::RequestStateEntry(
   }
   n->status = RequestStateStatus::kPending;
   n->rng = RandomGenerator(rng_seed);
-  n->stop_str_handler = StopStrHandler(
-      !request->generation_cfg->ignore_eos ? request->generation_cfg->stop_strs : Array<String>(),
-      token_table);
+  n->stop_str_handler = StopStrHandler(!request->generation_cfg->debug_config.ignore_eos
+                                           ? request->generation_cfg->stop_strs
+                                           : Array<String>(),
+                                       token_table);
   n->request = std::move(request);
   n->parent_idx = parent_idx;
   n->mstates = std::move(mstates);
@@ -148,7 +149,7 @@ DeltaRequestReturn RequestStateEntryNode::GetReturnTokenIds(const Tokenizer& tok
   // Case 3. Any of the stop tokens appears in the committed tokens ===> Finished
   // `stop_token_ids` includes the stop tokens from conversation template and user-provided tokens.
   // This check will be ignored when `ignore_eos` is set for the benchmarking purpose.
-  if (!request->generation_cfg->ignore_eos) {
+  if (!request->generation_cfg->debug_config.ignore_eos) {
     for (int i = 0; i < static_cast<int>(return_token_ids.size()); ++i) {
       if (std::any_of(
               request->generation_cfg->stop_token_ids.begin(),

--- a/cpp/serve/threaded_engine.h
+++ b/cpp/serve/threaded_engine.h
@@ -76,11 +76,11 @@ class ThreadedEngine {
 
   /************** Query/Profile/Debug **************/
 
-  /*! \brief Return the default generation config JSON string. */
-  virtual String GetDefaultGenerationConfigJSONString() const = 0;
+  /*! \brief Return the default generation config. */
+  virtual GenerationConfig GetDefaultGenerationConfig() const = 0;
 
-  /*! \brief Return the complete engine config JSON string. */
-  virtual String GetCompleteEngineConfigJSONString() const = 0;
+  /*! \brief Return the complete engine config. */
+  virtual EngineConfig GetCompleteEngineConfig() const = 0;
 
   /*! \brief Print the metrics of the engine. */
   virtual String JSONMetrics() = 0;

--- a/docs/deploy/rest.rst
+++ b/docs/deploy/rest.rst
@@ -232,8 +232,6 @@ The REST API provides the following endpoints:
 
 - **user** (*Optional[str]*): An optional identifier for the user initiating the request.
 
-- **ignore_eos** (*bool*, optional, default=False): If `True`, the model will ignore the end-of-sequence token for generating responses.
-
 - **response_format** (*RequestResponseFormat*, optional): Specifies the format of the response. Can be either "text" or "json_object", with optional schema definition for JSON responses.
 
 **Returns**

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -91,6 +91,11 @@ def main(argv):
         help=HELP["mode_serve"] + ' (default: "%(default)s")',
     )
     parser.add_argument(
+        "--enable-debug",
+        action="store_true",
+        help="whether we enable debug end points and debug config when accepting requests",
+    )
+    parser.add_argument(
         "--additional-models", type=str, nargs="*", help=HELP["additional_models_serve"]
     )
     parser.add_argument(
@@ -161,6 +166,7 @@ def main(argv):
         device=parsed.device,
         model_lib=parsed.model_lib,
         mode=parsed.mode,
+        enable_debug=parsed.enable_debug,
         additional_models=additional_models,
         speculative_mode=parsed.speculative_mode,
         prefix_cache_mode=parsed.prefix_cache_mode,

--- a/python/mlc_llm/json_ffi/engine.py
+++ b/python/mlc_llm/json_ffi/engine.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Union
 
 import tvm
 
-from mlc_llm.protocol import openai_api_protocol
+from mlc_llm.protocol import debug_protocol, openai_api_protocol
 from mlc_llm.serve import engine_utils
 from mlc_llm.serve.engine_base import (
     EngineConfig,
@@ -131,9 +131,9 @@ class Completions:
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Iterator[openai_api_protocol.ChatCompletionStreamResponse]:
         if request_id is None:
             request_id = f"chatcmpl-{engine_utils.random_uuid()}"
@@ -165,10 +165,14 @@ class Completions:
                 ),
                 tool_choice=tool_choice,
                 user=user,
-                ignore_eos=ignore_eos,
                 response_format=(
                     openai_api_protocol.RequestResponseFormat.model_validate(response_format)
                     if response_format is not None
+                    else None
+                ),
+                debug_config=(
+                    debug_protocol.DebugConfig.model_validate(debug_config)
+                    if debug_config is not None
                     else None
                 ),
             ).model_dump_json(),

--- a/python/mlc_llm/protocol/debug_protocol.py
+++ b/python/mlc_llm/protocol/debug_protocol.py
@@ -4,6 +4,12 @@ from pydantic import BaseModel
 
 
 class DebugConfig(BaseModel):
-    """The class of debug options."""
+    """The class of debug options.
 
+    These optionals are available to engine
+    but won't be available to serving endpoint
+    unless an explicit --enable-debug-config passed
+    """
+
+    ignore_eos: bool = False
     pinned_system_prompt: bool = False

--- a/python/mlc_llm/protocol/openai_api_protocol.py
+++ b/python/mlc_llm/protocol/openai_api_protocol.py
@@ -94,7 +94,7 @@ class CompletionRequest(BaseModel):
     logprobs: bool = False
     top_logprobs: int = 0
     logit_bias: Optional[Dict[int, float]] = None
-    max_tokens: int = 16
+    max_tokens: Optional[int] = None
     n: int = 1
     seed: Optional[int] = None
     stop: Optional[Union[str, List[str]]] = None
@@ -103,7 +103,6 @@ class CompletionRequest(BaseModel):
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     user: Optional[str] = None
-    ignore_eos: bool = False
     response_format: Optional[RequestResponseFormat] = None
     debug_config: Optional[DebugConfig] = None
 
@@ -218,7 +217,6 @@ class ChatCompletionRequest(BaseModel):
     tools: Optional[List[ChatTool]] = None
     tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None
     user: Optional[str] = None
-    ignore_eos: bool = False
     response_format: Optional[RequestResponseFormat] = None
     debug_config: Optional[DebugConfig] = None
 
@@ -406,7 +404,6 @@ def openai_api_get_generation_config(
         "top_logprobs",
         "logit_bias",
         "seed",
-        "ignore_eos",
         "debug_config",
     ]
     for arg_name in arg_names:

--- a/python/mlc_llm/serve/config.py
+++ b/python/mlc_llm/serve/config.py
@@ -101,10 +101,6 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
     stop_token_ids : List[int]
         The list of token ids that mark the end of generation.
 
-    ignore_eos: bool
-        When it is true, ignore the eos token and generate tokens until `max_tokens`.
-        Default is set to False.
-
     response_format : ResponseFormat
         The response format of the generation output.
 
@@ -126,7 +122,6 @@ class GenerationConfig:  # pylint: disable=too-many-instance-attributes
     seed: Optional[int] = None
     stop_strs: List[str] = field(default_factory=list)
     stop_token_ids: List[int] = field(default_factory=list)
-    ignore_eos: bool = False
 
     response_format: ResponseFormat = field(default_factory=ResponseFormat)
 

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -20,10 +20,9 @@ from typing import (
 
 from tvm.runtime import Device
 
-from mlc_llm.protocol import openai_api_protocol
+from mlc_llm.protocol import debug_protocol, openai_api_protocol
 from mlc_llm.serve import data, engine_utils
 from mlc_llm.serve.config import EngineConfig, GenerationConfig
-from mlc_llm.serve.request import Request
 from mlc_llm.streamer import TextStreamer
 from mlc_llm.support import logging
 
@@ -77,9 +76,9 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> AsyncGenerator[openai_api_protocol.ChatCompletionStreamResponse, Any]:
         """Asynchronous streaming chat completion interface with OpenAI API compatibility.
         The method is a coroutine that streams ChatCompletionStreamResponse
@@ -92,6 +91,10 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Yields
         ------
@@ -127,9 +130,9 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> openai_api_protocol.ChatCompletionResponse:
         """Asynchronous non-streaming chat completion interface with OpenAI API compatibility.
         The method is a coroutine that streams ChatCompletionStreamResponse
@@ -142,6 +145,10 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Returns
         ------
@@ -176,9 +183,9 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Union[
         AsyncGenerator[openai_api_protocol.ChatCompletionStreamResponse, Any],
         openai_api_protocol.ChatCompletionResponse,
@@ -192,6 +199,10 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -216,9 +227,9 @@ class AsyncChatCompletion:  # pylint: disable=too-few-public-methods
             tools=tools,
             tool_choice=tool_choice,
             user=user,
-            ignore_eos=ignore_eos,
             response_format=response_format,
             request_id=request_id,
+            debug_config=debug_config,
         )
 
 
@@ -254,9 +265,9 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Iterator[openai_api_protocol.ChatCompletionStreamResponse]:
         """Synchronous streaming chat completion interface with OpenAI API compatibility.
         The method streams back ChatCompletionStreamResponse that conforms to
@@ -269,6 +280,10 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Yields
         ------
@@ -304,9 +319,9 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> openai_api_protocol.ChatCompletionResponse:
         """Synchronous non-streaming chat completion interface with OpenAI API compatibility.
 
@@ -317,6 +332,10 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Returns
         ------
@@ -351,9 +370,9 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Union[
         Iterator[openai_api_protocol.ChatCompletionStreamResponse],
         openai_api_protocol.ChatCompletionResponse,
@@ -367,6 +386,10 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -391,9 +414,9 @@ class ChatCompletion:  # pylint: disable=too-few-public-methods
             tools=tools,
             tool_choice=tool_choice,
             user=user,
-            ignore_eos=ignore_eos,
             response_format=response_format,
             request_id=request_id,
+            debug_config=debug_config,
         )
 
 
@@ -422,7 +445,7 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -430,9 +453,9 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> AsyncGenerator[openai_api_protocol.CompletionResponse, Any]:
         """Asynchronous streaming completion interface with OpenAI API compatibility.
         The method is a coroutine that streams CompletionResponse
@@ -472,7 +495,7 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -481,9 +504,9 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> openai_api_protocol.CompletionResponse:
         """Asynchronous non-streaming completion interface with OpenAI API compatibility.
 
@@ -494,6 +517,10 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Returns
         ------
@@ -520,7 +547,7 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -529,9 +556,9 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Union[
         AsyncGenerator[openai_api_protocol.CompletionResponse, Any],
         openai_api_protocol.CompletionResponse,
@@ -545,6 +572,10 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -570,9 +601,9 @@ class AsyncCompletion:  # pylint: disable=too-few-public-methods
             temperature=temperature,
             top_p=top_p,
             user=user,
-            ignore_eos=ignore_eos,
             response_format=response_format,
             request_id=request_id,
+            debug_config=debug_config,
         )
 
 
@@ -601,7 +632,7 @@ class Completion:  # pylint: disable=too-few-public-methods
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -609,9 +640,9 @@ class Completion:  # pylint: disable=too-few-public-methods
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> openai_api_protocol.CompletionResponse:
         """Synchronous streaming completion interface with OpenAI API compatibility.
         The method streams back CompletionResponse that conforms to
@@ -624,6 +655,10 @@ class Completion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Yields
         ------
@@ -651,7 +686,7 @@ class Completion:  # pylint: disable=too-few-public-methods
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -660,9 +695,9 @@ class Completion:  # pylint: disable=too-few-public-methods
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Iterator[openai_api_protocol.CompletionResponse]:
         """Synchronous non-streaming completion interface with OpenAI API compatibility.
 
@@ -673,6 +708,10 @@ class Completion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Returns
         ------
@@ -699,7 +738,7 @@ class Completion:  # pylint: disable=too-few-public-methods
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -708,9 +747,9 @@ class Completion:  # pylint: disable=too-few-public-methods
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Iterator[openai_api_protocol.CompletionResponse]:
         """Synchronous completion interface with OpenAI API compatibility.
 
@@ -721,6 +760,10 @@ class Completion:  # pylint: disable=too-few-public-methods
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -746,9 +789,9 @@ class Completion:  # pylint: disable=too-few-public-methods
             temperature=temperature,
             top_p=top_p,
             user=user,
-            ignore_eos=ignore_eos,
             response_format=response_format,
             request_id=request_id,
+            debug_config=debug_config,
         )
 
 
@@ -854,9 +897,9 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Union[
         AsyncGenerator[openai_api_protocol.ChatCompletionStreamResponse, Any],
         openai_api_protocol.ChatCompletionResponse,
@@ -870,6 +913,10 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -905,10 +952,14 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
                 ),
                 tool_choice=tool_choice,
                 user=user,
-                ignore_eos=ignore_eos,
                 response_format=(
                     openai_api_protocol.RequestResponseFormat.model_validate(response_format)
                     if response_format is not None
+                    else None
+                ),
+                debug_config=(
+                    debug_protocol.DebugConfig.model_validate(debug_config)
+                    if debug_config is not None
                     else None
                 ),
             ),
@@ -974,7 +1025,7 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -983,9 +1034,9 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Union[
         AsyncGenerator[openai_api_protocol.CompletionResponse, Any],
         openai_api_protocol.CompletionResponse,
@@ -999,6 +1050,10 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -1027,14 +1082,18 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
                 temperature=temperature,
                 top_p=top_p,
                 user=user,
-                ignore_eos=ignore_eos,
                 response_format=(
                     openai_api_protocol.RequestResponseFormat.model_validate(response_format)
                     if response_format is not None
                     else None
                 ),
+                debug_config=(
+                    debug_protocol.DebugConfig.model_validate(debug_config)
+                    if debug_config is not None
+                    else None
+                ),
             ),
-            request_id,
+            request_id=request_id,
         )
         if stream:
             # Stream response.
@@ -1234,9 +1293,7 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         # Create the request with the given id, input data, generation
         # config and the created callback.
         input_data = engine_utils.convert_prompts_to_data(prompt)
-        request = Request(
-            request_id, input_data, generation_config, self.default_generation_cfg_json_str
-        )
+        request = self._ffi["create_request"](request_id, input_data, generation_config.asjson())
 
         # Create the unique async request stream of the request.
         stream = engine_base.AsyncRequestStream()
@@ -1378,9 +1435,9 @@ class MLCEngine(engine_base.MLCEngineBase):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[Literal["none", "auto"], Dict]] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Union[
         Iterator[openai_api_protocol.ChatCompletionStreamResponse],
         openai_api_protocol.ChatCompletionResponse,
@@ -1394,6 +1451,10 @@ class MLCEngine(engine_base.MLCEngineBase):
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -1429,10 +1490,14 @@ class MLCEngine(engine_base.MLCEngineBase):
                 ),
                 tool_choice=tool_choice,
                 user=user,
-                ignore_eos=ignore_eos,
                 response_format=(
                     openai_api_protocol.RequestResponseFormat.model_validate(response_format)
                     if response_format is not None
+                    else None
+                ),
+                debug_config=(
+                    debug_protocol.DebugConfig.model_validate(debug_config)
+                    if debug_config is not None
                     else None
                 ),
             ),
@@ -1491,7 +1556,7 @@ class MLCEngine(engine_base.MLCEngineBase):
         logprobs: bool = False,
         top_logprobs: int = 0,
         logit_bias: Optional[Dict[int, float]] = None,
-        max_tokens: int = 16,
+        max_tokens: Optional[int] = None,
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
@@ -1500,9 +1565,9 @@ class MLCEngine(engine_base.MLCEngineBase):
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         user: Optional[str] = None,
-        ignore_eos: bool = False,
         response_format: Optional[Dict[str, Any]] = None,
         request_id: Optional[str] = None,
+        debug_config: Optional[Dict[str, Any]] = None,
     ) -> Iterator[openai_api_protocol.CompletionResponse]:
         """Synchronous completion internal interface with OpenAI API compatibility.
 
@@ -1513,6 +1578,10 @@ class MLCEngine(engine_base.MLCEngineBase):
         request_id : Optional[str]
             The optional request id.
             A random one will be generated if it is not given.
+
+        debug_config: Optional[Dict[str, Any]]
+            The optional debug config
+            Extra debug options to pass to the request.
 
         Raises
         ------
@@ -1541,14 +1610,18 @@ class MLCEngine(engine_base.MLCEngineBase):
                 temperature=temperature,
                 top_p=top_p,
                 user=user,
-                ignore_eos=ignore_eos,
                 response_format=(
                     openai_api_protocol.RequestResponseFormat.model_validate(response_format)
                     if response_format is not None
                     else None
                 ),
+                debug_config=(
+                    debug_protocol.DebugConfig.model_validate(debug_config)
+                    if debug_config is not None
+                    else None
+                ),
             ),
-            request_id,
+            request_id=request_id,
         )
         if stream:
             # Stream response.
@@ -1729,9 +1802,7 @@ class MLCEngine(engine_base.MLCEngineBase):
         # Create the request with the given id, input data, generation
         # config and the created callback.
         input_data = engine_utils.convert_prompts_to_data(prompt)
-        request = Request(
-            request_id, input_data, generation_config, self.default_generation_cfg_json_str
-        )
+        request = self._ffi["create_request"](request_id, input_data, generation_config.asjson())
 
         # Record the stream in the tracker
         self.state.sync_output_queue = queue.Queue()

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -548,7 +548,7 @@ class MLCEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
                 "reload",
                 "init_threaded_engine",
                 "exit_background_loop",
-                "get_default_generation_config",
+                "create_request",
                 "get_complete_engine_config",
                 "json_metrics",
                 "reset",
@@ -579,7 +579,6 @@ class MLCEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
         engine_config.additional_models = model_args[1:]  # type: ignore
         engine_config.mode = mode
         self._ffi["reload"](engine_config.asjson())
-        self.default_generation_cfg_json_str: str = self._ffi["get_default_generation_config"]()
         self.engine_config = EngineConfig.from_json(self._ffi["get_complete_engine_config"]())
         self.max_input_sequence_length = min(
             self.engine_config.max_single_sequence_length,

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -41,6 +41,10 @@ async def request_completion(request: CompletionRequest, raw_request: fastapi.Re
     """
     # - Check the requested model.
     server_context: ServerContext = ServerContext.current()
+    # remove debug config if debug is not enabled
+    if not server_context.enable_debug:
+        request.debug_config = None
+
     async_engine = server_context.get_engine(request.model)
     if async_engine is None:
         return error_protocol.create_error_response(
@@ -128,6 +132,10 @@ async def request_chat_completion(
     """
     # - Check the requested model.
     server_context: ServerContext = ServerContext.current()
+    # remove debug config if debug is not enabled
+    if not server_context.enable_debug:
+        request.debug_config = None
+
     async_engine = server_context.get_engine(request.model)
     if async_engine is None:
         return error_protocol.create_error_response(

--- a/python/mlc_llm/serve/request.py
+++ b/python/mlc_llm/serve/request.py
@@ -1,6 +1,5 @@
 """The request class in MLC LLM serving"""
-
-from typing import List, Optional, Union
+from typing import List
 
 import tvm._ffi
 from tvm.runtime import Object
@@ -16,41 +15,11 @@ class Request(Object):
     a unique request id, a list of multi-modal inputs, a set of
     generation configuration parameters.
 
-    Parameters
-    ----------
-    request_id : str
-        The unique identifier of the request.
-        Different requests should have different ids.
-
-    inputs : List[Data]
-        The user inputs of a request. Input may have multi-modality.
-
-    generation_config : GenerationConfig
-        The sampling configuration which may contain temperature,
-        top_p, repetition_penalty, max_gen_len, etc.
-
-    default_generation_config_json_str : Optional[str]
-        The JSON string of the default generation config.
-        When a field in the input generation_config is not defined,
-        we use the value in the default generation config.
+    Note
+    ----
+    Do not explicitly construct this class.
+    Construct this object via engine.create_request functions.
     """
-
-    def __init__(  # pylint: disable=too-many-arguments
-        self,
-        request_id: str,
-        inputs: Union[Data, List[Data]],
-        generation_config: GenerationConfig,
-        default_generation_config_json_str: Optional[str] = None,
-    ):
-        if not isinstance(inputs, list):
-            inputs = [inputs]
-        self.__init_handle_by_constructor__(
-            _ffi_api.Request,  # type: ignore  # pylint: disable=no-member
-            request_id,
-            inputs,
-            generation_config.asjson(),
-            default_generation_config_json_str,
-        )
 
     @property
     def inputs(self) -> List[Data]:

--- a/python/mlc_llm/serve/server/server_context.py
+++ b/python/mlc_llm/serve/server/server_context.py
@@ -11,6 +11,7 @@ class ServerContext:
     """
 
     server_context: Optional["ServerContext"] = None
+    enable_debug: bool = False
 
     def __init__(self):
         self._models: Dict[str, AsyncMLCEngine] = {}

--- a/tests/python/json_ffi/test_json_ffi_engine.py
+++ b/tests/python/json_ffi/test_json_ffi_engine.py
@@ -146,10 +146,7 @@ def run_json_schema_function_calling(
 @require_test_model("Llama-2-7b-chat-hf-q4f16_1-MLC")
 def test_chat_completion(model):
     # Create engine.
-    engine = JSONFFIEngine(
-        model,
-        max_total_sequence_length=1024,
-    )
+    engine = JSONFFIEngine(model)
 
     run_chat_completion(engine, model)
 
@@ -164,10 +161,7 @@ def test_chat_completion(model):
 @require_test_model("Llama-2-7b-chat-hf-q4f16_1-MLC")
 def test_reload_reset_unload(model):
     # Create engine.
-    engine = JSONFFIEngine(
-        model,
-        max_total_sequence_length=1024,
-    )
+    engine = JSONFFIEngine(model)
 
     # Run chat completion before and after reload/reset.
     run_chat_completion(engine, model)
@@ -182,10 +176,7 @@ def test_reload_reset_unload(model):
 
 @require_test_model("Hermes-2-Pro-Mistral-7B-q4f16_1-MLC")
 def test_json_schema_with_system_prompt(model):
-    engine = JSONFFIEngine(
-        model,
-        max_total_sequence_length=1024,
-    )
+    engine = JSONFFIEngine(model)
 
     # run function calling
     run_json_schema_function_calling(engine, model, function_calling_prompts, tools)

--- a/tests/python/serve/test_serve_sync_engine.py
+++ b/tests/python/serve/test_serve_sync_engine.py
@@ -22,6 +22,7 @@ prompts = [
 
 
 def create_requests(
+    engine: SyncMLCEngine,
     num_requests: int,
     stop_token_id: Optional[int] = None,
     temperature: float = 0.8,
@@ -36,7 +37,7 @@ def create_requests(
     for req_id, prompt in zip(range(num_requests), prompts):
         max_tokens = np.random.randint(max_tokens_low, max_tokens_high)
         requests.append(
-            Request(
+            engine.create_request(
                 request_id=str(req_id),
                 inputs=data.TextData(prompt),
                 generation_config=GenerationConfig(
@@ -87,6 +88,7 @@ def test_engine_basic():
 
     # Create requests
     requests = create_requests(
+        engine,
         num_requests,
         temperature=temperature,
         repetition_penalty=repetition_penalty,
@@ -161,6 +163,7 @@ def test_engine_continuous_batching_1():
 
     # Create requests
     requests = create_requests(
+        engine,
         num_requests,
         temperature=temperature,
         repetition_penalty=repetition_penalty,
@@ -240,6 +243,7 @@ def test_engine_continuous_batching_2():
 
     # Create requests
     requests = create_requests(
+        engine,
         num_requests,
         stop_token_id=stop_token_id,
         temperature=temperature,
@@ -324,6 +328,7 @@ def test_engine_continuous_batching_3():
 
     # Create requests
     requests = create_requests(
+        engine,
         num_requests,
         stop_token_id=stop_token_id,
         temperature=temperature,


### PR DESCRIPTION
This PR reorganizes GenerationConfig, DebugConfig and FFI.

- Internally, we now directly use the config object instead of json stream.
- Request construction turns into engine side so it can make use of debug_config.
- Ignore eos now moves to debug_config option.
- Removes most string based re-export of gen conifg.