### PR TITLE
[Fix] Set the missed prefill finish time

### DIFF
--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -439,6 +439,7 @@ void BatchPrefillBaseActionObj::UpdateRequestStateEntriesWithSampleResults(
         mstate->CommitToken(sample_results[i]);
         // live update the output metrics
         rsentries_for_sample[i]->rstate->metrics.completion_tokens += 1;
+        rsentries_for_sample[i]->rstate->metrics.prefill_end_time_point = tnow;
       }
       continue;
     }


### PR DESCRIPTION
This PR fixes a bug which fails to set the prefill finish time and results in metric error.