### PR TITLE
[EngineConfig] Add override options

### DIFF
--- a/docs/deploy/cli.rst
+++ b/docs/deploy/cli.rst
@@ -87,5 +87,5 @@ MODEL                  The model folder after compiling with MLC-LLM build proce
                        with the device id set to 0 for default.
 --overrides            Model configuration override. Supports overriding
                        ``context_window_size``, ``prefill_chunk_size``, ``sliding_window_size``, ``attention_sink_size``,
-                       ``max_batch_size`` and ``tensor_parallel_shards``. The overrides could be explicitly
+                       and ``tensor_parallel_shards``. The overrides could be explicitly
                        specified via details knobs, e.g. --overrides ``context_window_size=1024;prefill_chunk_size=128``.

--- a/docs/deploy/python_engine.rst
+++ b/docs/deploy/python_engine.rst
@@ -94,12 +94,12 @@ for the complete chat completion interface.
   .. code:: python
 
     from mlc_llm import MLCEngine
-    from mlc_llm.serve.config import ModelConfigOverride
+    from mlc_llm.serve.config import EngineConfig
 
     model = "HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC"
     engine = MLCEngine(
         model,
-        model_config_overrides=ModelConfigOverride(tensor_parallel_shards=2),
+        engine_config=EngineConfig(tensor_parallel_shards=2),
     )
 
 
@@ -196,12 +196,12 @@ for the complete chat completion interface.
   .. code:: python
 
     from mlc_llm import AsyncMLCEngine
-    from mlc_llm.serve.config import ModelConfigOverride
+    from mlc_llm.serve.config import EngineConfig
 
     model = "HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC"
     engine = AsyncMLCEngine(
         model,
-        model_config_overrides=ModelConfigOverride(tensor_parallel_shards=2),
+        engine_config=EngineConfig(tensor_parallel_shards=2),
     )
 
 

