### PR TITLE
[FP8] Use f32 scale to enable better fusion

### DIFF
--- a/python/mlc_llm/interface/calibrate.py
+++ b/python/mlc_llm/interface/calibrate.py
@@ -30,7 +30,7 @@ class CalibrationObserver:
 
     @tvm.register_func("mlc_llm.calibration_observer")
     @staticmethod
-    def callback(name, mode, value, out_value):
+    def callback(name: str, mode: str, value: "tvm.nd.NDArray", out_value: "tvm.nd.NDArray"):
         """The callback function to update the saved calibration parameters."""
         instance = CalibrationObserver.get()
         if mode == "max":
@@ -48,7 +48,7 @@ class CalibrationObserver:
         tvmjs.dump_ndarray_cache(
             self.params,
             output,
-            encode_format="raw",
+            encode_format="f32-to-bf16",
             meta_data=None,
             show_progress=False,
             update_if_exists=True,

--- a/python/mlc_llm/op/moe_matmul.py
+++ b/python/mlc_llm/op/moe_matmul.py
@@ -238,7 +238,7 @@ def dequantize_float8_gemv(
     def _func_with_scale(
         x: T.Buffer((x_leading_dim, in_features), model_dtype),
         w: T.Buffer((local_experts, out_features, num_storage), storage_dtype),
-        scale: T.Buffer((1,), model_dtype),
+        scale: T.Buffer((1,), "float32"),
         indptr: T.Buffer((1, experts_per_tok), "int32"),
         o: T.Buffer((experts_per_tok, out_features), model_dtype),
     ):


### PR DESCRIPTION
This changes FP8 quantization to use f32 scale. It allows offloading to the matmul scaling pattern in cublas.

cc @tqchen 