### PR TITLE
[Fix] Fix config parsing for rnn models like RWKV

### DIFF
--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -66,7 +66,8 @@ ModelMetadata ModelMetadata::FromJSON(const picojson::object& metadata,
   result.tensor_parallel_shards = json::Lookup<int64_t>(metadata, "tensor_parallel_shards");
   result.kv_state_kind = KVStateKindFromString(
       json::LookupOrDefault<std::string>(metadata, "kv_state_kind", "kv_cache"));
-  if (result.kv_state_kind != KVStateKind::kNone) {
+  if (result.kv_state_kind != KVStateKind::kNone &&
+      result.kv_state_kind != KVStateKind::kRNNState) {
     result.kv_cache_metadata =
         KVCacheMetadata::FromJSON(json::Lookup<picojson::object>(metadata, "kv_cache"));
   } else {

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -310,7 +310,6 @@ EngineConfig EngineConfig::FromJSONAndInferredConfig(
     const picojson::object& json, const InferrableEngineConfig& inferred_config) {
   CHECK(inferred_config.max_num_sequence.has_value());
   CHECK(inferred_config.max_total_sequence_length.has_value());
-  CHECK(inferred_config.max_single_sequence_length.has_value());
   CHECK(inferred_config.prefill_chunk_size.has_value());
   CHECK(inferred_config.max_history_size.has_value());
   ObjectPtr<EngineConfigNode> n = make_object<EngineConfigNode>();
@@ -350,7 +349,9 @@ EngineConfig EngineConfig::FromJSONAndInferredConfig(
   // - Fields from the inferred engine config.
   n->max_num_sequence = inferred_config.max_num_sequence.value();
   n->max_total_sequence_length = inferred_config.max_total_sequence_length.value();
-  n->max_single_sequence_length = inferred_config.max_single_sequence_length.value();
+  if (inferred_config.max_single_sequence_length.has_value()) {
+    n->max_single_sequence_length = inferred_config.max_single_sequence_length.value();
+  }
   n->prefill_chunk_size = inferred_config.prefill_chunk_size.value();
   n->max_history_size = inferred_config.max_history_size.value();
 

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -782,7 +782,10 @@ class EngineImpl : public Engine {
     inferrable_cfg = inferrable_cfg_res.Unwrap();
     ICHECK(inferrable_cfg.max_num_sequence.has_value());
     ICHECK(inferrable_cfg.max_total_sequence_length.has_value());
-    ICHECK(inferrable_cfg.max_single_sequence_length.has_value());
+    use_kv_cache = ModelsUseKVCache(model_configs);
+    if (use_kv_cache.Unwrap()) {
+      ICHECK(inferrable_cfg.max_single_sequence_length.has_value());
+    }
     ICHECK(inferrable_cfg.prefill_chunk_size.has_value());
     ICHECK(inferrable_cfg.max_history_size.has_value());
     return TResult::Ok(EngineConfig::FromJSONAndInferredConfig(config, inferrable_cfg));


### PR DESCRIPTION
Support for RWKV in mlc-llm seems to be broken after commit [b310ee1cccd92fe5939d4f5825063e7cca10cc0f](https://github.com/mlc-ai/mlc-llm/commit/b310ee1cccd92fe5939d4f5825063e7cca10cc0f). 
For example, [here](https://github.com/mlc-ai/mlc-llm/blob/03a50c25bf3c57034508ea3812bec269b67b1dd0/cpp/serve/engine.cc#L774) in ``InferForRNNState()`` it ensures that ``max_single_sequence_length.has_value()`` is false, while right after that [it](https://github.com/mlc-ai/mlc-llm/blob/03a50c25bf3c57034508ea3812bec269b67b1dd0/cpp/serve/engine.cc#L785) checks to ensure the opposite.

BTW the prefix_cache functionality is also broken for RNN models. Disabling that makes RWKV inference without problems. I'm not sure how to fix that tho :P