### PR TITLE
[TEST] MockEchoEngine

### DIFF
--- a/python/mlc_llm/json_ffi/engine.py
+++ b/python/mlc_llm/json_ffi/engine.py
@@ -129,7 +129,7 @@ class Completions:
         n: int = 1,
         seed: Optional[int] = None,
         stop: Optional[Union[str, List[str]]] = None,
-        stream: bool = False,
+        stream: bool = True,
         stream_options: Optional[Dict[str, Any]] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
@@ -143,6 +143,8 @@ class Completions:
         if request_id is None:
             request_id = f"chatcmpl-{engine_utils.random_uuid()}"
         debug_config = extra_body.get("debug_config", None) if extra_body is not None else None
+        if not stream:
+            raise ValueError("JSONFFIEngine only support stream=True")
         request = openai_api_protocol.ChatCompletionRequest(
             messages=[
                 openai_api_protocol.ChatCompletionMessage.model_validate(message)

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -133,7 +133,10 @@ def _process_model_args(
         if model.model_lib is not None:
             # do model lib search if the model lib is provided
             # error out if file not found
-            if Path(model.model_lib).is_file():
+            if model.model_lib.startswith("mock://"):
+                model_lib = model.model_lib
+                logger.info("[DEBUG] mock test: %s", model_lib)
+            elif Path(model.model_lib).is_file():
                 model_lib = model.model_lib
                 logger.info("Using library model: %s", model_lib)
             else:
@@ -802,6 +805,9 @@ def process_chat_completion_stream_output(  # pylint: disable=too-many-arguments
                 delta_outputs[0].request_final_usage_json_str
             ),
         )
+        # non streaming mode always comes with usage
+        if not request.stream:
+            return response
         # skip usage if stream option does not indicate include usage
         if request.stream_options is None:
             return None
@@ -981,6 +987,9 @@ def process_completion_stream_output(  # pylint: disable=too-many-arguments
                 delta_outputs[0].request_final_usage_json_str
             ),
         )
+        # non streaming mode always comes with usage
+        if not request.stream:
+            return response
         if request.stream_options is None:
             return None
         if not request.stream_options.include_usage:

--- a/tests/python/json_ffi/test_json_ffi_engine_mock.py
+++ b/tests/python/json_ffi/test_json_ffi_engine_mock.py
@@ -1,0 +1,80 @@
+import json
+
+import pytest
+import tvm
+
+from mlc_llm.json_ffi import JSONFFIEngine
+from mlc_llm.testing import require_test_model
+
+# test category "unittest"
+pytestmark = [pytest.mark.unittest]
+
+
+def check_error_handling(engine, expect_str, **params):
+    """Check error handling in raw completion API"""
+    body = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "stream_options": {"include_usage": True},
+    }
+    body.update(params)
+
+    for response in engine._raw_chat_completion(
+        json.dumps(body), include_usage=False, request_id="123"
+    ):
+        if response.choices[0].finish_reason is not None:
+            break
+    if response.choices[0].finish_reason != "error":
+        raise RuntimeError(f"expect the request {params} to hit an error")
+
+    if expect_str not in response.choices[0].delta.content:
+        raise RuntimeError(
+            f"expect '{expect_str}' in error msg, " f"but get '{response.choices[0].delta.content}'"
+        )
+
+
+# NOTE: we only need tokenizers in folder
+# launch time of mock test is fast so we can put it in unittest
+@require_test_model("Llama-3-8B-Instruct-q4f16_1-MLC")
+def test_chat_completion_misuse(model: str):
+    engine = JSONFFIEngine(model, tvm.cpu(), model_lib="mock://echo")
+    # Test malformed requests.
+    for response in engine._raw_chat_completion(
+        "malformed_string", include_usage=False, request_id="123"
+    ):
+        assert len(response.choices) == 1
+        assert response.choices[0].finish_reason == "error"
+    # check parameters
+    check_error_handling(engine, "should be non-negative", temperature=-1)
+    check_error_handling(engine, "in range [0, 1]", top_p=100)
+    check_error_handling(engine, "frequency_penalty", frequency_penalty=100)
+
+
+# NOTE: we only need tokenizers in folder
+# launch time of mock test is fast so we can put it in unittest
+@require_test_model("Llama-3-8B-Instruct-q4f16_1-MLC")
+def test_chat_completion_api(model: str):
+    engine = JSONFFIEngine(model, tvm.cpu(), model_lib="mock://echo")
+    param_dict = {
+        "top_p": 0.6,
+        "temperature": 0.8,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.1,
+    }
+    usage = None
+    for response in engine.chat.completions.create(
+        messages=[{"role": "user", "content": "hello"}],
+        stream=True,
+        stream_options={"include_usage": True},
+        **param_dict,  # type: ignore
+    ):
+        if response.usage is not None:
+            usage = response.usage
+
+    # echo mock will echo back the generation config
+    for k, v in param_dict.items():
+        assert usage.extra[k] == v, f"{k} mismatch"
+
+
+if __name__ == "__main__":
+    test_chat_completion_api()
+    test_chat_completion_misuse()

--- a/tests/python/serve/test_serve_engine_mock.py
+++ b/tests/python/serve/test_serve_engine_mock.py
@@ -1,0 +1,39 @@
+"""Mock testing engine I/O conventions
+
+Mock test only can help checking the overall input
+output processing options are passed correctly
+"""
+
+import pytest
+import tvm
+
+from mlc_llm.serve import MLCEngine
+from mlc_llm.testing import require_test_model
+
+# test category "unittest"
+pytestmark = [pytest.mark.unittest]
+
+
+# NOTE: we only need tokenizers in folder
+# launch time of mock test is fast so we can put it in unittest
+@require_test_model("Llama-3-8B-Instruct-q4f16_1-MLC")
+def test_completion_api(model: str):
+    engine = MLCEngine(model, tvm.cpu(), model_lib="mock://echo")
+    param_dict = {
+        "top_p": 0.6,
+        "temperature": 0.9,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.1,
+        "n": 2,
+    }
+    response = engine.chat.completions.create(  # type: ignore
+        messages=[{"role": "user", "content": "hello"}],
+        **param_dict,
+    )
+    # echo mock will echo back the generation config
+    for k, v in param_dict.items():
+        assert response.usage.extra[k] == v
+
+
+if __name__ == "__main__":
+    test_completion_api()


### PR DESCRIPTION
This PR introduces a MockEchoEngine that echos the inputs prompt and the generation conflig(as part of usage.extra).

The engine can be used to create unit-test cases that covers engine API handling. Note that mock tests cannot replace real engine tests.