### PR TITLE
[Fix] Fix JSONFFI MemoryBufferStream after dmlc bump

### DIFF
--- a/cpp/json_ffi/image_utils.cc
+++ b/cpp/json_ffi/image_utils.cc
@@ -29,7 +29,7 @@ class MemoryBufferStream : public dmlc::Stream {
     return size;
   }
 
-  void Write(const void* ptr, size_t size) override {
+  size_t Write(const void* ptr, size_t size) override {
     LOG(FATAL) << "MemoryBufferStream does not support write";
   }
 


### PR DESCRIPTION
A recent bump in dmlc has changed the `Write` signature of `dmlc::Stream`. This commit updates the codebase to follow the upstream change.