### PR TITLE
[Fix] Fix vector OOB when no inputs can be prefilled in spec decode

### DIFF
--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -175,6 +175,10 @@ BatchPrefillBaseActionObj::GetRequestStateEntriesToPrefill(EngineState estate) {
         std::min(num_prefill_inputs, static_cast<int>(prefill_inputs_for_all_models[i].size()));
   }
 
+  if (num_prefill_inputs == 0) {
+    return {};
+  }
+
   std::vector<PrefillInput> prefill_inputs(
       prefill_inputs_for_all_models[0].begin(),
       prefill_inputs_for_all_models[0].begin() + num_prefill_inputs);


### PR DESCRIPTION
This PR fixes an issue that causes vector index out of bound. This happens in speculative decoding, when an model can accept inputs while the other cannot.

We still need to look into this inconsistency. Ideally all models should behave the same.