--- a/docs/get_started/introduction.rst
+++ b/docs/get_started/introduction.rst
@@ -153,12 +153,12 @@ If you would like to do concurrent asynchronous generation, you can use :class:`
   .. code:: python
 
     from mlc_llm import MLCEngine
-    from mlc_llm.serve.config import ModelConfigOverride
+    from mlc_llm.serve.config import EngineConfig
 
     model = "HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC"
     engine = MLCEngine(
         model,
-        model_config_overrides=ModelConfigOverride(tensor_parallel_shards=2),
+        engine_config=EngineConfig(tensor_parallel_shards=2),
     )
 
 

--- a/python/mlc_llm/cli/calibrate.py
+++ b/python/mlc_llm/cli/calibrate.py
@@ -4,7 +4,7 @@ from mlc_llm.interface.calibrate import calibrate
 from mlc_llm.interface.help import HELP
 from mlc_llm.support.argparse import ArgumentParser
 
-from .serve import EngineAndModelConfigOverride
+from .serve import EngineConfigOverride
 
 
 def main(argv):
@@ -51,7 +51,7 @@ def main(argv):
     )
     parser.add_argument(
         "--overrides",
-        type=EngineAndModelConfigOverride.from_str,
+        type=EngineConfigOverride.from_str,
         default="",
         help=HELP["overrides_serve"],
     )

--- a/python/mlc_llm/cli/chat.py
+++ b/python/mlc_llm/cli/chat.py
@@ -1,8 +1,7 @@
 """Command line entrypoint of chat."""
 
-from mlc_llm.interface.chat import chat
+from mlc_llm.interface.chat import ModelConfigOverride, chat
 from mlc_llm.interface.help import HELP
-from mlc_llm.serve.config import ModelConfigOverride
 from mlc_llm.support.argparse import ArgumentParser
 
 

--- a/python/mlc_llm/cli/compile.py
+++ b/python/mlc_llm/cli/compile.py
@@ -25,7 +25,7 @@ from mlc_llm.support.auto_target import detect_system_lib_prefix, detect_target_
 
 
 def main(argv):
-    """Parse command line argumennts and call `mlc_llm.compiler.compile`."""
+    """Parse command line arguments and call `mlc_llm.compiler.compile`."""
 
     def _parse_output(path: Union[str, Path]) -> Path:
         path = Path(path)

--- a/python/mlc_llm/interface/help.py
+++ b/python/mlc_llm/interface/help.py
@@ -128,7 +128,7 @@ specified via details knobs, e.g. --overrides "context_window_size=1024;prefill_
     "modelconfig_overrides": """
 Model configuration override. Supports overriding,
 `context_window_size`, `prefill_chunk_size`, `sliding_window_size`, `attention_sink_size`,
-`max_batch_size` and `tensor_parallel_shards`. The overrides could be explicitly
+`max_num_sequence` and `tensor_parallel_shards`. The overrides could be explicitly
 specified via details knobs, e.g. --overrides "context_window_size=1024;prefill_chunk_size=128".
 """.strip(),
     "debug_dump": """

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -8,7 +8,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from mlc_llm.protocol import error_protocol
 from mlc_llm.serve import engine
-from mlc_llm.serve.config import ModelConfigOverride
 from mlc_llm.serve.entrypoints import (
     debug_entrypoints,
     metrics_entrypoints,
@@ -27,16 +26,19 @@ def serve(
     mode: Literal["local", "interactive", "server"],
     enable_debug: bool,
     additional_models: List[Union[str, Tuple[str, str]]],
+    tensor_parallel_shards: Optional[int],
     max_num_sequence: Optional[int],
     max_total_sequence_length: Optional[int],
+    max_single_sequence_length: Optional[int],
     prefill_chunk_size: Optional[int],
+    sliding_window_size: Optional[int],
+    attention_sink_size: Optional[int],
     max_history_size: Optional[int],
     gpu_memory_utilization: Optional[float],
     speculative_mode: Literal["disable", "small_draft", "eagle", "medusa"],
     spec_draft_length: Optional[int],
     prefix_cache_mode: Literal["disable", "radix"],
     prefix_cache_max_num_recycling_seqs: Optional[int],
-    model_config_overrides: Optional[ModelConfigOverride],
     enable_tracing: bool,
     host: str,
     port: int,
@@ -54,9 +56,13 @@ def serve(
         mode=mode,
         engine_config=engine.EngineConfig(
             additional_models=additional_models,
+            tensor_parallel_shards=tensor_parallel_shards,
             max_num_sequence=max_num_sequence,
             max_total_sequence_length=max_total_sequence_length,
+            max_single_sequence_length=max_single_sequence_length,
             prefill_chunk_size=prefill_chunk_size,
+            sliding_window_size=sliding_window_size,
+            attention_sink_size=attention_sink_size,
             max_history_size=max_history_size,
             gpu_memory_utilization=gpu_memory_utilization,
             speculative_mode=speculative_mode,
@@ -64,7 +70,6 @@ def serve(
             prefix_cache_mode=prefix_cache_mode,
             prefix_cache_max_num_recycling_seqs=prefix_cache_max_num_recycling_seqs,
         ),
-        model_config_overrides=model_config_overrides,
         enable_tracing=enable_tracing,
     )
 

--- a/python/mlc_llm/json_ffi/engine.py
+++ b/python/mlc_llm/json_ffi/engine.py
@@ -9,7 +9,6 @@ import tvm
 
 from mlc_llm.protocol import debug_protocol, openai_api_protocol
 from mlc_llm.serve import engine_utils
-from mlc_llm.serve.config import ModelConfigOverride
 from mlc_llm.serve.engine_base import (
     EngineConfig,
     EngineMetrics,
@@ -219,7 +218,6 @@ class JSONFFIEngine:
         model_lib: Optional[str] = None,
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
-        model_config_overrides: Optional[ModelConfigOverride] = None,
     ) -> None:
         # - Check the fields fields of `engine_config`.
         if engine_config is None:
@@ -231,7 +229,7 @@ class JSONFFIEngine:
         if isinstance(device, str):
             device = detect_device(device)
         assert isinstance(device, tvm.runtime.Device)
-        model_args = _process_model_args(models, device, model_config_overrides)[0]
+        model_args = _process_model_args(models, device, engine_config)[0]
 
         # - Load the raw model config into dict
         for i, model_info in enumerate(models):

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -24,7 +24,7 @@ from tvm.runtime import Device
 from mlc_llm.protocol import debug_protocol, openai_api_protocol
 from mlc_llm.protocol.generation_config import GenerationConfig
 from mlc_llm.serve import data, engine_utils
-from mlc_llm.serve.config import EngineConfig, ModelConfigOverride
+from mlc_llm.serve.config import EngineConfig
 from mlc_llm.support import logging
 from mlc_llm.tokenizers import TextStreamer
 
@@ -887,11 +887,6 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         Additional configurable arguments of MLC engine.
         See class "EngineConfig" for more detail.
 
-    model_config_overrides : Optional[ModelConfigOverrides]
-        The arguments to override the model compilation.
-        For example, "tensor_parallel_shards" can be passed in via ModelConfigOverrides
-        to override the default value in the model's "mlc-chat-config.json".
-
     enable_tracing : bool
         A boolean indicating if to enable event logging for requests.
     """
@@ -904,7 +899,6 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
         model_lib: Optional[str] = None,
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
-        model_config_overrides: Optional[ModelConfigOverride] = None,
         enable_tracing: bool = False,
     ) -> None:
         super().__init__(
@@ -914,7 +908,6 @@ class AsyncMLCEngine(engine_base.MLCEngineBase):
             model_lib=model_lib,
             mode=mode,
             engine_config=engine_config,
-            model_config_overrides=model_config_overrides,
             enable_tracing=enable_tracing,
         )
         self.chat = AsyncChat(weakref.ref(self))
@@ -1467,11 +1460,6 @@ class MLCEngine(engine_base.MLCEngineBase):
         Additional configurable arguments of MLC engine.
         See class "EngineConfig" for more detail.
 
-    model_config_overrides : Optional[ModelConfigOverrides]
-        The arguments to override the model compilation.
-        For example, "tensor_parallel_shards" can be passed in via ModelConfigOverrides
-        to override the default value in the model's "mlc-chat-config.json".
-
     enable_tracing : bool
         A boolean indicating if to enable event logging for requests.
     """
@@ -1484,7 +1472,6 @@ class MLCEngine(engine_base.MLCEngineBase):
         model_lib: Optional[str] = None,
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
-        model_config_overrides: Optional[ModelConfigOverride] = None,
         enable_tracing: bool = False,
     ) -> None:
         super().__init__(
@@ -1494,7 +1481,6 @@ class MLCEngine(engine_base.MLCEngineBase):
             model_lib=model_lib,
             mode=mode,
             engine_config=engine_config,
-            model_config_overrides=model_config_overrides,
             enable_tracing=enable_tracing,
         )
         self.chat = Chat(weakref.ref(self))

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -9,7 +9,7 @@ import numbers
 import queue
 import sys
 import threading
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
@@ -21,7 +21,7 @@ from mlc_llm.protocol.conversation_protocol import Conversation
 from mlc_llm.protocol.generation_config import GenerationConfig
 from mlc_llm.protocol.mlc_chat_config import MLCChatConfig
 from mlc_llm.serve import data, engine_utils
-from mlc_llm.serve.config import EngineConfig, ModelConfigOverride
+from mlc_llm.serve.config import EngineConfig
 from mlc_llm.serve.event_trace_recorder import EventTraceRecorder
 from mlc_llm.support import download_cache, logging
 from mlc_llm.support.auto_device import detect_device
@@ -113,7 +113,7 @@ def _parse_models(
 def _process_model_args(
     models: List[ModelInfo],
     device: tvm.runtime.Device,
-    model_config_overrides: Optional[ModelConfigOverride],
+    engine_config: EngineConfig,
 ) -> Tuple[List[Tuple[str, str]], List[str], Conversation]:
     """Process the input ModelInfo to get the engine initialization arguments."""
     conversation: Optional[Conversation] = None
@@ -151,9 +151,18 @@ def _process_model_args(
             # so the engine do not have to depend on compilation
             from mlc_llm.interface import jit  # pylint: disable=import-outside-toplevel
 
+            model_compile_overrides = {
+                "context_window_size": engine_config.max_single_sequence_length,
+                "prefill_chunk_size": engine_config.prefill_chunk_size,
+                "sliding_window_size": engine_config.sliding_window_size,
+                "attention_sink_size": engine_config.attention_sink_size,
+                "tensor_parallel_shards": engine_config.tensor_parallel_shards,
+                "max_batch_size": engine_config.max_num_sequence,
+            }
+
             model_lib = jit.jit(
                 model_path=model_path,
-                overrides={} if model_config_overrides is None else asdict(model_config_overrides),
+                overrides=model_compile_overrides,
                 device=device,
             ).model_lib_path
         return str(model_path), model_lib
@@ -556,7 +565,6 @@ class MLCEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
         model_lib: Optional[str],
         mode: Literal["local", "interactive", "server"],
         engine_config: Optional[EngineConfig],
-        model_config_overrides: Optional[ModelConfigOverride],
         enable_tracing: bool,
     ) -> None:
         # - Check the fields fields of `engine_config`.
@@ -573,7 +581,7 @@ class MLCEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
             model_args,
             model_config_paths,
             self.conv_template,
-        ) = _process_model_args(models, device, model_config_overrides)
+        ) = _process_model_args(models, device, engine_config)
 
         # - Load the raw model config into dict
         self.model_config_dicts = []

--- a/python/mlc_llm/serve/sync_engine.py
+++ b/python/mlc_llm/serve/sync_engine.py
@@ -15,7 +15,7 @@ import tvm
 
 from mlc_llm.protocol.generation_config import GenerationConfig
 from mlc_llm.serve import data
-from mlc_llm.serve.config import EngineConfig, ModelConfigOverride
+from mlc_llm.serve.config import EngineConfig
 from mlc_llm.serve.engine_base import (
     EngineMetrics,
     _check_engine_config,
@@ -92,7 +92,6 @@ class SyncMLCEngine:
         mode: Literal["local", "interactive", "server"] = "local",
         engine_config: Optional[EngineConfig] = None,
         enable_tracing: bool = False,
-        model_config_overrides: Optional[ModelConfigOverride] = None,
         request_stream_callback: Optional[Callable[[List[data.RequestStreamOutput]], None]] = None,
     ):
         # - Check the fields fields of `engine_config`.
@@ -114,7 +113,7 @@ class SyncMLCEngine:
             model_args,
             model_config_paths,
             self.conv_template,
-        ) = _process_model_args(models, device, model_config_overrides)
+        ) = _process_model_args(models, device, engine_config)
 
         # - Load the raw model config into dict
         self.model_config_dicts = []


### PR DESCRIPTION
This PR introduces override options to the Python side EngineConfig so that they'll be reflected in JIT model compilation.