### PR TITLE
[Model] Add tie_word_embedding option for Minicpm model

### DIFF
--- a/python/mlc_llm/model/minicpm/minicpm_model.py
+++ b/python/mlc_llm/model/minicpm/minicpm_model.py
@@ -109,7 +109,7 @@ class MiniCPMAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
             out_features=(self.num_heads + 2 * self.num_key_value_heads) * self.head_dim,
             bias=False,
         )
-         self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
 
     def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
         d, h_q, h_kv = self.head_dim, self.num_heads, self.num_key_value_heads

--- a/python/mlc_llm/model/minicpm/minicpm_model.py
+++ b/python/mlc_llm/model/minicpm/minicpm_model.py
@@ -132,6 +132,7 @@ ACT2FN = {
     "gelu_new": partial(nn.gelu, approximate=True),
 }
 
+
 class MiniCPMEmbedding(nn.Embedding):
     """The embedding module specialized for MiniCPM so that
     it can be shared with the final lm_head.

--- a/python/mlc_llm/model/model_preset.py
+++ b/python/mlc_llm/model/model_preset.py
@@ -588,10 +588,6 @@ MODEL_PRESETS: Dict[str, Any] = {
     },
     "baichuan": {
         "architectures": ["BaichuanForCausalLM"],
-        "auto_map": {
-            "AutoConfig": "configuration_baichuan.BaichuanConfig",
-            "AutoModelForCausalLM": "modeling_baichuan.BaichuanForCausalLM",
-        },
         "tokenizer_class": "BaichuanTokenizer",
         "bos_token_id": 1,
         "eos_token_id": 2,
@@ -614,11 +610,6 @@ MODEL_PRESETS: Dict[str, Any] = {
     },
     "internlm": {
         "architectures": ["InternLMForCausalLM"],
-        "auto_map": {
-            "AutoConfig": "configuration_internlm.InternLMConfig",
-            "AutoModel": "modeling_internlm.InternLMForCausalLM",
-            "AutoModelForCausalLM": "modeling_internlm.InternLMForCausalLM",
-        },
         "bias": True,
         "bos_token_id": 1,
         "eos_token_id": 2,
@@ -821,11 +812,6 @@ MODEL_PRESETS: Dict[str, Any] = {
     "chatglm": {
         "architectures": ["ChatGLMModel"],
         "model_type": "chatglm",
-        "auto_map": {
-            "AutoConfig": "configuration_chatglm.ChatGLMConfig",
-            "AutoModel": "modeling_chatglm.ChatGLMForConditionalGeneration",
-            "AutoModelForCausalLM": "modeling_chatglm.ChatGLMForConditionalGeneration",
-        },
         "add_bias_linear": False,
         "add_qkv_bias": True,
         "apply_query_key_layer_scaling": True,
@@ -1116,11 +1102,6 @@ MODEL_PRESETS: Dict[str, Any] = {
     "internlm2": {
         "architectures": ["InternLM2ForCausalLM"],
         "attn_implementation": "eager",
-        "auto_map": {
-            "AutoConfig": "configuration_internlm2.InternLM2Config",
-            "AutoModelForCausalLM": "modeling_internlm2.InternLM2ForCausalLM",
-            "AutoModel": "modeling_internlm2.InternLM2ForCausalLM",
-        },
         "bias": False,
         "bos_token_id": 1,
         "eos_token_id": 2,
@@ -1146,11 +1127,6 @@ MODEL_PRESETS: Dict[str, Any] = {
     "internlm2_5_7b": {
         "architectures": ["InternLM2ForCausalLM"],
         "attn_implementation": "eager",
-        "auto_map": {
-            "AutoConfig": "configuration_internlm2.InternLM2Config",
-            "AutoModelForCausalLM": "modeling_internlm2.InternLM2ForCausalLM",
-            "AutoModel": "modeling_internlm2.InternLM2ForCausalLM",
-        },
         "bias": False,
         "bos_token_id": 1,
         "eos_token_id": 2,
@@ -1340,5 +1316,28 @@ MODEL_PRESETS: Dict[str, Any] = {
         "scale_depth": 1.4,
         "tie_word_embeddings": False,
         "rope_theta": 1000000.0,
+    },
+    "minicpm_2b_sft_bf16": {
+        "architectures": ["MiniCPMForCausalLM"],
+        "bos_token_id": 1,
+        "eos_token_id": 2,
+        "hidden_act": "silu",
+        "hidden_size": 2304,
+        "initializer_range": 0.1,
+        "intermediate_size": 5760,
+        "max_position_embeddings": 4096,
+        "model_type": "minicpm",
+        "num_attention_heads": 36,
+        "num_hidden_layers": 40,
+        "num_key_value_heads": 36,
+        "rms_norm_eps": 1e-05,
+        "torch_dtype": "bfloat16",
+        "tie_word_embeddings": True,
+        "transformers_version": "4.36.0",
+        "use_cache": True,
+        "vocab_size": 122753,
+        "scale_emb": 12,
+        "dim_model_base": 256,
+        "scale_depth": 1.4,
     },
 }


### PR DESCRIPTION
This PR updates the Minicpm model with the `tie_word_embedding` option, as most models in the Minicpm family, like `MiniCPM-2B-sft-bf16`, require `tie_word_embedding` to be turned on.
The preset of `minicpm_2b_sft_bf16` is also added in this PR.
Here is the demonstration after the update:
```
tlopex@tlopex-OMEN-by-HP-Laptop-17-ck1xxx:~/mlc-llm$ mlc_llm chat dist/MiniCPM-2B-sft-bf16-q4f16_1-MLC \
>              --device "cuda:0" --overrides context_window_size=2048 \
>              --model-lib ./dist/libs/MiniCPM-2B-sft-bf16-q4f16_1-cuda.so
[2024-08-15 00:02:59] INFO auto_device.py:79: Found device: cuda:0
[2024-08-15 00:02:59] INFO engine_base.py:143: Using library model: ./dist/libs/MiniCPM-2B-sft-bf16-q4f16_1-cuda.so
[00:02:59] /home/tlopex/mlc-llm/cpp/serve/config.cc:668: Under mode "local", max batch size will be set to 4, max KV cache token capacity will be set to 4096, prefill chunk size will be set to 2048. 
[00:02:59] /home/tlopex/mlc-llm/cpp/serve/config.cc:668: Under mode "interactive", max batch size will be set to 1, max KV cache token capacity will be set to 4096, prefill chunk size will be set to 2048. 
[00:02:59] /home/tlopex/mlc-llm/cpp/serve/config.cc:668: Under mode "server", max batch size will be set to 80, max KV cache token capacity will be set to 28092, prefill chunk size will be set to 2048. 
[00:02:59] /home/tlopex/mlc-llm/cpp/serve/config.cc:748: The actual engine mode is "interactive". So max batch size is 1, max KV cache token capacity is 4096, prefill chunk size is 2048.
[00:02:59] /home/tlopex/mlc-llm/cpp/serve/config.cc:753: Estimated total single GPU memory usage: 5113.495 MB (Parameters: 1461.996 MB. KVCache: 1524.583 MB. Temporary buffer: 2126.916 MB). The actual usage might be slightly larger than the estimated number.
You can use the following special commands:
  /help               print the special commands
  /exit               quit the cli
  /stats              print out stats of last request (token/sec)
  /metrics            print out full engine metrics
  /reset              restart a fresh chat
  /set [overrides]    override settings in the generation config. For example,
                      `/set temperature=0.5;top_p=0.8;seed=23;max_tokens=100;stop=str1,str2`
                      Note: Separate stop words in the `stop` option with commas (,).
  Multi-line input: Use escape+enter to start a new line.

>>> Who are you?
I am an AI assistant. How can I help you today?
>>> Can you tell me something about Chile?
Chile is a country located in South America. It has a population of around 19 million people. It has a high standard of living and is known for its beautiful landscapes. What else would you like to know about Chile?
```

By the way, this PR deletes some unused lines of previous model in preset. And MOE version of Minicpm will be followed up in the next PR.