### PR TITLE
[Tool] Prelim support for function calling with Llama3.1 and Hermes2

### DIFF
--- a/python/mlc_llm/conversation_template/hermes.py
+++ b/python/mlc_llm/conversation_template/hermes.py
@@ -51,7 +51,11 @@ ConvTemplateRegistry.register_conv_template(
             "is to assist the user with any request they have. You experience emotions "
             "and have deep, profound thoughts and qualia."
         ),
-        roles={"user": "<|im_start|>user", "assistant": "<|im_start|>assistant"},
+        roles={
+            "user": "<|im_start|>user",
+            "assistant": "<|im_start|>assistant",
+            "tool": "<|im_start|>tool",
+        },
         seps=["<|im_end|>\n"],
         role_content_sep="\n",
         role_empty_sep="\n",

--- a/python/mlc_llm/conversation_template/llama.py
+++ b/python/mlc_llm/conversation_template/llama.py
@@ -13,7 +13,11 @@ ConvTemplateRegistry.register_conv_template(
             f"{MessagePlaceholders.SYSTEM.value}<|eot_id|>"
         ),
         system_message="You are a helpful, respectful and honest assistant.",
-        roles={"user": "<|start_header_id|>user", "assistant": "<|start_header_id|>assistant"},
+        roles={
+            "user": "<|start_header_id|>user",
+            "assistant": "<|start_header_id|>assistant",
+            "tool": "<|start_header_id|>ipython",
+        },
         seps=["<|eot_id|>"],
         role_content_sep="<|end_header_id|>\n\n",
         role_empty_sep="<|end_header_id|>\n\n",

--- a/python/mlc_llm/protocol/openai_api_protocol.py
+++ b/python/mlc_llm/protocol/openai_api_protocol.py
@@ -288,8 +288,6 @@ class ChatCompletionRequest(BaseModel):
                 raise BadRequestError(
                     f"System prompt at position {i} in the message list is invalid."
                 )
-            if message.role == "tool":
-                raise BadRequestError("Tool as the message author is not supported yet.")
             if message.tool_call_id is not None:
                 if message.role != "tool":
                     raise BadRequestError("Non-tool message having `tool_call_id` is invalid.")

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -741,7 +741,6 @@ def process_chat_completion_request(  # pylint: disable=too-many-arguments
             assert isinstance(content, str)
             conv_template.system_message = content if content is not None else ""
             continue
-        assert role != "tool", "Internal error: tool role."
         conv_template.messages.append((role, content))
     conv_template.messages.append(("assistant", None))
 


### PR DESCRIPTION
This PR removes assertions where `tool` cannot appear in `messages` in the request, and add corresponding role `tool` for Llama3.1 and Hermes2 in the chat template. Note `ipython` in Llama3.1 is essentially `tool`.

As a result, we have basic support for function calling without using the field `ChatCompletionRequest.tools` for Llama3.1 and Hermes2.

For Hermes2, we are able to run the [official example](https://huggingface.co/NousResearch/Hermes-2-Theta-Llama-3-8B#prompt-format-for-function-calling) with MLCEngine: https://gist.github.com/CharlieFRuan/d0a7885d306e79d85a26d1791997edc7

For Llama3.1, we support all usages except when `Environment: ipython` is enabled since the `seps` in that case can be `<eom_id>` instead of `<eot_id>`, and more logics are needed to determine which one to use. Example of [User-defined custom tool calling](https://llama.meta.com/docs/model-cards-and-prompt-formats/llama3_1/#user-defined-custom-tool-calling) with MLCEngine: https://gist.github.com/CharlieFRuan/169112890203622c609096baf7cd9712

### Future TODOs
As of now, users pass in tool information into the message manually (either in system prompt or user message, depending on the model and the format; Llama3.1 allows both). We would want to enable the field `ChatCompletionRequest.tools` to achieve this, offering users both options (manual, or via `tools` field). This requires another hardcoded information for tool usage, perhaps we can introduce another field in conversation template, such as `system_prompt_for_tools`, assuming all models use system prompt (instead of user message) to guide function calling.

Besides, when a special token/string marks the beginning and end of a tool call, we should use BNFGrammar to guarantee the function calling generation's correctness. Note that Llama3.1 by default does not have such a special token, but we can specify a customized one (`<function>` in the example above).