### PR TITLE
[Bench] Add mlc bench

### DIFF
--- a/python/mlc_llm/bench/__init__.py
+++ b/python/mlc_llm/bench/__init__.py
@@ -1,6 +1,6 @@
 """Subdirectory of bench."""
 
-from .metrics import MetricsCalculator
+from .metrics import get_metrics_summary
 from .prompts import PromptsGenerator
 from .replay import load_replay_log, replay
 from .request import OpenAIRequestSender

--- a/python/mlc_llm/bench/__init__.py
+++ b/python/mlc_llm/bench/__init__.py
@@ -1,6 +1,6 @@
 """Subdirectory of bench."""
 
-from .metrics import get_metrics_summary
+from .metrics import MetricsProcessor
 from .prompts import PromptsGenerator
 from .replay import load_replay_log, replay
 from .request import OpenAIRequestSender

--- a/python/mlc_llm/bench/__init__.py
+++ b/python/mlc_llm/bench/__init__.py
@@ -1,3 +1,3 @@
 """Subdirectory of bench."""
 
-from .replay import RequestReplayer
+from .replay import OpenAIRequestSender, load_replay_log, replay

--- a/python/mlc_llm/bench/__init__.py
+++ b/python/mlc_llm/bench/__init__.py
@@ -1,3 +1,5 @@
 """Subdirectory of bench."""
 
-from .replay import OpenAIRequestSender, load_replay_log, replay
+from .metrics import MetricsCollector
+from .replay import load_replay_log, replay
+from .request import OpenAIRequestSender

--- a/python/mlc_llm/bench/__init__.py
+++ b/python/mlc_llm/bench/__init__.py
@@ -1,0 +1,3 @@
+"""Subdirectory of bench."""
+
+from .replay import RequestReplayer

--- a/python/mlc_llm/bench/__init__.py
+++ b/python/mlc_llm/bench/__init__.py
@@ -1,5 +1,6 @@
 """Subdirectory of bench."""
 
-from .metrics import MetricsCollector
+from .metrics import MetricsCalculator
+from .prompts import PromptsGenerator
 from .replay import load_replay_log, replay
 from .request import OpenAIRequestSender

--- a/python/mlc_llm/bench/metrics.py
+++ b/python/mlc_llm/bench/metrics.py
@@ -2,9 +2,6 @@
 import json
 from typing import Any, Dict, List, Union
 
-import pandas as pd
-from transformers import LlamaTokenizerFast
-
 from mlc_llm.support import logging
 
 logging.enable_logging()
@@ -20,12 +17,6 @@ METRIC_NAMES = [
     "num_input_tokens",
     "num_output_tokens",
 ]
-
-
-def get_token_length(text):
-    """Get the number of tokens."""
-    tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
-    return len(tokenizer.encode(text))
 
 
 class MetricsCollector:
@@ -86,6 +77,8 @@ class MetricsCollector:
         end_time : float
             The end time of the metrics collection.
         """
+        import pandas as pd  # pylint: disable=import-outside-toplevel,import-error
+
         if not self.all_metrics:
             return None
 

--- a/python/mlc_llm/bench/metrics.py
+++ b/python/mlc_llm/bench/metrics.py
@@ -1,6 +1,6 @@
 """ MLC LLM bench Metrics"""
 import json
-from typing import Dict, List, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -23,96 +23,179 @@ class Metrics(BaseModel):
     completion_tokens: int
 
 
-def _get_metrics(metrics: List[RequestRecords]) -> List[Metrics]:
-    """
-    Augments raw metrics.
+class MetricsProcessor:
+    """The metrics processor class
 
     Parameters
     ----------
-    metrics : List[Metrics]
-        The list of raw metrics data collected.
+    tokenizer : Optional[Tokenizer]
+        The tokenizer.
 
-    Returns
-    -------
-    metrics : List[Metrics]
-        The list of augmented metrics with additional items.
+    request_records : List[RequestRecords]
+        The list of request records.
     """
-    from transformers import (  # pylint: disable=import-outside-toplevel,import-error
-        LlamaTokenizerFast,
-    )
 
-    tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
+    def __init__(self, request_records: List[RequestRecords], tokenizer=None) -> None:
+        self.tokenizer = tokenizer
+        if self.tokenizer is None:
+            from transformers import (  # pylint: disable=import-outside-toplevel,import-error
+                LlamaTokenizerFast,
+            )
 
-    def _count_tokens(text: str, tokenizer) -> int:
-        return len(tokenizer.encode(text))
+            self.tokenizer = LlamaTokenizerFast.from_pretrained(
+                "hf-internal-testing/llama-tokenizer"
+            )
+            logger.warning("No tokenizer provided. Using default tokenizer.")
+        self.all_metrics: List[Metrics] = self.extract_metrics_from_request_records(request_records)
 
