### PR TITLE
[Fix][Phi3] Add `</s>` as stop token for phi3

### DIFF
--- a/python/mlc_llm/conversation_template.py
+++ b/python/mlc_llm/conversation_template.py
@@ -260,7 +260,7 @@ ConvTemplateRegistry.register_conv_template(
         role_empty_sep="\n",
         system_prefix_token_ids=[1],
         stop_str=["<|endoftext|>"],
-        stop_token_ids=[32000, 32001, 32007],
+        stop_token_ids=[2, 32000, 32001, 32007],
     )
 )
 


### PR DESCRIPTION
Add `</s>`, token 2, as stop token for phi3. Motivated by grammar.

Though `</s>` is not described as the stop token anywhere in the official phi-3 HF repo, when we do not mask `</s>` at the end of a json generation, it is possible to be generated as shown in the screenshot.

This is because the following lines accept `</s>` as a stop token in grammar state matcher regardless whether `</s>` is registered as the stop token in MLC:
https://github.com/mlc-ai/mlc-llm/blob/d1f5f51afcdba14399ed5df4b64bf0eeed0d9d8e/cpp/serve/grammar/grammar_state_matcher_preproc.h#L316-L318

While we could modify the lines above to only add stop tokens that are registered in `mlc-chat-config.json`, adding `</s>` into phi-3's stop tokens may be an easier way for now.

Motivating error:
<img width="1039" alt="image" src="https://github.com/mlc-ai/mlc-llm/assets/53290280/e45b5096-ef4a-4804-afde-22f166b62738">
