### PR TITLE
[Engine] Lazy recompute in GetRunningRequestStateEntries

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -600,6 +600,7 @@ class EngineImpl : public Engine {
 
     // Send a callback to notice the abortion.
     this->StreamBackError(request, "abort");
+    estate_->running_rsentries_changed = true;
   }
 
   void AbortAllRequests() final {

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -96,6 +96,7 @@ void ProcessFinishedRequestStateEntries(std::vector<RequestStateEntry> finished_
       callback_delta_outputs->push_back(RequestStreamOutput::Usage(
           root_rsentry->request->id, rstate->metrics.AsUsageJSONStr(true)));
     }
+    estate->running_rsentries_changed = true;
   }
 }
 
@@ -294,6 +295,7 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
     // Add to the front of waiting queue.
     estate->waiting_queue.insert(estate->waiting_queue.begin(), request);
   }
+  estate->running_rsentries_changed = true;
   return rsentry;
 }
 

--- a/cpp/serve/engine_actions/action_commons.h
+++ b/cpp/serve/engine_actions/action_commons.h
@@ -65,22 +65,6 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
     Optional<DraftTokenWorkspaceManager> draft_token_workspace_manager,
     Optional<EventTraceRecorder> trace_recorder);
 
-/*! \brief Get the running request entries from the engine state. */
-inline std::vector<RequestStateEntry> GetRunningRequestStateEntries(const EngineState& estate) {
-  std::vector<RequestStateEntry> rsentries;
-  for (const Request& request : estate->running_queue) {
-    for (const RequestStateEntry& rsentry : estate->GetRequestState(request)->entries) {
-      // One request entry is considered as running for decode if it is a leaf and has
-      // finished all input prefill.
-      if (rsentry->status == RequestStateStatus::kAlive && rsentry->child_indices.empty() &&
-          rsentry->mstates[0]->inputs.empty()) {
-        rsentries.push_back(rsentry);
-      }
-    }
-  }
-  return rsentries;
-}
-
 /*!
  * \brief Apply the logit processor to the logits and sample one token for each request.
  *

--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -49,7 +49,7 @@ class BatchDecodeActionObj : public EngineActionObj {
     std::vector<RequestStateEntry> running_rsentries;
     {
       NVTXScopedRange nvtx_scope("BatchDecode getting requests");
-      running_rsentries = GetRunningRequestStateEntries(estate);
+      running_rsentries = estate->GetRunningRequestStateEntries();
       while (!CanDecode(running_rsentries.size())) {
         if (estate->prefix_cache->TryFreeMemory()) continue;
         RequestStateEntry preempted =

--- a/cpp/serve/engine_actions/batch_draft.cc
+++ b/cpp/serve/engine_actions/batch_draft.cc
@@ -45,7 +45,7 @@ class BatchDraftActionObj : public EngineActionObj {
     }
 
     // Preempt request state entries when decode cannot apply.
-    std::vector<RequestStateEntry> running_rsentries = GetRunningRequestStateEntries(estate);
+    std::vector<RequestStateEntry> running_rsentries = estate->GetRunningRequestStateEntries();
     while (!CanDecode(running_rsentries.size())) {
       if (estate->prefix_cache->TryFreeMemory()) continue;
       RequestStateEntry preempted = PreemptLastRunningRequestStateEntry(

--- a/cpp/serve/engine_actions/batch_jumpforward.cc
+++ b/cpp/serve/engine_actions/batch_jumpforward.cc
@@ -42,7 +42,7 @@ class BatchJumpForwardActionObj : public EngineActionObj {
     std::vector<RequestStateEntry> running_rsentries;
     {
       NVTXScopedRange nvtx_scope("BatchJumpForward getting requests");
-      running_rsentries = GetRunningRequestStateEntries(estate);
+      running_rsentries = estate->GetRunningRequestStateEntries();
       while (!CheckMemForJumpForward(running_rsentries.size())) {
         if (estate->prefix_cache->TryFreeMemory()) continue;
         RequestStateEntry preempted =

--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -255,7 +255,7 @@ class BatchVerifyActionObj : public EngineActionObj {
     int num_available_pages = models_[verify_model_id_]->GetNumAvailablePages();
 
     // Preempt the request state entries that cannot fit the large model for verification.
-    std::vector<RequestStateEntry> running_rsentries = GetRunningRequestStateEntries(estate);
+    std::vector<RequestStateEntry> running_rsentries = estate->GetRunningRequestStateEntries();
     std::vector<int> num_page_requirement;
     num_page_requirement.reserve(running_rsentries.size());
     for (const RequestStateEntry& rsentry : running_rsentries) {

--- a/cpp/serve/engine_actions/eagle_batch_draft.cc
+++ b/cpp/serve/engine_actions/eagle_batch_draft.cc
@@ -45,7 +45,7 @@ class EagleBatchDraftActionObj : public EngineActionObj {
     }
 
     // Preempt request state entries when decode cannot apply.
-    std::vector<RequestStateEntry> running_rsentries = GetRunningRequestStateEntries(estate);
+    std::vector<RequestStateEntry> running_rsentries = estate->GetRunningRequestStateEntries();
     while (!CanDecode(running_rsentries.size())) {
       if (estate->prefix_cache->TryFreeMemory()) continue;
       RequestStateEntry preempted = PreemptLastRunningRequestStateEntry(

--- a/cpp/serve/engine_actions/eagle_batch_verify.cc
+++ b/cpp/serve/engine_actions/eagle_batch_verify.cc
@@ -351,7 +351,7 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
     int num_available_pages = models_[verify_model_id_]->GetNumAvailablePages();
 
     // Preempt the request state entries that cannot fit the large model for verification.
-    std::vector<RequestStateEntry> running_rsentries = GetRunningRequestStateEntries(estate);
+    std::vector<RequestStateEntry> running_rsentries = estate->GetRunningRequestStateEntries();
     std::vector<int> num_page_requirement;
     num_page_requirement.reserve(running_rsentries.size());
     for (const RequestStateEntry& rsentry : running_rsentries) {

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -331,6 +331,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
 
     std::vector<Request> processed_requests =
         RemoveProcessedRequests(prefill_inputs, estate, rstates_of_entries);
+    estate->running_rsentries_changed = true;
     return processed_requests;
   }
 

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -252,6 +252,7 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
 
     std::vector<Request> processed_requests =
         RemoveProcessedRequests(prefill_inputs, estate, rstates_of_entries);
+    estate->running_rsentries_changed = true;
     return processed_requests;
   }
 

--- a/cpp/serve/engine_state.cc
+++ b/cpp/serve/engine_state.cc
@@ -29,6 +29,25 @@ RequestState EngineStateObj::GetRequestState(Request request) {
   return it->second;
 }
 
+const std::vector<RequestStateEntry>& EngineStateObj::GetRunningRequestStateEntries() {
+  if (running_rsentries_changed) {
+    cached_running_rsentries_.clear();
+    for (const Request& request : running_queue) {
+      for (const RequestStateEntry& rsentry : GetRequestState(request)->entries) {
+        // One request entry is considered as running for decode if it is a leaf and has
+        // finished all input prefill.
+        if (rsentry->status == RequestStateStatus::kAlive && rsentry->child_indices.empty() &&
+            rsentry->mstates[0]->inputs.empty()) {
+          cached_running_rsentries_.push_back(rsentry);
+        }
+      }
+    }
+    running_rsentries_changed = false;
+  }
+  return cached_running_rsentries_;
+  //
+}
+
 }  // namespace serve
 }  // namespace llm
 }  // namespace mlc

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -64,16 +64,23 @@ class EngineStateObj : public Object {
   EngineMetrics metrics;
   /*! \brief The prefix cache. */
   PrefixCache prefix_cache{nullptr};