-    result = []
-    for metric in metrics:
-        prompt_tokens = _count_tokens(metric.input, tokenizer)
-        completion_tokens = _count_tokens(metric.output, tokenizer)
-        assert prompt_tokens > 0 and completion_tokens >= 0, "Invalid number of tokens"
-        end_to_end_latency = metric.end_to_end_latency
-        # TODO(yongwww): handle the non-streaming case where ttft is 0
-        refined_metric = Metrics(
-            inter_token_latency=end_to_end_latency / completion_tokens,
-            decode_token_latency=(end_to_end_latency - metric.ttft) / completion_tokens,
-            ttft=metric.ttft,
-            end_to_end_latency=end_to_end_latency,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
+    def count_tokens(self, prompt: str) -> int:
+        """Count the number of tokens in the text
+
+        Parameters
+        ----------
+        prompt : str
+            The text to count the tokens.
+
+        Returns
+        -------
+        prompt_tokens : int
+            The number of tokens in the prompt.
+        """
+        return len(self.tokenizer.encode(prompt))
+
+    def extract_metrics_from_request_records(
+        self, request_records: List[RequestRecords]
+    ) -> List[Metrics]:
+        """
+        Extract the metrics from request records.
+
+        Parameters
+        ----------
+        request_records : List[RequestRecords]
+            The list of raw request records collected.
+
+        Returns
+        -------
+        metrics : List[Metrics]
+            The list of extracted metrics with additional items.
+        """
+
+        result = []
+        for metric in request_records:
+            prompt_tokens = self.count_tokens(metric.input)
+            completion_tokens = self.count_tokens(metric.output)
+            assert prompt_tokens > 0 and completion_tokens >= 0, "Invalid prompt tokens"
+            end_to_end_latency = metric.end_to_end_latency
+            refined_metric = Metrics(
+                inter_token_latency=end_to_end_latency / completion_tokens,
+                decode_token_latency=(end_to_end_latency - metric.ttft) / completion_tokens,
+                ttft=metric.ttft,
+                end_to_end_latency=end_to_end_latency,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
+            result.append(refined_metric)
+        return result
+
+    def get_metrics(self) -> List[Metrics]:
+        """
+        Get the metrics collected.
+
+        Returns
+        -------
+        all_metrics : List[Metrics]
+            The list of metrics collected.
+        """
+        return self.all_metrics
+
+    def reset_metrics(self, metrics: List[Metrics]) -> None:
+        """Reset the metrics collected.
+
+        Parameters
+        ----------
+        metrics : List[Metrics]
+            The list of metrics to reset.
+        """
+        self.all_metrics = metrics
+
+    def filter_metrics(self, criteria: Optional[Callable[[Metrics], bool]] = None) -> List[Metrics]:
+        """
+        Filters the metrics based on the provided criteria. If no criteria are provided,
+        it filters out metrics with any fields set to None or 0.
+
+        Parameters
+        ----------
+        criteria : Optional[Callable[[Metrics], bool]]
+            A function that takes a metric as input,
+            returns True if the metric should be included.
+
+        Returns
+        -------
+        filtered_metrics : List[Metrics]
+            The list of metrics that meet the specified criteria.
+        """
+        if criteria is None:
+            # Default criteria to filter out metrics with None or 0 in certain fields
+            def criteria(metric: Metrics) -> bool:
+                for field, _ in Metrics.model_fields.items():
+                    val = getattr(metric, field)
+                    if val is None or val == 0:
+                        return False
+                return True
+
+        filered_metrics = [metric for metric in self.all_metrics if criteria(metric)]
+        self.reset_metrics(filered_metrics)
+        return filered_metrics
+
+    def generate_metrics_summary(
+        self, start_time: float, end_time: float
+    ) -> Dict[str, Union[int, float]]:
+        """
+        Computes summary statistics across all metrics collected.
+
+        Parameters
+        ----------
+        all_metrics : List[RequestRecords]
+            All the metrics data collected in the monitoring period.
+
+        start_time : float
+            The start time of the monitoring period.
+
+        end_time : float
+            The end time of the monitoring period.
+
+        Returns
+        -------
+        report : Dict
+            A dictionary containing the summary statistics of the collected metrics.
+        """
+        import pandas as pd  # pylint: disable=import-outside-toplevel,import-error
+
+        if not self.all_metrics:
+            return {}
+
+        metrics = self.all_metrics
+        df = pd.DataFrame([metric.model_dump() for metric in metrics])
+
+        report: Dict = {}
+        for key, _ in Metrics.model_fields.items():
+            if key in df.columns:
+                series = df[key].dropna()
+                report[key] = {
+                    "quantiles": {
+                        f"p{int(q * 100)}": v
+                        for q, v in series.quantile([0.25, 0.5, 0.75, 0.9, 0.95, 0.99]).items()
+                    },
+                    "mean": series.mean(),
+                    "min": series.min(),
+                    "max": series.max(),
+                    "stddev": series.std(),
+                }
+
+        report["num_completed_requests"] = len(metrics)
+        report["overall_output_throughput"] = df["completion_tokens"].sum() / (
+            end_time - start_time
         )
-        result.append(refined_metric)
-    return result
 
-
-def get_metrics_summary(
-    all_metrics: List[Union[RequestRecords, Metrics]], start_time: float, end_time: float
-) -> Dict[str, Union[int, float]]:
-    """
-    Computes summary statistics across all metrics collected.
-
-    Parameters
-    ----------
-    all_metrics : List[RequestRecords]
-        All the metrics data collected in the monitoring period.
-
-    start_time : float
-        The start time of the monitoring period.
-
-    end_time : float
-        The end time of the monitoring period.
-
-    Returns
-    -------
-    report : Dict
-        A dictionary containing the summary statistics of the collected metrics.
-    """
-    import pandas as pd  # pylint: disable=import-outside-toplevel,import-error
-
-    if not all_metrics:
-        logger.warning("No metrics collected.")
-        return {}
-
-    metrics = all_metrics if isinstance(all_metrics[0], Metrics) else _get_metrics(all_metrics)
-    df = pd.DataFrame([metric.model_dump() for metric in metrics])
-
-    report: Dict = {}
-    for key, _ in Metrics.model_fields.items():
-        if key in df.columns:
-            series = df[key].dropna()
-            report[key] = {
-                "quantiles": {
-                    f"p{int(q * 100)}": v
-                    for q, v in series.quantile([0.25, 0.5, 0.75, 0.9, 0.95, 0.99]).items()
-                },
-                "mean": series.mean(),
-                "min": series.min(),
-                "max": series.max(),
-                "stddev": series.std(),
-            }
-
-    report["num_completed_requests"] = len(metrics)
-    report["overall_output_throughput"] = df["completion_tokens"].sum() / (end_time - start_time)
-
-    logger.info("Metrics Summary:\n%s", json.dumps(report, indent=4, default=str))
-    return report
+        logger.info("Metrics Summary:\n%s", json.dumps(report, indent=4, default=str))
+        return report

--- a/python/mlc_llm/bench/metrics.py
+++ b/python/mlc_llm/bench/metrics.py
@@ -6,35 +6,35 @@ from pydantic import BaseModel
 
 from mlc_llm.support import logging
 
-from .request import RawMetrics
+from .request import RequestRecords
 
 logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 
-class RefinedMetrics(BaseModel):
+class Metrics(BaseModel):
     """The list of metric keys"""
 
     ttft: float
     end_to_end_latency: float
     inter_token_latency: float
     decode_token_latency: float
-    num_input_tokens: int
-    num_output_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
 
 
-def refine_metrics(metrics: List[RawMetrics]) -> List[RefinedMetrics]:
+def _get_metrics(metrics: List[RequestRecords]) -> List[Metrics]:
     """
     Augments raw metrics.
 
     Parameters
     ----------
-    metrics : List[RefinedMetrics]
+    metrics : List[Metrics]
         The list of raw metrics data collected.
 
     Returns
     -------
-    metrics : List[RefinedMetrics]
+    metrics : List[Metrics]
         The list of augmented metrics with additional items.
     """
     from transformers import (  # pylint: disable=import-outside-toplevel,import-error
@@ -48,32 +48,32 @@ def refine_metrics(metrics: List[RawMetrics]) -> List[RefinedMetrics]:
 
     result = []
     for metric in metrics:
-        num_input_tokens = _count_tokens(metric.input, tokenizer)
-        num_output_tokens = _count_tokens(metric.output, tokenizer)
-        assert num_input_tokens > 0 and num_output_tokens >= 0, "Invalid number of tokens"
+        prompt_tokens = _count_tokens(metric.input, tokenizer)
+        completion_tokens = _count_tokens(metric.output, tokenizer)
+        assert prompt_tokens > 0 and completion_tokens >= 0, "Invalid number of tokens"
         end_to_end_latency = metric.end_to_end_latency
         # TODO(yongwww): handle the non-streaming case where ttft is 0
-        refined_metric = RefinedMetrics(
-            inter_token_latency=end_to_end_latency / num_output_tokens,
-            decode_token_latency=(end_to_end_latency - metric.ttft) / num_output_tokens,
+        refined_metric = Metrics(
+            inter_token_latency=end_to_end_latency / completion_tokens,
+            decode_token_latency=(end_to_end_latency - metric.ttft) / completion_tokens,
             ttft=metric.ttft,
             end_to_end_latency=end_to_end_latency,
-            num_input_tokens=num_input_tokens,
-            num_output_tokens=num_output_tokens,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
         )
         result.append(refined_metric)
     return result
 
 
 def get_metrics_summary(
-    all_metrics: List[RawMetrics], start_time: float, end_time: float
+    all_metrics: List[Union[RequestRecords, Metrics]], start_time: float, end_time: float
 ) -> Dict[str, Union[int, float]]:
     """
     Computes summary statistics across all metrics collected.
 
     Parameters
     ----------
-    all_metrics : List[RawMetrics]
+    all_metrics : List[RequestRecords]
         All the metrics data collected in the monitoring period.
 
     start_time : float
@@ -93,11 +93,11 @@ def get_metrics_summary(
         logger.warning("No metrics collected.")
         return {}
 
-    metrics = refine_metrics(all_metrics)
+    metrics = all_metrics if isinstance(all_metrics[0], Metrics) else _get_metrics(all_metrics)
     df = pd.DataFrame([metric.model_dump() for metric in metrics])
 
     report: Dict = {}
-    for key, _ in RefinedMetrics.model_fields.items():
+    for key, _ in Metrics.model_fields.items():
         if key in df.columns:
             series = df[key].dropna()
             report[key] = {
@@ -112,7 +112,7 @@ def get_metrics_summary(
             }
 
     report["num_completed_requests"] = len(metrics)
-    report["overall_output_throughput"] = df["num_output_tokens"].sum() / (end_time - start_time)
+    report["overall_output_throughput"] = df["completion_tokens"].sum() / (end_time - start_time)
 
     logger.info("Metrics Summary:\n%s", json.dumps(report, indent=4, default=str))
     return report

--- a/python/mlc_llm/bench/metrics.py
+++ b/python/mlc_llm/bench/metrics.py
@@ -1,0 +1,115 @@
+""" MLC LLM bench Metrics Collector"""
+import json
+from typing import Any, Dict, List, Union
+
+import pandas as pd
+from transformers import LlamaTokenizerFast
+
+from mlc_llm.support import logging
+
+logging.enable_logging()
+logger = logging.getLogger(__name__)
+
+# The list of metric keys, overall_output_throughput and num_completed_requests
+# are able to be computed based on the other metrics
+METRIC_NAMES = [
+    "inter_token_latency",
+    "decode_token_latency",
+    "ttft",
+    "end_to_end_latency",
+    "num_input_tokens",
+    "num_output_tokens",
+]
+
+
+def get_token_length(text):
+    """Get the number of tokens."""
+    tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
+    return len(tokenizer.encode(text))
+
+
+class MetricsCollector:
+    """
+    A class to manage various performance metrics.
+
+    Attributes
+    ----------
+    metric_keys : List[str]
+        A list of all the metric keys managed by the collector.
+    all_metrics : List[Dict[str, Any]]
+        A list containing all metrics data recorded, each as a dictionary.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the metrics collector.
+        """
+        self.metric_keys: List = list(METRIC_NAMES)
+        self.all_metrics: List[Dict] = []
+
+    def add_metrics(self, metrics: Dict[str, Union[int, float]]) -> None:
+        """
+        Adds a new set of metric data to the collection.
+
+        Parameters
+        ----------
+        metrics : Dict[str, Union[int, float]]
+            A dictionary containing values for the metrics defined in metric_keys.
+        """
+        if not all(key in self.metric_keys for key in metrics.keys()):
+            logger.error("Metric dictionary keys do not match the predefined metric keys.")
+        self.all_metrics.append(metrics)
+
+    def get_all_metrics(self) -> List[Dict[str, Any]]:
+        """
+        Returns all the metric data collected.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            A list of all metric data dictionaries.
+        """
+        return self.all_metrics
+
+    def get_metrics_summary(self, start_time: int, end_time: int) -> Dict[str, Any]:
+        """
+        Computes summary statistics across all metrics collected.
+
+        Returns
+        -------
+        ret : Dict[str, Any]
+            A dictionary containing the summary statistics of the collected metrics.
+
+        start_time : int
+            The start time of the metrics collection.
+
+        end_time : int
+            The end time of the metrics collection.
+        """
+        if not self.all_metrics:
+            return None
+
+        ret: Dict[str, Any] = {}
+        metrics = self.all_metrics
+
+        df = pd.DataFrame(metrics)
+
+        for key in self.metric_keys:
+            ret[key] = {}
+            series = df[key].dropna()
+            quantiles = series.quantile([0.25, 0.5, 0.75, 0.9, 0.95, 0.99]).to_dict()
+            quantiles_reformatted_keys = {}
+            for quantile, value in quantiles.items():
+                reformatted_key = f"p{int(quantile * 100)}"
+                quantiles_reformatted_keys[reformatted_key] = value
+            ret[key]["quantiles"] = quantiles_reformatted_keys
+            mean = series.mean()
+            ret[key]["mean"] = mean
+            ret[key]["min"] = series.min()
+            ret[key]["max"] = series.max()
+            ret[key]["stddev"] = series.std()
+
+        ret["num_completed_requests"] = len(metrics)
+        ret["overall_output_throughput"] = df["num_output_tokens"].sum() / (end_time - start_time)
+        logger.info("Metrics Summary:\n%s", json.dumps(ret, indent=4, default=str))
+        return ret

--- a/python/mlc_llm/bench/metrics.py
+++ b/python/mlc_llm/bench/metrics.py
@@ -71,7 +71,7 @@ class MetricsCollector:
         """
         return self.all_metrics
 
-    def get_metrics_summary(self, start_time: int, end_time: int) -> Dict[str, Any]:
+    def get_metrics_summary(self, start_time: float, end_time: float) -> Dict[str, Any]:
         """
         Computes summary statistics across all metrics collected.
 
@@ -80,10 +80,10 @@ class MetricsCollector:
         ret : Dict[str, Any]
             A dictionary containing the summary statistics of the collected metrics.
 
-        start_time : int
+        start_time : float
             The start time of the metrics collection.
 
-        end_time : int
+        end_time : float
             The end time of the metrics collection.
         """
         if not self.all_metrics:

--- a/python/mlc_llm/bench/prompts.py
+++ b/python/mlc_llm/bench/prompts.py
@@ -1,0 +1,90 @@
+"""MLC LLM bench prompts generator"""
+import random
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+class PromptsGenerator:  # pylint: disable=too-few-public-methods
+    """
+    Generates prompts of a specified token length from a text file containing potential prompts.
+    """
+
+    def __init__(self, file_path: Optional[str] = None) -> None:
+        """
+        Initializes the PromptsGenerator with the file path and tokenizer.
+
+        Parameters
+        ----------
+        file_path : Optional[str]
+            The path to the text file containing the prompts.
+        """
+        from transformers import (  # pylint: disable=import-outside-toplevel,import-error
+            LlamaTokenizerFast,
+        )
+
+        # TODO(yongwww): Add a default plain prompts source
+        prompt_path = Path(file_path) if file_path else Path(__file__).parent / "prompts.txt"
+        with prompt_path.open("r") as file:
+            self.source_prompts = file.readlines()
+        self.tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
+
+    def _get_token_length(self, text: str) -> int:
+        """Get the number of tokens.
+
+        Parameters
+        ----------
+        text : str
+            The text to tokenize.
+
+        Returns
+        -------
+        output : int
+            The number of tokens
+        """
+        return len(self.tokenizer.encode(text))
+
+    def generate_prompt(
+        self, tokens_mean: int, tokens_stddev: Optional[int] = 0, seed: Optional[int] = 11111
+    ) -> Tuple[str, int]:
+        """
+        Generates a prompt that closely matches the desired token count.
+
+        Parameters
+        ----------
+        token_mean : int
+            The desired mean number of tokens in the prompt.
+
+        token_stddev : Optional[int]
+            The desired standard deviation of tokens in the prompt.
+
+        seed : Optional[int]
+            The seed for the random number generator.
+
+        Returns
+        -------
+        out: Tuple[str, int]
+            A tuple containing:
+            1) A prompt string with the specified number of tokens.
+            2) The actual number of tokens in the prompt.
+        """
+        assert tokens_mean > 0, "The mean number of tokens must be greater than 0."
+        random.seed(seed)
+        num_out_tokens = (
+            int(random.gauss(tokens_mean, tokens_stddev)) if tokens_stddev else tokens_mean
+        )
+        if num_out_tokens <= 0:
+            num_out_tokens = tokens_mean
+        random.shuffle(self.source_prompts)
+        remaining_num_tokens = num_out_tokens
+        out_prompt = ""
+        while remaining_num_tokens > 0:
+            for tokens in self.source_prompts:
+                num_tokens = self._get_token_length(tokens)
+                if remaining_num_tokens - num_tokens < 0:
+                    out_prompt += tokens[:remaining_num_tokens]
+                    remaining_num_tokens = 0
+                    break
+                out_prompt += tokens
+                remaining_num_tokens -= num_tokens
+        self._get_token_length(out_prompt)
+        return (out_prompt, num_out_tokens)

--- a/python/mlc_llm/bench/prompts.py
+++ b/python/mlc_llm/bench/prompts.py
@@ -1,7 +1,7 @@
 """MLC LLM bench prompts generator"""
 import random
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 
 class PromptsGenerator:  # pylint: disable=too-few-public-methods
@@ -28,7 +28,7 @@ class PromptsGenerator:  # pylint: disable=too-few-public-methods
             self.source_prompts = file.readlines()
         self.tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
 
-    def _get_token_length(self, text: str) -> int:
+    def _count_tokens(self, text: str) -> int:
         """Get the number of tokens.
 
         Parameters
@@ -45,7 +45,7 @@ class PromptsGenerator:  # pylint: disable=too-few-public-methods
 
     def generate_prompt(
         self, tokens_mean: int, tokens_stddev: Optional[int] = 0, seed: Optional[int] = 11111
-    ) -> Tuple[str, int]:
+    ) -> str:
         """
         Generates a prompt that closely matches the desired token count.
 
@@ -62,10 +62,8 @@ class PromptsGenerator:  # pylint: disable=too-few-public-methods
 
         Returns
         -------
-        out: Tuple[str, int]
-            A tuple containing:
-            1) A prompt string with the specified number of tokens.
-            2) The actual number of tokens in the prompt.
+        out: str
+            A prompt string with the specified number of tokens.
         """
         assert tokens_mean > 0, "The mean number of tokens must be greater than 0."
         random.seed(seed)
@@ -79,12 +77,12 @@ class PromptsGenerator:  # pylint: disable=too-few-public-methods
         out_prompt = ""
         while remaining_num_tokens > 0:
             for tokens in self.source_prompts:
-                num_tokens = self._get_token_length(tokens)
+                num_tokens = self._count_tokens(tokens)
                 if remaining_num_tokens - num_tokens < 0:
                     out_prompt += tokens[:remaining_num_tokens]
                     remaining_num_tokens = 0
                     break
                 out_prompt += tokens
                 remaining_num_tokens -= num_tokens
-        self._get_token_length(out_prompt)
-        return (out_prompt, num_out_tokens)
+        self._count_tokens(out_prompt)
+        return out_prompt

--- a/python/mlc_llm/bench/replay.py
+++ b/python/mlc_llm/bench/replay.py
@@ -4,8 +4,6 @@ import json
 from datetime import datetime
 from typing import Dict, List, Optional
 
-import pandas as pd
-
 
 def load_replay_log(log_path: str) -> List[Dict]:
     """
@@ -22,6 +20,8 @@ def load_replay_log(log_path: str) -> List[Dict]:
         A list of preprocessed event data for replay.
     """
     if log_path.endswith(".csv"):
+        import pandas as pd  # pylint: disable=import-outside-toplevel,import-error
+
         df = pd.read_csv(log_path)
         column_names = df.columns.values
         assert (

--- a/python/mlc_llm/bench/replay.py
+++ b/python/mlc_llm/bench/replay.py
@@ -1,0 +1,184 @@
+"""MLC LLM bench replay request"""
+import asyncio
+import json
+import os
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import aiohttp
+import pandas as pd
+
+from mlc_llm.support import logging
+
+logging.enable_logging()
+logger = logging.getLogger(__name__)
+
+
+class RequestReplayer:
+    """
+    Replay generated events based on historical timestamps. The replaying requests start
+    from a new start time while preserving the intervals between requests.
+
+    Parameters
+    ----------
+    log_path : str
+        The path to the event log CSV or JSONL file containing the events to replay.
+
+    host : Optional[str]
+        The host address for the API. Default is "127.0.0.1".
+
+    port : Optional[int]
+        The port number for the API. Default is 8008.
+
+    stream : Optional[bool]
+        Indicates whether the streaming should be enabled. Default is True.
+
+    timeout : Optional[int]
+        The timeout in seconds for each request. Default is 180.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        log_path: str,
+        host: Optional[str] = "127.0.0.1",
+        port: Optional[int] = 8008,
+        stream: Optional[bool] = True,
+        timeout: Optional[int] = 180,
+    ) -> None:
+        self.url = f"http://{host}:{port}/v1/chat/completions"
+        self.stream = stream
+        self.timeout = timeout
+        self.headers = {"Content-Type": "application/json"}
+        if os.getenv("MLC_API_KEY"):
+            self.headers["Authorization"] = f"Bearer {os.getenv('MLC_API_KEY')}"
+        self.request_params = self.get_request_params(log_path)
+
+    def get_request_params(self, log_path: str) -> List[Dict]:
+        """
+        Loads and preprocesses the event log from either a CSV or JSONL file to prepare payloads and
+        request parameters for replay.
+
+        Parameters
+        ----------
+        log_path : str
+            The path to the event log CSV or JSONL file containing the events to replay.
+
+        Returns
+        -------
+        res: List[Dict]
+            A list of preprocessed event data dictionaries for replay.
+        """
+        if log_path.endswith(".csv"):
+            return self._load_csv(log_path)
+        if log_path.endswith(".jsonl"):
+            return self._load_jsonl(log_path)
+        raise ValueError("Unsupported file format. Please use .csv or .jsonl.")
+
+    def _load_csv(self, filepath: str) -> List[Dict]:
+        """
+        Loads parameters from a CSV file and returns a list of event data dictionaries.
+
+        Parameters
+        ----------
+        filepath : str
+            The path to the CSV file.
+
+        Returns
+        -------
+        res: List[Dict]
+            A list of event data dictionaries from the CSV file, sorted by timestamp.
+        """
+        df = pd.read_csv(filepath)
+        column_names = df.columns.values
+        assert (
+            ("Date" in column_names)
+            and ("@request" in column_names)
+            and ("Message" in column_names)
+        )
+        df["timestamp"] = pd.to_datetime(df["Date"])
+        df.sort_values("timestamp", inplace=True)
+        # Get the request params from the loaded CSV
+        params = []
+        for _, row in df.iterrows():
+            request = row["@request"]
+            payload = json.loads(str(request))
+            params.append(
+                {
+                    "timestamp": row["timestamp"],
+                    "payload": payload,
+                }
+            )
+        return params
+
+    def _load_jsonl(self, filepath: str) -> List[Dict]:
+        """
+        Loads parameters from a JSONL file and returns a list of event data dictionaries.
+
+        Parameters
+        ----------
+        filepath : str
+            The path to the JSONL file.
+
+        Returns
+        -------
+        res: List[Dict]
+            A list of event data dictionaries from the JSONL file, sorted by timestamp.
+        """
+        with open(filepath, "r", encoding="utf-8") as file:
+            data = [json.loads(line) for line in file]
+            for item in data:
+                item["timestamp"] = datetime.fromisoformat(item["timestamp"])
+        data.sort(key=lambda x: x["timestamp"])
+        return data
+
+    async def send_request(self, session, params: Dict):
+        """
+        Sends an asynchronous HTTP POST request using an aiohttp session.
+
+        Parameters
+        ----------
+        session : aiohttp.ClientSession
+            The active aiohttp client session.
+
+        params : dict
+            The parameters for the request, including URL, headers, and payload, etc.
+
+        Returns
+        -------
+        res
+            The JSON response from the server or None if an error occurs.
+        """
+        try:
+            url = params.get("address", self.url)
+            headers = params.get("headers", self.headers)
+            payload = params["payload"]
+            async with session.post(
+                url, json=payload, headers=headers, timeout=self.timeout
+            ) as response:
+                return await response.json()
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error("Error in send request %s", err)
+
+    async def run(self):
+        """
+        Replays the stored requests.
+
+        Utilizes the asyncio event loop to schedule each request according to its timestamp,
+        adjusting for the current time.
+        """
+        if not self.request_params:
+            return
+        async with aiohttp.ClientSession() as session:
+            loop = asyncio.get_running_loop()
+            start_time = loop.time()
+            first_timestamp = self.request_params[0]["timestamp"]
+
+            for params in self.request_params:
+                original_delay = (params["timestamp"] - first_timestamp).total_seconds()
+                loop.call_at(
+                    start_time + original_delay,
+                    lambda p=params: asyncio.create_task(self.send_request(session, p)),
+                )
+
+            last_delay = (self.request_params[-1]["timestamp"] - first_timestamp).total_seconds()
+            await asyncio.sleep(last_delay + 1)

--- a/python/mlc_llm/bench/request.py
+++ b/python/mlc_llm/bench/request.py
@@ -1,0 +1,165 @@
+"""MLC LLM bench request"""
+import time
+from typing import Dict, Optional
+
+import httpx
+from openai import AsyncOpenAI
+from typing_extensions import Self
+
+from mlc_llm.support import logging
+
+from .metrics import MetricsCollector, get_token_length
+
+logging.enable_logging()
+logger = logging.getLogger(__name__)
+
+OPENAI_COMPLETION_PARAMS = [
+    "messages",
+    "model",
+    "stream",
+    "loglikelihood",
+    "seed",
+    "max_tokens",
+    "presence_penalty",
+    "echo",
+    "n",
+    "top_p",
+    "frequency_penalty",
+    "best_of",
+    "stop",
+    "stream",
+    "temperature",
+    "model",
+    "force_asset_download",
+]
+
+
+class OpenAIRequestSender:
+    """
+    Collect inference statistics.
+
+    Parameters
+    ----------
+    host : Optional[str]
+        The host address for the API, by default "127.0.0.1".
+
+    port : Optional[int]
+        The port number for the API, by default 8008.
+
+    stream : Optional[bool]
+        Indicates whether streaming should be enabled. Default is True.
+
+    timeout : Optional[float]
+        The timeout in seconds for each request, by default 180.
+
+    Attributes
+    ----------
+    stats : dict
+        A dictionary to store statistics about requests and responses.
+    """
+
+    def __init__(
+        self,
+        host: Optional[str] = "127.0.0.1",
+        port: Optional[int] = 8008,
+        stream: Optional[bool] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self.stream = stream
+        self.timeout = timeout
+        self.client = AsyncOpenAI(
+            base_url=f"http://{host}:{port}/v1",
+            api_key="None",
+            http_client=httpx.AsyncClient(http2=True),
+        )
+        self.metrics_collector = MetricsCollector()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        await self.client.close()
+
+    def get_stats(self, start_time: float, end_time: float) -> Dict:
+        """
+        Returns the statistics summary.
+
+        Parameters
+        ----------
+        start_time : float
+            The start time for the statistics collection.
+
+        end_time : float
+            The end time for the statistics collection.
+
+        Returns
+        -------
+        stats : Dict
+            The performance statistics.
+        """
+        return self.metrics_collector.get_metrics_summary(start_time, end_time)
+
+    async def __call__(self, params: Dict = None) -> None:
+        """
+        Send request to the deployed serving endpoint.
+
+        Parameters
+        ----------
+        params : Dict
+            The parameters for the request.
+
+        Returns
+        -------
+        response : Union[Dict, None]
+            The JSON response from the server or None if an error occurs.
+        """
+
+        def _get_chat_completion_params(params):
+            chat_params = {}
+            for key in OPENAI_COMPLETION_PARAMS:
+                if key in params:
+                    chat_params[key] = params[key]
+            return chat_params
+
+        chat_params = _get_chat_completion_params(params)
+        # Use the stream specified in constructor
+        if self.stream:
+            chat_params["stream"] = self.stream
+        if self.timeout:
+            chat_params["timeout"] = self.timeout
+
+        metrics = {}
+        time_to_next_token = []
+        total_request_time = 0
+        tokens_received = 0
+        generated_text = ""
+        ttft = None
+        prompt = params["messages"][0]["content"]
+        metrics["num_input_tokens"] = get_token_length(prompt)
+        most_recent_received_token_time = start_time = time.monotonic()
+
+        response = await self.client.chat.completions.create(**chat_params)
+
+        # Don't collect stats for non-streaming requests
+        if chat_params["stream"] is False:
+            return None
+
+        async for chunk in response:
+            tokens_received += 1
+            if chunk.choices[0].delta.content is not None:
+                if not ttft:
+                    ttft = time.monotonic() - start_time
+                    time_to_next_token.append(ttft)
+                else:
+                    time_to_next_token.append(time.monotonic() - most_recent_received_token_time)
+                most_recent_received_token_time = time.monotonic()
+                generated_text += chunk.choices[0].delta.content
+
+        total_request_time = time.monotonic() - start_time  # type: ignore
+        # assert num_output_tokens == get_token_length(generated_text)
+        metrics["num_output_tokens"] = tokens_received
+        metrics["ttft"] = ttft
+        metrics["end_to_end_latency"] = total_request_time
+        metrics["inter_token_latency"] = sum(time_to_next_token)
+        metrics["decode_token_latency"] = metrics["inter_token_latency"] - ttft
+        self.metrics_collector.add_metrics(metrics)

--- a/python/mlc_llm/bench/request.py
+++ b/python/mlc_llm/bench/request.py
@@ -1,14 +1,12 @@
 """MLC LLM bench request"""
 import time
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, List
 
 import httpx
 from openai import AsyncOpenAI
 from typing_extensions import Self
 
 from mlc_llm.support import logging
-
-from .metrics import MetricsCollector
 
 logging.enable_logging()
 logger = logging.getLogger(__name__)
@@ -65,6 +63,11 @@ class OpenAIRequestSender:
         stream: Optional[bool] = None,
         timeout: Optional[float] = None,
     ) -> None:
+        # TODO(yongwww): explore to use mlc_llm.tokenizer.Tokenizer
+        from transformers import (  # pylint: disable=import-outside-toplevel,import-error
+            LlamaTokenizerFast,
+        )
+
         self.stream = stream
         self.timeout = timeout
         self.client = AsyncOpenAI(
@@ -72,53 +75,14 @@ class OpenAIRequestSender:
             api_key="None",
             http_client=httpx.AsyncClient(http2=True),
         )
-        self.metrics_collector = MetricsCollector()
+        self.tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
+        self.all_metrics = []
 
     async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         await self.client.close()
-
-    def _get_token_length(self, text: str) -> int:
-        """Get the number of tokens.
-
-        Parameters
-        ----------
-        text : str
-            The text to tokenize.
-
-        Returns
-        -------
-        output : int
-            The number of tokens
-        """
-        from transformers import (  # pylint: disable=import-outside-toplevel,import-error
-            LlamaTokenizerFast,
-        )
-
-        # TODO(yongwww): explore to use mlc_llm.tokenizer.Tokenizer
-        tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
-        return len(tokenizer.encode(text))
-
-    def get_stats(self, start_time: float, end_time: float) -> Dict:
-        """
-        Returns the statistics summary.
-
-        Parameters
-        ----------
-        start_time : float
-            The start time for the statistics collection.
-
-        end_time : float
-            The end time for the statistics collection.
-
-        Returns
-        -------
-        stats : Dict
-            The performance statistics.
-        """
-        return self.metrics_collector.get_metrics_summary(start_time, end_time)
 
     async def __call__(self, params: Dict = None) -> None:
         """
@@ -134,19 +98,11 @@ class OpenAIRequestSender:
         response : Union[Dict, None]
             The JSON response from the server or None if an error occurs.
         """
-
-        def _get_chat_completion_params(params):
-            chat_params = {}
-            for key in OPENAI_COMPLETION_PARAMS:
-                if key in params:
-                    chat_params[key] = params[key]
-            return chat_params
-
-        chat_params = _get_chat_completion_params(params)
+        chat_params = self._get_chat_completion_params(params)
         # Use the stream specified in constructor
-        if self.stream:
+        if "stream" not in chat_params:
             chat_params["stream"] = self.stream
-        if self.timeout:
+        if "timeout" not in chat_params:
             chat_params["timeout"] = self.timeout
 
         metrics: Dict[str, Union[float, int]] = {}
@@ -156,7 +112,7 @@ class OpenAIRequestSender:
         generated_text = ""
         ttft = None
         prompt = params["messages"][0]["content"]
-        metrics["num_input_tokens"] = self._get_token_length(prompt)
+        # metrics["num_input_tokens"] = self._get_token_length(prompt)
         most_recent_received_token_time = start_time = time.monotonic()
 
         response = await self.client.chat.completions.create(**chat_params)
@@ -165,22 +121,64 @@ class OpenAIRequestSender:
         if chat_params["stream"] is False:
             return None
 
-        async for chunk in response:
-            tokens_received += 1
-            if chunk.choices[0].delta.content is not None:
-                if not ttft:
-                    ttft = time.monotonic() - start_time
-                    time_to_next_token.append(ttft)
-                else:
-                    time_to_next_token.append(time.monotonic() - most_recent_received_token_time)
-                most_recent_received_token_time = time.monotonic()
-                generated_text += chunk.choices[0].delta.content
+        if chat_params["stream"]:
+            async for chunk in response:
+                tokens_received += 1
+                if chunk.choices[0].delta.content is not None:
+                    if not ttft:
+                        ttft = time.monotonic() - start_time
+                        time_to_next_token.append(ttft)
+                    else:
+                        time_to_next_token.append(
+                            time.monotonic() - most_recent_received_token_time
+                        )
+                    most_recent_received_token_time = time.monotonic()
+                    generated_text += chunk.choices[0].delta.content
+        else:
+            tokens_received = 1
+            generated_text = response.choices[0].message.content
 
         total_request_time = time.monotonic() - start_time  # type: ignore
         # assert num_output_tokens == get_token_length(generated_text)
-        metrics["num_output_tokens"] = tokens_received
+        # metrics["num_output_tokens"] = tokens_received
         metrics["ttft"] = ttft
         metrics["end_to_end_latency"] = total_request_time
-        metrics["inter_token_latency"] = sum(time_to_next_token)
-        metrics["decode_token_latency"] = metrics["inter_token_latency"] - ttft
-        self.metrics_collector.add_metrics(metrics)
+        # metrics["inter_token_latency"] = sum(time_to_next_token)
+        # metrics["decode_token_latency"] = metrics["inter_token_latency"] - ttft
+        metrics["input"] = prompt
+        metrics["output"] = generated_text
+
+        # [input, output, ttft, e2e_latency]
+        # Note: ttft could be None for non-streaming requests
+        self.all_metrics.append(metrics)
+
+    def _get_chat_completion_params(self, params: Dict) -> Dict:
+        """
+        Get the chat completion parameters from the request parameters.
+
+        Parameters
+        ----------
+        params : Dict
+            The parameters for the request.
+
+        Returns
+        -------
+        chat_params : Dict
+            The chat completion parameters.
+        """
+        chat_params = {}
+        for key in OPENAI_COMPLETION_PARAMS:
+            if key in params:
+                chat_params[key] = params[key]
+        return chat_params
+
+    def get_metrics(self) -> List[Dict[str, Union[str, int, float]]]:
+        """
+        Get the metrics collected.
+
+        Returns
+        -------
+        metrics : List[Dict[str, Union[str, int, float]]]
+            The metrics collected.
+        """
+        return self.all_metrics

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from typing import AsyncGenerator, List, Optional
 
 import fastapi
+import structlog
 
 from mlc_llm.protocol import error_protocol
 from mlc_llm.protocol.openai_api_protocol import (
@@ -18,7 +19,7 @@ from mlc_llm.serve import engine_base, engine_utils
 from mlc_llm.serve.server import ServerContext
 
 app = fastapi.APIRouter()
-
+logger = structlog.stdlib.get_logger(__name__)
 ################ v1/models ################
 
 
@@ -136,6 +137,8 @@ async def request_chat_completion(
     API reference: https://platform.openai.com/docs/api-reference/chat
     """
     # - Check the requested model.
+    logger.info("Received chat completion request", request=request)
+
     server_context: ServerContext = ServerContext.current()
     request_final_usage_include_extra = server_context.enable_debug
     request_include_debug_config = server_context.enable_debug

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -139,7 +139,6 @@ async def request_chat_completion(
     API reference: https://platform.openai.com/docs/api-reference/chat
     """
     # - Check the requested model.
-
     server_context: ServerContext = ServerContext.current()
     request_final_usage_include_extra = server_context.enable_debug
     request_include_debug_config = server_context.enable_debug

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -7,7 +7,6 @@ from http import HTTPStatus
 from typing import AsyncGenerator, List, Optional
 
 import fastapi
-import structlog
 
 from mlc_llm.protocol import error_protocol
 from mlc_llm.protocol.openai_api_protocol import (
@@ -21,7 +20,6 @@ from mlc_llm.serve import engine_base, engine_utils
 from mlc_llm.serve.server import ServerContext
 
 app = fastapi.APIRouter()
-logger = structlog.stdlib.get_logger(__name__)
 ################ v1/models ################
 
 
@@ -144,6 +142,10 @@ async def request_chat_completion(
     request_include_debug_config = server_context.enable_debug
 
     if server_context.enable_debug:
+        import structlog  # pylint: disable=import-outside-toplevel,import-error
+
+        logger = structlog.stdlib.get_logger(__name__)
+
         request_param = await raw_request.json()
         timestamp = {"timestamp": datetime.now().isoformat()}
         request_param = {**timestamp, **request_param}


### PR DESCRIPTION
This PR:
- Adds a util to replay requests, we can replay the generated/saved request events with it.
- Adds prompts generator for benchmarking.
- Implements OpenAIRequestSender to help handle the request to deployed endpoint.
- Calculates some perf statistics like ttft, decode token latency.

cc: @tqchen 