### PR TITLE
feat: use swift-markdown-ui to display markdown text in an iOS app

### DIFF
--- a/ios/MLCChat/MLCChat.xcodeproj/project.pbxproj
+++ b/ios/MLCChat/MLCChat.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		AEC27EFA2A85C2AC00254E67 /* ParamsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC27EF92A85C2AC00254E67 /* ParamsConfig.swift */; };
 		AEC27EFC2A85C3B000254E67 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC27EFB2A85C3B000254E67 /* AppConfig.swift */; };
 		AEC27F022A86337E00254E67 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC27F012A86337E00254E67 /* Constants.swift */; };
+		B08647022C6D0293001A8B5E /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = B08647012C6D0293001A8B5E /* MarkdownUI */; };
 		C04105DD2BEBBEA6005A434D /* MLCSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C04105DC2BEBBEA6005A434D /* MLCSwift */; };
 		C0D643B329F99A7F004DDAA4 /* MLCChatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D643B229F99A7F004DDAA4 /* MLCChatApp.swift */; };
 		C0D643B729F99A80004DDAA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0D643B629F99A80004DDAA4 /* Assets.xcassets */; };
@@ -77,6 +78,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C04105DD2BEBBEA6005A434D /* MLCSwift in Frameworks */,
+				B08647022C6D0293001A8B5E /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -200,6 +202,7 @@
 			name = MLCChat;
 			packageProductDependencies = (
 				C04105DC2BEBBEA6005A434D /* MLCSwift */,
+				B08647012C6D0293001A8B5E /* MarkdownUI */,
 			);
 			productName = MLCChat;
 			productReference = C0D643AF29F99A7F004DDAA4 /* MLCChat.app */;
@@ -232,6 +235,7 @@
 			mainGroup = C0D643A629F99A7F004DDAA4;
 			packageReferences = (
 				C04105DB2BEBBEA6005A434D /* XCLocalSwiftPackageReference "../MLCSwift" */,
+				B08647002C6D0293001A8B5E /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 			);
 			productRefGroup = C0D643B029F99A7F004DDAA4 /* Products */;
 			projectDirPath = "";
@@ -527,7 +531,23 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		B08647002C6D0293001A8B5E /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		B08647012C6D0293001A8B5E /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B08647002C6D0293001A8B5E /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
 		C04105DC2BEBBEA6005A434D /* MLCSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MLCSwift;

--- a/ios/MLCChat/MLCChat/Views/ChatView.swift
+++ b/ios/MLCChat/MLCChat/Views/ChatView.swift
@@ -77,7 +77,7 @@ private extension ChatView {
 
                     // display the system message
                     if hasSystemMessage {
-                        MessageView(role: chatState.displayMessages[0].role, message: chatState.displayMessages[0].message)
+                        MessageView(role: chatState.displayMessages[0].role, message: chatState.displayMessages[0].message, isMarkdownSupported: false)
                     }
 
                     // display image

--- a/ios/MLCChat/MLCChat/Views/MessageView.swift
+++ b/ios/MLCChat/MLCChat/Views/MessageView.swift
@@ -4,11 +4,21 @@
 //
 
 import SwiftUI
+import MarkdownUI
 
 struct MessageView: View {
     let role: MessageRole;
     let message: String
+    let isMarkdownSupported: Bool
     
+    @State private var showMarkdown: Bool
+    
+    init(role: MessageRole, message: String, isMarkdownSupported: Bool = true) {
+        self.role = role
+        self.message = message
+        self.isMarkdownSupported = isMarkdownSupported
+        _showMarkdown = State(initialValue: isMarkdownSupported)
+    }
     var body: some View {
         let textColor = role.isUser ? Color.white : Color(UIColor.label)
         let background = role.isUser ? Color.blue : Color(UIColor.secondarySystemBackground)
@@ -16,14 +26,45 @@ struct MessageView: View {
         HStack {
             if role.isUser {
                 Spacer()
+                Text(message)
+                    .padding(10)
+                    .foregroundColor(textColor)
+                    .background(background)
+                    .cornerRadius(10)
+                    .textSelection(.enabled)
             }
-            Text(message)
-                .padding(10)
-                .foregroundColor(textColor)
-                .background(background)
-                .cornerRadius(10)
-                .textSelection(.enabled)
             if !role.isUser {
+                VStack(alignment: .leading) {
+                    // Toggle switch to show/hide Markdown
+                    if(isMarkdownSupported){
+                        Toggle(isOn: $showMarkdown) {
+                            Text("Show as Markdown")
+                                .font(.footnote)
+                                .foregroundColor(.blue)
+                        }
+                        .padding(.bottom, 10)
+                    }
+                    
+                    // Conditionally display Text or Markdown
+                    if showMarkdown {
+                        Markdown {
+                            message
+                        }
+                        .markdownTheme(.gitHub)
+                        .padding(10)
+                        .foregroundColor(textColor)
+                        .background(background)
+                        .cornerRadius(10)
+                        .textSelection(.enabled)
+                    } else {
+                        Text(message)
+                            .padding(10)
+                            .foregroundColor(textColor)
+                            .background(background)
+                            .cornerRadius(10)
+                            .textSelection(.enabled)
+                    }
+                }
                 Spacer()
             }
         }


### PR DESCRIPTION
use [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui) to render the text.


| markdown ON | markdown OFF |
|---------|---------|
| <img src="https://github.com/user-attachments/assets/77100c7a-fdfc-43cc-847c-783e9303cddd" width="300" alt="IMG_0111" /> | <img src="https://github.com/user-attachments/assets/da586612-3f3a-4e6a-8969-5b49c69bb03f" width="300" alt="IMG_0110" /> |
