### PR TITLE
[Android]: render markdown text as default

### DIFF
--- a/android/MLCChat/app/build.gradle
+++ b/android/MLCChat/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation project(":mlc4j")
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'com.github.jeziellago:compose-markdown:0.5.2'
     implementation 'androidx.activity:activity-compose:1.7.1'
     implementation platform('androidx.compose:compose-bom:2022.10.00')
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'

--- a/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/ChatView.kt
+++ b/android/MLCChat/app/src/main/java/ai/mlc/mlcchat/ChatView.kt
@@ -30,12 +30,14 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -44,8 +46,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import dev.jeziellago.compose.markdowntext.MarkdownText
 import kotlinx.coroutines.launch
 
 @ExperimentalMaterial3Api
@@ -135,26 +139,63 @@ fun ChatView(
 
 @Composable
 fun MessageView(messageData: MessageData) {
+    // default render the Assistant text as MarkdownText
+    var useMarkdown by remember { mutableStateOf(true) }
+
     SelectionContainer {
         if (messageData.role == MessageRole.Assistant) {
-            Row(
-                horizontalArrangement = Arrangement.Start,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(
-                    text = messageData.text,
-                    textAlign = TextAlign.Left,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier
-                        .wrapContentWidth()
-                        .background(
-                            color = MaterialTheme.colorScheme.secondaryContainer,
-                            shape = RoundedCornerShape(5.dp)
+            Column {
+                if (messageData.text.isNotEmpty()) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "Show as Markdown",
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier
+                                .wrapContentWidth()
+                                .padding(end = 8.dp)
+                                .widthIn(max = 300.dp)
                         )
-                        .padding(5.dp)
-                        .widthIn(max = 300.dp)
-                )
-
+                        Switch(
+                            checked = useMarkdown,
+                            onCheckedChange = { useMarkdown = it }
+                        )
+                    }
+                }
+                Row(
+                    horizontalArrangement = Arrangement.Start,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    if (useMarkdown) {
+                        MarkdownText(
+                            isTextSelectable = true,
+                            modifier = Modifier
+                                .wrapContentWidth()
+                                .background(
+                                    color = MaterialTheme.colorScheme.secondaryContainer,
+                                    shape = RoundedCornerShape(5.dp)
+                                )
+                                .padding(5.dp)
+                                .widthIn(max = 300.dp),
+                            markdown = messageData.text,
+                        )
+                    } else {
+                        Text(
+                            text = messageData.text,
+                            textAlign = TextAlign.Left,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier
+                                .wrapContentWidth()
+                                .background(
+                                    color = MaterialTheme.colorScheme.secondaryContainer,
+                                    shape = RoundedCornerShape(5.dp)
+                                )
+                                .padding(5.dp)
+                                .widthIn(max = 300.dp)
+                        )
+                    }
+                }
             }
         } else {
             Row(
@@ -217,4 +258,19 @@ fun SendMessageView(chatState: AppViewModel.ChatState) {
             )
         }
     }
+}
+
+@Preview
+@Composable
+fun MessageViewPreviewWithMarkdown() {
+    MessageView(
+        messageData = MessageData(
+            role = MessageRole.Assistant, text = """
+# Sample  Header
+* Markdown  
+* [Link](https://example.com)  
+<a href="https://www.google.com/">Google</a>
+"""
+        )
+    )
 }

--- a/android/MLCChat/settings.gradle
+++ b/android/MLCChat/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 rootProject.name = "MLCChat"


### PR DESCRIPTION
similar as this iOS PR: https://github.com/mlc-ai/mlc-llm/pull/2809, use [compose-markdown](https://github.com/jeziellago/compose-markdown) to render the markdown text as default


| markdown ON | markdown OFF |
|---------|---------|
| <img src="https://github.com/user-attachments/assets/b3e4c1c6-8dbd-44aa-820a-578d11c1acb0" width="300" alt="IMG_0111" /> | <img src="https://github.com/user-attachments/assets/00c88a65-c095-4e9c-be28-73e2bc79e0a6" width="300" alt="IMG_0110" /> |