### PR TITLE
[LogitProcessor] Use min float value as the mask value

### DIFF
--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -128,6 +128,9 @@ class LogitProcessorImpl : public LogitProcessorObj {
     RECORD_EVENT(trace_recorder_, request_ids, "finish apply penalty");
 
     // Update 3. Vocabulary mask.
+    // Note: The mask application must be placed as the last step in logit processor.
+    // This is because the masked logits are set to the minimal value.
+    // Further logit subtraction may cause issue such as underflow.
     RECORD_EVENT(trace_recorder_, request_ids, "start apply logit mask");
     UpdateWithMask(logits, mstates, cum_num_token, draft_tokens);
     RECORD_EVENT(trace_recorder_, request_ids, "finish apply logit mask");

--- a/python/mlc_llm/compiler_pass/attach_logit_processor.py
+++ b/python/mlc_llm/compiler_pass/attach_logit_processor.py
@@ -166,7 +166,7 @@ def _get_apply_bitmask_inplace(target: tvm.target.Target):
                     logits[seq_ids[vs], vv] = T.if_then_else(
                         (bitmask[seq_ids[vs], vv // 32] >> (vv % 32)) & 1 == 1,
                         logits[seq_ids[vs], vv],
-                        T.float32(-1e10),
+                        T.min_value("float32"),
                     )
 
     return _apply_bitmask_inplace


### PR DESCRIPTION
This PR updates the mask values in LogitProcessor to the min value of float32. Prior to this PR it was -1e10. This update is the safest for softmax as long as the masking is always the last step in logit processor.