### PR TITLE
[Fix] Fix metrics division by 0

### DIFF
--- a/cpp/serve/metrics.h
+++ b/cpp/serve/metrics.h
@@ -134,7 +134,9 @@ struct RequestMetrics {
   }
 
   /*! \return the inter token latency (ITL) in seconds */
-  double GetInterTokenLatency() const { return GetTotalTime() / completion_tokens; }
+  double GetInterTokenLatency() const {
+    return completion_tokens > 0 ? GetTotalTime() / completion_tokens : 0.0;
+  }
 
   /*! \brief Reset the metric. */
   void Reset() {

--- a/ios/MLCSwift/Sources/Swift/LLMEngine.swift
+++ b/ios/MLCSwift/Sources/Swift/LLMEngine.swift
@@ -92,6 +92,7 @@ public class MLCEngine {
                     }
                 }
             }
+            // Todo(mlc-team): check the last error in engine and report if there's any
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue of the per-request metrics, where division-by-0 may happen when the request does not run any decode step.

The division-by-0 results in `inf`, and is added into a JSON file. However, `inf` is usually not recognized as a float value in JSON grammar. Thus JSON parsers fail on parsing any JSON string that comes with `inf` wihtout being quoted.