### PR TITLE
[Test][Refactor] Update tests to use require_test_model

### DIFF
--- a/python/mlc_llm/support/constants.py
+++ b/python/mlc_llm/support/constants.py
@@ -53,7 +53,10 @@ def _get_test_model_path() -> List[Path]:
     # by default, we reuse the cache dir via mlc_llm chat
     # note that we do not auto download for testcase
     # to avoid networking dependencies
-    return [_get_cache_dir() / "model_weights" / "mlc-ai"]
+    return [
+        _get_cache_dir() / "model_weights" / "mlc-ai",
+        Path(os.path.abspath(os.path.curdir)),
+    ]
 
 
 MLC_TEMP_DIR = os.getenv("MLC_TEMP_DIR", None)

--- a/python/mlc_llm/testing/pytest_utils.py
+++ b/python/mlc_llm/testing/pytest_utils.py
@@ -1,6 +1,8 @@
 """Extra utilities to mark tests"""
 
 import functools
+import inspect
+from pathlib import Path
 from typing import Callable
 
 import pytest
@@ -8,7 +10,7 @@ import pytest
 from mlc_llm.support.constants import MLC_TEST_MODEL_PATH
 
 
-def require_test_model(model: str):
+def require_test_model(*models: str):
     """Testcase decorator to require a model
 
     Examples
@@ -24,31 +26,54 @@ def require_test_model(model: str):
 
     Parameters
     ----------
-    model : str
-        The model dir name
+    models : List[str]
+        The model directories or URLs.
     """
-    model_path = None
-    for base_path in MLC_TEST_MODEL_PATH:
-        if (base_path / model / "mlc-chat-config.json").is_file():
-            model_path = base_path / model
-    missing_model = model_path is None
+    model_paths = []
+    missing_models = []
+
+    for model in models:
+        model_path = None
+        for base_path in MLC_TEST_MODEL_PATH:
+            if (base_path / model / "mlc-chat-config.json").is_file():
+                model_path = base_path / model
+        if model_path is None and (Path(model) / "mlc-chat-config.json").is_file():
+            model_path = Path(model)
+
+        if model_path is None:
+            missing_models.append(model)
+        else:
+            model_paths.append(str(model_path))
+
     message = (
-        f"Model {model} does not exist in candidate paths {[str(p) for p in MLC_TEST_MODEL_PATH]},"
+        f"Model {', '.join(missing_models)} not found in candidate paths "
+        f"{[str(p) for p in MLC_TEST_MODEL_PATH]},"
         " if you set MLC_TEST_MODEL_PATH, please ensure model paths are in the right location,"
         " by default we reuse cache, try to run mlc_llm chat to download right set of models."
     )
 
-    def _decorator(func: Callable[[str], None]):
-        wrapped = functools.partial(func, str(model_path))
+    def _decorator(func: Callable[..., None]):
+        wrapped = functools.partial(func, *model_paths)
         wrapped.__name__ = func.__name__  # type: ignore
 
-        @functools.wraps(wrapped)
-        def wrapper(*args, **kwargs):
-            if missing_model:
-                print(f"{message} skipping...")
-                return
-            wrapped(*args, **kwargs)
+        if inspect.iscoroutinefunction(wrapped):
+            # The function is a coroutine function ("async def func(...)")
+            @functools.wraps(wrapped)
+            async def wrapper(*args, **kwargs):
+                if len(missing_models) > 0:
+                    print(f"{message} skipping...")
+                    return
+                await wrapped(*args, **kwargs)
 
-        return pytest.mark.skipif(missing_model, reason=message)(wrapper)
+        else:
+            # The function is a normal function ("def func(...)")
+            @functools.wraps(wrapped)
+            def wrapper(*args, **kwargs):
+                if len(missing_models) > 0:
+                    print(f"{message} skipping...")
+                    return
+                wrapped(*args, **kwargs)
+
+        return pytest.mark.skipif(len(missing_models) > 0, reason=message)(wrapper)
 
     return _decorator

--- a/tests/python/serve/test_serve_async_engine.py
+++ b/tests/python/serve/test_serve_async_engine.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import List
 
 from mlc_llm.serve import AsyncMLCEngine, EngineConfig, GenerationConfig
