### PR TITLE
[Serving] PagedKVCache Quantization

### DIFF
--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -46,6 +46,7 @@ ModelMetadata::KVCacheMetadata ModelMetadata::KVCacheMetadata::FromJSON(
   kv_cache_metadata.head_dim = json::Lookup<int64_t>(json, "head_dim");
   kv_cache_metadata.num_attention_heads = json::Lookup<int64_t>(json, "num_attention_heads");
   kv_cache_metadata.num_key_value_heads = json::Lookup<int64_t>(json, "num_key_value_heads");
+  kv_cache_metadata.kv_nbits = json::Lookup<int64_t>(json, "kv_nbits");
   return kv_cache_metadata;
 }
 
@@ -73,7 +74,8 @@ ModelMetadata ModelMetadata::FromJSON(const picojson::object& metadata,
     result.kv_cache_metadata = {/*num_hidden_layers=*/0,
                                 /*head_dim=*/0,
                                 /*num_attention_heads=*/0,
-                                /*num_key_value_heads=*/0};
+                                /*num_key_value_heads=*/0,
+                                /*kv_nbits=*/0};
   }
   {
     std::vector<ModelMetadata::Param>& params = result.params;

--- a/cpp/metadata/model.h
+++ b/cpp/metadata/model.h
@@ -67,6 +67,7 @@ struct ModelMetadata {
     int64_t num_attention_heads;
     int64_t num_key_value_heads;
     int64_t head_dim;
+    int64_t kv_nbits;
     static KVCacheMetadata FromJSON(const picojson::object& json);
   };
 

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -567,8 +567,10 @@ Result<MemUsageEstimationResult> EstimateMemoryUsageOnMode(
     int64_t head_dim = model_metadata[i].kv_cache_metadata.head_dim;
     int64_t num_qo_heads = model_metadata[i].kv_cache_metadata.num_attention_heads;
     int64_t num_kv_heads = model_metadata[i].kv_cache_metadata.num_key_value_heads;
+    int64_t kv_nbits = model_metadata[i].kv_cache_metadata.kv_nbits;
     int64_t hidden_size = head_dim * num_qo_heads;
-    kv_bytes_per_token += head_dim * num_kv_heads * num_layers * 4 + 1.25;
+    double kv_nbytes = kv_nbits / 8.0f;
+    kv_bytes_per_token += head_dim * num_kv_heads * num_layers * kv_nbytes * 2 + 1.25;
     kv_aux_workspace_bytes +=
         (max_num_sequence + 1) * 88 + prefill_chunk_size * (num_qo_heads + 1) * 8 +
         prefill_chunk_size * head_dim * (num_qo_heads + num_kv_heads) * 4 + 48 * 1024 * 1024;

--- a/python/mlc_llm/bench/metrics.py
+++ b/python/mlc_llm/bench/metrics.py
@@ -1,4 +1,5 @@
 """ MLC LLM bench Metrics"""
+
 import json
 from typing import Any, Callable, Dict, List, Optional, Union
 

--- a/python/mlc_llm/bench/replay.py
+++ b/python/mlc_llm/bench/replay.py
@@ -1,4 +1,5 @@
 """MLC LLM bench replay request"""
+
 import asyncio
 import json
 from datetime import datetime

--- a/python/mlc_llm/model/baichuan/baichuan_model.py
+++ b/python/mlc_llm/model/baichuan/baichuan_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -41,6 +42,7 @@ class BaichuanConfig(ConfigBase):  # pylint: disable=too-many-instance-attribute
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
     head_dim: int = 0
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -203,6 +205,7 @@ class BaichuanForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         self.vocab_size = config.vocab_size
         self.rope_theta = 10000
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -291,6 +294,7 @@ class BaichuanForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/baichuan/baichuan_quantization.py
+++ b/python/mlc_llm/model/baichuan/baichuan_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a BaichuanLM-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = BaichuanForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/chatglm3/chatglm3_model.py
+++ b/python/mlc_llm/model/chatglm3/chatglm3_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -43,6 +44,7 @@ class GLMConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     tensor_parallel_shards: int = 1
     head_dim: int = 0
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -279,6 +281,7 @@ class ChatGLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         self.vocab_size = config.vocab_size
         self.rope_theta = 10000
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -367,6 +370,7 @@ class ChatGLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/chatglm3/chatglm3_quantization.py
+++ b/python/mlc_llm/model/chatglm3/chatglm3_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a ChatGLM-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = ChatGLMForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/eagle/eagle_model.py
+++ b/python/mlc_llm/model/eagle/eagle_model.py
@@ -90,6 +90,7 @@ class EagleForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         self.vocab_size = config.vocab_size
         self.rope_theta = config.position_embedding_base
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def fuse_embed_hidden_states(self, input_embed: Tensor, hidden_states: Tensor):
@@ -177,6 +178,7 @@ class EagleForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/eagle/eagle_quantization.py
+++ b/python/mlc_llm/model/eagle/eagle_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Eagle-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = EagleForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/gemma/gemma_model.py
+++ b/python/mlc_llm/model/gemma/gemma_model.py
@@ -9,6 +9,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -36,6 +37,7 @@ class GemmaConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     prefill_chunk_size: int = 0
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -228,6 +230,7 @@ class GemmaForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         self.vocab_size = config.vocab_size
         self.rope_theta = config.position_embedding_base
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -316,6 +319,7 @@ class GemmaForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribut
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/gemma/gemma_quantization.py
+++ b/python/mlc_llm/model/gemma/gemma_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Gemma-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = GemmaForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/gpt2/gpt2_model.py
+++ b/python/mlc_llm/model/gpt2/gpt2_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -36,6 +37,7 @@ class GPT2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     tensor_parallel_shards: int = 1
     head_dim: int = 0
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -223,6 +225,7 @@ class GPT2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
         self.n_head = config.n_head
         self.head_dim = config.head_dim
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -311,6 +314,7 @@ class GPT2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
             rope_mode=RopeMode.NONE,
             rope_scale=-1,
             rope_theta=-1,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/gpt2/gpt2_quantization.py
+++ b/python/mlc_llm/model/gpt2/gpt2_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a GPT-2-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = GPT2LMHeadModel(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/gpt_bigcode/gpt_bigcode_model.py
+++ b/python/mlc_llm/model/gpt_bigcode/gpt_bigcode_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -35,6 +36,7 @@ class GPTBigCodeConfig(ConfigBase):  # pylint: disable=too-many-instance-attribu
     prefill_chunk_size: int = 0
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -190,6 +192,7 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
         self.num_kv_heads = 1
         self.head_dim = config.n_embd // config.n_head
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -278,6 +281,7 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
             rope_mode=RopeMode.NONE,
             rope_scale=-1,
             rope_theta=-1,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/gpt_bigcode/gpt_bigcode_quantization.py
+++ b/python/mlc_llm/model/gpt_bigcode/gpt_bigcode_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a GPTBigCode-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = GPTBigCodeForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_llm/model/gpt_neox/gpt_neox_model.py
@@ -13,6 +13,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
 from mlc_llm.support.style import bold
@@ -39,6 +40,7 @@ class GPTNeoXConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     tensor_parallel_shards: int = 1
     ffn_out_dtype: str = "float32"
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -253,6 +255,7 @@ class GPTNeoXForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         self.vocab_size = config.vocab_size
         self.rope_theta = config.position_embedding_base
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
         self.rotary_pct = config.rotary_pct
 
@@ -342,6 +345,7 @@ class GPTNeoXForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
             rotary_dim=int(self.head_dim * self.rotary_pct),
         )

--- a/python/mlc_llm/model/gpt_neox/gpt_neox_quantization.py
+++ b/python/mlc_llm/model/gpt_neox/gpt_neox_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a GPTNeoX-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = GPTNeoXForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/internlm/internlm_model.py
+++ b/python/mlc_llm/model/internlm/internlm_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -40,6 +41,7 @@ class InternLMConfig(ConfigBase):  # pylint: disable=too-many-instance-attribute
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
     head_dim: int = 0
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -214,6 +216,7 @@ class InternLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         self.vocab_size = config.vocab_size
         self.rope_theta = 10000
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -302,6 +305,7 @@ class InternLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/internlm/internlm_quantization.py
+++ b/python/mlc_llm/model/internlm/internlm_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a InternLM-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = InternLMForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/internlm2/internlm2_model.py
+++ b/python/mlc_llm/model/internlm2/internlm2_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -42,6 +43,7 @@ class InternLM2Config(ConfigBase):  # pylint: disable=too-many-instance-attribut
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
     head_dim: int = 0
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -222,6 +224,7 @@ class InternLM2ForCausalLM(nn.Module):  # pylint: disable=R0902
         self.head_dim = config.head_dim
         self.rope_theta = config.rope_theta
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
 
     def to(self, dtype: Optional[str] = None):
         super().to(dtype=dtype)
@@ -309,6 +312,7 @@ class InternLM2ForCausalLM(nn.Module):  # pylint: disable=R0902
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/internlm2/internlm2_quantization.py
+++ b/python/mlc_llm/model/internlm2/internlm2_quantization.py
@@ -1,5 +1,6 @@
 """This file specifies how MLC's InternLM2 parameters are quantized using group quantization
 or other formats."""
+
 from typing import Tuple
 
 from tvm.relax.frontend import nn
@@ -15,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a InternLM2-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = InternLM2ForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/llama/llama_model.py
+++ b/python/mlc_llm/model/llama/llama_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -37,6 +38,7 @@ class LlamaConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     head_dim: int = 0
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -209,6 +211,7 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         self.vocab_size = config.vocab_size
         self.rope_theta = config.position_embedding_base
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -344,6 +347,7 @@ class LlamaForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/llama/llama_quantization.py
+++ b/python/mlc_llm/model/llama/llama_quantization.py
@@ -22,6 +22,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Llama-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = LlamaForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/llava/llava_quantization.py
+++ b/python/mlc_llm/model/llava/llava_quantization.py
@@ -15,6 +15,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Llava model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = LlavaForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/mistral/mistral_model.py
+++ b/python/mlc_llm/model/mistral/mistral_model.py
@@ -11,6 +11,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -38,6 +39,7 @@ class MistralConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     attention_sink_size: int = 4
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):  # pylint: disable=too-many-branches
@@ -228,6 +230,7 @@ class MistralForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         self.rope_theta = config.position_embedding_base
         self.tensor_parallel_shards = config.tensor_parallel_shards
         self.sliding_window_size = config.sliding_window_size
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -316,6 +319,7 @@ class MistralForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attrib
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/mistral/mistral_quantization.py
+++ b/python/mlc_llm/model/mistral/mistral_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Mistral-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = MistralForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/mixtral/mixtral_quantization.py
+++ b/python/mlc_llm/model/mixtral/mixtral_quantization.py
@@ -22,6 +22,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Mixtral-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = MixtralForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/orion/orion_model.py
+++ b/python/mlc_llm/model/orion/orion_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -37,6 +38,7 @@ class OrionConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     head_dim: int = 0
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -210,6 +212,7 @@ class OrionForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         self.vocab_size = config.vocab_size
         self.rope_theta = config.position_embedding_base
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -298,6 +301,7 @@ class OrionForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/orion/orion_quantization.py
+++ b/python/mlc_llm/model/orion/orion_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Orion-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = OrionForCasualLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/phi/phi_quantization.py
+++ b/python/mlc_llm/model/phi/phi_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Phi-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = PhiForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/phi3/phi3_model.py
+++ b/python/mlc_llm/model/phi3/phi3_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -38,6 +39,7 @@ class Phi3Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     head_dim: int = 0
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -217,6 +219,7 @@ class Phi3ForCausalLM(nn.Module):
         self.vocab_size = config.vocab_size
         self.rope_theta = config.position_embedding_base
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -308,6 +311,7 @@ class Phi3ForCausalLM(nn.Module):
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/phi3/phi3_quantization.py
+++ b/python/mlc_llm/model/phi3/phi3_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Phi-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = Phi3ForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/qwen/qwen_model.py
+++ b/python/mlc_llm/model/qwen/qwen_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -38,6 +39,7 @@ class QWenConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
     head_dim: int = 0
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -208,6 +210,7 @@ class QWenLMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
         self.head_dim = config.head_dim
         self.tensor_parallel_shards = config.tensor_parallel_shards
         self.rotary_emb_base = config.rotary_emb_base
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -297,6 +300,7 @@ class QWenLMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rotary_emb_base,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/qwen/qwen_quantization.py
+++ b/python/mlc_llm/model/qwen/qwen_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a QWen-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = QWenLMHeadModel(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/qwen2/qwen2_model.py
+++ b/python/mlc_llm/model/qwen2/qwen2_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
 from mlc_llm.support.config import ConfigBase
@@ -40,6 +41,7 @@ class QWen2Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     head_dim: int = 0
     dtype: str = "float32"
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -240,6 +242,7 @@ class QWen2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribut
         self.vocab_size = config.vocab_size
         self.tensor_parallel_shards = config.tensor_parallel_shards
         self.head_dim = config.head_dim
+        self.kv_quantization = config.kv_quantization
 
     def to(self, dtype: Optional[str] = None):
         super().to(dtype=dtype)
@@ -337,6 +340,7 @@ class QWen2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribut
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/qwen2/qwen2_quantization.py
+++ b/python/mlc_llm/model/qwen2/qwen2_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a QWen-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = QWen2LMHeadModel(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/qwen2_moe/qwen2_moe_model.py
+++ b/python/mlc_llm/model/qwen2_moe/qwen2_moe_model.py
@@ -233,6 +233,7 @@ class Qwen2MoeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         self.vocab_size = config.vocab_size
         self.tensor_parallel_shards = config.tensor_parallel_shards
         self.head_dim = config.head_dim
+        self.kv_quantization = config.kv_quantization
 
     def to(self, dtype: Optional[str] = None):
         super().to(dtype=dtype)
@@ -320,6 +321,7 @@ class Qwen2MoeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/qwen2_moe/qwen2_moe_quantization.py
+++ b/python/mlc_llm/model/qwen2_moe/qwen2_moe_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a Qwen2MoE-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = Qwen2MoeForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/stable_lm/stablelm_quantization.py
+++ b/python/mlc_llm/model/stable_lm/stablelm_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a StableLM-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = StableLmForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/model/starcoder2/starcoder2_model.py
+++ b/python/mlc_llm/model/starcoder2/starcoder2_model.py
@@ -12,6 +12,7 @@ from tvm.relax.frontend.nn import Tensor, op
 
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 from mlc_llm.support import logging
 from mlc_llm.support.config import ConfigBase
 from mlc_llm.support.style import bold
@@ -40,6 +41,7 @@ class Starcoder2Config(ConfigBase):  # pylint: disable=too-many-instance-attribu
     prefill_chunk_size: int = 0
     tensor_parallel_shards: int = 1
     max_batch_size: int = 1
+    kv_quantization: PagedKVCacheQuantization = PagedKVCacheQuantization.KV_NO_QUANT
     kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
@@ -196,6 +198,7 @@ class Starcoder2ForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
         self.vocab_size = config.vocab_size
         self.rope_theta = config.rope_theta
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.kv_quantization = config.kv_quantization
         self.dtype = "float32"
 
     def to(self, dtype: Optional[str] = None):
@@ -282,6 +285,7 @@ class Starcoder2ForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,
+            kv_quantization=self.kv_quantization,
             dtype=self.dtype,
         )
 

--- a/python/mlc_llm/model/starcoder2/starcoder2_quantization.py
+++ b/python/mlc_llm/model/starcoder2/starcoder2_quantization.py
@@ -16,6 +16,7 @@ def group_quant(
     quantization: GroupQuantize,
 ) -> Tuple[nn.Module, QuantizeMapping]:
     """Quantize a InternLM-architecture model using group quantization."""
+    model_config.kv_quantization = quantization.kv_quantization
     model: nn.Module = Starcoder2ForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})

