### PR TITLE
Change instruction_queue copy to use std::move in `ThreadEngineImpl`

### DIFF
--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -138,8 +138,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
         });
         engine_waiting_ = false;
 
-        local_instruction_queue = instruction_queue_;
-        instruction_queue_.clear();
+        local_instruction_queue = std::move(instruction_queue_);
         pending_request_operation_cnt_ = 0;
       }
       for (const auto& [kind, arg] : local_instruction_queue) {


### PR DESCRIPTION
move operation might be more efficient than copy and clear operations.

but I'm not sure how frequent this op occurs so the effect might be negligible.