+  /*! \brief A boolean flag denoting whether the running request state entry list has changed. */
+  bool running_rsentries_changed = true;
 
   /*! \brief Reset the engine state and clear the metrics. */
   void Reset();
   /*! \brief Get the request state of the given request. */
   RequestState GetRequestState(Request request);
+  /*! \brief Return the running request state entries*/
+  const std::vector<RequestStateEntry>& GetRunningRequestStateEntries();
 
   static constexpr const char* _type_key = "mlc.serve.EngineState";
   static constexpr const bool _type_has_method_sequal_reduce = false;
   static constexpr const bool _type_has_method_shash_reduce = false;
   TVM_DECLARE_FINAL_OBJECT_INFO(EngineStateObj, Object);
+
+ private:
+  std::vector<RequestStateEntry> cached_running_rsentries_;
 };
 
 /*!

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -133,7 +133,7 @@ class RequestModelState : public ObjectRef {
 
 struct DeltaRequestReturn {
   std::vector<int64_t> delta_token_ids;
-  Array<String> delta_logprob_json_strs;
+  std::vector<String> delta_logprob_json_strs;
   Optional<String> finish_reason;
   /*! \brief The extra string to prepend the delta output. The delta output should be
    * extra_prefix_string + detokenize(delta_token_ids). */


### PR DESCRIPTION
This PR updates GetRunningRequestStateEntries to make it lazy. We use a dirty flag to check whether the running request state entries are changed since the last recompute.

We make this improvement due to the observation that this function may cause some CPU overhead. During consecutive rounds of batch decode, the running requests don't change, so we can effectively use this dirty flag to avoid recomputation.