### PR TITLE
[Compile] Add max_batch_size to metadata

### DIFF
--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -56,6 +56,7 @@ ModelMetadata ModelMetadata::FromJSON(const picojson::object& metadata,
   result.quantization = json::Lookup<std::string>(metadata, "quantization");
   result.context_window_size = json::Lookup<int64_t>(metadata, "context_window_size");
   result.prefill_chunk_size = json::Lookup<int64_t>(metadata, "prefill_chunk_size");
+  result.max_batch_size = json::Lookup<int64_t>(metadata, "max_batch_size");
   if (metadata.count("sliding_window_size"))
     result.sliding_window_size = json::Lookup<int64_t>(metadata, "sliding_window_size");
   if (metadata.count("sliding_window"))  // to be removed after SLM migration

--- a/cpp/metadata/model.h
+++ b/cpp/metadata/model.h
@@ -74,6 +74,7 @@ struct ModelMetadata {
   std::string quantization;
   int64_t context_window_size;
   int64_t prefill_chunk_size;
+  int64_t max_batch_size;
   int64_t sliding_window_size;
   int64_t tensor_parallel_shards;
   int64_t attention_sink_size;

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -444,11 +444,7 @@ Result<ModelConfigLimits> GetModelConfigLimits(const std::vector<picojson::objec
           std::min(model_max_prefill_chunk_size, runtime_prefill_chunk_size);
     }
     // - The maximum batch size is the minimum max batch size among all models.
-    model_max_batch_size = std::min(
-        model_max_batch_size,
-        json::LookupOptional<int64_t>(
-            json::Lookup<picojson::object>(model_configs[i], "model_config"), "max_batch_size")
-            .value_or(128));
+    model_max_batch_size = std::min(model_max_batch_size, model_metadata[i].max_batch_size);
     // - The maximum sliding window size is the minimum among all models.
     int64_t runtime_sliding_window_size =
         json::LookupOptional<int64_t>(model_configs[i], "sliding_window_size").value_or(-1);

--- a/python/mlc_llm/interface/compile.py
+++ b/python/mlc_llm/interface/compile.py
@@ -166,6 +166,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
             "prefill_chunk_size": model_config.prefill_chunk_size,  # type: ignore
             "tensor_parallel_shards": model_config.tensor_parallel_shards,  # type: ignore
             "kv_state_kind": _infer_kv_state_kind(args.model.name),
+            "max_batch_size": getattr(model_config, "max_batch_size", 1),
         }
         logger.info("Registering metadata: %s", metadata)
         metadata["params"] = [_get_param_metadata(name, param) for name, param in named_params]

--- a/python/mlc_llm/model/qwen2/qwen2_model.py
+++ b/python/mlc_llm/model/qwen2/qwen2_model.py
@@ -38,6 +38,7 @@ class QWen2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     tensor_parallel_shards: int = 1
     head_dim: int = 0
     dtype: str = "float32"
+    max_batch_size: int = 1
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):


### PR DESCRIPTION
This PR adds the max_batch_size at compile time to metadata for runtime to read.

**Note.** This may be a breaking change for the compiled model libraries. And please set environment variable `MLC_JIT_POLICY=REDO` to recompile the models with JIT, or manually recompile the model libraries.

This PR also adds the max_batch_size to qwen2.