### PR TITLE
[Fix] Fix the global func name of TokenizerDecode

### DIFF
--- a/cpp/tokenizers/tokenizers.cc
+++ b/cpp/tokenizers/tokenizers.cc
@@ -428,7 +428,7 @@ TVM_REGISTER_GLOBAL("mlc.tokenizers.TokenizerEncodeBatch")
       return ret;
     });
 
-TVM_REGISTER_GLOBAL("mlc.TokenizerDecode")
+TVM_REGISTER_GLOBAL("mlc.tokenizers.TokenizerDecode")
     .set_body_typed([](const Tokenizer& tokenizer, const IntTuple& token_ids) {
       return tokenizer->Decode({token_ids->data, token_ids->data + token_ids->size});
     });


### PR DESCRIPTION
This PR fixes the global func name for `TokenizerDecode`, which was not updated when adding the namespace `tokenizers`.