### PR TITLE
[CONFIG] Remove mean_gen_len from the config

### DIFF
--- a/docs/deploy/mlc_chat_config.rst
+++ b/docs/deploy/mlc_chat_config.rst
@@ -61,9 +61,6 @@ Below is the ``mlc-chat-config.json`` file corresponding to Llama2 model:
     },
 
     // 4. Chat related fields that affect runtime behavior
-    "mean_gen_len": 128,
-    "max_gen_len": 512,
-    "shift_fill_factor": 0.3,
     "temperature": 0.6,
     "repetition_penalty": 1.0,
     "top_p": 0.9
@@ -97,14 +94,6 @@ can be customized to change the behavior of the model.**
 
   For additional information on top-p sampling, please refer to this `blog post <https://huggingface.co/blog/how-to-generate#top-p-nucleus-sampling>`_.
 
-``mean_gen_len``
-  The approximated average number of generated tokens in each round. Used to determine whether the maximum window size would be exceeded.
-
-``max_gen_len``
-  This parameter determines the maximum length of the generated text. If it is not set, the model will generate text until it encounters a stop token.
-
-``shift_fill_factor``
-  The fraction of maximum window size to shift when it is exceeded.
 
 .. _struct-conv:
 

--- a/python/mlc_llm/protocol/mlc_chat_config.py
+++ b/python/mlc_llm/protocol/mlc_chat_config.py
@@ -17,9 +17,6 @@ MLC_CHAT_SYSTEM_DEFAULT = {
     "frequency_penalty": 0.0,
     "repetition_penalty": 1.0,
     "top_p": 1.0,
-    "mean_gen_len": 128,
-    "max_gen_len": 512,
-    "shift_fill_factor": 0.3,
 }
 """system default values."""
 
@@ -59,12 +56,6 @@ class MLCChatConfig(BaseModel):
     pad_token_id: Optional[int] = None
     bos_token_id: Optional[int] = None
     eos_token_id: Optional[Union[int, List[int]]] = None
-    # Legacy fields
-    # Control the behavior of the runtime
-    # these fields will be deprecated soon
-    mean_gen_len: Optional[int] = None
-    max_gen_len: Optional[int] = None
-    shift_fill_factor: Optional[float] = None
 
     def get_system_defaults_for_missing_fields(self) -> Dict[str, Any]:
         """Apply system default value for fields that are None


### PR DESCRIPTION
This PR removes legacy mean_gen_len from the config