### PR TITLE
Save the packed_weight as storage data type

### DIFF
--- a/python/mlc_llm/quantization/utils.py
+++ b/python/mlc_llm/quantization/utils.py
@@ -180,5 +180,5 @@ def pack_weight(
             axis=r,
         ),
         name="packed_weight",
-    )
+    ).astype(storage_dtype)
     return packed_weight


### PR DESCRIPTION
Packed weight save as int32 by default, don't follow storage data type. If don't set storage type to int32, it will cause dtype of q_weight don't match.