### PR TITLE
[CI] Enable long file paths for Windows CI

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -19,6 +19,9 @@ jobs:
         shell: 'cmd /C call {0}'
 
     steps:
+    - name: Git config
+      run: >-
+        git config --system core.longpaths true
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'


### PR DESCRIPTION
This PR enables the long file paths for Windows CI since the FlashInfer kernel file paths may be longer than the Windows limit.