### PR TITLE
[Serving] Use preferred host memory for host NDArrays

### DIFF
--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -49,16 +49,21 @@ class LogitProcessorImpl : public LogitProcessorObj {
         apply_penalty_func_(ft->apply_penalty_func_),
         apply_bitmask_func_(ft->apply_bitmask_func_),
         trace_recorder_(std::move(trace_recorder)) {
-    DLDevice device_cpu{DLDeviceType::kDLCPU, /*device_id=*/0};
+    Device preferred_host_device = GetPreferredHostDevice(device);
     // Initialize auxiliary arrays on CPU.
-    seq_ids_host_ = NDArray::Empty({max_num_token}, dtype_i32_, device_cpu);
-    pos2seq_id_host_ = NDArray::Empty({max_num_token * vocab_size}, dtype_i32_, device_cpu);
-    token_ids_host_ = NDArray::Empty({max_num_token * vocab_size}, dtype_i32_, device_cpu);
-    token_cnt_host_ = NDArray::Empty({max_num_token * vocab_size}, dtype_i32_, device_cpu);
-    token_logit_bias_host_ = NDArray::Empty({max_num_token * vocab_size}, dtype_f32_, device_cpu);
-    penalties_host_ = NDArray::Empty({max_num_token, 3}, dtype_f32_, device_cpu);
-    bitmask_host_ = NDArray::Empty({max_num_token, bitmask_size_}, dtype_u32_, device_cpu);
-    temperature_host_ = NDArray::Empty({max_num_token}, dtype_f32_, device_cpu);
+    seq_ids_host_ = NDArray::Empty({max_num_token}, dtype_i32_, preferred_host_device);
+    pos2seq_id_host_ =
+        NDArray::Empty({max_num_token * vocab_size}, dtype_i32_, preferred_host_device);
+    token_ids_host_ =
+        NDArray::Empty({max_num_token * vocab_size}, dtype_i32_, preferred_host_device);
+    token_cnt_host_ =
+        NDArray::Empty({max_num_token * vocab_size}, dtype_i32_, preferred_host_device);
+    token_logit_bias_host_ =
+        NDArray::Empty({max_num_token * vocab_size}, dtype_f32_, preferred_host_device);
+    penalties_host_ = NDArray::Empty({max_num_token, 3}, dtype_f32_, preferred_host_device);
+    bitmask_host_ =
+        NDArray::Empty({max_num_token, bitmask_size_}, dtype_u32_, preferred_host_device);
+    temperature_host_ = NDArray::Empty({max_num_token}, dtype_f32_, preferred_host_device);
     // Initialize auxiliary arrays on GPU.
     seq_ids_device_ = NDArray::Empty({max_num_token}, dtype_i32_, device);
     pos2seq_id_device_ = NDArray::Empty({max_num_token * vocab_size}, dtype_i32_, device);

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -673,12 +673,13 @@ class ModelImpl : public ModelObj {
 
   void SetPrefillChunkSize(int prefill_chunk_size) final {
     this->prefill_chunk_size_ = prefill_chunk_size;
-    Device device_host{DLDeviceType::kDLCPU, 0};
-    memory::Allocator* allocator =
-        memory::MemoryManager::GetOrCreateAllocator(device_host, memory::AllocatorType::kNaive);
+    Device preferred_host_device = GetPreferredHostDevice(device_);
+    memory::Allocator* allocator = memory::MemoryManager::GetOrCreateAllocator(
+        preferred_host_device, memory::AllocatorType::kNaive);
     ICHECK_NOTNULL(allocator);
     token_ids_storage_ = memory::Storage(
-        allocator->Alloc(device_host, {prefill_chunk_size_}, DataType::Int(32)), allocator);
+        allocator->Alloc(preferred_host_device, {prefill_chunk_size_}, DataType::Int(32)),
+        allocator);
   }
 
   LogitProcessor CreateLogitProcessor(int max_num_token,

--- a/cpp/serve/sampler/gpu_sampler.cc
+++ b/cpp/serve/sampler/gpu_sampler.cc
@@ -54,23 +54,28 @@ class GPUSampler : public SamplerObj {
     flashinfer_multinomial_sample_func_ =
         Registry::Get("flashinfer.sampling.parallel_sampling_from_prob");
 
-    DLDevice device_cpu{DLDeviceType::kDLCPU, /*device_id=*/0};
+    Device preferred_host_device = GetPreferredHostDevice(device);
     // We support at most 5 top prob results for each sequence.
     // Initialize auxiliary arrays on CPU.
-    uniform_samples_host_ = NDArray::Empty({max_num_sample}, dtype_f32_, device_cpu);
-    sample_indices_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, device_cpu);
-    top_p_host_ = NDArray::Empty({max_num_sample}, dtype_f32_, device_cpu);
-    top_p_init_pivots_host_ =
-        NDArray::Empty({max_num_sample, num_top_p_cutoff_pivots_}, dtype_f32_, device_cpu);
-    top_prob_offsets_host_ = NDArray::Empty({max_num_sample * 5}, dtype_i32_, device_cpu);
-    draft_tokens_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, device_cpu);
-    token_tree_first_child_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, device_cpu);
-    token_tree_next_sibling_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, device_cpu);
-    token_tree_parent_ptr_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, device_cpu);
-    sampled_token_ids_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, device_cpu);
-    sampled_probs_host_ = NDArray::Empty({max_num_sample}, dtype_f32_, device_cpu);
-    top_prob_probs_host_ = NDArray::Empty({max_num_sample * 5}, dtype_f32_, device_cpu);
-    top_prob_indices_host_ = NDArray::Empty({max_num_sample * 5}, dtype_i32_, device_cpu);
+    uniform_samples_host_ = NDArray::Empty({max_num_sample}, dtype_f32_, preferred_host_device);
+    sample_indices_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, preferred_host_device);
+    top_p_host_ = NDArray::Empty({max_num_sample}, dtype_f32_, preferred_host_device);
+    top_p_init_pivots_host_ = NDArray::Empty({max_num_sample, num_top_p_cutoff_pivots_}, dtype_f32_,
+                                             preferred_host_device);
+    top_prob_offsets_host_ =
+        NDArray::Empty({max_num_sample * 5}, dtype_i32_, preferred_host_device);
+    draft_tokens_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, preferred_host_device);
+    token_tree_first_child_host_ =
+        NDArray::Empty({max_num_sample}, dtype_i32_, preferred_host_device);
+    token_tree_next_sibling_host_ =
+        NDArray::Empty({max_num_sample}, dtype_i32_, preferred_host_device);
+    token_tree_parent_ptr_host_ =
+        NDArray::Empty({max_num_sample}, dtype_i32_, preferred_host_device);
+    sampled_token_ids_host_ = NDArray::Empty({max_num_sample}, dtype_i32_, preferred_host_device);
+    sampled_probs_host_ = NDArray::Empty({max_num_sample}, dtype_f32_, preferred_host_device);
+    top_prob_probs_host_ = NDArray::Empty({max_num_sample * 5}, dtype_f32_, preferred_host_device);
+    top_prob_indices_host_ =
+        NDArray::Empty({max_num_sample * 5}, dtype_i32_, preferred_host_device);
     // Initialize auxiliary arrays on GPU.
     uniform_samples_device_ = NDArray::Empty({max_num_sample}, dtype_f32_, device);
     sample_indices_device_ = NDArray::Empty({max_num_sample}, dtype_i32_, device);


### PR DESCRIPTION
This PR updates the host memory in model, logit processor and GPUSampler that for CUDA and ROCm the pinned memory will be used for the host arrays, which may be faster than the default CPU memory during copying.