### PR TITLE
[Protocol] Use `by_alias=True` when dumping pydantic classes

### DIFF
--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -218,7 +218,7 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
     apply_system_defaults_for_missing_fields(mlc_chat_config)
     # Step 5. Dump the configuration file to output directory
     with (output / "mlc-chat-config.json").open("w", encoding="utf-8") as out_file:
-        json.dump(mlc_chat_config.model_dump(), out_file, indent=2)
+        json.dump(mlc_chat_config.model_dump(by_alias=True), out_file, indent=2)
         logger.info("Dumping configuration file to: %s", bold(out_file.name))
 
 

--- a/python/mlc_llm/protocol/conversation_protocol.py
+++ b/python/mlc_llm/protocol/conversation_protocol.py
@@ -103,7 +103,7 @@ class Conversation(BaseModel):
 
     def to_json_dict(self) -> Dict[str, Any]:
         """Convert to a json dictionary"""
-        return self.model_dump(exclude_none=True)
+        return self.model_dump(by_alias=True, exclude_none=True)
 
     @classmethod
     def from_json_dict(cls: Type[T], json_dict: Dict[str, Any]) -> T:

--- a/python/mlc_llm/protocol/openai_api_protocol.py
+++ b/python/mlc_llm/protocol/openai_api_protocol.py
@@ -344,7 +344,7 @@ class ChatCompletionRequest(BaseModel):
         for tool in self.tools:  # pylint: disable=not-an-iterable
             if tool.type != "function":
                 raise BadRequestError("Only 'function' tool type is supported")
-            function_list.append(tool.function.model_dump())
+            function_list.append(tool.function.model_dump(by_alias=True))
 
         conv_template.use_function_calling = True
         conv_template.function_string = json.dumps(function_list)


### PR DESCRIPTION
This PR sets the parameter `by_alias=True` for all the `model_dump` of pydantic classes, so that aliases are always respected.