### PR TITLE
[Serving] Support tensor parallel shards override in command line

### DIFF
--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -70,22 +70,14 @@ PackedFunc FunctionTable::SessionFuncAsPackedFunc(Session sess, DRef sess_func, 
 }
 
 void FunctionTable::Init(String reload_lib_path, Device device, picojson::object model_config,
-                         Optional<Session> session) {
+                         Optional<Session> session, int num_shards) {
   local_gpu_device = device;
   Device null_device{DLDeviceType(0), 0};
-  int num_shards;
-  {
-    if (model_config.count("tensor_parallel_shards")) {
-      CHECK(model_config["tensor_parallel_shards"].is<int64_t>());
-      num_shards = model_config["tensor_parallel_shards"].get<int64_t>();
-    } else {
-      num_shards = 1;
-    }
-  }
   this->model_config = model_config;
   this->cached_buffers = Map<String, ObjectRef>();
 
   if (num_shards > 1) {
+    ICHECK(session.defined());
     this->sess = session.value();
     this->use_disco = true;
     this->disco_mod = sess->CallPacked(sess->GetGlobalFunc("runtime.disco.load_vm_module"),
@@ -111,6 +103,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
         ModelMetadata::FromModule(this->disco_mod->DebugGetFromRemote(0), std::move(model_config));
     this->_InitFunctions();
   } else {
+    ICHECK(!session.defined());
     Module executable{nullptr};
     PackedFunc fload_exec{nullptr};
     if (StartsWith(reload_lib_path, "system://")) {
@@ -145,6 +138,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
     this->model_metadata_ = ModelMetadata::FromModule(this->local_vm, std::move(model_config));
     this->_InitFunctions();
   }
+  ICHECK_EQ(this->model_metadata_.tensor_parallel_shards, num_shards);
 }
 
 ObjectRef FunctionTable::LoadParams(const std::string& model_path, Device device) {

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -42,7 +42,7 @@ struct FunctionTable {
   static PackedFunc SessionFuncAsPackedFunc(Session sess, DRef sess_func, String name);
 
   void Init(String reload_lib_path, Device device, picojson::object model_config,
-            Optional<Session> session);
+            Optional<Session> session, int num_shards);
 
   ObjectRef LoadParams(const std::string& model_path, Device device);
 

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -368,12 +368,13 @@ class Model : public ObjectRef {
    * \param model_config The model config json object.
    * \param device The device to run the model on.
    * \param session The session to run the model on.
+   * \param num_shards The number of tensor parallel shards of the model.
    * \param trace_enabled A boolean indicating whether tracing is enabled.
    * \return The created runtime module.
    */
   static Model Create(String reload_lib_path, String model_path,
                       const picojson::object& model_config, DLDevice device,
-                      const Optional<Session>& session, bool trace_enabled);
+                      const Optional<Session>& session, int num_shards, bool trace_enabled);
 
   /*!
    * Load the model config from the given model path.

--- a/docs/deploy/python_engine.rst
+++ b/docs/deploy/python_engine.rst
@@ -85,6 +85,23 @@ Please refer to `OpenAI's Python package <https://github.com/openai/openai-pytho
 and `OpenAI chat completion API <https://platform.openai.com/docs/api-reference/chat/create>`_
 for the complete chat completion interface.
 
+.. note::
+
+  If you want to enable tensor parallelism to run LLMs on multiple GPUs,
+  please specify argument ``model_config_overrides`` in MLCEngine constructor.
+  For example,
+
+  .. code:: python
+
+    from mlc_llm import MLCEngine
+    from mlc_llm.serve.config import ModelConfigOverride
+
+    model = "HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC"
+    engine = MLCEngine(
+        model,
+        model_config_overrides=ModelConfigOverride(tensor_parallel_shards=2),
+    )
+
 
 .. _python-engine-async-llm-engine:
 
@@ -169,6 +186,23 @@ interface.
 Please refer to `OpenAI's Python package <https://github.com/openai/openai-python?tab=readme-ov-file#usage>`_
 and `OpenAI chat completion API <https://platform.openai.com/docs/api-reference/chat/create>`_
 for the complete chat completion interface.
+
+.. note::
+
+  If you want to enable tensor parallelism to run LLMs on multiple GPUs,
+  please specify argument ``model_config_overrides`` in AsyncMLCEngine constructor.
+  For example,
+
+  .. code:: python
+
+    from mlc_llm import AsyncMLCEngine
+    from mlc_llm.serve.config import ModelConfigOverride
+
+    model = "HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC"
+    engine = AsyncMLCEngine(
+        model,
+        model_config_overrides=ModelConfigOverride(tensor_parallel_shards=2),
+    )
 
 
 Engine Mode

--- a/docs/deploy/rest.rst
+++ b/docs/deploy/rest.rst
@@ -21,7 +21,7 @@ SERVE is a part of the MLC-LLM package, installation instruction for which can b
 
 You should see serve help message if the installation was successful.
 
-Quick start
+Quick Start
 ------------
 
 This section provides a quick start guide to work with MLC-LLM REST API. To launch a server, run the following command:
@@ -52,6 +52,16 @@ Once you have launched the Server, you can use the API in your own program to se
    choices = r.json()["choices"]
    for choice in choices:
       print(f"{choice['message']['content']}\n")
+
+.. note::
+
+  If you want to enable tensor parallelism to run LLMs on multiple GPUs,
+  please specify argument ``--overrides "tensor_parallel_shards=$NGPU"``.
+  For example,
+
+  .. code:: shell
+
+    mlc_llm serve HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC --overrides "tensor_parallel_shards=2"
 
 ------------------------------------------------
 
@@ -137,13 +147,14 @@ MODEL                  The model folder after compiling with MLC-LLM build proce
                        - ``medusa``, denoting the medusa-style speculative decoding.
 --overrides            Overriding extra configurable fields of EngineConfig.
 
-                       Supporting fields that can be be overridden: ``max_num_sequence``, ``max_total_seq_length``,
-                       ``prefill_chunk_size``, ``max_history_size``, ``gpu_memory_utilization``,
-                       ``spec_draft_length``, ``prefix_cache_max_num_recycling_seqs``.
+                       Supporting fields that can be be overridden: ``tensor_parallel_shards``, ``max_num_sequence``,
+                       ``max_total_seq_length``, ``prefill_chunk_size``, ``max_history_size``, ``gpu_memory_utilization``,
+                       ``spec_draft_length``, ``prefix_cache_max_num_recycling_seqs``, ``context_window_size``,
+                       ``sliding_window_size``, ``attention_sink_size``.
 
                        Please check out the documentation of EngineConfig in ``mlc_llm/serve/config.py``
                        for detailed docstring of each field.
-                       Example: ``--overrides "max_num_sequence=32;max_total_seq_length=4096;gpu_memory_utilization=0.8"``
+                       Example: ``--overrides "max_num_sequence=32;max_total_seq_length=4096;tensor_parallel_shards=2"``
 --enable-tracing       A boolean indicating if to enable event logging for requests.
 --host                 The host at which the server should be started, defaults to ``127.0.0.1``.
 --port                 The port on which the server should be started, defaults to ``8000``.

--- a/docs/get_started/introduction.rst
+++ b/docs/get_started/introduction.rst
@@ -78,7 +78,15 @@ Therefore, phase 1 and 2 will only execute **once** over multiple runs.
 
   Workflow in MLC LLM
 
-|
+.. note::
+
+  If you want to enable tensor parallelism to run LLMs on multiple GPUs,
+  please specify argument ``--overrides "tensor_parallel_shards=$NGPU"``.
+  For example,
+
+  .. code:: shell
+
+    mlc_llm chat HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC --overrides "tensor_parallel_shards=2"
 
 .. _introduction-to-mlc-llm-python-api:
 
@@ -136,6 +144,24 @@ If you want to run without streaming, you can run
 You can also try different arguments supported in `OpenAI chat completion API <https://platform.openai.com/docs/api-reference/chat/create>`_.
 If you would like to do concurrent asynchronous generation, you can use :class:`mlc_llm.AsyncMLCEngine` instead.
 
+.. note::
+
+  If you want to enable tensor parallelism to run LLMs on multiple GPUs,
+  please specify argument ``model_config_overrides`` in MLCEngine constructor.
+  For example,
+
+  .. code:: python
+
+    from mlc_llm import MLCEngine
+    from mlc_llm.serve.config import ModelConfigOverride
+
+    model = "HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC"
+    engine = MLCEngine(
+        model,
+        model_config_overrides=ModelConfigOverride(tensor_parallel_shards=2),
+    )
+
+
 REST Server
 -----------
 
@@ -166,6 +192,16 @@ we can open a new shell and send a cURL request via the following command:
 The server will process this request and send back the response.
 Similar to :ref:`introduction-to-mlc-llm-python-api`, you can pass argument ``"stream": true``
 to request for stream responses.
+
+.. note::
+
+  If you want to enable tensor parallelism to run LLMs on multiple GPUs,
+  please specify argument ``--overrides "tensor_parallel_shards=$NGPU"``.
+  For example,
+
+  .. code:: shell
+
+    mlc_llm serve HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC --overrides "tensor_parallel_shards=2"
 
 .. _introduction-deploy-your-own-model:
 

--- a/python/mlc_llm/cli/calibrate.py
+++ b/python/mlc_llm/cli/calibrate.py
@@ -4,7 +4,7 @@ from mlc_llm.interface.calibrate import calibrate
 from mlc_llm.interface.help import HELP
 from mlc_llm.support.argparse import ArgumentParser
 
-from .serve import EngineConfigOverride
+from .serve import EngineAndModelConfigOverride
 
 
 def main(argv):
@@ -51,7 +51,7 @@ def main(argv):
     )
     parser.add_argument(
         "--overrides",
-        type=EngineConfigOverride.from_str,
+        type=EngineAndModelConfigOverride.from_str,
         default="",
         help=HELP["overrides_serve"],
     )

--- a/python/mlc_llm/cli/chat.py
+++ b/python/mlc_llm/cli/chat.py
@@ -2,6 +2,7 @@
 
 from mlc_llm.interface.chat import chat
 from mlc_llm.interface.help import HELP
+from mlc_llm.serve.config import ModelConfigOverride
 from mlc_llm.support.argparse import ArgumentParser
 
 
@@ -26,9 +27,16 @@ def main(argv):
         default=None,
         help=HELP["model_lib"] + ' (default: "%(default)s")',
     )
+    parser.add_argument(
+        "--overrides",
+        type=ModelConfigOverride.from_str,
+        default="",
+        help=HELP["modelconfig_overrides"] + ' (default: "%(default)s")',
+    )
     parsed = parser.parse_args(argv)
     chat(
         model=parsed.model,
         device=parsed.device,
         model_lib=parsed.model_lib,
+        overrides=parsed.overrides,
     )

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -7,14 +7,16 @@ from typing import Optional
 
 from mlc_llm.interface.help import HELP
 from mlc_llm.interface.serve import serve
+from mlc_llm.serve.config import ModelConfigOverride
 from mlc_llm.support import argparse
 from mlc_llm.support.argparse import ArgumentParser
 
 
 @dataclasses.dataclass
-class EngineConfigOverride:
+class EngineAndModelConfigOverride:  # pylint: disable=too-many-instance-attributes
     """Arguments for overriding engine config."""
 
+    # Overrides for EngineConfig (runtime)
     max_num_sequence: Optional[int] = None
     max_total_seq_length: Optional[int] = None
     prefill_chunk_size: Optional[int] = None
@@ -22,6 +24,12 @@ class EngineConfigOverride:
     gpu_memory_utilization: Optional[float] = None
     spec_draft_length: Optional[int] = None
     prefix_cache_max_num_recycling_seqs: Optional[int] = None
+
+    # Overrides for model config (compile time)
+    context_window_size: Optional[int] = None
+    sliding_window_size: Optional[int] = None
+    attention_sink_size: Optional[int] = None
+    tensor_parallel_shards: Optional[int] = None
 
     def __repr__(self) -> str:
         out = StringIO()
@@ -36,10 +44,14 @@ class EngineConfigOverride:
             file=out,
             end="",
         )
+        print(f";context_window_size={self.context_window_size}", file=out, end="")
+        print(f";sliding_window_size={self.sliding_window_size}", file=out, end="")
+        print(f";attention_sink_size={self.attention_sink_size}", file=out, end="")
+        print(f";tensor_parallel_shards={self.tensor_parallel_shards}", file=out, end="")
         return out.getvalue().rstrip()
 
     @staticmethod
-    def from_str(source: str) -> "EngineConfigOverride":
+    def from_str(source: str) -> "EngineAndModelConfigOverride":
         """Parse engine config override values from a string."""
         parser = argparse.ArgumentParser(description="Engine config override values")
 
@@ -50,8 +62,12 @@ class EngineConfigOverride:
         parser.add_argument("--gpu_memory_utilization", type=float, default=None)
         parser.add_argument("--spec_draft_length", type=int, default=None)
         parser.add_argument("--prefix_cache_max_num_recycling_seqs", type=int, default=None)
+        parser.add_argument("--context_window_size", type=int, default=None)
+        parser.add_argument("--sliding_window_size", type=int, default=None)
+        parser.add_argument("--attention_sink_size", type=int, default=None)
+        parser.add_argument("--tensor_parallel_shards", type=int, default=None)
         results = parser.parse_args([f"--{i}" for i in source.split(";") if i])
-        return EngineConfigOverride(
+        return EngineAndModelConfigOverride(
             max_num_sequence=results.max_num_sequence,
             max_total_seq_length=results.max_total_seq_length,
             prefill_chunk_size=results.prefill_chunk_size,
@@ -59,6 +75,21 @@ class EngineConfigOverride:
             gpu_memory_utilization=results.gpu_memory_utilization,
             spec_draft_length=results.spec_draft_length,
             prefix_cache_max_num_recycling_seqs=results.prefix_cache_max_num_recycling_seqs,
+            context_window_size=results.context_window_size,
+            sliding_window_size=results.sliding_window_size,
+            attention_sink_size=results.attention_sink_size,
+            tensor_parallel_shards=results.tensor_parallel_shards,
+        )
+
+    def to_model_config_overrides(self) -> ModelConfigOverride:
+        """Extract the model config overrides."""
+        return ModelConfigOverride(
+            context_window_size=self.context_window_size,
+            sliding_window_size=self.sliding_window_size,
+            prefill_chunk_size=self.prefill_chunk_size,
+            attention_sink_size=self.attention_sink_size,
+            max_batch_size=self.max_num_sequence,
+            tensor_parallel_shards=self.tensor_parallel_shards,
         )
 
 
@@ -114,7 +145,7 @@ def main(argv):
     )
     parser.add_argument(
         "--overrides",
-        type=EngineConfigOverride.from_str,
+        type=EngineAndModelConfigOverride.from_str,
         default="",
         help=HELP["overrides_serve"],
     )
@@ -177,6 +208,7 @@ def main(argv):
         gpu_memory_utilization=parsed.overrides.gpu_memory_utilization,
         spec_draft_length=parsed.overrides.spec_draft_length,
         prefix_cache_max_num_recycling_seqs=parsed.overrides.prefix_cache_max_num_recycling_seqs,
+        model_config_overrides=parsed.overrides.to_model_config_overrides(),
         enable_tracing=parsed.enable_tracing,
         host=parsed.host,
         port=parsed.port,

--- a/python/mlc_llm/interface/chat.py
+++ b/python/mlc_llm/interface/chat.py
@@ -8,6 +8,7 @@ from prompt_toolkit.key_binding import KeyBindings  # pylint: disable=import-err
 
 from mlc_llm.json_ffi import JSONFFIEngine
 from mlc_llm.protocol import openai_api_protocol
+from mlc_llm.serve.config import EngineConfig, ModelConfigOverride
 from mlc_llm.serve.engine import MLCEngine
 from mlc_llm.serve.engine_base import _query_engine_metrics
 from mlc_llm.support import argparse
@@ -239,7 +240,23 @@ class ChatState:
                 self.generate(prompt)
 
 
-def chat(model: str, device: str, model_lib: Optional[str]):
+def chat(
+    model: str,
+    device: str,
+    model_lib: Optional[str],
+    overrides: ModelConfigOverride,
+):
     """Chat cli entry"""
     # By default we use JSONFFIEngine
-    ChatState(JSONFFIEngine(model, device, model_lib=model_lib, mode="interactive")).chat()
+    ChatState(
+        JSONFFIEngine(
+            model,
+            device,
+            model_lib=model_lib,
+            mode="interactive",
+            engine_config=EngineConfig(
+                prefill_chunk_size=overrides.prefill_chunk_size,
+            ),
+            model_config_overrides=overrides,
+        )
+    ).chat()

--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -195,7 +195,7 @@ OPT_FLAG_PRESET = {
     "O2": OptimizationFlags(
         flashinfer=True,
         cublas_gemm=True,
-        faster_transformer=True,
+        faster_transformer=False,
         cudagraph=True,
         cutlass=True,
     ),

--- a/python/mlc_llm/interface/help.py
+++ b/python/mlc_llm/interface/help.py
@@ -125,10 +125,10 @@ Model configuration override. Configurations to override `mlc-chat-config.json`.
 `max_batch_size` and `tensor_parallel_shards`. Meanwhile, model config could be explicitly
 specified via details knobs, e.g. --overrides "context_window_size=1024;prefill_chunk_size=128".
 """.strip(),
-    "chatconfig_overrides": """
-Chat configuration override. Configurations to override ChatConfig. Supports `conv_template`,
+    "modelconfig_overrides": """
+Model configuration override. Supports overriding,
 `context_window_size`, `prefill_chunk_size`, `sliding_window_size`, `attention_sink_size`,
-`max_batch_size` and `tensor_parallel_shards`. Meanwhile, model chat could be explicitly
+`max_batch_size` and `tensor_parallel_shards`. The overrides could be explicitly
 specified via details knobs, e.g. --overrides "context_window_size=1024;prefill_chunk_size=128".
 """.strip(),
     "debug_dump": """
@@ -220,13 +220,14 @@ The maximum number of sequences in prefix cache, default as max_batch_size.
 And set 0 to disable prefix cache, set -1 to have infinite capacity prefix cache.
 """.strip(),
     "overrides_serve": """
-Overriding extra configurable fields of EngineConfig.
-Supporting fields that can be be overridden: "max_num_sequence", "max_total_seq_length",
-"prefill_chunk_size", "max_history_size", "gpu_memory_utilization", "spec_draft_length",
-"prefix_cache_max_num_recycling_seqs".
+Overriding extra configurable fields of EngineConfig and model compilation config.
+Supporting fields that can be be overridden: "tensor_parallel_shards", "max_num_sequence",
+"max_total_seq_length", "prefill_chunk_size", "max_history_size", "gpu_memory_utilization",
+"spec_draft_length", "prefix_cache_max_num_recycling_seqs", "context_window_size",
+"sliding_window_size", "attention_sink_size".
 Please check out the documentation of EngineConfig in mlc_llm/serve/config.py for detailed docstring
 of each field.
-Example: --overrides "max_num_sequence=32;max_total_seq_length=4096;gpu_memory_utilization=0.8"
+Example: --overrides "max_num_sequence=32;max_total_seq_length=4096;tensor_parallel_shards=2"
 """.strip(),
     "config_package": """
 The path to "mlc-package-config.json" which is used for package build.

--- a/python/mlc_llm/interface/jit.py
+++ b/python/mlc_llm/interface/jit.py
@@ -84,8 +84,6 @@ def jit(  # pylint: disable=too-many-locals,too-many-statements
                 if field.name in forbid_list and value == -1:
                     continue
                 result.append(f"{field.name}={value}")
-        if not result:
-            result = ["tensor_parallel_shards=1"]
         return ";".join(result)
 
     def _get_model_config() -> Dict[str, Any]:

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from mlc_llm.protocol import error_protocol
 from mlc_llm.serve import engine
+from mlc_llm.serve.config import ModelConfigOverride
 from mlc_llm.serve.entrypoints import (
     debug_entrypoints,
     metrics_entrypoints,
@@ -35,6 +36,7 @@ def serve(
     spec_draft_length: Optional[int],
     prefix_cache_mode: Literal["disable", "radix"],
     prefix_cache_max_num_recycling_seqs: Optional[int],
+    model_config_overrides: Optional[ModelConfigOverride],
     enable_tracing: bool,
     host: str,
     port: int,
@@ -62,6 +64,7 @@ def serve(
             prefix_cache_mode=prefix_cache_mode,
             prefix_cache_max_num_recycling_seqs=prefix_cache_max_num_recycling_seqs,
         ),
+        model_config_overrides=model_config_overrides,
         enable_tracing=enable_tracing,
     )
 

--- a/python/mlc_llm/json_ffi/engine.py
+++ b/python/mlc_llm/json_ffi/engine.py
@@ -9,6 +9,7 @@ import tvm
 
 from mlc_llm.protocol import debug_protocol, openai_api_protocol
 from mlc_llm.serve import engine_utils
+from mlc_llm.serve.config import ModelConfigOverride
 from mlc_llm.serve.engine_base import (
     EngineConfig,
     EngineMetrics,
@@ -218,6 +219,7 @@ class JSONFFIEngine:
         model_lib: Optional[str] = None,
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
+        model_config_overrides: Optional[ModelConfigOverride] = None,
     ) -> None:
         # - Check the fields fields of `engine_config`.
         if engine_config is None:
@@ -229,7 +231,7 @@ class JSONFFIEngine:
         if isinstance(device, str):
             device = detect_device(device)
         assert isinstance(device, tvm.runtime.Device)
-        model_args = _process_model_args(models, device)[0]
+        model_args = _process_model_args(models, device, model_config_overrides)[0]
 
         # - Load the raw model config into dict
         for i, model_info in enumerate(models):

--- a/python/mlc_llm/serve/config.py
+++ b/python/mlc_llm/serve/config.py
@@ -4,6 +4,9 @@ import json
 from dataclasses import asdict, dataclass, field
 from typing import List, Literal, Optional, Tuple, Union
 
+from mlc_llm.support import argparse
+from mlc_llm.support.config import ConfigOverrideBase
+
 
 @dataclass
 class EngineConfig:  # pylint: disable=too-many-instance-attributes
@@ -124,3 +127,36 @@ class EngineConfig:  # pylint: disable=too-many-instance-attributes
     def from_json(json_str: str) -> "EngineConfig":
         """Construct a config from JSON string."""
         return EngineConfig(**json.loads(json_str))
+
+
+@dataclass
+class ModelConfigOverride(ConfigOverrideBase):  # pylint: disable=too-many-instance-attributes
+    """Flags for overriding model config."""
+
+    context_window_size: Optional[int] = None
+    sliding_window_size: Optional[int] = None
+    prefill_chunk_size: Optional[int] = None
+    attention_sink_size: Optional[int] = None
+    max_batch_size: Optional[int] = None
+    tensor_parallel_shards: Optional[int] = None
+
+    @staticmethod
+    def from_str(source: str) -> "ModelConfigOverride":
+        """Parse model config override values from a string."""
+        parser = argparse.ArgumentParser(description="model config override values")
+        parser.add_argument("--tensor_parallel_shards", type=int, default=None)
+        parser.add_argument("--context_window_size", type=int, default=None)
+        parser.add_argument("--sliding_window_size", type=int, default=None)
+        parser.add_argument("--prefill_chunk_size", type=int, default=None)
+        parser.add_argument("--attention_sink_size", type=int, default=None)
+        parser.add_argument("--max_batch_size", type=int, default=None)
+
+        results = parser.parse_args([f"--{i}" for i in source.split(";") if i])
+        return ModelConfigOverride(
+            tensor_parallel_shards=results.tensor_parallel_shards,
+            context_window_size=results.context_window_size,
+            sliding_window_size=results.sliding_window_size,
+            prefill_chunk_size=results.prefill_chunk_size,
+            attention_sink_size=results.attention_sink_size,
+            max_batch_size=results.max_batch_size,
+        )

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -24,7 +24,7 @@ from tvm.runtime import Device
 from mlc_llm.protocol import debug_protocol, openai_api_protocol
 from mlc_llm.protocol.generation_config import GenerationConfig
 from mlc_llm.serve import data, engine_utils
-from mlc_llm.serve.config import EngineConfig
+from mlc_llm.serve.config import EngineConfig, ModelConfigOverride
 from mlc_llm.support import logging
 from mlc_llm.tokenizers import TextStreamer
 
@@ -887,6 +887,11 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         Additional configurable arguments of MLC engine.
         See class "EngineConfig" for more detail.
 
+    model_config_overrides : Optional[ModelConfigOverrides]
+        The arguments to override the model compilation.
+        For example, "tensor_parallel_shards" can be passed in via ModelConfigOverrides
+        to override the default value in the model's "mlc-chat-config.json".
+
     enable_tracing : bool
         A boolean indicating if to enable event logging for requests.
     """
@@ -899,6 +904,7 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         model_lib: Optional[str] = None,
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
+        model_config_overrides: Optional[ModelConfigOverride] = None,
         enable_tracing: bool = False,
     ) -> None:
         super().__init__(
@@ -908,6 +914,7 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
             model_lib=model_lib,
             mode=mode,
             engine_config=engine_config,
+            model_config_overrides=model_config_overrides,
             enable_tracing=enable_tracing,
         )
         self.chat = AsyncChat(weakref.ref(self))
@@ -1459,6 +1466,11 @@ class MLCEngine(engine_base.MLCEngineBase):
         Additional configurable arguments of MLC engine.
         See class "EngineConfig" for more detail.
 
+    model_config_overrides : Optional[ModelConfigOverrides]
+        The arguments to override the model compilation.
+        For example, "tensor_parallel_shards" can be passed in via ModelConfigOverrides
+        to override the default value in the model's "mlc-chat-config.json".
+
     enable_tracing : bool
         A boolean indicating if to enable event logging for requests.
     """
@@ -1471,6 +1483,7 @@ class MLCEngine(engine_base.MLCEngineBase):
         model_lib: Optional[str] = None,
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
+        model_config_overrides: Optional[ModelConfigOverride] = None,
         enable_tracing: bool = False,
     ) -> None:
         super().__init__(
@@ -1480,6 +1493,7 @@ class MLCEngine(engine_base.MLCEngineBase):
             model_lib=model_lib,
             mode=mode,
             engine_config=engine_config,
+            model_config_overrides=model_config_overrides,
             enable_tracing=enable_tracing,
         )
         self.chat = Chat(weakref.ref(self))

--- a/python/mlc_llm/serve/sync_engine.py
+++ b/python/mlc_llm/serve/sync_engine.py
@@ -15,7 +15,7 @@ import tvm
 
 from mlc_llm.protocol.generation_config import GenerationConfig
 from mlc_llm.serve import data
-from mlc_llm.serve.config import EngineConfig
+from mlc_llm.serve.config import EngineConfig, ModelConfigOverride
 from mlc_llm.serve.engine_base import (
     EngineMetrics,
     _check_engine_config,
@@ -92,12 +92,18 @@ class SyncMLCEngine:
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
         enable_tracing: bool = False,
+        model_config_overrides: Optional[ModelConfigOverride] = None,
         request_stream_callback: Optional[Callable[[List[data.RequestStreamOutput]], None]] = None,
     ):
         # - Check the fields fields of `engine_config`.
         if engine_config is None:
             engine_config = EngineConfig()
-        _check_engine_config(model, model_lib, mode, engine_config)
+        _check_engine_config(
+            model,
+            model_lib,
+            mode,
+            engine_config,
+        )
 
         # - Initialize model loading info.
         models = _parse_models(model, model_lib, engine_config.additional_models)
@@ -108,7 +114,7 @@ class SyncMLCEngine:
             model_args,
             model_config_paths,
             self.conv_template,
-        ) = _process_model_args(models, device)
+        ) = _process_model_args(models, device, model_config_overrides)
 
         # - Load the raw model config into dict
         self.model_config_dicts = []


### PR DESCRIPTION
This PR supports the command line overrides for model JIT compilation. This is especially helpful for enabling tensor parallelism out of box, so people don't need to manually tweak `mlc-chat-config.json` to use tensor parallelism.