### PR TITLE
[Protocol] Use `by_alias=True` when dumping pydantic classes

### DIFF
--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -22,7 +22,7 @@ class ConvTemplateRegistry:
         if name in ConvTemplateRegistry._conv_templates and not override:
             raise ValueError(
                 "The name of the template has been registered "
-                f"for {ConvTemplateRegistry._conv_templates[name].model_dump_json()}"
+                f"for {ConvTemplateRegistry._conv_templates[name].model_dump_json(by_alias=True)}"
             )
         ConvTemplateRegistry._conv_templates[name] = conv_template
 

--- a/python/mlc_llm/json_ffi/engine.py
+++ b/python/mlc_llm/json_ffi/engine.py
@@ -186,7 +186,7 @@ class Completions:
         )
         chatcmpl_generator = self._state.handle_chat_completion(
             self._ffi,
-            request.model_dump_json(),
+            request.model_dump_json(by_alias=True),
             include_usage=(
                 request.stream_options is not None and request.stream_options.include_usage
             ),

--- a/python/mlc_llm/protocol/error_protocol.py
+++ b/python/mlc_llm/protocol/error_protocol.py
@@ -25,7 +25,7 @@ class ErrorResponse(BaseModel):
 def create_error_response(status_code: HTTPStatus, message: str) -> fastapi.responses.JSONResponse:
     """Create a JSON response that reports error with regarding the input message."""
     return fastapi.responses.JSONResponse(
-        ErrorResponse(message=message, code=status_code.value).model_dump_json(),
+        ErrorResponse(message=message, code=status_code.value).model_dump_json(by_alias=True),
         status_code=status_code.value,
     )
 

--- a/python/mlc_llm/protocol/openai_api_protocol.py
+++ b/python/mlc_llm/protocol/openai_api_protocol.py
@@ -327,7 +327,7 @@ class ChatCompletionRequest(BaseModel):
                     ]
                 ):
                     conv_template.use_function_calling = True
-                    conv_template.function_string = tool.function.model_dump_json()
+                    conv_template.function_string = tool.function.model_dump_json(by_alias=True)
                     return
 
             # pylint: disable=unsubscriptable-object

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -1374,7 +1374,7 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         # config and the created callback.
         input_data = engine_utils.convert_prompts_to_data(prompt)
         request = self._ffi["create_request"](
-            request_id, input_data, generation_config.model_dump_json()
+            request_id, input_data, generation_config.model_dump_json(by_alias=True)
         )
 
         # Create the unique async request stream of the request.
@@ -1902,7 +1902,7 @@ class MLCEngine(engine_base.MLCEngineBase):
         # config and the created callback.
         input_data = engine_utils.convert_prompts_to_data(prompt)
         request = self._ffi["create_request"](
-            request_id, input_data, generation_config.model_dump_json()
+            request_id, input_data, generation_config.model_dump_json(by_alias=True)
         )
 
         # Record the stream in the tracker

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -70,9 +70,9 @@ async def request_completion(request: CompletionRequest, raw_request: fastapi.Re
             if isinstance(first_response, StopAsyncIteration):
                 yield "data: [DONE]\n\n"
                 return
-            yield f"data: {first_response.model_dump_json()}\n\n"
+            yield f"data: {first_response.model_dump_json(by_alias=True)}\n\n"
             async for response in stream_generator:
-                yield f"data: {response.model_dump_json()}\n\n"
+                yield f"data: {response.model_dump_json(by_alias=True)}\n\n"
             yield "data: [DONE]\n\n"
 
         return fastapi.responses.StreamingResponse(
@@ -166,9 +166,9 @@ async def request_chat_completion(
             if isinstance(first_response, StopAsyncIteration):
                 yield "data: [DONE]\n\n"
                 return
-            yield f"data: {first_response.model_dump_json()}\n\n"
+            yield f"data: {first_response.model_dump_json(by_alias=True)}\n\n"
             async for response in stream_generator:
-                yield f"data: {response.model_dump_json()}\n\n"
+                yield f"data: {response.model_dump_json(by_alias=True)}\n\n"
             yield "data: [DONE]\n\n"
 
         return fastapi.responses.StreamingResponse(

--- a/python/mlc_llm/serve/sync_engine.py
+++ b/python/mlc_llm/serve/sync_engine.py
@@ -308,7 +308,9 @@ class SyncMLCEngine:
         """
         if not isinstance(inputs, list):
             inputs = [inputs]
-        return self._ffi["create_request"](request_id, inputs, generation_config.model_dump_json())
+        return self._ffi["create_request"](
+            request_id, inputs, generation_config.model_dump_json(by_alias=True)
+        )
 
     def add_request(self, request: Request) -> None:
         """Add a new request to the engine.


### PR DESCRIPTION
This PR sets the parameter `by_alias=True` for all the `model_dump_json` of pydantic classes, so that aliases are always respected.