### PR TITLE
[DOWNLOAD] MLC_DOWNLOAD_POLICY and MLC_LLM_READONLY_WEIGHT_CACHES

### DIFF
--- a/python/mlc_llm/chat_module.py
+++ b/python/mlc_llm/chat_module.py
@@ -356,11 +356,11 @@ def _get_model_path(model: str) -> Tuple[str, str]:
     """
     if model.startswith("HF://"):
         from mlc_llm.support.download import (  # pylint: disable=import-outside-toplevel
-            download_mlc_weights,
+            download_and_cache_mlc_weights,
         )
 
         logger.info("Downloading model from HuggingFace: %s", model)
-        mlc_dir = download_mlc_weights(model)
+        mlc_dir = download_and_cache_mlc_weights(model)
         cfg_dir = mlc_dir / "mlc-chat-config.json"
         return str(mlc_dir), str(cfg_dir)
 

--- a/python/mlc_llm/support/auto_config.py
+++ b/python/mlc_llm/support/auto_config.py
@@ -35,12 +35,12 @@ def detect_mlc_chat_config(mlc_chat_config: str) -> Path:
     # pylint: disable=import-outside-toplevel
     from mlc_llm.model import MODEL_PRESETS
 
-    from .download import download_mlc_weights
+    from .download import download_and_cache_mlc_weights
 
     # pylint: enable=import-outside-toplevel
 
     if mlc_chat_config.startswith("HF://") or mlc_chat_config.startswith("http"):
-        mlc_chat_config_path = Path(download_mlc_weights(model_url=mlc_chat_config))
+        mlc_chat_config_path = Path(download_and_cache_mlc_weights(model_url=mlc_chat_config))
     elif isinstance(mlc_chat_config, str) and mlc_chat_config in MODEL_PRESETS:
         logger.info("%s mlc preset model: %s", FOUND, mlc_chat_config)
         content = MODEL_PRESETS[mlc_chat_config].copy()

--- a/python/mlc_llm/support/constants.py
+++ b/python/mlc_llm/support/constants.py
@@ -13,6 +13,13 @@ def _check():
             f"but got {MLC_JIT_POLICY}."
         )
 
+    if MLC_DOWNLOAD_POLICY not in ["ON", "OFF", "REDO", "READONLY"]:
+        raise ValueError(
+            "Invalid MLC_AUTO_DOWNLOAD_POLICY. "
+            'It has to be one of "ON", "OFF", "REDO", "READONLY"'
+            f"but got {MLC_DOWNLOAD_POLICY}."
+        )
+
 
 def _get_cache_dir() -> Path:
     if "MLC_LLM_HOME" in os.environ:
@@ -48,23 +55,31 @@ def _get_dso_suffix() -> str:
 
 
 def _get_test_model_path() -> List[Path]:
-    if "MLC_TEST_MODEL_PATH" in os.environ:
-        return [Path(p) for p in os.environ["MLC_TEST_MODEL_PATH"].split(os.pathsep)]
+    if "MLC_LLM_TEST_MODEL_PATH" in os.environ:
+        return [Path(p) for p in os.environ["MLC_LLM_TEST_MODEL_PATH"].split(os.pathsep)]
     # by default, we reuse the cache dir via mlc_llm chat
     # note that we do not auto download for testcase
     # to avoid networking dependencies
-    return [
-        _get_cache_dir() / "model_weights" / "mlc-ai",
-        Path(os.path.abspath(os.path.curdir)),
+    base_list = ["hf"]
+    return [_get_cache_dir() / "model_weights" / base / "mlc-ai" for base in base_list] + [
+        Path(os.path.abspath(os.path.curdir))
     ]
+
+
+def _get_read_only_weight_caches() -> List[Path]:
+    if "MLC_LLM_READONLY_WEIGHT_CACHES" in os.environ:
+        return [Path(p) for p in os.environ["MLC_LLM_READONLY_WEIGHT_CACHES"].split(os.pathsep)]
+    return []
 
 
 MLC_TEMP_DIR = os.getenv("MLC_TEMP_DIR", None)
 MLC_MULTI_ARCH = os.environ.get("MLC_MULTI_ARCH", None)
-MLC_LLM_HOME: Path = _get_cache_dir()
 MLC_JIT_POLICY = os.environ.get("MLC_JIT_POLICY", "ON")
 MLC_DSO_SUFFIX = _get_dso_suffix()
 MLC_TEST_MODEL_PATH: List[Path] = _get_test_model_path()
 
+MLC_DOWNLOAD_POLICY = os.environ.get("MLC_DOWNLOAD_POLICY", "ON")
+MLC_LLM_HOME: Path = _get_cache_dir()
+MLC_LLM_READONLY_WEIGHT_CACHES = _get_read_only_weight_caches()
 
 _check()


### PR DESCRIPTION
This PR introduces support for MLC_DOWNLOAD_POLICY and MLC_LLM_READONLY_WEIGHT_CACHES

Allows reading from readonly cache besides MLC_LLM_HOME. Also introduces a domain subfolder in cached weights