### PR TITLE
[Fix] Fix prefix cache reuse with eagle mode

### DIFF
--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -457,6 +457,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
             models_[i]->PopNFromKVCache(rsentry->mstates[0]->internal_id,
                                         result.reused_seq_pop_last_tokens + 1);
           }
+          result.prefilled_offset -= 1;
         }
       }
       // Pop matched prefix


### PR DESCRIPTION
This PR fixes the prefix cache bug with eagle mode on. The prefilled offset is forgotten to be shifted in this case.

cc: @vinx13 