### PR TITLE
[Conv] Add tinyLlama v1.0 conv template

### DIFF
--- a/python/mlc_llm/conversation_template/__init__.py
+++ b/python/mlc_llm/conversation_template/__init__.py
@@ -22,7 +22,7 @@ from . import (
     redpajama,
     rwkv,
     stablelm,
-    wizardlm,
     tinyllama,
+    wizardlm,
 )
 from .registry import ConvTemplateRegistry

--- a/python/mlc_llm/conversation_template/__init__.py
+++ b/python/mlc_llm/conversation_template/__init__.py
@@ -23,5 +23,6 @@ from . import (
     rwkv,
     stablelm,
     wizardlm,
+    tinyllama,
 )
 from .registry import ConvTemplateRegistry

--- a/python/mlc_llm/conversation_template/tinyllama.py
+++ b/python/mlc_llm/conversation_template/tinyllama.py
@@ -1,0 +1,21 @@
+"""Tiny Llama default templates"""
+
+from mlc_llm.protocol.conversation_protocol import Conversation, MessagePlaceholders
+
+from .registry import ConvTemplateRegistry
+
+
+# TinyLlama v1.0
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="tinyllama_v1_0",
+        system_template=f"<|system|>\n{MessagePlaceholders.SYSTEM.value}</s>",
+        system_message="You are a helpful chatbot.",
+        roles={"user": "<|user|>", "assistant": "<|assistant|>"},
+        seps=["</s>"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["</s>"],
+        stop_token_ids=[2],
+    )
+)

--- a/python/mlc_llm/conversation_template/tinyllama.py
+++ b/python/mlc_llm/conversation_template/tinyllama.py
@@ -4,7 +4,6 @@ from mlc_llm.protocol.conversation_protocol import Conversation, MessagePlacehol
 
 from .registry import ConvTemplateRegistry
 
-
 # TinyLlama v1.0
 ConvTemplateRegistry.register_conv_template(
     Conversation(

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -273,4 +273,5 @@ CONV_TEMPLATES = {
     "orion",
     "llava",
     "hermes2_pro_llama3",
+    "tinyllama_v1_0",
 }


### PR DESCRIPTION
TinyLlama v1.0 does not use chatml anymore, unlike v0.4. This PR adds the conv template following https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0/blob/main/tokenizer_config.json