### PR TITLE
[Grammar][Wasm] Update new grammar to wasm runtime

### DIFF
--- a/python/mlc_llm/protocol/mlc_chat_config.py
+++ b/python/mlc_llm/protocol/mlc_chat_config.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-instance-attributes
 """Schema for mlc-chat-config"""
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -58,7 +58,7 @@ class MLCChatConfig(BaseModel):
     # but we keep them for book-keep purposes
     pad_token_id: Optional[int] = None
     bos_token_id: Optional[int] = None
-    eos_token_id: Optional[int] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
     # Legacy fields
     # Control the behavior of the runtime
     # these fields will be deprecated soon

--- a/web/emcc/mlc_wasm_runtime.cc
+++ b/web/emcc/mlc_wasm_runtime.cc
@@ -42,3 +42,6 @@
 #include "serve/grammar/grammar_state_matcher.cc"
 #include "serve/grammar/json_schema_converter.cc"
 #include "support/encoding.cc"
+
+// Only compiles necessary functions for mlc.PostProcessTokenTable
+#include "tokenizers.cc"


### PR DESCRIPTION
This PR updates MLC's wasm runtime to catch up with the latest changes to grammar:
- https://github.com/mlc-ai/mlc-llm/pull/2248
- https://github.com/mlc-ai/mlc-llm/pull/2335
- https://github.com/mlc-ai/mlc-llm/pull/2416

We mainly expose `PostProcessTokenTable()` and `PostProcessToken()` as global func, and compile all the necessary code needed in `cpp/tokenizers.cc` while skipping others with `COMPILE_MLC_WASM_RUNTIME` to avoid dependency to `tokenizers-cpp`.

The only change needed from WebLLM in runtime is to call `PostProcessTokenTable()` with the correct post processing method before creating `GrammarStateMatcher` from token table.

Verified with Llama-2 and Llama-3 grammar (w/ and w/o schema) in WebLLM.

Also fix `eos_token_id` type to avoid pydantic error; Phi-3 has 3 eos token ids as of now: https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC/blob/main/mlc-chat-config.json#L70