### PR TITLE
[Fix] Mark the decode requests in hybrid prefill

### DIFF
--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -70,7 +70,8 @@ BatchPrefillBaseActionObj::GetRequestStateEntriesToPrefill(EngineState estate) {
     int total_required_pages = num_decode_inputs;
     // Reserve decode requests first.
     for (const RequestStateEntry& rsentry : running_rsentries) {
-      prefill_inputs.push_back({rsentry, rsentry->mstates[i]->num_tokens_for_next_decode, 0});
+      prefill_inputs.push_back(
+          {rsentry, rsentry->mstates[i]->num_tokens_for_next_decode, 0, /*is_decode=*/true});
       total_input_length += rsentry->mstates[i]->num_tokens_for_next_decode;
     }
     int num_available_pages = models_[i]->GetNumAvailablePages();
@@ -138,7 +139,8 @@ BatchPrefillBaseActionObj::GetRequestStateEntriesToPrefill(EngineState estate) {
                          total_input_length, total_required_pages, num_available_pages,
                          current_total_seq_len, num_running_rsentries, kv_state_kind,
                          sliding_window_enabled)) {
-            prefill_inputs.push_back({rsentry, input_length, num_child_to_activate});
+            prefill_inputs.push_back(
+                {rsentry, input_length, num_child_to_activate, /*is_decode=*/false});
             num_prefill_rsentries += 1 + num_child_to_activate;
             can_prefill = true;
             break;
@@ -177,7 +179,7 @@ BatchPrefillBaseActionObj::GetRequestStateEntriesToPrefill(EngineState estate) {
         if (CanPrefill(estate, num_prefill_rsentries, total_input_length, total_required_pages,
                        num_available_pages, current_total_seq_len, num_running_rsentries,
                        kv_state_kind, sliding_window_enabled)) {
-          prefill_inputs.push_back({rsentry, input_length, 0});
+          prefill_inputs.push_back({rsentry, input_length, 0, /*is_decode=*/false});
         }
 
         // - Prefill stops here.

--- a/cpp/serve/engine_actions/batch_prefill_base.h
+++ b/cpp/serve/engine_actions/batch_prefill_base.h
@@ -25,6 +25,7 @@ class BatchPrefillBaseActionObj : public EngineActionObj {
     RequestStateEntry rsentry;
     int max_prefill_length = 0;
     int num_child_to_activate = 0;
+    bool is_decode = false;
   };
 
   BatchPrefillBaseActionObj(Array<Model> models, EngineConfig engine_config,

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -100,7 +100,7 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
         request_internal_ids.push_back(mstate->internal_id);
         RECORD_EVENT(trace_recorder_, rsentry->request->id, "start embedding");
         for (int i = 0; i < static_cast<int>(input_data.size()); ++i) {
-          if (!model_id) {
+          if (!model_id && !prefill_inputs[i].is_decode) {
             mstate->prefilled_inputs.push_back(input_data[i]);
           }
           embeddings = input_data[i]->GetEmbedding(models_[model_id],


### PR DESCRIPTION
This PR fixes an issue that may cause duplicate prefix updates for the decode requests in the hybrid prefill action.