### PR TITLE
[Compile] Skip CUDA graph rewrite when target is not CUDA

### DIFF
--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -124,10 +124,17 @@ class OptimizationFlags:
                 return False
             return self.cutlass
 
+        def _cudagraph(target) -> bool:
+            """correct cudagraph flag"""
+            if not target.kind.name == "cuda":
+                return False
+            return self.cudagraph
+
         self.flashinfer = _flashinfer(target)
         self.cublas_gemm = _cublas_gemm(target, quantization)
         self.faster_transformer = _faster_transformer(target)
         self.cutlass = _cutlass(target)
+        self.cudagraph = _cudagraph(target)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This PR rewrites the CUDA graph compiler flag to false when the backend is not CUDA. Otherwise, CUDA graph may be enabled for other backends and causes result error.