### PR TITLE
[Android] Update include path for tvm runtime src

### DIFF
--- a/android/mlc4j/CMakeLists.txt
+++ b/android/mlc4j/CMakeLists.txt
@@ -56,6 +56,7 @@ target_include_directories(tvm4j_runtime_packed PUBLIC
   ${TVM_SOURCE_DIR}/3rdparty/OpenCL-Headers
   ${TVM_SOURCE_DIR}/3rdparty/picojson
   ${TVM_SOURCE_DIR}/include
+  ${TVM_SOURCE_DIR}/src
 )
 target_compile_definitions(tvm4j_runtime_packed PUBLIC ${MLC_LLM_COMPILE_DEFS})
 target_compile_definitions(tvm4j_runtime_packed PUBLIC TVM_RELAX_VM_ENABLE_PROFILER=0)

--- a/android/mlc4j/src/cpp/tvm_runtime.h
+++ b/android/mlc4j/src/cpp/tvm_runtime.h
@@ -6,43 +6,36 @@
 #include <dmlc/logging.h>
 #include <dmlc/thread_local.h>
 
-#define STRINGIFY_MACRO(x) STR(x)
-#define STR(x) #x
-#define EXPAND(x) x
-#define CONCAT(n1, n2) STRINGIFY_MACRO(EXPAND(n1) EXPAND(n2))
-
-// clang-format off
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/c_runtime_api.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/container.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/cpu_device_api.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/file_utils.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/library_module.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/logging.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/module.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/ndarray.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/object.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/opencl/opencl_device_api.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/opencl/opencl_module.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/opencl/opencl_wrapper/opencl_wrapper.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/opencl/texture_pool.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/profiling.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/registry.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/source_utils.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/system_library.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/thread_pool.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/threading_backend.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/workspace_pool.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/memory/memory_manager.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/nvtx.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/builtin.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/bytecode.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/executable.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/kv_state.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/ndarray_cache_support.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/paged_kv_cache.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/rnn_state.cc)
-#include CONCAT(TVM_SOURCE_DIR,/src/runtime/relax_vm/vm.cc)
-// clang-format on
+#include <runtime/c_runtime_api.cc>
+#include <runtime/container.cc>
+#include <runtime/cpu_device_api.cc>
+#include <runtime/file_utils.cc>
+#include <runtime/library_module.cc>
+#include <runtime/logging.cc>
+#include <runtime/memory/memory_manager.cc>
+#include <runtime/module.cc>
+#include <runtime/ndarray.cc>
+#include <runtime/nvtx.cc>
+#include <runtime/object.cc>
+#include <runtime/opencl/opencl_device_api.cc>
+#include <runtime/opencl/opencl_module.cc>
+#include <runtime/opencl/opencl_wrapper/opencl_wrapper.cc>
+#include <runtime/opencl/texture_pool.cc>
+#include <runtime/profiling.cc>
+#include <runtime/registry.cc>
+#include <runtime/relax_vm/builtin.cc>
+#include <runtime/relax_vm/bytecode.cc>
+#include <runtime/relax_vm/executable.cc>
+#include <runtime/relax_vm/kv_state.cc>
+#include <runtime/relax_vm/ndarray_cache_support.cc>
+#include <runtime/relax_vm/paged_kv_cache.cc>
+#include <runtime/relax_vm/rnn_state.cc>
+#include <runtime/relax_vm/vm.cc>
+#include <runtime/source_utils.cc>
+#include <runtime/system_library.cc>
+#include <runtime/thread_pool.cc>
+#include <runtime/threading_backend.cc>
+#include <runtime/workspace_pool.cc>
 
 static_assert(TVM_LOG_CUSTOMIZE == 1, "TVM_LOG_CUSTOMIZE must be 1");
 


### PR DESCRIPTION
This PR updates the include directories for the Android app so that we can avoid using macros for src file include.