### PR TITLE
[Serving] Requiring explicit passing draft tokens to logit processor

### DIFF
--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -62,14 +62,18 @@ class BatchVerifyActionObj : public EngineActionObj {
     std::vector<int64_t> request_internal_ids;
     std::vector<int32_t> all_tokens_to_verify;
     Array<RequestModelState> verify_request_mstates;
+    Array<RequestModelState> draft_request_mstates;
     Array<GenerationConfig> generation_cfg;
     std::vector<RandomGenerator*> rngs;
     std::vector<std::vector<SampleResult>> draft_output_tokens;
     std::vector<int64_t> token_tree_parent_ptr;
+    std::vector<std::vector<int>> draft_token_indices;
     token_tree_parent_ptr.reserve(total_verify_length);
     request_internal_ids.reserve(num_rsentries);
     all_tokens_to_verify.reserve(total_verify_length);
+    draft_token_indices.reserve(num_rsentries);
     verify_request_mstates.reserve(num_rsentries);
+    draft_request_mstates.reserve(num_rsentries);
     rngs.reserve(num_rsentries);
     generation_cfg.reserve(num_rsentries);
     draft_output_tokens.reserve(num_rsentries);
@@ -86,12 +90,17 @@ class BatchVerifyActionObj : public EngineActionObj {
       draft_token_slots_.push_back(0);  // placeholder for the last committed token
       all_tokens_to_verify.push_back(draft_mstate->committed_tokens.back().GetTokenId());
       token_tree_parent_ptr.push_back(-1);
+      std::vector<int> cur_draft_token_indices;
+      cur_draft_token_indices.resize(draft_mstate->draft_output_tokens.size() + 1);
+      std::iota(cur_draft_token_indices.begin(), cur_draft_token_indices.end(), -1);
       for (int j = 0; j < static_cast<int>(draft_mstate->draft_output_tokens.size()); ++j) {
         all_tokens_to_verify.push_back(draft_mstate->draft_output_tokens[j].GetTokenId());
         draft_token_slots_.push_back(draft_mstate->draft_token_slots[j]);
         token_tree_parent_ptr.push_back(draft_mstate->draft_token_parent_idx[j] + 1);
       }
+      draft_token_indices.emplace_back(std::move(cur_draft_token_indices));
       verify_request_mstates.push_back(verify_mstate);
+      draft_request_mstates.push_back(draft_mstate);
       generation_cfg.push_back(rsentries[i]->request->generation_cfg);
       rngs.push_back(&rsentries[i]->rng);
       draft_output_tokens.push_back(draft_mstate->draft_output_tokens);
@@ -121,7 +130,8 @@ class BatchVerifyActionObj : public EngineActionObj {
     }
     logits = logits.CreateView({total_verify_length, logits->shape[2]}, logits->dtype);
     logit_processor_->InplaceUpdateLogits(logits, generation_cfg, verify_request_mstates,
-                                          request_ids, &cum_verify_lengths, &draft_output_tokens);
+                                          request_ids, &cum_verify_lengths, &draft_request_mstates,
+                                          &draft_token_indices);
 
     // - Compute probability distributions.
     NDArray probs_on_device = logit_processor_->ComputeProbsFromLogits(

--- a/cpp/serve/logit_processor.h
+++ b/cpp/serve/logit_processor.h
@@ -41,15 +41,18 @@ class LogitProcessorObj : public Object {
    * \param request_ids The ids of each request.
    * \param cum_num_token The pointer to the cumulative token length of the sequences.
    * If the pointer is nullptr, it means each sequence has only one token.
-   * \param draft_tokens The pointer to the draft tokens of each sequence
-   * when speculation is enabled, in which case some sequences may have
-   * more than one token.
+   * \param draft_mstates Optional. The draft request states of each sequence.
+   * \param draft_token_indices Optional. The pointer to the draft token indices of each draft token
+   * in the model state (-1 indicates the token is not a draft token) when speculation is enabled.
+   * This is used to compute the sequence state with the draft tokens considered (the saved sequence
+   * state is not updated with the draft tokens).
    */
   virtual void InplaceUpdateLogits(
       NDArray logits, const Array<GenerationConfig>& generation_cfg,
       const Array<RequestModelState>& mstates, const Array<String>& request_ids,
       const std::vector<int>* cum_num_token = nullptr,
-      const std::vector<std::vector<SampleResult>>* draft_tokens = nullptr) = 0;
+      const Array<RequestModelState>* draft_mstates = nullptr,
+      const std::vector<std::vector<int>>* draft_token_indices = nullptr) = 0;
 
   /*!
    * \brief Compute probability distributions for the input batch of logits.

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -80,18 +80,12 @@ void RequestModelStateNode::AddDraftToken(SampleResult sampled_token, int draft_
   draft_output_tokens.push_back(std::move(sampled_token));
   draft_token_slots.push_back(draft_token_slot);
   draft_token_parent_idx.push_back(parent_idx);
-  appeared_token_ids[sampled_token.GetTokenId()] += 1;
 }
 
 void RequestModelStateNode::RemoveLastDraftToken() {
   ICHECK(!draft_output_tokens.empty());
-  auto it = appeared_token_ids.find(draft_output_tokens.back().GetTokenId());
   draft_output_tokens.pop_back();
   draft_token_parent_idx.pop_back();
-  CHECK(it != appeared_token_ids.end());
-  if (--it->second == 0) {
-    appeared_token_ids.erase(it);
-  }
 }
 
 void RequestModelStateNode::RemoveAllDraftTokens(std::vector<int>* removed_draft_token_slots) {


### PR DESCRIPTION
Previously model state (such as `appeared_tokens`) are updated with draft tokens, this is not suitable for drafting multiple tokens. Refactored logit processor to explicit passing draft tokens, and the new model states are computed on the fly.


cc @MasterJH5574 