### PR TITLE
[Tokenizer] Auto-detect TokenizerInfo from tokenizer.json

### DIFF
--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -109,7 +109,7 @@ TVM_REGISTER_GLOBAL("mlc.serve.ImageDataGetImage").set_body_typed([](ImageData d
 /*! \brief Convert a single token with probability to JSON string. */
 inline void TokenToLogProbJSON(const Tokenizer& tokenizer, const TokenProbPair& token_prob,
                                std::ostringstream* os) {
-  const std::string& token = tokenizer->TokenTable()[token_prob.first];
+  const std::string& token = tokenizer->PostProcessedTokenTable()[token_prob.first];
 
   (*os) << "\"token\": \"";
   for (char ch : token) {

--- a/cpp/serve/grammar/grammar_state_matcher.cc
+++ b/cpp/serve/grammar/grammar_state_matcher.cc
@@ -483,14 +483,12 @@ GrammarStateMatcher::GrammarStateMatcher(std::shared_ptr<GrammarStateInitContext
 #ifndef COMPILE_MLC_WASM_RUNTIME
 // This creates tokenizer dependency issue in WASM building for web, hence skipped
 TVM_REGISTER_GLOBAL("mlc.serve.GrammarStateMatcherFromTokenizer")
-    .set_body_typed([](BNFGrammar grammar, Optional<Tokenizer> tokenizer, int max_rollback_steps,
-                       String token_table_postproc_method) {
+    .set_body_typed([](BNFGrammar grammar, Optional<Tokenizer> tokenizer, int max_rollback_steps) {
       auto preproc_start = std::chrono::high_resolution_clock::now();
       std::shared_ptr<mlc::llm::serve::GrammarStateInitContext> init_ctx;
       if (tokenizer) {
-        auto token_table = Tokenizer::PostProcessTokenTable(tokenizer.value()->TokenTable(),
-                                                            token_table_postproc_method);
-        init_ctx = GrammarStateMatcher::CreateInitContext(grammar, token_table);
+        init_ctx = GrammarStateMatcher::CreateInitContext(
+            grammar, tokenizer.value()->PostProcessedTokenTable());
       } else {
         init_ctx = GrammarStateMatcher::CreateInitContext(grammar, {});
       }

--- a/cpp/serve/grammar/grammar_state_matcher.h
+++ b/cpp/serve/grammar/grammar_state_matcher.h
@@ -40,7 +40,8 @@ using namespace tvm::runtime;
  * \example
  * \code
  * Tokenizer tokenizer = ...;
- * auto init_ctx = GrammarStateMatcher::CreateInitContext(grammar, tokenizer->TokenTable());
+ * auto init_ctx = GrammarStateMatcher::CreateInitContext(grammar,
+ *                                                        tokenizer->PostProcessedTokenTable());
  * GrammarStateMatcher matcher(init_ctx, 10);
  * matcher->AcceptToken(67);
  *

--- a/cpp/serve/grammar/grammar_state_matcher_base.h
+++ b/cpp/serve/grammar/grammar_state_matcher_base.h
@@ -8,7 +8,6 @@
 
 #include <vector>
 
-#include "../../tokenizers.h"
 #include "grammar.h"
 #include "grammar_state_matcher_state.h"
 

--- a/cpp/streamer.cc
+++ b/cpp/streamer.cc
@@ -263,7 +263,7 @@ StopStrHandler::StopStrHandler(Array<String> stop_strs,
 
 TVM_REGISTER_GLOBAL("mlc.StopStrHandler")
     .set_body_typed([](Array<String> stop_strs, const Tokenizer& tokenizer) {
-      return StopStrHandler(std::move(stop_strs), tokenizer->TokenTable());
+      return StopStrHandler(std::move(stop_strs), tokenizer->PostProcessedTokenTable());
     });
 
 TVM_REGISTER_GLOBAL("mlc.StopStrHandlerPut")

--- a/cpp/tokenizers.cc
+++ b/cpp/tokenizers.cc
@@ -5,6 +5,7 @@
 
 #include "tokenizers.h"
 
+#include <picojson.h>
 #include <tokenizers_cpp.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/registry.h>
@@ -20,11 +21,47 @@
 namespace mlc {
 namespace llm {
 
+TVM_REGISTER_OBJECT_TYPE(TokenizerInfoNode);
+
+String TokenizerInfoNode::AsJSONString() const {
+  picojson::object obj;
+  obj["token_postproc_method"] = picojson::value(token_postproc_method);
+  obj["prepend_space_in_encode"] = picojson::value(prepend_space_in_encode);
+  obj["strip_space_in_decode"] = picojson::value(strip_space_in_decode);
+  return picojson::value(obj).serialize(false);
+}
+
+TokenizerInfo TokenizerInfo::FromJSON(String json_string) {
+  picojson::value v;
+  std::string err = picojson::parse(v, json_string.operator std::string());
+  ICHECK(err.empty()) << "Failed to parse JSON: " << err;
+
+  ICHECK(v.is<picojson::object>()) << "JSON must be an object.";
+  const picojson::object& obj = v.get<picojson::object>();
+
+  ObjectPtr<TokenizerInfoNode> n = make_object<TokenizerInfoNode>();
+  if (obj.count("token_postproc_method")) {
+    ICHECK(obj.at("token_postproc_method").is<std::string>());
+    n->token_postproc_method = obj.at("token_postproc_method").get<std::string>();
+  }
+  if (obj.count("prepend_space_in_encode")) {
+    ICHECK(obj.at("prepend_space_in_encode").is<bool>());
+    n->prepend_space_in_encode = obj.at("prepend_space_in_encode").get<bool>();
+  }
+  if (obj.count("strip_space_in_decode")) {
+    ICHECK(obj.at("strip_space_in_decode").is<bool>());
+    n->strip_space_in_decode = obj.at("strip_space_in_decode").get<bool>();
+  }
+
+  return TokenizerInfo(n);
+}
+
 TVM_REGISTER_OBJECT_TYPE(TokenizerObj);
 
-Tokenizer::Tokenizer(std::unique_ptr<tokenizers::Tokenizer> tokenizer) {
+Tokenizer::Tokenizer(std::unique_ptr<tokenizers::Tokenizer> tokenizer, TokenizerInfo info) {
   ObjectPtr<TokenizerObj> n = make_object<TokenizerObj>();
   n->tokenizer = std::move(tokenizer);
+  n->info_ = std::move(info);
   data_ = std::move(n);
 }
 
@@ -46,7 +83,8 @@ int32_t TokenizerObj::TokenToId(const std::string& token) const {
   return tokenizer->TokenToId(token);
 }
 
-Tokenizer Tokenizer::FromPath(const String& _path) {
+Tokenizer Tokenizer::FromPath(const String& _path, std::optional<TokenizerInfo> info) {
+  TokenizerInfo info_value = info.value_or(DetectTokenizerInfo(_path));
   std::filesystem::path path(_path.operator std::string());
   std::filesystem::path sentencepiece;
   std::filesystem::path huggingface;
@@ -66,7 +104,8 @@ Tokenizer Tokenizer::FromPath(const String& _path) {
         std::string vocab = LoadBytesFromFile(vocab_path.string());
         std::string merges = LoadBytesFromFile(merges_path.string());
         std::string added_tokens = LoadBytesFromFile(added_tokens_path.string());
-        return Tokenizer(tokenizers::Tokenizer::FromBlobByteLevelBPE(vocab, merges, added_tokens));
+        return Tokenizer(tokenizers::Tokenizer::FromBlobByteLevelBPE(vocab, merges, added_tokens),
+                         info_value);
       }
     }
   } else {
@@ -75,7 +114,8 @@ Tokenizer Tokenizer::FromPath(const String& _path) {
     rwkvworld = path.parent_path() / "tokenizer_model";
   }
   if (std::filesystem::exists(huggingface)) {
-    return Tokenizer(tokenizers::Tokenizer::FromBlobJSON(LoadBytesFromFile(huggingface.string())));
+    return Tokenizer(tokenizers::Tokenizer::FromBlobJSON(LoadBytesFromFile(huggingface.string())),
+                     info_value);
   }
   if (std::filesystem::exists(sentencepiece)) {
     LOG(WARNING)
@@ -85,12 +125,157 @@ Tokenizer Tokenizer::FromPath(const String& _path) {
         << "Consider converting `tokenizer.model` to `tokenizer.json` by compiling the model "
         << "with MLC again, or see if MLC's huggingface provides this file.";
     return Tokenizer(
-        tokenizers::Tokenizer::FromBlobSentencePiece(LoadBytesFromFile(sentencepiece.string())));
+        tokenizers::Tokenizer::FromBlobSentencePiece(LoadBytesFromFile(sentencepiece.string())),
+        info_value);
   }
   if (std::filesystem::exists(rwkvworld)) {
-    return Tokenizer(tokenizers::Tokenizer::FromBlobRWKVWorld(rwkvworld.string()));
+    return Tokenizer(tokenizers::Tokenizer::FromBlobRWKVWorld(rwkvworld.string()), info_value);
   }
   LOG(FATAL) << "Cannot find any tokenizer under: " << _path;
+}
+
+TokenizerInfo Tokenizer::DetectTokenizerInfo(const String& path_str) {
+  std::filesystem::path path(path_str.operator std::string());
+  CHECK(std::filesystem::exists(path)) << "Cannot find tokenizer via path: " << path_str;
+  if (!std::filesystem::is_directory(path)) {
+    path = path.parent_path();
+  }
+  path = path / "tokenizer.json";
+  if (!std::filesystem::exists(path)) {
+    LOG(WARNING) << "Tokenizer info is not detected as tokenizer.json is not found. The default "
+                 << "tokenizer info will be used.";
+    return TokenizerInfo();
+  }
+
+  std::string tokenizer_json = LoadBytesFromFile(path.string());
+  picojson::value v;
+  std::string err = picojson::parse(v, tokenizer_json);
+  ICHECK(err.empty()) << "Failed to parse JSON: " << err;
+  ICHECK(v.is<picojson::object>()) << "JSON must be an object.";
+  const picojson::object& obj = v.get<picojson::object>();
+
+  ObjectPtr<TokenizerInfoNode> n = make_object<TokenizerInfoNode>();
+
+  // Step 1. Detect token_postproc_method: byte_fallback or byte_level
+  // Detect {"type": "ByteLevel"} or {"type": "ByteFallback"} in "decoder" field of the tokenizer
+  if (!obj.count("decoder") || !obj.at("decoder").is<picojson::object>()) {
+    LOG(WARNING) << "Decoder field is not found in tokenizer.json. Use ByteFallback as default.";
+    n->token_postproc_method = "byte_fallback";
+  } else {
+    auto decoder_obj = obj.at("decoder").get<picojson::object>();
+    ICHECK(decoder_obj.count("type") && decoder_obj.at("type").is<std::string>());
+    auto type = decoder_obj.at("type").get<std::string>();
+
+    auto f_detect_decoder_type = [](ObjectPtr<TokenizerInfoNode> n,
+                                    const picojson::value& decoder_json) {
+      ICHECK(decoder_json.is<picojson::object>());
+      ICHECK(decoder_json.get<picojson::object>().count("type") &&
+             decoder_json.get<picojson::object>().at("type").is<std::string>());
+      auto type = decoder_json.get<picojson::object>().at("type").get<std::string>();
+      if (type == "ByteLevel") {
+        n->token_postproc_method = "byte_level";
+        return true;
+      } else if (type == "ByteFallback") {
+        n->token_postproc_method = "byte_fallback";
+        return true;
+      }
+      return false;
+    };
+
+    bool found = false;
+
+    // For sequence, examine every decoder
+    if (type == "Sequence") {
+      ICHECK(decoder_obj.count("decoders") && decoder_obj.at("decoders").is<picojson::array>());
+      for (const picojson::value& decoder : decoder_obj.at("decoders").get<picojson::array>()) {
+        if (f_detect_decoder_type(n, decoder)) {
+          found = true;
+        }
+      }
+    } else {
+      if (f_detect_decoder_type(n, obj.at("decoder"))) {
+        found = true;
+      }
+    }
+
+    if (!found) {
+      LOG(WARNING) << "Neither ByteLevel nor ByteFallback decoder is detected in tokenizer.json. "
+                   << "Use ByteFallback as default.";
+      n->token_postproc_method = "byte_fallback";
+    }
+  }
+
+  // Step 2. Detect prepend_space_in_encode
+  // Find {"type": "Prepend", "prepend": "▁"} in "normalizer" field of the tokenizer
+  if (obj.count("normalizer") && obj.at("normalizer").is<picojson::object>()) {
+    const picojson::value& normalizer_json = obj.at("normalizer");
+
+    auto f_handle_normalizer = [](ObjectPtr<TokenizerInfoNode> n,
+                                  const picojson::value& normalizer_json) {
+      ICHECK(normalizer_json.is<picojson::object>());
+      auto obj = normalizer_json.get<picojson::object>();
+      ICHECK(obj.count("type") && obj.at("type").is<std::string>());
+      if (obj.at("type").get<std::string>() == "Prepend" && obj.count("prepend") &&
+          obj.at("prepend").is<std::string>() && obj.at("prepend").get<std::string>() == "▁") {
+        n->prepend_space_in_encode = true;
+        return true;
+      }
+      return false;
+    };
+
+    auto type = normalizer_json.get<picojson::object>().at("type").get<std::string>();
+    if (type == "Sequence") {
+      ICHECK(normalizer_json.get<picojson::object>().count("normalizers") &&
+             normalizer_json.get<picojson::object>().at("normalizers").is<picojson::array>());
+      for (const picojson::value& normalizer :
+           normalizer_json.get<picojson::object>().at("normalizers").get<picojson::array>()) {
+        if (f_handle_normalizer(n, normalizer)) {
+          break;
+        }
+      }
+    } else {
+      f_handle_normalizer(n, normalizer_json);
+    }
+  }
+
+  // Step 3. Detect strip_space_in_decode
+  // Find {"type": "Strip", "content": " ", "start": 1, "stop": 0} in "decoder" field of the
+  // tokenizer
+  if (obj.count("decoder") && obj.at("decoder").is<picojson::object>()) {
+    const picojson::value& decoders_json = obj.at("decoder");
+
+    auto f_handle_decoder = [](ObjectPtr<TokenizerInfoNode> n,
+                               const picojson::value& decoder_json) {
+      ICHECK(decoder_json.is<picojson::object>());
+      auto obj = decoder_json.get<picojson::object>();
+      ICHECK(obj.count("type") && obj.at("type").is<std::string>());
+      if (obj.at("type").get<std::string>() == "Strip" && obj.count("content") &&
+          obj.at("content").is<std::string>() && obj.at("content").get<std::string>() == " " &&
+          obj.count("start") && obj.at("start").is<int64_t>() &&
+          obj.at("start").get<int64_t>() == 1 && obj.count("stop") &&
+          obj.at("stop").is<int64_t>() && obj.at("stop").get<int64_t>() == 0) {
+        n->strip_space_in_decode = true;
+        return true;
+      }
+      return false;
+    };
+
+    auto type = decoders_json.get<picojson::object>().at("type").get<std::string>();
+    if (type == "Sequence") {
+      ICHECK(decoders_json.get<picojson::object>().count("decoders") &&
+             decoders_json.get<picojson::object>().at("decoders").is<picojson::array>());
+      for (const picojson::value& decoder :
+           decoders_json.get<picojson::object>().at("decoders").get<picojson::array>()) {
+        if (f_handle_decoder(n, decoder)) {
+          break;
+        }
+      }
+    } else {
+      f_handle_decoder(n, decoders_json);
+    }
+  }
+
+  return TokenizerInfo(n);
 }
 
 /*! \brief ByteFallback decoder: transform tokens like <0x1B> to hex char byte 1B */
@@ -174,37 +359,41 @@ inline std::string ByteLevelDecoder(const std::string& token) {
 /*!
  * \brief Post-process a raw token to the actual token with the given post-processing method.
  */
-inline std::string PostProcessToken(const std::string& token, const std::string& postproc_method) {
-  if (postproc_method == "byte_fallback") {
+inline std::string PostProcessToken(const std::string& token,
+                                    const std::string& token_postproc_method) {
+  if (token_postproc_method == "byte_fallback") {
     return SpaceReplacerDecoder(ByteFallbackDecoder(token));
-  } else if (postproc_method == "byte_level") {
+  } else if (token_postproc_method == "byte_level") {
     return ByteLevelDecoder(token);
   } else {
-    LOG(FATAL) << "Unknown post-processing method: " << postproc_method;
+    LOG(FATAL) << "Unknown post-processing method: " << token_postproc_method;
   }
 }
 
-const std::vector<std::string>& TokenizerObj::TokenTable() {
-  if (!token_table_.empty()) {
-    return token_table_;
+const std::vector<std::string>& TokenizerObj::PostProcessedTokenTable() {
+  if (!post_processed_token_table_.empty()) {
+    return post_processed_token_table_;
   }
 
+  std::vector<std::string> raw_token_table;
   int vocab_size = tokenizer->GetVocabSize();
-  token_table_.reserve(vocab_size);
+  raw_token_table.reserve(vocab_size);
   for (int32_t token_id = 0; token_id < vocab_size; ++token_id) {
-    token_table_.push_back(tokenizer->IdToToken(token_id));
+    raw_token_table.push_back(tokenizer->IdToToken(token_id));
   }
-  return token_table_;
+  post_processed_token_table_ =
+      Tokenizer::PostProcessTokenTable(raw_token_table, info_->token_postproc_method);
+  return post_processed_token_table_;
 }
 
 std::vector<std::string> Tokenizer::PostProcessTokenTable(
-    const std::vector<std::string>& token_table, const std::string& postproc_method) {
-  std::vector<std::string> postprocessed_token_table;
-  postprocessed_token_table.reserve(token_table.size());
+    const std::vector<std::string>& token_table, const std::string& token_postproc_method) {
+  std::vector<std::string> post_processed_token_table;
+  post_processed_token_table.reserve(token_table.size());
   for (const std::string& token : token_table) {
-    postprocessed_token_table.push_back(PostProcessToken(token, postproc_method));
+    post_processed_token_table.push_back(PostProcessToken(token, token_postproc_method));
   }
-  return postprocessed_token_table;
+  return post_processed_token_table;
 }
 
 TVM_REGISTER_GLOBAL("mlc.Tokenizer").set_body_typed([](const String& path) {
@@ -221,6 +410,10 @@ TVM_REGISTER_GLOBAL("mlc.TokenizerDecode")
     .set_body_typed([](const Tokenizer& tokenizer, const IntTuple& token_ids) {
       return tokenizer->Decode({token_ids->data, token_ids->data + token_ids->size});
     });
+
+TVM_REGISTER_GLOBAL("mlc.DetectTokenizerInfo").set_body_typed([](const String& path) {
+  return Tokenizer::DetectTokenizerInfo(path)->AsJSONString();
+});
 
 }  // namespace llm
 }  // namespace mlc

--- a/cpp/tokenizers.h
+++ b/cpp/tokenizers.h
@@ -11,6 +11,7 @@
 #include <tvm/runtime/container/string.h>
 #include <tvm/runtime/object.h>
 
+#include <optional>
 #include <unordered_map>
 
 #include "base.h"
@@ -20,6 +21,43 @@ namespace llm {
 
 using namespace tvm::runtime;
 
+/*! \brief Useful information of the tokenizer during generation. */
+class TokenizerInfoNode : public Object {
+ public:
+  /*! \brief The method to post-process the tokens to their original strings.
+   * Possible values (each refers to a kind of tokenizer):
+   * - "byte_fallback": The same as the byte-fallback BPE tokenizer, including LLaMA-2,
+   *   Mixtral-7b, etc. E.g. "▁of" -> " of", "<0x1B>" -> "\x1B".
+   *   This method:
+   *   1) Transform tokens like <0x1B> to hex char byte 1B. (so-called byte-fallback)
+   *   2) Replace \\u2581 "▁" with space.
+   * - "byte_level": The same as the byte-level BPE tokenizer, including LLaMA-3, GPT-2,
+   *   Phi-2, etc. E.g. "Ġin" -> " in", "ě" -> "\x1B"
+   *   This method inverses the bytes-to-unicode transformation in the encoding process in
+   *   https://github.com/huggingface/transformers/blob/87be06ca77166e6a6215eee5a990ab9f07238a18/src/transformers/models/gpt2/tokenization_gpt2.py#L38-L59
+   */
+  String token_postproc_method = "byte_fallback";
+  /*! \brief Whether to prepend a space during encoding. */
+  bool prepend_space_in_encode = false;
+  /*! \brief Whether to strip the first space during decoding. */
+  bool strip_space_in_decode = false;
+
+  String AsJSONString() const;
+
+  static constexpr const char* _type_key = "mlc.serve.TokenizerInfo";
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  TVM_DECLARE_BASE_OBJECT_INFO(TokenizerInfoNode, Object);
+};
+
+class TokenizerInfo : public ObjectRef {
+ public:
+  /*! \brief Create a TokenizerInfo object from a dumped string. */
+  static TokenizerInfo FromJSON(String json_string);
+
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(TokenizerInfo, ObjectRef, TokenizerInfoNode);
+};
+
 /*! \brief A wrapper object class for tokenizer. */
 class TokenizerObj : public Object {
  public:
@@ -28,10 +66,12 @@ class TokenizerObj : public Object {
 
   /*! \brief Encode text into ids. */
   std::vector<int32_t> Encode(const std::string& text) const;
+
   /*! \brief Decode token ids into text. */
   std::string Decode(const std::vector<int32_t>& token_ids) const;
-  /*! \brief Return the token table of the tokenizer. Special tokens are included. */
-  const std::vector<std::string>& TokenTable();
+
+  /*! \brief Return the post-processed token table of the tokenizer. Special tokens are included. */
+  const std::vector<std::string>& PostProcessedTokenTable();
 
   /*!
    * \brief Returns the vocabulary size. Special tokens are considered.
@@ -49,44 +89,44 @@ class TokenizerObj : public Object {
    */
   int32_t TokenToId(const std::string& token) const;
 
+  friend class Tokenizer;
   static constexpr const char* _type_key = "mlc.Tokenizer";
   static constexpr const bool _type_has_method_sequal_reduce = false;
   static constexpr const bool _type_has_method_shash_reduce = false;
   TVM_DECLARE_FINAL_OBJECT_INFO(TokenizerObj, Object);
 
  private:
+  TokenizerInfo info_;
   /*! \brief The cached token table. */
-  std::vector<std::string> token_table_;
+  std::vector<std::string> post_processed_token_table_;
 };
 
 class Tokenizer : public ObjectRef {
  public:
-  /*! \brief Create a tokenizer from a directory path on disk. */
-  MLC_LLM_DLL static Tokenizer FromPath(const String& path);
+  /*!
+   * \brief Create a tokenizer from a directory path on disk.
+   * \param path The path to the tokenizer or the tokenizer directory.
+   * \param info The tokenizer info. If not provided, the info will be detected automatically.
+   */
+  MLC_LLM_DLL static Tokenizer FromPath(const String& path,
+                                        std::optional<TokenizerInfo> info = std::nullopt);
+
+  /*! \brief Detect the tokenizer info from the given path of the tokenizer. */
+  MLC_LLM_DLL static TokenizerInfo DetectTokenizerInfo(const String& path);
 
   /*!
-   * \brief Convert raw tokens provided by the tokenizer to their original string to simplify
-   * later processing. E.g. For LLaMA-2, convert "▁of" to " of".
-   *
+   * \brief Post-process the token table to their original strings.
    * \param token_table The raw token table.
-   * \param postproc_method The postprocessing method to use. Now we only support "byte_fallback"
-   * and "byte_level", which refers to the type of the decoder of the tokenizer.
-   *   - "byte_fallback": Use the decoding method in the byte-fallback BPE tokenizer. This is used
-   *     by LLaMA-2, Mixtral-7b, etc. This method: 1) transform tokens like <0x1B> to hex char
-   *     byte 1B. (known as the byte-fallback method); 2) transform \\u2581 to space.
-   *   - "byte_level": Use the decoding method in the byte-level BPE tokenizer. This is used by
-   *     LLaMA-3, GPT-2, Phi-2, etc. This method inverses the bytes-to-unicode transformation in
-   *     the encoding process as in
-   * https://github.com/huggingface/transformers/blob/87be06ca77166e6a6215eee5a990ab9f07238a18/src/transformers/models/gpt2/tokenization_gpt2.py#L38-L59
+   * \param postproc_method The postprocessing method to use.
    * \returns The postprocessed token table containing the original strings.
    */
   static std::vector<std::string> PostProcessTokenTable(const std::vector<std::string>& token_table,
-                                                        const std::string& postproc_method);
+                                                        const std::string& token_postproc_method);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Tokenizer, ObjectRef, TokenizerObj);
 
  private:
-  explicit Tokenizer(std::unique_ptr<tokenizers::Tokenizer> tokenizer);
+  explicit Tokenizer(std::unique_ptr<tokenizers::Tokenizer> tokenizer, TokenizerInfo info);
 };
 
 }  // namespace llm

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -4,14 +4,16 @@ import dataclasses
 import json
 import re
 import shutil
+from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from mlc_llm.conversation_template import ConvTemplateRegistry
 from mlc_llm.model import Model
 from mlc_llm.quantization import Quantization
 from mlc_llm.support import convert_tiktoken, logging
 from mlc_llm.support.style import bold, green, red
+from mlc_llm.tokenizer import Tokenizer
 
 from .compiler_flags import ModelConfigOverride
 
@@ -53,9 +55,8 @@ class MLCChatConfig:  # pylint: disable=too-many-instance-attributes
     eos_token_id: int = None
     # Tokenizer configuration
     tokenizer_files: List[str] = dataclasses.field(default_factory=list)
-    # The method to post-process the token table. See
-    # cpp/tokenizers.h::Tokenizer::PostProcessTokenTable for details
-    token_table_postproc_method: Literal["byte_fallback", "byte_level"] = None
+    # The content of tokenizer.TokenizerInfo
+    tokenizer_info: Dict[str, Any] = dataclasses.field(default_factory=dict)
     # Version control
     version: str = VERSION
 
@@ -131,70 +132,6 @@ def json2rwkv_tokenizer(vocab: Path, out: Path) -> None:
         import msgpack  # pylint: disable=import-outside-toplevel,import-error
 
         msgpack.pack(idx2token, f)
-
-
-def detect_token_table_postproc_method(output_path: Path) -> Literal["byte_fallback", "byte_level"]:
-    """Detect the token table postprocessing method from tokenizer.json that is found under
-    output_path. If not detected, use ByteFallback as default.
-
-    Check the decoder field of the tokenizer. If it uses ByteFallback decoder, return
-    "byte_fallback". If it uses ByteLevel decoder, return "byte_level". Otherwise, use
-    ByteFallback as default.
-
-    See also cpp/tokenizers.h::Tokenizer::PostProcessTokenTable.
-    """
-    output_tokenizer_path = output_path / "tokenizer.json"
-    if not output_tokenizer_path.exists():
-        logger.warning(
-            "Tokenizer token table postprocessing method is not detected as tokenizer.json "
-            "is not found, use ByteFallback (the same as LLaMA/LLaMA2) by default"
-        )
-        return "byte_fallback"
-
-    with output_tokenizer_path.open("r", encoding="utf-8") as in_file:
-        tokenizer_json = json.load(in_file)
-
-    # Find all decoders in tokenizer.json
-    decoders = []
-
-    if "decoder" not in tokenizer_json:
-        logger.warning(
-            "Decoder field is not found in tokenizer.json, use ByteFallback (the same as "
-            "LLaMA/LLaMA2) as the token table postprocessing method by default"
-        )
-        return "byte_fallback"
-
-    decoders_json = tokenizer_json["decoder"]
-    assert "type" in decoders_json, "Decoder type is not specified in tokenizer.json"
-    if decoders_json["type"] == "Sequence":
-        assert "decoders" in decoders_json
-        decoders = decoders_json["decoders"]
-    else:
-        decoders = [decoders_json]
-
-    is_byte_level = False
-    is_byte_fallback = False
-
-    for decoder in decoders:
-        if decoder["type"] == "ByteLevel":
-            is_byte_level = True
-        if decoder["type"] == "ByteFallback":
-            is_byte_fallback = True
-    assert not (
-        is_byte_level and is_byte_fallback
-    ), "Tokenizer decoder cannot have both type ByteLevel and type ByteFallback"
-
-    if is_byte_level:
-        return "byte_level"
-    if is_byte_fallback:
-        return "byte_fallback"
-
-    logger.warning(
-        "Neither ByteLevel nor ByteFallback decoder is detected in tokenizer.json, use "
-        "ByteFallback (the same as LLaMA/LLaMA2) as the token table postprocessing method "
-        "by default"
-    )
-    return "byte_fallback"
 
 
 def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-branches,too-many-statements
@@ -323,9 +260,9 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
         except Exception:  # pylint: disable=broad-exception-caught
             logger.exception("%s with the exception below. Skipping", FAILED)
 
-    # 3.4. Find the token table postprocessing method from tokenizer.json if it exists. If not
-    # detected, use "byte_fallback" as default.
-    mlc_chat_config.token_table_postproc_method = detect_token_table_postproc_method(output)
+    # 3.4. Detect tokenizer info
+    mlc_chat_config.tokenizer_info = asdict(Tokenizer.detect_tokenizer_info(str(output)))
+    logger.info("Detected tokenizer info: %s", mlc_chat_config.tokenizer_info)
 
     # Step 4. Load system default value
     mlc_chat_config.apply_defaults()

--- a/python/mlc_llm/serve/grammar.py
+++ b/python/mlc_llm/serve/grammar.py
@@ -1,6 +1,6 @@
 """Classes handling the grammar guided generation of MLC LLM serving"""
 
-from typing import List, Literal, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import tvm
 import tvm._ffi
@@ -246,11 +246,6 @@ class GrammarStateMatcher(Object):
 
     max_rollback_steps : int
         The maximum number of steps to rollback when backtracking. Default: 0.
-
-    token_table_postproc_method : Literal["byte_fallback", "byte_level"]
-        A helper parameter for the tokenizer. Only useful when the tokenizer is specified.
-        The method to postprocess the token table. For LLaMA and LLaMA-2 tokenizer, use
-        "byte_fallback"; for LLaMA-3 tokenizer, use "byte_level". Default: "byte_fallback".
     """
 
     def __init__(
@@ -258,7 +253,6 @@ class GrammarStateMatcher(Object):
         grammar: BNFGrammar,
         tokenizer: Union[None, Tokenizer, List[str]] = None,
         max_rollback_steps: int = 0,
-        token_table_postproc_method: Literal["byte_fallback", "byte_level"] = "byte_fallback",
     ):
         if isinstance(tokenizer, list):
             self.__init_handle_by_constructor__(
@@ -273,7 +267,6 @@ class GrammarStateMatcher(Object):
                 grammar,
                 tokenizer,
                 max_rollback_steps,
-                token_table_postproc_method,
             )
 
     def accept_token(self, token_id: int) -> bool:

--- a/python/mlc_llm/tokenizer.py
+++ b/python/mlc_llm/tokenizer.py
@@ -3,13 +3,56 @@ This tokenizer essentially wraps and binds the HuggingFace tokenizer
 library and sentencepiece.
 Reference: https://github.com/mlc-ai/tokenizers-cpp
 """
-from typing import List
+
+import json
+from dataclasses import asdict, dataclass
+from typing import List, Literal
 
 import tvm
 import tvm._ffi
 from tvm.runtime import Object
 
 from . import _ffi_api
+
+
+@dataclass
+class TokenizerInfo:  # pylint: disable=too-many-instance-attributes
+    """Useful information of the tokenizer during generation.
+
+    Attributes
+    ----------
+    token_postproc_method : Literal["byte_fallback", "byte_level"]
+        The method to post-process the tokens to their original strings.
+        Possible values (each refers to a kind of tokenizer):
+        - "byte_fallback": The same as the byte-fallback BPE tokenizer, including LLaMA-2,
+            Mixtral-7b, etc. E.g. "▁of" -> " of", "<0x1B>" -> "\x1B".
+            This method:
+            1) Transform tokens like <0x1B> to hex char byte 1B. (so-called byte-fallback)
+            2) Replace \\u2581 "▁" with space.
+        - "byte_level": The same as the byte-level BPE tokenizer, including LLaMA-3, GPT-2,
+            Phi-2, etc. E.g. "Ġin" -> " in", "ě" -> "\x1B"
+            This method inverses the bytes-to-unicode transformation in the encoding process in
+            https://github.com/huggingface/transformers/blob/87be06ca77166e6a6215eee5a990ab9f07238a18/src/transformers/models/gpt2/tokenization_gpt2.py#L38-L59
+
+    prepend_space_in_encode : bool
+        Whether to prepend a space during encoding.
+
+    strip_space_in_decode : bool
+        Whether to strip the first space during decoding.
+    """
+
+    token_postproc_method: Literal["byte_fallback", "byte_level"] = "byte_fallback"
+    prepend_space_in_encode: bool = False
+    strip_space_in_decode: bool = False
+
+    def asjson(self) -> str:
+        """Return the config in string of JSON format."""
+        return json.dumps(asdict(self))
+
+    @staticmethod
+    def from_json(json_str: str) -> "TokenizerInfo":
+        """Construct a config from JSON string."""
+        return TokenizerInfo(**json.loads(json_str))
 
 
 @tvm._ffi.register_object("mlc.Tokenizer")  # pylint: disable=protected-access
@@ -53,3 +96,19 @@ class Tokenizer(Object):
         return _ffi_api.TokenizerDecode(  # type: ignore  # pylint: disable=no-member
             self, tvm.runtime.ShapeTuple(token_ids)
         )
+
+    @staticmethod
+    def detect_tokenizer_info(tokenizer_path: str) -> TokenizerInfo:
+        """Detect the tokenizer info from the given path of the tokenizer.
+
+        Parameters
+        ----------
+        tokenizer_path : str
+            The tokenizer directory path.
+
+        Returns
+        -------
+        tokenizer_info : str
+            The detected tokenizer info in JSON string.
+        """
+        return TokenizerInfo.from_json(_ffi_api.DetectTokenizerInfo(tokenizer_path))  # type: ignore  # pylint: disable=no-member

--- a/tests/python/serve/test_grammar_state_matcher_json.py
+++ b/tests/python/serve/test_grammar_state_matcher_json.py
@@ -2,7 +2,7 @@
 # pylint: disable=redefined-outer-name,unbalanced-tuple-unpacking
 """This test uses the optimized JSON grammar provided by the grammar library."""
 import sys
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 import pytest
 import tvm
@@ -213,12 +213,7 @@ def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
     assert GrammarStateMatcher(json_grammar).debug_match_complete_string(json_input_pressure)
 
 
-(
-    tokenizer_path,
-    input_find_rejected_tokens,
-    expected_rejected_sizes,
-    token_table_postproc_method,
-) = tvm.testing.parameters(
+(tokenizer_path, input_find_rejected_tokens, expected_rejected_sizes) = tvm.testing.parameters(
     (
         # short test
         "dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
@@ -229,7 +224,6 @@ def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
             272, 31973, 31846, 31846, 265, 265, 265, 265, 265, 265, 265, 265, 31974, 31999
             # fmt: on
         ],
-        "byte_fallback",
     ),
     (
         # short test
@@ -242,7 +236,6 @@ def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
             4952, 128066, 128111, 4952, 128066, 128111, 4952, 127873, 128254
             # fmt: on
         ],
-        "byte_level",
     ),
     (
         # long test
@@ -268,7 +261,6 @@ def test_json_pressure(json_grammar: BNFGrammar, json_input_pressure):
             31846, 265, 265, 265, 265, 31974, 31974, 31999
             # fmt: on
         ],
-        "byte_fallback",
     ),
 )
 
@@ -278,12 +270,9 @@ def test_find_next_rejected_tokens(
     tokenizer_path: str,
     input_find_rejected_tokens: str,
     expected_rejected_sizes: Optional[List[int]],
-    token_table_postproc_method: Literal["byte_fallback", "byte_level"],
 ):
     tokenizer = Tokenizer(tokenizer_path)
-    grammar_state_matcher = GrammarStateMatcher(
-        json_grammar, tokenizer, token_table_postproc_method=token_table_postproc_method
-    )
+    grammar_state_matcher = GrammarStateMatcher(json_grammar, tokenizer)
     input_bytes = input_find_rejected_tokens.encode("utf-8")
     rejected_sizes = []
 
@@ -444,7 +433,6 @@ if __name__ == "__main__":
         "dist/Llama-2-7b-chat-hf-q4f16_1-MLC",
         '{"id": 1,"name": "Example"}',
         None,
-        "byte_fallback",
     )
 
     test_find_next_rejected_tokens(
@@ -452,7 +440,6 @@ if __name__ == "__main__":
         "dist/Meta-Llama-3-8B-Instruct-q4f16_1-MLC",
         '{"id": 1,"name": "Example哈哈"}',
         None,
-        "byte_level",
     )
 
     tvm.testing.main()


### PR DESCRIPTION
This PR adds a new `TokenizerInfo` class that contains useful information about the tokenizer during generation. It is auto-detected from tokenizer.json if it exists. Otherwise it raises a warning and uses the default value (byte fallback tokenizer, not prepend/strip space).