### PR TITLE
Fix compilation for gcc 13.2

### DIFF
--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -6,6 +6,7 @@
 #ifndef MLC_LLM_SUPPORT_ENCODING_H_
 #define MLC_LLM_SUPPORT_ENCODING_H_
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
default for Ubuntu 23.10