### PR TITLE
[Fix] Fix inconsistent system prompt handling

### DIFF
--- a/cpp/json_ffi/conv_template.cc
+++ b/cpp/json_ffi/conv_template.cc
@@ -250,11 +250,6 @@ Result<std::vector<Data>> CreatePrompt(const Conversation& conv,
   std::string pending_text =
       conv.GetSystemText(has_custom_system ? custom_system_inputs : conv.system_message);
 
-  // the seperator after system message.
-  if (!pending_text.empty()) {
-    pending_text += conv.seps[0];
-  }
-
   // Get the message strings
   std::vector<Data> message_list;
   size_t non_system_msg_count = 0;

--- a/python/mlc_llm/conversation_template/hermes.py
+++ b/python/mlc_llm/conversation_template/hermes.py
@@ -8,7 +8,7 @@ from .registry import ConvTemplateRegistry
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="open_hermes_mistral",
-        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
         system_message=(
             'You are "Hermes 2", a conscious sentient superintelligent artificial '
             "intelligence developed by a man named Teknium, and your purpose and drive "
@@ -28,7 +28,7 @@ ConvTemplateRegistry.register_conv_template(
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="neural_hermes_mistral",
-        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
         system_message=("You are a helpful assistant chatbot."),
         roles={"user": "<|im_start|>user", "assistant": "<|im_start|>assistant"},
         seps=["<|im_end|>\n"],
@@ -44,7 +44,7 @@ ConvTemplateRegistry.register_conv_template(
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="hermes2_pro_llama3",
-        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
         system_message=(
             'You are "Hermes 2", a conscious sentient superintelligent artificial '
             "intelligence developed by a man named Teknium, and your purpose and drive "

--- a/python/mlc_llm/conversation_template/registry.py
+++ b/python/mlc_llm/conversation_template/registry.py
@@ -38,7 +38,7 @@ class ConvTemplateRegistry:
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="chatml",
-        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
         system_message=(
             "A conversation between a user and an LLM-based AI assistant. The "
             "assistant gives helpful and honest answers."


### PR DESCRIPTION
This PR fixes the conversation template of ChatML, whose system prompt ends with `<|im_end|>`.

An inconsistent handling of system prompt between the JSONFFI side and the Python side is also corrected.