+from mlc_llm.testing import require_test_model
 
 prompts = [
     "What is the meaning of life?",
@@ -19,9 +20,9 @@ prompts = [
 ]
 
 
-async def test_engine_generate():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+async def test_engine_generate(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
@@ -74,9 +75,9 @@ async def test_engine_generate():
     del async_engine
 
 
-async def test_chat_completion():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+async def test_chat_completion(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
@@ -101,6 +102,7 @@ async def test_chat_completion():
         ):
             for choice in response.choices:
                 assert choice.delta.role == "assistant"
+                assert isinstance(choice.delta.content, str)
                 output_texts[rid][choice.index] += choice.delta.content
 
     tasks = [
@@ -124,9 +126,9 @@ async def test_chat_completion():
     del async_engine
 
 
-async def test_chat_completion_non_stream():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+async def test_chat_completion_non_stream(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
@@ -150,6 +152,7 @@ async def test_chat_completion_non_stream():
         )
         for choice in response.choices:
             assert choice.message.role == "assistant"
+            assert isinstance(choice.message.content, str)
             output_texts[rid][choice.index] += choice.message.content
 
     tasks = [
@@ -173,9 +176,9 @@ async def test_chat_completion_non_stream():
     del async_engine
 
 
-async def test_completion():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+async def test_completion(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",
@@ -223,9 +226,9 @@ async def test_completion():
     del async_engine
 
 
-async def test_completion_non_stream():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+async def test_completion_non_stream(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     async_engine = AsyncMLCEngine(
         model=model,
         mode="server",

--- a/tests/python/serve/test_serve_engine_grammar.py
+++ b/tests/python/serve/test_serve_engine_grammar.py
@@ -10,19 +10,20 @@ from pydantic import BaseModel
 from mlc_llm.serve import AsyncMLCEngine, GenerationConfig
 from mlc_llm.serve.config import ResponseFormat
 from mlc_llm.serve.sync_engine import SyncMLCEngine
+from mlc_llm.testing import require_test_model
 
 prompts_list = [
     "Generate a JSON string containing 20 objects:",
     "Generate a JSON containing a non-empty list:",
     "Generate a JSON with 5 elements:",
 ]
-model_path = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
 
 
-def test_batch_generation_with_grammar():
+@require_test_model("Llama-2-7b-chat-hf-q4f16_1-MLC")
+def test_batch_generation_with_grammar(model: str):
     # Create engine
     engine = SyncMLCEngine(
-        model=model_path,
+        model=model,
         mode="server",
     )
 
@@ -69,9 +70,10 @@ def test_batch_generation_with_grammar():
                 print(f"Output {req_id}({i}):{output}\n")
 
 
-def test_batch_generation_with_schema():
+@require_test_model("Llama-2-7b-chat-hf-q4f16_1-MLC")
+def test_batch_generation_with_schema(model: str):
     # Create engine
-    engine = SyncMLCEngine(model=model_path, mode="server")
+    engine = SyncMLCEngine(model=model, mode="server")
 
     prompt = (
         "Generate a json containing three fields: an integer field named size, a "
@@ -121,9 +123,10 @@ def test_batch_generation_with_schema():
                 print(f"Output {req_id}({i}): {output}\n")
 
 
-async def run_async_engine():
+@require_test_model("Llama-2-7b-chat-hf-q4f16_1-MLC")
+async def run_async_engine(model: str):
     # Create engine
-    async_engine = AsyncMLCEngine(model=model_path, mode="server")
+    async_engine = AsyncMLCEngine(model=model, mode="server")
 
     prompts = prompts_list * 20
 

--- a/tests/python/serve/test_serve_engine_prefix_cache.py
+++ b/tests/python/serve/test_serve_engine_prefix_cache.py
@@ -1,5 +1,6 @@
 from mlc_llm.serve import DebugConfig, GenerationConfig
 from mlc_llm.serve.sync_engine import EngineConfig, SyncMLCEngine
+from mlc_llm.testing import require_test_model
 
 prompts = [
     "The meaning of life is",
@@ -69,9 +70,9 @@ def test_engine_multi_round(engine):
     assert metrics["num_prefill_tokens_sum"] == sum_prefill_tokens + 2 * num_requests
 
 
-def test_basic_engine_system_prompt():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_basic_engine_system_prompt(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
         mode="local",
@@ -83,9 +84,9 @@ def test_basic_engine_system_prompt():
     test_engine_system_prompt(engine)
 
 
-def test_basic_engine_multi_round():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_basic_engine_multi_round(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
         mode="server",
@@ -94,11 +95,12 @@ def test_basic_engine_multi_round():
     test_engine_multi_round(engine)
 
 
-def test_engine_spec_multi_round():
+@require_test_model(
+    "Llama-2-7b-chat-hf-q0f16-MLC",
+    "Llama-2-7b-chat-hf-q4f16_1-MLC",
+)
+def test_engine_spec_multi_round(model: str, small_model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
-    small_model = "HF://mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC"
-
     engine = SyncMLCEngine(
         model=model,
         mode="server",
@@ -112,9 +114,9 @@ def test_engine_spec_multi_round():
     test_engine_multi_round(engine)
 
 
-def test_engine_eagle_multi_round():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_engine_eagle_multi_round(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     small_model = "dist/Eagle-llama2-7b-chat-q0f16-MLC"
     small_model_lib = "dist/Eagle-llama2-7b-chat-q0f16-MLC/Eagle-llama2-7b-chat-q0f16-MLC-cuda.so"
     engine = SyncMLCEngine(

--- a/tests/python/serve/test_serve_sync_engine.py
+++ b/tests/python/serve/test_serve_sync_engine.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from mlc_llm.serve import GenerationConfig, Request, RequestStreamOutput, data
 from mlc_llm.serve.sync_engine import EngineConfig, SyncMLCEngine
+from mlc_llm.testing import require_test_model
 
 prompts = [
     "What is the meaning of life?",
@@ -51,7 +52,8 @@ def create_requests(
     return requests
 
 
-def test_engine_basic():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_engine_basic(model: str):
     """Test engine **without continuous batching**.
 
     - Add all requests to the engine altogether in the beginning.
@@ -69,7 +71,7 @@ def test_engine_basic():
     np.random.seed(0)
 
     # Output list
-    outputs = [[] for _ in range(num_requests)]
+    outputs: List[List[int]] = [[] for _ in range(num_requests)]
 
     # Define the callback function for request generation results
     def fcallback(delta_outputs: List[RequestStreamOutput]):
@@ -79,7 +81,6 @@ def test_engine_basic():
             outputs[int(request_id)] += stream_outputs[0].delta_token_ids
 
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
         mode="server",
@@ -110,7 +111,8 @@ def test_engine_basic():
         print(f"Output {req_id}:{engine.tokenizer.decode(output)}\n")
 
 
-def test_engine_continuous_batching_1():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_engine_continuous_batching_1(model: str):
     """Test engine **with continuous batching**.
 
     - Add all requests to the engine altogether in the beginning.
@@ -130,8 +132,8 @@ def test_engine_continuous_batching_1():
     np.random.seed(0)
 
     # Output list
-    outputs = [[] for _ in range(num_requests)]
-    finish_time = [None] * num_requests
+    outputs: List[List[int]] = [[] for _ in range(num_requests)]
+    finish_time: List[Optional[int]] = [None] * num_requests
 
     # Define the callback class for request generation results
     class CallbackTimer:
@@ -154,7 +156,6 @@ def test_engine_continuous_batching_1():
 
     # Create engine
     timer = CallbackTimer()
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
         mode="server",
@@ -190,7 +191,8 @@ def test_engine_continuous_batching_1():
         ), f"finish time = {fin_time}, max tokens = {request.generation_config.max_tokens - 1}"
 
 
-def test_engine_continuous_batching_2():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_engine_continuous_batching_2(model: str):
     """Test engine **with continuous batching**.
 
     - Add all requests to the engine altogether in the beginning.
@@ -210,8 +212,8 @@ def test_engine_continuous_batching_2():
     np.random.seed(0)
 
     # Output list
-    outputs = [[] for _ in range(num_requests)]
-    finish_time = [None] * num_requests
+    outputs: List[List[int]] = [[] for _ in range(num_requests)]
+    finish_time: List[Optional[int]] = [None] * num_requests
 
     # Define the callback class for request generation results
     class CallbackTimer:
@@ -234,7 +236,6 @@ def test_engine_continuous_batching_2():
 
     # Create engine
     timer = CallbackTimer()
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
         mode="server",
@@ -270,7 +271,8 @@ def test_engine_continuous_batching_2():
         print(f"Output {req_id}:{engine.tokenizer.decode(output)}\n")
 
 
-def test_engine_continuous_batching_3():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_engine_continuous_batching_3(model: str):
     """Test engine **with continuous batching**.
 
     - Add requests randomly between time [0, 200).
@@ -290,8 +292,8 @@ def test_engine_continuous_batching_3():
     np.random.seed(0)
 
     # Output list
-    outputs = [[] for _ in range(num_requests)]
-    finish_time = [None] * num_requests
+    outputs: List[List[int]] = [[] for _ in range(num_requests)]
+    finish_time: List[Optional[int]] = [None] * num_requests
 
     # Define the callback class for request generation results
     class CallbackTimer:
@@ -319,7 +321,6 @@ def test_engine_continuous_batching_3():
 
     # Create engine
     timer = CallbackTimer()
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
         mode="server",
@@ -358,9 +359,9 @@ def test_engine_continuous_batching_3():
         print(f"Output {req_id}:{engine.tokenizer.decode(output)}\n")
 
 
-def test_engine_generate():
+@require_test_model("Llama-2-7b-chat-hf-q0f16-MLC")
+def test_engine_generate(model: str):
     # Create engine
-    model = "HF://mlc-ai/Llama-2-7b-chat-hf-q0f16-MLC"
     engine = SyncMLCEngine(
         model=model,
         mode="server",


### PR DESCRIPTION
This PR updates tests to use the `require_test_model` testing util for better out-of-box testing while avoid automatic downloading.

Some tests that require manually model compilation are kept in the old test style (e.g., with model "llava", "eagle", etc.).

This PR also fixes some typing issues suggested by mypy.