### PR TITLE
[Fix] Provide a GetTokenId API for SampleResult

### DIFF
--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -138,6 +138,8 @@ inline void TokenToLogProbJSON(const Tokenizer& tokenizer, const TokenProbPair& 
   (*os) << "]";
 }
 
+int32_t SampleResult::GetTokenId() const { return this->sampled_token_id.first; }
+
 std::string SampleResult::GetLogProbJSON(const Tokenizer& tokenizer, bool logprob) const {
   ICHECK(top_prob_tokens.empty() || logprob);
   if (!logprob) {

--- a/cpp/serve/data.h
+++ b/cpp/serve/data.h
@@ -138,6 +138,9 @@ struct SampleResult {
   /*! \brief The token id and probability of the tokens with top probabilities. */
   std::vector<TokenProbPair> top_prob_tokens;
 
+  /*! \brief Get the sampled token id. */
+  int32_t GetTokenId() const;
+
   /*!
    * \brief Get the logprob JSON string of this token with regard
    * to OpenAI API at https://platform.openai.com/docs/api-reference/chat/object.

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -122,7 +122,7 @@ void UpdatePrefixCache(Array<Request> requests, EngineState estate) {
                           rsentry->mstates[0]->cached_committed_tokens));
           for (int i = rsentry->mstates[0]->cached_committed_tokens;
                i < static_cast<int64_t>(rsentry->mstates[0]->committed_tokens.size()) - 1; ++i) {
-            tokens.push_back(rsentry->mstates[0]->committed_tokens[i].sampled_token_id.first);
+            tokens.push_back(rsentry->mstates[0]->committed_tokens[i].GetTokenId());
           }
           estate->prefix_cache->ExtendSequence(rsentry->mstates[0]->internal_id, IntTuple(tokens));
           rsentry->mstates[0]->cached_committed_tokens =
@@ -246,7 +246,7 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
     std::vector<int32_t> committed_token_ids;
     committed_token_ids.reserve(mstate->committed_tokens.size());
     for (const SampleResult& committed_token : mstate->committed_tokens) {
-      committed_token_ids.push_back(committed_token.sampled_token_id.first);
+      committed_token_ids.push_back(committed_token.GetTokenId());
     }
     mstate->num_prefilled_tokens = 0;
 

--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -88,7 +88,7 @@ class BatchDecodeActionObj : public EngineActionObj {
     generation_cfg.reserve(num_rsentries);
     rngs.reserve(num_rsentries);
     for (const RequestStateEntry& rsentry : running_rsentries) {
-      input_tokens.push_back(rsentry->mstates[0]->committed_tokens.back().sampled_token_id.first);
+      input_tokens.push_back(rsentry->mstates[0]->committed_tokens.back().GetTokenId());
       request_ids.push_back(rsentry->request->id);
       request_internal_ids.push_back(rsentry->mstates[0]->internal_id);
       mstates.push_back(rsentry->mstates[0]);

--- a/cpp/serve/engine_actions/batch_draft.cc
+++ b/cpp/serve/engine_actions/batch_draft.cc
@@ -99,9 +99,9 @@ class BatchDraftActionObj : public EngineActionObj {
         input_tokens.clear();
         for (int i = 0; i < num_rsentries; ++i) {
           // The first draft proposal uses the last committed token.
-          input_tokens.push_back(
-              draft_id == 0 ? mstates[i]->committed_tokens.back().sampled_token_id.first
-                            : mstates[i]->draft_output_tokens.back().sampled_token_id.first);
+          input_tokens.push_back(draft_id == 0
+                                     ? mstates[i]->committed_tokens.back().GetTokenId()
+                                     : mstates[i]->draft_output_tokens.back().GetTokenId());
         }
 
         // - Compute embeddings.

--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -399,8 +399,7 @@ void BatchPrefillBaseActionObj::UpdateRequestStateEntriesWithSampleResults(
       if (!rsentry_activated[i]) {
         // When the child rsentry is not activated,
         // add the sampled token as an input of the mstate for prefill.
-        mstate->inputs.push_back(
-            TokenData(std::vector<int64_t>{sample_results[i].sampled_token_id.first}));
+        mstate->inputs.push_back(TokenData(std::vector<int64_t>{sample_results[i].GetTokenId()}));
       }
     }
     // prefill has finished

--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -82,9 +82,9 @@ class BatchVerifyActionObj : public EngineActionObj {
       ICHECK_EQ(verify_lengths[i], draft_mstate->draft_token_slots.size() + 1);
       // the last committed token + all the draft tokens.
       draft_token_slots_.push_back(0);  // placeholder for the last committed token
-      all_tokens_to_verify.push_back(draft_mstate->committed_tokens.back().sampled_token_id.first);
+      all_tokens_to_verify.push_back(draft_mstate->committed_tokens.back().GetTokenId());
       for (int j = 0; j < static_cast<int>(draft_mstate->draft_output_tokens.size()); ++j) {
-        all_tokens_to_verify.push_back(draft_mstate->draft_output_tokens[j].sampled_token_id.first);
+        all_tokens_to_verify.push_back(draft_mstate->draft_output_tokens[j].GetTokenId());
         draft_token_slots_.push_back(draft_mstate->draft_token_slots[j]);
       }
       verify_request_mstates.push_back(verify_mstate);
@@ -204,7 +204,7 @@ class BatchVerifyActionObj : public EngineActionObj {
         input_tokens.push_back(rsentries[rsentry_id]
                                    ->mstates[verify_model_id_]
                                    ->committed_tokens[num_committed_tokens - 2]
-                                   .sampled_token_id.first);
+                                   .GetTokenId());
         fully_accepted_request_internal_ids.push_back(
             rsentries[rsentry_id]->mstates[draft_model_id_]->internal_id);
       }

--- a/cpp/serve/engine_actions/eagle_batch_draft.cc
+++ b/cpp/serve/engine_actions/eagle_batch_draft.cc
@@ -111,7 +111,7 @@ class EagleBatchDraftActionObj : public EngineActionObj {
         input_tokens.clear();
         for (int i = 0; i < num_rsentries; ++i) {
           ICHECK(!mstates[i]->draft_output_tokens.empty());
-          input_tokens.push_back(mstates[i]->draft_output_tokens.back().sampled_token_id.first);
+          input_tokens.push_back(mstates[i]->draft_output_tokens.back().GetTokenId());
         }
 
         // - Compute embeddings.

--- a/cpp/serve/engine_actions/eagle_batch_verify.cc
+++ b/cpp/serve/engine_actions/eagle_batch_verify.cc
@@ -81,10 +81,10 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
       ICHECK_EQ(draft_lengths[i], draft_mstate->draft_output_tokens.size());
       ICHECK_EQ(draft_lengths[i], draft_mstate->draft_token_slots.size());
       // the last committed token + all the draft tokens but the last one.
-      all_tokens_to_verify.push_back(draft_mstate->committed_tokens.back().sampled_token_id.first);
+      all_tokens_to_verify.push_back(draft_mstate->committed_tokens.back().GetTokenId());
       draft_token_slots_.push_back(0);  // placeholder for the last committed token
       for (int j = 0; j < static_cast<int>(draft_mstate->draft_output_tokens.size()); ++j) {
-        all_tokens_to_verify.push_back(draft_mstate->draft_output_tokens[j].sampled_token_id.first);
+        all_tokens_to_verify.push_back(draft_mstate->draft_output_tokens[j].GetTokenId());
         draft_token_slots_.push_back(draft_mstate->draft_token_slots[j]);
       }
       verify_request_mstates.push_back(verify_mstate);
@@ -221,7 +221,7 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
         input_tokens.push_back(rsentries[rsentry_id]
                                    ->mstates[verify_model_id_]
                                    ->committed_tokens[num_committed_tokens - 2]
-                                   .sampled_token_id.first);
+                                   .GetTokenId());
 
         // Taking the hidden states of the token before the last token
         hidden_states_positions_for_fully_accepted.push_back(
@@ -273,7 +273,7 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
       }
       for (int i = 0; i < num_rsentries; ++i) {
         ICHECK(!mstates[i]->committed_tokens.empty());
-        input_tokens.push_back(mstates[i]->committed_tokens.back().sampled_token_id.first);
+        input_tokens.push_back(mstates[i]->committed_tokens.back().GetTokenId());
       }
 
       Array<NDArray> multi_step_logits{nullptr};  // for medusa output

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -298,7 +298,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
                     Downcast<TokenData>(rsentries_for_sample[i]->mstates[mid]->inputs.back());
                 std::vector<int32_t> token_ids = {token_data->token_ids.begin(),
                                                   token_data->token_ids.end()};
-                token_ids.push_back(sample_results[i].sampled_token_id.first);
+                token_ids.push_back(sample_results[i].GetTokenId());
                 int ninputs =
                     static_cast<int>(rsentries_for_sample[i]->mstates[mid]->inputs.size());
                 rsentries_for_sample[i]->mstates[mid]->inputs.Set(

--- a/cpp/serve/sampler/cpu_sampler.cc
+++ b/cpp/serve/sampler/cpu_sampler.cc
@@ -434,7 +434,7 @@ class CPUSampler : public SamplerObj {
           // Sub 1 to ignore the last prediction.
           for (; cur_token_idx < verify_end - verify_start - 1; ++cur_token_idx) {
             float* p_probs = global_p_probs + (verify_start + cur_token_idx) * vocab_size;
-            int cur_token = draft_output_tokens[i][cur_token_idx].sampled_token_id.first;
+            int cur_token = draft_output_tokens[i][cur_token_idx].GetTokenId();
             float q_value = draft_output_tokens[i][cur_token_idx].sampled_token_id.second;
             float p_value = p_probs[cur_token];
 

--- a/cpp/serve/sampler/gpu_sampler.cc
+++ b/cpp/serve/sampler/gpu_sampler.cc
@@ -233,7 +233,7 @@ class GPUSampler : public SamplerObj {
       ICHECK_EQ(draft_output_tokens_i.size() + 1, end - start);
       for (int j = 0; j < end - start - 1; j++) {
         // Copy sampled token id
-        p_draft_tokens_host[start + j + 1] = draft_output_tokens_i[j].sampled_token_id.first;
+        p_draft_tokens_host[start + j + 1] = draft_output_tokens_i[j].GetTokenId();
       }
     }
     CopyArray(draft_tokens_host, draft_tokens_device, copy_stream_);

--- a/python/mlc_llm/support/constants.py
+++ b/python/mlc_llm/support/constants.py
@@ -57,15 +57,18 @@ def _get_dso_suffix() -> str:
 
 
 def _get_test_model_path() -> List[Path]:
+    paths = []
     if "MLC_LLM_TEST_MODEL_PATH" in os.environ:
-        return [Path(p) for p in os.environ["MLC_LLM_TEST_MODEL_PATH"].split(os.pathsep)]
+        paths += [Path(p) for p in os.environ["MLC_LLM_TEST_MODEL_PATH"].split(os.pathsep)]
     # by default, we reuse the cache dir via mlc_llm chat
     # note that we do not auto download for testcase
     # to avoid networking dependencies
     base_list = ["hf"]
-    return [_get_cache_dir() / "model_weights" / base / "mlc-ai" for base in base_list] + [
-        Path(os.path.abspath(os.path.curdir))
+    paths += [_get_cache_dir() / "model_weights" / base / "mlc-ai" for base in base_list] + [
+        Path(os.path.abspath(os.path.curdir)),
+        Path(os.path.abspath(os.path.curdir)) / "dist",
     ]
+    return paths
 
 
 def _get_read_only_weight_caches() -> List[Path]:


### PR DESCRIPTION
Currently we use `sampled_token_id.first` to find the sampled token id of a SampleResult object, which is obscure. This PR provides a `GetTokenId` API for SampleResult to get the sampled token id.

This PR also updates the testing model path to include `./dist/`.