### PR TITLE
[FIX] Add a positional argument for tree_attn

### DIFF
--- a/tests/python/op/test_tree_attn.py
+++ b/tests/python/op/test_tree_attn.py
@@ -114,7 +114,7 @@ def test_tree_attn(nbatch, h_q, h_kv, d, rotary_mode):
     lse_tvm = tvm.nd.array(lse, dev)
 
     target = tvm.target.Target("cuda")
-    kernel = tree_attn(h_kv=h_kv, h_q=h_q, d=d, dtype="float16", target=target)
+    kernel = tree_attn(h_kv=h_kv, h_q=h_q, d=d, dtype="float16", rope_scaling={}, target=target)
     mod = tvm.build(kernel, target=target)
     mod(
         q_tvm,


### PR DESCRIPTION
Since #2682  added a positional argument `rope_scaling`, the test_tree_attn.py script couldn't run the tests. After adding a dummy argument, test_tree_attn.py was able to run the unit tests and pass all 24 test cases.

cc @MasterJH5574 