### PR TITLE
[Fix][Bitmask] Mask dummy padded tokens for grammar

### DIFF
--- a/cpp/tokenizers/tokenizers.h
+++ b/cpp/tokenizers/tokenizers.h
@@ -87,7 +87,9 @@ class TokenizerObj : public Object {
   const DynamicBitset& GetPrefixTokenMask();
 
   /*!
-   * \brief Returns the vocabulary size. Special tokens are considered.
+   * \brief Returns the vocabulary size. Special tokens are considered. This may be smaller than the
+   * `vocab_size` in config.json (length of logits), see https://github.com/QwenLM/Qwen2/issues/147
+   * and https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/discussions/47.
    */
   size_t GetVocabSize() const;
 

--- a/python/mlc_llm/grammar/grammar.py
+++ b/python/mlc_llm/grammar/grammar.py
@@ -310,16 +310,22 @@ class GrammarStateMatcher(Object):
 
         return _ffi_api.GrammarStateMatcherFindNextRejectedTokens(self, verbose)  # type: ignore  # pylint: disable=no-member
 
-    def find_next_token_bitmask_as_ndarray(self) -> tvm.nd.array:
-        """Find the ids of the rejected tokens for the next step.
+    def find_next_token_bitmask_as_ndarray(self, full_vocab_size: int) -> tvm.nd.array:
+        """Find the bitmask for the next step.
+
+        Parameters
+        ----------
+        full_vocab_size: int
+            Different from `tokenizer->GetVocabSize()` or `init_ctx_->vocab_size`, this is the
+            vocab_size read from `config.json` that can be potentially larger.
 
         Returns
         -------
-        rejected_token_ids : List[int]
-            A list of rejected token ids.
+        bitmask_ndarray : tvm.nd.array
+            Bitmask for the next step.
         """
 
-        return _ffi_api.GrammarStateMatcherFindNextTokenBitmaskAsNDArray(self)  # type: ignore  # pylint: disable=no-member
+        return _ffi_api.GrammarStateMatcherFindNextTokenBitmaskAsNDArray(self, full_vocab_size)  # type: ignore  # pylint: disable=no-member
 
     def find_jump_forward_string(self) -> str:
         """Find the jump-forward string for jump-forward decoding. This is the longest string that


### PR DESCRIPTION
This PR addresses an issue with Grammar for models like `Phi-3` and `Qwen2`, where `vocab_size` read from `config.json` can be larger than `tokenizer->GetVocabSize()`. For instance, `Phi-3` has 32064 according to its `config.json`, but its `tokenizer.json` only has information up to `32010` (making `GetVocabSize()` 32011). See [this thread](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/discussions/47) for why it may be the case. In such cases, since our Grammar uses `tokenizer->GetVocabSize()` throughout, we do not mask out the dummy tokens (32011-32063), hence potentially sampling them and accepting them, leading to error like the following
```
[FATAL] mlc-llm/cpp/grammar/grammar_state_matcher.cc:202: Check failed: (token_id >= 0 && token_id < init_ctx_->vocab_size) is false: Invalid token id 32042 for GrammarStateMatcher
```

Unrelatedly, we add a check in `mlc_llm gen_config` to make sure `tokenizer.json`'s `added_tokens` do not have redundant tokens, which will cause correctness issues in runtime when using `huggingface/tokenizers`. See [this case](https://huggingface.co/NousResearch/Hermes-2-Pro-Llama-3-8B/discussions/15) for more. If it happens (the current case for Hermes-2-Pro-Llama-3), the user needs to manually modify the `tokenizer.json`.