### PR TITLE
[C++] Handle system_prefix_token_ids in C++ Conv template

### DIFF
--- a/cpp/json_ffi/conv_template.cc
+++ b/cpp/json_ffi/conv_template.cc
@@ -356,6 +356,10 @@ Result<std::vector<Data>> CreatePrompt(const Conversation& conv,
   if (pending_text.length() != 0) {
     message_list.push_back(TextData(pending_text));
   }
+  // Handle system_prefix_token_ids
+  if (conv.system_prefix_token_ids.has_value()) {
+    message_list.insert(message_list.begin(), TokenData(conv.system_prefix_token_ids.value()));
+  }
   return TResult::Ok(message_list);
 }
 

--- a/python/mlc_llm/conversation_template/gemma.py
+++ b/python/mlc_llm/conversation_template/gemma.py
@@ -8,7 +8,7 @@ from .registry import ConvTemplateRegistry
 ConvTemplateRegistry.register_conv_template(
     Conversation(
         name="gemma_instruction",
-        system_template=f"<bos>{MessagePlaceholders.SYSTEM.value}",
+        system_template=f"{MessagePlaceholders.SYSTEM.value}",
         system_message="",
         roles={"user": "<start_of_turn>user", "assistant": "<start_of_turn>model"},
         seps=["<end_of_turn>\n"],


### PR DESCRIPTION
The `system_prefix_token_ids` of conv template already contains the bos token usually, which should be processed when converting message list to a single prompt. However, the C++ side didn't well respect this field before.