### PR TITLE
[C++] Skip getting global multi-gpu function when disco not enabled

### DIFF
--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -261,7 +261,10 @@ void FunctionTable::_InitFunctions() {
   this->nd_copy_embedding_to_offset_func_ = get_global_func("mlc.copy_embedding_to_offset");
   support_backtracking_kv_ = true;
   this->tuple_getitem_func_ = get_global_func("vm.builtin.tuple_getitem");
-  this->last_group_send_to_worker_0_ = get_global_func("mlc.multi_gpu.SendFromLastGroupToWorker0");
+  if (use_disco) {
+    this->last_group_send_to_worker_0_ =
+        get_global_func("mlc.multi_gpu.SendFromLastGroupToWorker0");
+  }
 
   this->gather_probs_func_ = mod->GetFunction("gather_probs", true);
   this->scatter_probs_func_ = mod->GetFunction("scatter_probs", true);


### PR DESCRIPTION
This PR fixes an issue on Android that queries a global multi-gpu function while that function does not exist.