### PR TITLE
[Fix] Update number of available pages after prefix cache free

### DIFF
--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -109,6 +109,8 @@ BatchPrefillBaseActionObj::GetRequestStateEntriesToPrefill(EngineState estate) {
                              current_total_seq_len, num_running_rsentries, kv_state_kind,
                              sliding_window_enabled)) {
             if (!estate->prefix_cache->TryFreeMemory()) break;
+            // Update number of available pages after memory free.
+            num_available_pages = models_[i]->GetNumAvailablePages();
           }
           if (CanPrefill(estate, num_prefill_rsentries + 1 + num_child_to_activate,
                          total_input_length, total_required_pages, num_available_pages,


### PR DESCRIPTION
This PR fixes an issue that causes the inconsistency of CanPrefill result from different models.