--- a/python/mlc_llm/op/position_embedding.py
+++ b/python/mlc_llm/op/position_embedding.py
@@ -170,40 +170,33 @@ def llama_rope(  # pylint: disable=too-many-arguments
 
 
 def llama_rope_with_position_map(  # pylint: disable=too-many-arguments
+    kv_cache_config,
     theta: float,
     scale: float,
-    head_dim: int,
-    num_q_heads: int,
-    num_kv_heads: int,
-    dtype: str,
     rotary_dim: Optional[int] = None,
 ):
     """Return the TIR function that computes Llama-style RoPE with q position map.
 
     Parameters
     ----------
+    kv_cache_config : BaseKVConfig
+        Page KV Cache configuration.
+
     theta : float
         The theta value, or "base" in RoPE, which controls the frequency.
 
     scale : float
         The RoPE scaling factor.
 
-    head_dim : int
-        The number of features on each head.
-
-    num_q_heads : int
-        The number of query heads.
-
-    num_kv_heads : int
-        The number of key/value heads. It differs from `num_q_heads` in group-query attention.
-
-    dtype : str
-        The dtype of qkv data.
-
     rotary_dim : int
         The number of dimensions in the embedding that RoPE is applied to. By default, the
         rotary_dim is the same as head_dim.
     """
+    head_dim = kv_cache_config.head_dim
+    num_q_heads = kv_cache_config.num_attention_heads
+    num_kv_heads = kv_cache_config.num_key_value_heads
+    dtype = kv_cache_config.model_dtype
+
     fused_heads = num_q_heads + num_kv_heads * 2
     if rotary_dim is None:
         rotary_dim = head_dim

--- a/python/mlc_llm/quantization/__init__.py
+++ b/python/mlc_llm/quantization/__init__.py
@@ -5,5 +5,11 @@ from .fp8_quantization import FP8PerTensorQuantizeMixtralExperts
 from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize
 from .no_quantization import NoQuantize
+from .paged_kv_cache_quantization import (
+    BaseKVConfig,
+    PagedKVCacheQuantization,
+    get_kv_storage_dtype,
+    get_paged_kv_cache_config,
+)
 from .per_tensor_quantization import PerTensorQuantize
 from .quantization import QUANTIZATION, Quantization

--- a/python/mlc_llm/quantization/awq_quantization.py
+++ b/python/mlc_llm/quantization/awq_quantization.py
@@ -9,6 +9,7 @@ from tvm.runtime import NDArray
 
 from mlc_llm.loader import QuantizeMapping
 
+from .paged_kv_cache_quantization import PagedKVCacheQuantization
 from .utils import convert_uint_to_float, is_final_fc, is_moe_gate
 
 
@@ -41,6 +42,7 @@ class AWQQuantize:  # pylint: disable=too-many-instance-attributes
     quantize_dtype: str  # "int3", "int4", "int8"
     storage_dtype: str  # "uint32"
     model_dtype: str  # "float16", "float32"
+    kv_quantization: PagedKVCacheQuantization
 
     num_elem_per_storage: int = 0
     num_storage_per_group: int = 0

--- a/python/mlc_llm/quantization/ft_quantization.py
+++ b/python/mlc_llm/quantization/ft_quantization.py
@@ -21,6 +21,7 @@ from .group_quantization import (
     GroupQuantizeEmbedding,
     GroupQuantizeLinear,
 )
+from .paged_kv_cache_quantization import PagedKVCacheQuantization
 from .utils import is_final_fc, is_moe_gate
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
     quantize_dtype: Literal["int4", "int8"]
     storage_dtype: Literal["int8"]
     model_dtype: Literal["float16"]
+    kv_quantization: PagedKVCacheQuantization
     group_size: Optional[int] = None
 
     num_elem_per_storage: int = 0
@@ -57,6 +59,7 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
             storage_dtype="uint32",
             model_dtype=self.model_dtype,
             linear_weight_layout="NK",
+            kv_quantization=self.kv_quantization,
         )
 
     def __post_init__(self):

