### PR TITLE
support mistral-nemo

### DIFF
--- a/python/mlc_llm/model/mistral/mistral_model.py
+++ b/python/mlc_llm/model/mistral/mistral_model.py
@@ -77,7 +77,6 @@ class MistralConfig(ConfigBase):  # pylint: disable=too-many-instance-attributes
         if self.head_dim == 0:
             self.head_dim = self.hidden_size // self.num_attention_heads
         assert self.num_attention_heads % self.num_key_value_heads == 0
-        assert self.head_dim * self.num_attention_heads == self.hidden_size
         assert self.attention_sink_size >= 0
         if self.prefill_chunk_size == 0:
             prefill_chunk_size_candidates = []


### PR DESCRIPTION
It looks like the new model uses a smaller rope dimension based on head_dim, so the assertion doesn't hold any more. However, the underlying kernels already use head_dim as the rope dimension so removing the assert fixes the conversion, which seems to work.

The tekken tokenzier seems to be just tiktoken, and it seems to work fine with the byte level encoder. I did notice some issues with displaying emojis in the chat but not sure if that's related to the tokenizer.

<img width="863" alt="Screenshot 2024-07-21 at 20 27 52" src="https://github.com/user-attachments/assets/5cdf6e96-91f9-4bc8-9ae4-755532f203db">
