### PR TITLE
Initialize all `local_top_k` values in `gating_softmax_topk`

### DIFF
--- a/python/mlc_llm/op/moe_misc.py
+++ b/python/mlc_llm/op/moe_misc.py
@@ -82,7 +82,9 @@ def gating_softmax_topk(  # pylint: disable=too-many-statements
                     T.where(io * TX + ii < batch_size)
                     with T.block("init"):
                         local_top_k[0] = T.min_value(dtype)
+                        local_top_k[1] = T.min_value(dtype)
                         local_top_k_index[0] = 0
+                        local_top_k_index[1] = 1
                     for k in range(num_local_experts):
                         with T.block("update"):
                             vk = T.axis.remap("S", [k])
@@ -139,9 +141,9 @@ def gating_softmax_topk(  # pylint: disable=too-many-statements
                         local_top_k[2] = T.min_value(dtype)
                         local_top_k[3] = T.min_value(dtype)
                         local_top_k_index[0] = 0
-                        local_top_k_index[1] = 0
-                        local_top_k_index[2] = 0
-                        local_top_k_index[3] = 0
+                        local_top_k_index[1] = 1
+                        local_top_k_index[2] = 2
+                        local_top_k_index[3] = 3
                     for k in range(num_local_experts):
                         with T.block("update"):
                             vk = T.axis.remap("S", [k])


### PR DESCRIPTION
If `x` has `nan` or `-inf` values, the condition `x[vi,vk] > local_top_k[0]` may be false.  Falling back to the condition `x[vi,vk] > local_top_k[1]` then reads the uninitialized value in `local_top_k[1]`.

This can also result in out-of-bounds memory access.  If all values in `x[vi,vk]` are `nan` or `-inf` along some row `vi`, then `local_top_k_index[1]` is never populated.  For mixture-of-experts models, when `gating_softmax_topk` is used to select the expert, this uninitialized value is then used as an array index.

This commit updates the `top2_softmax_norm_func` implementation in `gating_softmax_topk` to initialize both elements of the `local_top_k` and `local_top_k_index` arrays, matching the implementation of `top4_softmax_norm_func`.