### PR TITLE
[Bench] Improve benchmark compatibility

### DIFF
--- a/python/mlc_llm/bench/__main__.py
+++ b/python/mlc_llm/bench/__main__.py
@@ -262,6 +262,18 @@ if __name__ == "__main__":
         help="The random number seed. Default to 0.",
     )
     parser.add_argument(
+        "--temperature",
+        type=float,
+        default=1.0,
+        help="The temperature value for logit adjustment. Default to 1.",
+    )
+    parser.add_argument(
+        "--top-p",
+        type=float,
+        default=1.0,
+        help="The top-p value for sampling. Default to 1.",
+    )
+    parser.add_argument(
         "--num-process-workers",
         type=int,
         help="The number of parallel process workers to send the requests.",

--- a/python/mlc_llm/bench/dataset.py
+++ b/python/mlc_llm/bench/dataset.py
@@ -96,7 +96,6 @@ class ShareGPTDataset(Dataset):  # pylint: disable=too-few-public-methods
                         ],
                         model="",
                         max_tokens=output_length,
-                        debug_config=DebugConfig(ignore_eos=True),
                     ),
                     metrics=Metrics(
                         success=False,
@@ -225,7 +224,6 @@ class JSONModeEvalDataset(Dataset):  # pylint: disable=too-few-public-methods
                         messages=prompt,
                         model="",
                         max_tokens=output_length,
-                        debug_config=DebugConfig(ignore_eos=True),
                         response_format=schema,
                     ),
                     metrics=Metrics(


### PR DESCRIPTION
This PR improves the benchmark compatibility to support other frameworks.

Some notes:
* Now the default temperature and top-p are set to 1 unless explicitly specified by `--temperature` and `top-p`.
* Now with ShareGPT dataset we will not add the `ignore_eos` flag.