### PR TITLE
[Chat] Support chat completion config override

### DIFF
--- a/cpp/json_ffi/json_ffi_engine.cc
+++ b/cpp/json_ffi/json_ffi_engine.cc
@@ -91,8 +91,8 @@ bool JSONFFIEngine::AddRequest(std::string request_json_str, std::string request
   gen_cfg->logprobs = request.logprobs;
   gen_cfg->top_logprobs = request.top_logprobs;
   gen_cfg->logit_bias = request.logit_bias.value_or(default_gen_cfg->logit_bias);
-  gen_cfg->seed = request.seed.value_or(default_gen_cfg->seed);
-  gen_cfg->max_tokens = request.seed.value_or(default_gen_cfg->max_tokens);
+  gen_cfg->seed = request.seed.value_or(std::random_device{}());
+  gen_cfg->max_tokens = request.max_tokens.value_or(default_gen_cfg->max_tokens);
   gen_cfg->stop_strs = std::move(stop_strs);
   gen_cfg->stop_token_ids = conv_template_.stop_token_ids;
   gen_cfg->debug_config = request.debug_config.value_or(DebugConfig());

--- a/cpp/json_ffi/openai_api_protocol.cc
+++ b/cpp/json_ffi/openai_api_protocol.cc
@@ -295,6 +295,20 @@ Result<ChatCompletionRequest> ChatCompletionRequest::FromJSON(const std::string&
   }
   request.model = model_res.Unwrap();
 
+  // temperature
+  Result<std::optional<double>> temperature_res =
+      json::LookupOptionalWithResultReturn<double>(json_obj, "temperature");
+  if (temperature_res.IsErr()) {
+    return TResult::Error(temperature_res.UnwrapErr());
+  }
+  request.temperature = temperature_res.Unwrap();
+  // top_p
+  Result<std::optional<double>> top_p_res =
+      json::LookupOptionalWithResultReturn<double>(json_obj, "top_p");
+  if (top_p_res.IsErr()) {
+    return TResult::Error(top_p_res.UnwrapErr());
+  }
+  request.top_p = top_p_res.Unwrap();
   // max_tokens
   Result<std::optional<int64_t>> max_tokens_res =
       json::LookupOptionalWithResultReturn<int64_t>(json_obj, "max_tokens");
@@ -302,7 +316,6 @@ Result<ChatCompletionRequest> ChatCompletionRequest::FromJSON(const std::string&
     return TResult::Error(max_tokens_res.UnwrapErr());
   }
   request.max_tokens = max_tokens_res.Unwrap();
-
   // frequency_penalty
   Result<std::optional<double>> frequency_penalty_res =
       json::LookupOptionalWithResultReturn<double>(json_obj, "frequency_penalty");
@@ -310,7 +323,6 @@ Result<ChatCompletionRequest> ChatCompletionRequest::FromJSON(const std::string&
     return TResult::Error(frequency_penalty_res.UnwrapErr());
   }
   request.frequency_penalty = frequency_penalty_res.Unwrap();
-
   // presence_penalty
   Result<std::optional<double>> presence_penalty_res =
       json::LookupOptionalWithResultReturn<double>(json_obj, "presence_penalty");
@@ -318,6 +330,31 @@ Result<ChatCompletionRequest> ChatCompletionRequest::FromJSON(const std::string&
     return TResult::Error(presence_penalty_res.UnwrapErr());
   }
   request.presence_penalty = presence_penalty_res.Unwrap();
+  // seed
+  Result<std::optional<int64_t>> seed_res =
+      json::LookupOptionalWithResultReturn<int64_t>(json_obj, "seed");
+  if (seed_res.IsErr()) {
+    return TResult::Error(seed_res.UnwrapErr());
+  }
+  request.seed = seed_res.Unwrap();
+
+  // stop strings
+  Result<std::optional<picojson::array>> stop_strs_res =
+      json::LookupOptionalWithResultReturn<picojson::array>(json_obj, "stop");
+  if (stop_strs_res.IsErr()) {
+    return TResult::Error(stop_strs_res.UnwrapErr());
+  }
+  std::optional<picojson::array> stop_strs = stop_strs_res.Unwrap();
+  if (stop_strs.has_value()) {
+    std::vector<std::string> stop;
+    for (picojson::value stop_str_value : stop_strs.value()) {
+      if (!stop_str_value.is<std::string>()) {
+        return TResult::Error("One given value in field \"stop\" is not a string.");
+      }
+      stop.push_back(stop_str_value.get<std::string>());
+    }
+    request.stop = std::move(stop);
+  }
 
   // tool_choice
   Result<std::string> tool_choice_res =


### PR DESCRIPTION
This PR supports chat CLI with arguments override.

Right now, arguments supported are: `top_p`, `temperature`, `presence_penalty`, `frequency_penalty`, `max_tokens`, `seed`, `stop`.

This PR adds the corresponding support to the ChatCompletion request parsing for JSONFFIEngine.