--- a/python/mlc_llm/quantization/group_quantization.py
+++ b/python/mlc_llm/quantization/group_quantization.py
@@ -12,6 +12,7 @@ from mlc_llm.loader import QuantizeMapping
 from mlc_llm.nn import MixtralExperts
 from mlc_llm.support import logging
 
+from .paged_kv_cache_quantization import PagedKVCacheQuantization
 from .utils import (
     apply_sharding,
     compile_quantize_func,
@@ -35,6 +36,7 @@ class GroupQuantize:  # pylint: disable=too-many-instance-attributes
     storage_dtype: Literal["uint32"]
     model_dtype: Literal["float16", "float32"]
     linear_weight_layout: Literal["KN", "NK"]
+    kv_quantization: PagedKVCacheQuantization
     quantize_embedding: bool = True
     quantize_final_fc: bool = True
 

--- a/python/mlc_llm/quantization/paged_kv_cache_quantization.py
+++ b/python/mlc_llm/quantization/paged_kv_cache_quantization.py
@@ -1,0 +1,323 @@
+"""Paged KV cache quantization config"""
+
+# pylint: disable=too-many-statements,too-many-lines,too-many-arguments,too-many-locals
+import enum
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+from tvm import DataType, tir
+from tvm.script import tir as T
+from tvm.target import Target
+
+
+class PagedKVCacheQuantization(enum.IntEnum):
+    """The quantization scheme to apply to Paged KV cache.
+    If it is none, quantization will not be applied to kv cache.
+    Otherwise, different quantization schemes can be applied to kv cache.
+    """
+
+    KV_NO_QUANT = 0
+    KV_GROUP_QUANT_INT_3 = 1
+    KV_GROUP_QUANT_INT_4 = 2
+
+
+@dataclass
+class BaseKVConfig:  # pylint: disable=too-many-instance-attributes
+    """Base configuration for key-value cache"""
+
+    name: str
+    kind: str
+    head_dim: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    model_dtype: DataType
+    target: Target
+
+
+@dataclass
+class NoQuantizeKV(BaseKVConfig):
+    """Configuration for key-value non-quantization"""
+
+    num_storage: int = 0
+    kv_storage_dtype: DataType = None
+
+    def __post_init__(self):
+        assert self.kind == "no-quant"
+        assert str(self.model_dtype) in ["float16", "float32"]
+
+        self.num_storage = self.head_dim
+        self.kv_storage_dtype = self.model_dtype
+
+
+@dataclass
+class GroupQuantizeKV(BaseKVConfig):  # pylint: disable=too-many-instance-attributes
+    """Configuration for key-value group quantization"""
+
+    group_size: int
+    kv_quantize_dtype: DataType
+
+    max_int_value: int = 0
+    num_elem_per_storage: int = 0
+    num_storage_per_group: int = 0
+    num_groups: int = 0
+    num_storage_weight: int = 0
+    num_storage_scale: int = 0
+    num_storage: int = 0
+    kv_storage_dtype: DataType = None
+
+    def __post_init__(self):
+        assert self.kind == "group-quant"
+        assert str(self.kv_quantize_dtype) in ["int3", "int4"]
+        assert str(self.model_dtype) in ["float16", "float32"]
+
+        self.kv_storage_dtype = {
+            "float16": DataType("uint16"),
+            "float32": DataType("uint32"),
+        }[str(self.model_dtype)]
+
+        self.max_int_value = (2 ** (self.kv_quantize_dtype.bits - 1)) - 1
+        self.num_elem_per_storage = self.kv_storage_dtype.bits // self.kv_quantize_dtype.bits
+        self.num_storage_per_group = self.group_size // self.num_elem_per_storage
+        self.num_groups = math.ceil(self.head_dim / self.group_size)
+        self.num_storage_weight = self.num_storage_per_group * self.num_groups
+        self.num_storage_scale = self.num_groups
+        self.num_storage = self.num_storage_weight + self.num_storage_scale
+
+        if self.kv_storage_dtype.bits < self.kv_quantize_dtype.bits:
+            raise ValueError("Storage unit should be greater or equal to quantized element")
+        if self.group_size % self.num_elem_per_storage != 0:
+            raise ValueError("Group size should be divisible by numbers of elements per storage")
+
+    def kv_cache_quantize_transpose_append(self):
+        """
+        Return the TIR function that appends new k/v data to PagedKVCache
+        (fused w/ kv quantization).
+        """
+
+        # pylint: disable=line-too-long,invalid-name
+        # fmt: off
+        @T.prim_func
+        def tir_kv_cache_transpose_append(
+            var_pages: T.handle,
+            var_k_data: T.handle,
+            var_v_data: T.handle,
+            var_position_map: T.handle,
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            ntoken = T.SizeVar("num_tokens_excluding_cache", "int64")
+            num_pages = T.int64()
+            position_map_elem_offset = T.int32()
+            pages = T.match_buffer(var_pages, (num_pages, 2, self.num_key_value_heads, 16, self.num_storage), self.kv_storage_dtype)
+            k_data = T.match_buffer(var_k_data, (ntoken, self.num_key_value_heads, self.head_dim), self.model_dtype)
+            v_data = T.match_buffer(var_v_data, (ntoken, self.num_key_value_heads, self.head_dim), self.model_dtype)
+            position_map = T.match_buffer(var_position_map, (ntoken,), "int32", elem_offset=position_map_elem_offset)
+
+            k_max_abs_value = T.alloc_buffer((ntoken, self.num_key_value_heads, self.num_groups), self.model_dtype)
+            v_max_abs_value = T.alloc_buffer((ntoken, self.num_key_value_heads, self.num_groups), self.model_dtype)
+            k_scale = T.alloc_buffer((ntoken, self.num_key_value_heads, self.num_groups), self.model_dtype)
+            v_scale = T.alloc_buffer((ntoken, self.num_key_value_heads, self.num_groups), self.model_dtype)
+            k_compute = T.alloc_buffer((ntoken, self.num_key_value_heads, self.num_storage_weight), self.kv_storage_dtype)
+            v_compute = T.alloc_buffer((ntoken, self.num_key_value_heads, self.num_storage_weight), self.kv_storage_dtype)
+
+            for i0, i1, i2, r in T.grid(ntoken, T.int64(self.num_key_value_heads), T.int64(self.num_groups), T.int64(self.group_size)):
+                with T.block("k_max_abs_value"):
+                    v_i0, v_i1, v_i2, v_r = T.axis.remap("SSSR", [i0, i1, i2, r])
+                    T.reads(k_data[v_i0, v_i1, v_i2 * self.group_size + v_r])
+                    T.writes(k_max_abs_value[v_i0, v_i1, v_i2])
+                    with T.init():
+                        k_max_abs_value[v_i0, v_i1, v_i2] = T.min_value(self.model_dtype)
+                    k_max_abs_value[v_i0, v_i1, v_i2] = T.max(
+                        k_max_abs_value[v_i0, v_i1, v_i2],
+                        T.if_then_else(
+                            v_i2 * self.group_size + v_r < self.head_dim,
+                            T.fabs(k_data[v_i0, v_i1, v_i2 * self.group_size + v_r]),
+                            T.min_value(self.model_dtype),
+                        ),
+                    )
+            for i0, i1, i2, r in T.grid(ntoken, T.int64(self.num_key_value_heads), T.int64(self.num_groups), T.int64(self.group_size)):
+                with T.block("v_max_abs_value"):
+                    v_i0, v_i1, v_i2, v_r = T.axis.remap("SSSR", [i0, i1, i2, r])
+                    T.reads(v_data[v_i0, v_i1, v_i2 * self.group_size + v_r])
+                    T.writes(v_max_abs_value[v_i0, v_i1, v_i2])
+                    with T.init():
+                        v_max_abs_value[v_i0, v_i1, v_i2] = T.min_value(self.model_dtype)
+                    v_max_abs_value[v_i0, v_i1, v_i2] = T.max(
+                        v_max_abs_value[v_i0, v_i1, v_i2],
+                        T.if_then_else(
+                            v_i2 * self.group_size + v_r < self.head_dim,
+                            T.fabs(v_data[v_i0, v_i1, v_i2 * self.group_size + v_r]),
+                            T.min_value(self.model_dtype),
+                        ),
+                    )
+
+            for i0, i1, i2 in T.grid(ntoken, T.int64(self.num_key_value_heads), T.int64(self.num_groups)):
+                with T.block("scale"):
+                    v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+                    T.reads(k_max_abs_value[v_i0, v_i1, v_i2], v_max_abs_value[v_i0, v_i1, v_i2])
+                    T.writes(k_scale[v_i0, v_i1, v_i2], v_scale[v_i0, v_i1, v_i2])
+                    k_scale[v_i0, v_i1, v_i2] = k_max_abs_value[v_i0, v_i1, v_i2] / self.max_int_value
+                    v_scale[v_i0, v_i1, v_i2] = v_max_abs_value[v_i0, v_i1, v_i2] / self.max_int_value
+
+            for i0, i1, i2, r in T.grid(ntoken, T.int64(self.num_key_value_heads), T.int64(self.num_storage_weight), T.int64(self.num_elem_per_storage)):
+                with T.block("k_compute_pack"):
+                    v_i0, v_i1, v_i2, v_r = T.axis.remap("SSSR", [i0, i1, i2, r])
+                    T.reads(
+                        k_data[v_i0, v_i1, v_i2 * self.num_elem_per_storage + v_r],
+                        k_scale[v_i0, v_i1, v_i2 // self.num_storage_per_group],
+                    )
+                    T.writes(k_compute[v_i0, v_i1, v_i2])
+                    with T.init():
+                        k_compute[v_i0, v_i1, v_i2] = 0
+                    k_compute[v_i0, v_i1, v_i2] = k_compute[v_i0, v_i1, v_i2] + T.if_then_else(
+                        v_i2 * self.num_elem_per_storage + v_r < self.head_dim,
+                        T.shift_left(
+                            T.Cast(
+                                self.kv_storage_dtype,
+                                T.min(
+                                    T.max(
+                                        T.round(
+                                            k_data[v_i0, v_i1, v_i2 * self.num_elem_per_storage + v_r]
+                                            / k_scale[v_i0, v_i1, v_i2 // self.num_storage_per_group]
+                                            + self.max_int_value
+                                        ),
+                                        0.0,
+                                    ),
+                                    self.max_int_value * 2.0,
+                                ),
+                            ),
+                            T.Cast(self.kv_storage_dtype, v_r * self.kv_quantize_dtype.bits),
+                        ),
+                        tir.const(0, str(self.kv_storage_dtype)),
+                    )
+            for i0, i1, i2, r in T.grid(ntoken, T.int64(self.num_key_value_heads), T.int64(self.num_storage_weight), T.int64(self.num_elem_per_storage)):
+                with T.block("v_compute_pack"):
+                    v_i0, v_i1, v_i2, v_r = T.axis.remap("SSSR", [i0, i1, i2, r])
+                    T.reads(
+                        v_data[v_i0, v_i1, v_i2 * self.num_elem_per_storage + v_r],
+                        v_scale[v_i0, v_i1, v_i2 // self.num_storage_per_group],
+                    )
+                    T.writes(v_compute[v_i0, v_i1, v_i2])
+                    with T.init():
+                        v_compute[v_i0, v_i1, v_i2] = 0
+                    v_compute[v_i0, v_i1, v_i2] = v_compute[v_i0, v_i1, v_i2] + T.if_then_else(
+                        v_i2 * self.num_elem_per_storage + v_r < self.head_dim,
+                        T.shift_left(
+                            T.Cast(
+                                self.kv_storage_dtype,
+                                T.min(
+                                    T.max(
+                                        T.round(
+                                            v_data[v_i0, v_i1, v_i2 * self.num_elem_per_storage + v_r]
+                                            / v_scale[v_i0, v_i1, v_i2 // self.num_storage_per_group]
+                                            + self.max_int_value
+                                        ),
+                                        0.0,
+                                    ),
+                                    self.max_int_value * 2.0,
+                                ),
+                            ),
+                            T.Cast(self.kv_storage_dtype, v_r * self.kv_quantize_dtype.bits),
+                        ),
+                        tir.const(0, str(self.kv_storage_dtype)),
+                    )
+
+            for global_pos, h, f in T.grid(ntoken, T.int64(self.num_key_value_heads), T.int64(self.num_storage)):
+                if position_map[global_pos] != T.int32(-1):
+                    with T.block("transpose_append"):
+                        vgpos, vh, vf = T.axis.remap("SSS", [global_pos, h, f])
+                        T.reads(
+                            position_map[vgpos],
+                            k_compute[vgpos, vh, 0:self.num_storage_weight],
+                            v_compute[vgpos, vh, 0:self.num_storage_weight],
+                            k_scale[vgpos, vh, 0:self.num_storage_scale],
+                            v_scale[vgpos, vh, 0:self.num_storage_scale],
+                        )
+                        T.writes(pages[position_map[vgpos] // 16, 0:2, vh, position_map[vgpos] % 16, vf])
+                        position: T.int32 = position_map[vgpos]  # type: ignore
+
+                        if vf < self.num_storage_weight:
+                            pages[T.floordiv(position, 16), 0, vh, T.floormod(position, 16), vf] = k_compute[vgpos, vh, vf]
+                            pages[T.floordiv(position, 16), 1, vh, T.floormod(position, 16), vf] = v_compute[vgpos, vh, vf]
+                        else:
+                            pages[T.floordiv(position, 16), 0, vh, T.floormod(position, 16), vf] = T.reinterpret(
+                                self.kv_storage_dtype, k_scale[vgpos, vh, vf - self.num_storage_weight]
+                            )
+                            pages[T.floordiv(position, 16), 1, vh, T.floormod(position, 16), vf] = T.reinterpret(
+                                self.kv_storage_dtype, v_scale[vgpos, vh, vf - self.num_storage_weight]
+                            )
+
+        # fmt: on
+        # pylint: enable=line-too-long,invalid-name
+
+        return tir_kv_cache_transpose_append
+
+    def kv_cache_dequantize(
+        self,
+        buffer: T.Buffer,
+        indices: Tuple[tir.Var, ...],
+    ):
+        """TIR dequantizae kv"""
+
+        d = indices[-1]
+        bin_mask = (1 << self.kv_quantize_dtype.bits) - 1
+
+        quantized_data = T.Cast(
+            self.model_dtype,
+            T.bitwise_and(
+                T.shift_right(
+                    buffer[indices[:-1] + (d // self.num_elem_per_storage,)],
+                    T.Cast("int32", (d % self.num_elem_per_storage) * self.kv_quantize_dtype.bits),
+                ),
+                bin_mask,
+            ),
+        )
+        data = (
+            quantized_data - tir.const(self.max_int_value, str(self.model_dtype))
+        ) * T.reinterpret(
+            self.model_dtype,
+            buffer[indices[:-1] + (self.num_storage_weight + (d // self.group_size),)],
+        )
+        return data
+
+
+def get_kv_storage_dtype(kv_quant_scheme: str, model_dtype: str) -> DataType:
+    """Get Cache storage dtype according to quantization scheme"""
+    return {
+        "kv_no_quant": DataType(model_dtype),
+        "kv_group_quant_int_3": DataType("int3"),
+        "kv_group_quant_int_4": DataType("int4"),
+    }[kv_quant_scheme]
+
+
+def get_paged_kv_cache_config(
+    kv_quant_scheme: str,
+    model_dtype: str,
+    kwargs: Dict[str, Any],
+) -> BaseKVConfig:
+    """Get Paged KV Cache configuration"""
+    return {
+        "kv_no_quant": NoQuantizeKV(
+            name="kv_no_quant",
+            kind="no-quant",
+            model_dtype=DataType(model_dtype),
+            **kwargs,
+        ),
+        "kv_group_quant_int_3": GroupQuantizeKV(
+            name="kv_group_quant_int_3",
+            kind="group-quant",
+            group_size=40,
+            kv_quantize_dtype=get_kv_storage_dtype("kv_group_quant_int_3", model_dtype),
+            model_dtype=DataType(model_dtype),
+            **kwargs,
+        ),
+        "kv_group_quant_int_4": GroupQuantizeKV(
+            name="kv_group_quant_int_4",
+            kind="group-quant",
+            group_size=32,
+            kv_quantize_dtype=get_kv_storage_dtype("kv_group_quant_int_4", model_dtype),
+            model_dtype=DataType(model_dtype),
+            **kwargs,
+        ),
+    }[kv_quant_scheme]

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -12,6 +12,7 @@ from mlc_llm.loader import QuantizeMapping
 from mlc_llm.nn import MixtralExperts
 from mlc_llm.support import logging
 
+from .paged_kv_cache_quantization import PagedKVCacheQuantization
 from .utils import (
     apply_sharding,
     compile_quantize_func,
@@ -34,6 +35,7 @@ class PerTensorQuantize:  # pylint: disable=too-many-instance-attributes
     weight_dtype: Literal["e4m3_float8", "e5m2_float8"]
     storage_dtype: Literal["uint32", "e4m3_float8", "e5m2_float8"]
     model_dtype: Literal["float16"]
+    kv_quantization: PagedKVCacheQuantization
     quantize_embedding: bool = True
     quantize_final_fc: bool = True
     quantize_linear: bool = True

--- a/python/mlc_llm/quantization/quantization.py
+++ b/python/mlc_llm/quantization/quantization.py
@@ -6,6 +6,7 @@ from .awq_quantization import AWQQuantize
 from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize
 from .no_quantization import NoQuantize
+from .paged_kv_cache_quantization import PagedKVCacheQuantization
 from .per_tensor_quantization import PerTensorQuantize
 
 Quantization = Any
@@ -48,6 +49,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         linear_weight_layout="KN",
         quantize_embedding=True,
         quantize_final_fc=True,
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "q3f16_1": GroupQuantize(
         name="q3f16_1",
@@ -59,6 +61,19 @@ QUANTIZATION: Dict[str, Quantization] = {
         linear_weight_layout="NK",
         quantize_embedding=True,
         quantize_final_fc=True,
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
+    ),
+    "q3f16kv": GroupQuantize(
+        name="q3f16kv",
+        kind="group-quant",
+        group_size=32,
+        quantize_dtype="int4",
+        storage_dtype="uint32",
+        model_dtype="float16",
+        linear_weight_layout="NK",
+        quantize_embedding=True,
+        quantize_final_fc=True,
+        kv_quantization=PagedKVCacheQuantization.KV_GROUP_QUANT_INT_3,
     ),
     "q4f16_0": GroupQuantize(
         name="q4f16_0",
@@ -70,6 +85,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         linear_weight_layout="KN",
         quantize_embedding=True,
         quantize_final_fc=True,
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "q4f16_1": GroupQuantize(
         name="q4f16_1",
@@ -81,6 +97,19 @@ QUANTIZATION: Dict[str, Quantization] = {
         linear_weight_layout="NK",
         quantize_embedding=True,
         quantize_final_fc=True,
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
+    ),
+    "q4f16kv": GroupQuantize(
+        name="q4f16kv",
+        kind="group-quant",
+        group_size=32,
+        quantize_dtype="int4",
+        storage_dtype="uint32",
+        model_dtype="float16",
+        linear_weight_layout="NK",
+        quantize_embedding=True,
+        quantize_final_fc=True,
+        kv_quantization=PagedKVCacheQuantization.KV_GROUP_QUANT_INT_4,
     ),
     "q4f32_1": GroupQuantize(
         name="q4f32_1",
@@ -92,6 +121,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         linear_weight_layout="NK",
         quantize_embedding=True,
         quantize_final_fc=True,
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "q4f16_2": GroupQuantize(
         name="q4f16_2",
@@ -103,6 +133,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         linear_weight_layout="NK",
         quantize_embedding=False,
         quantize_final_fc=False,
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "q4f16_autoawq": AWQQuantize(
         name="q4f16_autoawq",
@@ -111,6 +142,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_dtype="int4",
         storage_dtype="uint32",
         model_dtype="float16",
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "q4f16_ft": FTQuantize(
         name="q4f16_ft",
@@ -118,6 +150,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_dtype="int4",
         storage_dtype="int8",
         model_dtype="float16",
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "e5m2_e5m2_f16": PerTensorQuantize(
         name="e5m2_e5m2_f16",
@@ -130,6 +163,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_embedding=False,
         quantize_linear=True,
         use_scale=False,
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "e4m3_e4m3_f16": PerTensorQuantize(
         name="e4m3_e4m3_f16",
@@ -143,6 +177,7 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_linear=True,
         use_scale=True,
         calibration_mode="inference",
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
     "e4m3_e4m3_f16_max_calibrate": PerTensorQuantize(
         name="e4m3_e4m3_f16_max_calibrate",
@@ -156,5 +191,6 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_linear=True,
         use_scale=True,
         calibration_mode="max",
+        kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
     ),
 }

--- a/tests/python/model/test_kv_cache.py
+++ b/tests/python/model/test_kv_cache.py
@@ -7,6 +7,7 @@ from tvm.script import relax as R
 from tvm.script import tir as T
 
 from mlc_llm.nn.kv_cache import FlashInferPagedKVCache, PagedKVCache, RopeMode
+from mlc_llm.quantization import PagedKVCacheQuantization
 
 # mypy: disable-error-code="attr-defined"
 # pylint: disable=invalid-name,unused-argument,too-many-locals,too-many-statements
@@ -88,6 +89,7 @@ def test_nn_module_paged_kv_cache():
                 rope_scale=1,
                 rope_theta=10000,
                 rotary_dim=128,
+                kv_quantization=PagedKVCacheQuantization.KV_NO_QUANT,
                 dtype="float16",
             )
 


### PR DESCRIPTION
KV Cache might be a burden under tight memory constraints, and cache quantization can reduce its memory requirement by roughly 75% (float16 -> int3 KV cache). As a result, this PR intends to introduce initial support for KV Cache quantization, introducing two new quant schemes (`q3f16kv` and `q4f16kv`).

On Llama-3 (`context_window_size = 8192`) kv cache memory usage:
- 1113 MB (`q4f16_1`: float16 kv cache)
- 345 MB (`q4f16kv`: int4 kv cache)
- 281 MB (`q3f16kv`: int3 kv cache)

cc @MasterJH5574 