### PR TITLE
[Android] Updates the order of mode list and the APK link in the document

### DIFF
--- a/android/MLCChat/mlc-package-config.json
+++ b/android/MLCChat/mlc-package-config.json
@@ -2,6 +2,16 @@
     "device": "android",
     "model_list": [
         {
+            "model": "HF://mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
+            "estimated_vram_bytes": 4250586449,
+            "model_id": "Phi-3-mini-4k-instruct-q4f16_1-MLC"
+        },
+        {
+            "model": "HF://mlc-ai/Qwen1.5-1.8B-Chat-q4f16_1-MLC",
+            "estimated_vram_bytes": 2398127702,
+            "model_id": "Qwen1.5-1.8B-Chat-q4f16_1-MLC"
+        },
+        {
             "model": "HF://mlc-ai/gemma-2b-it-q4f16_1-MLC",
             "model_id": "gemma-2b-q4f16_1-MLC",
             "estimated_vram_bytes": 3000000000
@@ -16,11 +26,6 @@
             }
         },
         {
-            "model": "HF://mlc-ai/RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC",
-            "estimated_vram_bytes": 1948348579,
-            "model_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC"
-        },
-        {
             "model": "HF://mlc-ai/Mistral-7B-Instruct-v0.3-q4f16_1-MLC",
             "estimated_vram_bytes": 4115131883,
             "model_id": "Mistral-7B-Instruct-v0.3-q4f16_1-MLC",
@@ -28,11 +33,6 @@
                 "sliding_window_size": 768,
                 "prefill_chunk_size": 256
             }
-        },
-        {
-            "model": "HF://mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
-            "estimated_vram_bytes": 4250586449,
-            "model_id": "Phi-3-mini-4k-instruct-q4f16_1-MLC"
         }
     ]
 }

--- a/docs/deploy/android.rst
+++ b/docs/deploy/android.rst
@@ -14,7 +14,7 @@ The demo APK below is built for Samsung S23 with Snapdragon 8 Gen 2 chip.
 
 .. image:: https://seeklogo.com/images/D/download-android-apk-badge-logo-D074C6882B-seeklogo.com.png
   :width: 135
-  :target: https://github.com/mlc-ai/binary-mlc-llm-libs/releases/download/Android-06042024/mlc-chat.apk
+  :target: https://github.com/mlc-ai/binary-mlc-llm-libs/releases/download/Android-06062024/mlc-chat.apk
 
 Prerequisite
 ------------


### PR DESCRIPTION
This PR updates the order of mode list for Android App and the APK link in the document.

1. Phi-3-mini-4k-instruct-q4f16_1-MLC
2. Qwen1.5-1.8B-Chat-q4f16_1-MLC (new)
3. gemma-2b-q4f16_1-MLC
4. Llama-3-8B-Instruct-q3f16_1-MLC
5. Mistral-7B-Instruct-v0.3-q4f16_1-MLC

cc @tqchen 