### PR TITLE
[Fix] Fix qwen2 chat template

### DIFF
--- a/python/mlc_llm/conversation_template/__init__.py
+++ b/python/mlc_llm/conversation_template/__init__.py
@@ -20,6 +20,7 @@ from . import (
     oasst,
     orion,
     phi,
+    qwen2,
     redpajama,
     rwkv,
     stablelm,

--- a/python/mlc_llm/conversation_template/qwen2.py
+++ b/python/mlc_llm/conversation_template/qwen2.py
@@ -1,0 +1,20 @@
+"""Qwen2 default templates"""
+
+from mlc_llm.protocol.conversation_protocol import Conversation, MessagePlaceholders
+
+from .registry import ConvTemplateRegistry
+
+# Same as chatml except system message, stop token, and stop string
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="qwen2",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
+        system_message="You are a helpful assistant.",
+        roles={"user": "<|im_start|>user", "assistant": "<|im_start|>assistant"},
+        seps=["<|im_end|>\n"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["<|endoftext|>, <|im_end|>"],
+        stop_token_ids=[151643, 151645],
+    )
+)

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -263,6 +263,7 @@ CONV_TEMPLATES = {
     "llama-3_1",
     "chatml",
     "chatml_nosystem",
+    "qwen2",
     "open_hermes_mistral",
     "neural_hermes_mistral",
     "llama_default",


### PR DESCRIPTION
Added `qwen2` for chat template. Qwen2 used to use `chatml` for template, which has the wrong stop token id `2`. Instead, it should be `[151643, 151645]`.