### PR TITLE
[Fix][Config] Max total sequence length overflow with sliding window

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -615,8 +615,11 @@ Result<MemUsageEstimationResult> EstimateMemoryUsageOnMode(
            model_config_limits.model_max_sliding_window_size});
     } else {
       inferred_config.max_total_sequence_length =
-          std::min(model_max_total_sequence_length,
-                   max_num_sequence * model_config_limits.model_max_single_sequence_length);
+          model_config_limits.model_max_single_sequence_length ==
+                  std::numeric_limits<int64_t>::max()
+              ? model_max_total_sequence_length
+              : std::min(model_max_total_sequence_length,
+                         max_num_sequence * model_config_limits.model_max_single_sequence_length);
     }
     os << "max KV cache token capacity will be set to "
        << inferred_config.max_total_sequence_length.value() << ", ";

--- a/tests/python/serve/server/conftest.py
+++ b/tests/python/serve/server/conftest.py
@@ -28,6 +28,7 @@ def launch_server(served_model):  # pylint: disable=redefined-outer-name
         model_lib=served_model[1],
         enable_tracing=True,
         enable_debug=True,
+        port=8000,
     )
 
     with server:


### PR DESCRIPTION
This PR fixes an issue which causes the int64 multiplication overflow when sliding window is enabled.