### PR TITLE
[Docs] Rename javascript.rst to webllm.rst

### DIFF
--- a/docs/deploy/webllm.rst
+++ b/docs/deploy/webllm.rst
@@ -1,7 +1,7 @@
 .. _webllm-runtime:
 
-WebLLM and JavaScript API
-=========================
+WebLLM Javascript SDK
+=====================
 
 .. contents:: Table of Contents
    :local:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Check out :ref:`introduction-to-mlc-llm` for the introduction and tutorial of a 
    :caption: Build and Deploy Apps
    :hidden:
 
-   deploy/javascript.rst
+   deploy/webllm.rst
    deploy/rest.rst
    deploy/cli.rst
    deploy/python_engine.rst

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,5 +10,10 @@ shortuuid
 pydantic
 uvicorn
 fastapi
+openai
+prompt_toolkit
+safetensors
+tiktoken
+torch
 --find-links https://mlc.ai/wheels
 mlc-ai-nightly


### PR DESCRIPTION
This PR renames https://llm.mlc.ai/docs/deploy/javascript.html to https://llm.mlc.ai/docs/deploy/webllm.html.

Rename `WebLLM and JavaScript API` to `WebLLM Javascript SDK`.

Also update `docs/requirements.txt` to be more complete.