### PR TITLE
[CUDA] Turn on cuda graph at O2

### DIFF
--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -196,7 +196,7 @@ OPT_FLAG_PRESET = {
         flashinfer=True,
         cublas_gemm=True,
         faster_transformer=True,
-        cudagraph=False,
+        cudagraph=True,
         cutlass=True,
     ),
     "O3": OptimizationFlags(


### PR DESCRIPTION
This makes cuda graph default ON at O2 since it is generally helpful.