### PR TITLE
[Tokenizer][Fix] Fix SegFault when analyzing tokenizers without tokenizer.json

### DIFF
--- a/cpp/tokenizers/tokenizers.cc
+++ b/cpp/tokenizers/tokenizers.cc
@@ -153,7 +153,7 @@ TokenizerInfo Tokenizer::DetectTokenizerInfo(const String& path_str) {
   if (!std::filesystem::exists(path)) {
     LOG(WARNING) << "Tokenizer info is not detected as tokenizer.json is not found. The default "
                  << "tokenizer info will be used.";
-    return TokenizerInfo();
+    return TokenizerInfo(make_object<TokenizerInfoNode>());
   }
 
   std::string tokenizer_json = LoadBytesFromFile(path.string());


### PR DESCRIPTION
Previously the tokenizer would segfault when analyzing a tokenizer that did not have a tokenizer.json file. This is due to `TokenizerInfo()` is called previously, which creates a null object. This PR fixes this problem.