### PR TITLE
[Docs] Fix typo in mlc_llm chat command

### DIFF
--- a/docs/deploy/cli.rst
+++ b/docs/deploy/cli.rst
@@ -70,7 +70,7 @@ We provide the list of chat CLI interface for reference.
 
 .. code:: bash
 
-   mlc_llm serve MODEL [--model-lib PATH-TO-MODEL-LIB] [--device DEVICE] [--overrides OVERRIDES]
+   mlc_llm chat MODEL [--model-lib PATH-TO-MODEL-LIB] [--device DEVICE] [--overrides OVERRIDES]
 
 
 MODEL                  The model folder after compiling with MLC-LLM build process. The parameter


### PR DESCRIPTION
This PR fixes a typo in the documentation.

![image](https://github.com/mlc-ai/mlc-llm/assets/23090573/7607a109-fe4c-4a52-ba73-bbbdd9460334)
