### PR TITLE
[Op] Improve the RoPE embedding implementation

### DIFF
--- a/python/mlc_llm/compiler_pass/attach_sampler.py
+++ b/python/mlc_llm/compiler_pass/attach_sampler.py
@@ -56,9 +56,9 @@ class AttachGPUSamplingFunc:  # pylint: disable=too-few-public-methods
 
 
 def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
-    batch_size = tir.Var("batch_size", "int64")
-    num_samples = tir.Var("num_samples", "int64")
-    vocab_size = tir.Var("vocab_size", "int64")
+    batch_size = tir.SizeVar("batch_size", "int64")
+    num_samples = tir.SizeVar("num_samples", "int64")
+    vocab_size = tir.SizeVar("vocab_size", "int64")
     probs = relax.Var("probs", relax.TensorStructInfo((batch_size, vocab_size), "float32"))
     uniform_samples = relax.Var(
         "uniform_samples", relax.TensorStructInfo((num_samples,), "float32")
@@ -107,8 +107,8 @@ def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
 
 
 def _attach_argsort_func(bb: relax.BlockBuilder):
-    batch_size = tir.Var("batch_size", "int64")
-    vocab_size = tir.Var("vocab_size", "int64")
+    batch_size = tir.SizeVar("batch_size", "int64")
+    vocab_size = tir.SizeVar("vocab_size", "int64")
     probs = relax.Var("probs", relax.TensorStructInfo((batch_size, vocab_size), "float32"))
     with bb.function("argsort_probs", [probs]):
         with bb.dataflow():
@@ -140,9 +140,9 @@ def full(var_result: T.handle, value: T.int32):
 
 
 def _attach_sample_with_top_p(bb: relax.BlockBuilder):  # pylint: disable=too-many-locals
-    batch_size = tir.Var("batch_size", "int64")
-    num_samples = tir.Var("num_samples", "int64")
-    vocab_size = tir.Var("vocab_size", "int64")
+    batch_size = tir.SizeVar("batch_size", "int64")
+    num_samples = tir.SizeVar("num_samples", "int64")
+    vocab_size = tir.SizeVar("vocab_size", "int64")
     sorted_probs = relax.Var(
         "sorted_probs", relax.TensorStructInfo((batch_size, vocab_size), "float32")
     )
@@ -224,8 +224,8 @@ def _attach_sample_with_top_p(bb: relax.BlockBuilder):  # pylint: disable=too-ma
 
 
 def _attach_renormalize_by_top_p(bb: relax.BlockBuilder, target: tvm.target.Target):
-    batch_size = tir.Var("batch_size", "int64")
-    vocab_size = tir.Var("vocab_size", "int64")
+    batch_size = tir.SizeVar("batch_size", "int64")
+    vocab_size = tir.SizeVar("vocab_size", "int64")
     num_pivots = 3
     probs = relax.Var("probs", relax.TensorStructInfo((batch_size, vocab_size), "float32"))
     top_p = relax.Var("top_p", relax.TensorStructInfo((batch_size,), "float32"))
@@ -255,10 +255,10 @@ def _attach_renormalize_by_top_p(bb: relax.BlockBuilder, target: tvm.target.Targ
 
 
 def _attach_take_probs_func(bb: relax.BlockBuilder):
-    batch_size = tir.Var("batch_size", "int64")
-    num_samples = tir.Var("num_samples", "int64")
-    num_positions = tir.Var("num_positions", "int64")
-    vocab_size = tir.Var("vocab_size", "int64")
+    batch_size = tir.SizeVar("batch_size", "int64")
+    num_samples = tir.SizeVar("num_samples", "int64")
+    num_positions = tir.SizeVar("num_positions", "int64")
+    vocab_size = tir.SizeVar("vocab_size", "int64")
     unsorted_probs = relax.Var(
         "unsorted_probs", relax.TensorStructInfo((batch_size, vocab_size), "float32")
     )
@@ -325,9 +325,9 @@ def _attach_take_probs_func(bb: relax.BlockBuilder):
 
 
 def _attach_batch_verifier(bb: relax.BlockBuilder):
-    num_nodes = tir.Var("num_nodes", "int64")
-    nbatch = tir.Var("nbatch", "int64")
-    vocab_size = tir.Var("vocab_size", "int64")
+    num_nodes = tir.SizeVar("num_nodes", "int64")
+    nbatch = tir.SizeVar("nbatch", "int64")
+    vocab_size = tir.SizeVar("vocab_size", "int64")
     draft_probs = relax.Var(
         "draft_probs", relax.TensorStructInfo((num_nodes, vocab_size), "float32")
     )

--- a/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
+++ b/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
@@ -31,8 +31,8 @@ class _Rewriter(PyExprMutator):  # pylint: disable=abstract-method
 
     def transform(self) -> IRModule:
         """Entry point"""
-        batch_size = tir.Var("batch_size", "int64")
-        vocab_size = tir.Var("vocab_size", "int64")
+        batch_size = tir.SizeVar("batch_size", "int64")
+        vocab_size = tir.SizeVar("vocab_size", "int64")
         dtype = "float32"
         logits = relax.Var("logits", relax.TensorStructInfo([batch_size, 1, vocab_size], dtype))
         temperature = relax.Var("temperature", relax.TensorStructInfo([batch_size], dtype))

--- a/python/mlc_llm/compiler_pass/attach_spec_decode_aux_funcs.py
+++ b/python/mlc_llm/compiler_pass/attach_spec_decode_aux_funcs.py
@@ -72,9 +72,9 @@ def _get_gather_2d_inplace(dtype: str, global_symbol: str):
 
 
 def _add_scatter_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dtype: str):
-    batch_size = tir.Var("batch_size", "int64")
-    m = tir.Var("m", "int64")
-    n = tir.Var("n", "int64")
+    batch_size = tir.SizeVar("batch_size", "int64")
+    m = tir.SizeVar("m", "int64")
+    n = tir.SizeVar("n", "int64")
     src = relax.Var("src", struct_info=TensorStructInfo([batch_size, n], dtype))
     indices = relax.Var("indices", struct_info=TensorStructInfo([batch_size], "int32"))
     dst = relax.Var("dst", struct_info=TensorStructInfo([m, n], dtype))
@@ -98,9 +98,9 @@ def _add_scatter_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dt
 
 
 def _add_gather_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dtype: str):
-    batch_size = tir.Var("batch_size", "int64")
-    m = tir.Var("m", "int64")
-    n = tir.Var("n", "int64")
+    batch_size = tir.SizeVar("batch_size", "int64")
+    m = tir.SizeVar("m", "int64")
+    n = tir.SizeVar("n", "int64")
     src = relax.Var("src", struct_info=TensorStructInfo([m, n], dtype))
     indices = relax.Var("indices", struct_info=TensorStructInfo([batch_size], "int32"))
     dst = relax.Var("dst", struct_info=TensorStructInfo([batch_size, n], dtype))

--- a/python/mlc_llm/nn/kv_cache.py
+++ b/python/mlc_llm/nn/kv_cache.py
@@ -489,7 +489,7 @@ def _rope(
     rope_scaling: Dict[str, Any],
 ):
     d = indices[-1]
-    cos_freq, sin_freq = switch_rope_freq_func(rope_scaling)(
+    cos_freq, sin_freq, var_map = switch_rope_freq_func(rope_scaling)(
         offset * scale, d, rotary_dim, theta, "float32"
     )
     cos = cos_freq * buffer[indices].astype("float32")
@@ -498,7 +498,10 @@ def _rope(
         -buffer[indices[:-1] + (d + rotary_dim // 2,)],
         buffer[indices[:-1] + (d - rotary_dim // 2,)],
     ).astype("float32")
-    return (cos + sin).astype(qkv_dtype)
+    expr = (cos + sin).astype(qkv_dtype)
+    for var, value in var_map.items():
+        expr = tir.Let(var, value, expr)
+    return expr
 
 
 def _var(dtype):

--- a/python/mlc_llm/op/top_p_pivot.py
+++ b/python/mlc_llm/op/top_p_pivot.py
@@ -61,8 +61,8 @@ def top_p_pivot(pN, target: tvm.target.Target):
         var_final_lsum: T.handle,
     ):
         T.func_attr({"tir.is_scheduled": 1, "tir.noalias": True})
-        B = T.int32()
-        N = T.int32()
+        B = T.int32(is_size_var=True)
+        N = T.int32(is_size_var=True)
         prob = T.match_buffer(var_prob, (B, N,), "float32")
         top_p_arr = T.match_buffer(var_top_p_arr, (B,), dtype="float32")
         init_pivots = T.match_buffer(var_init_pivots, (B, pN), "float32")
@@ -309,8 +309,8 @@ def top_p_renorm(target: tvm.target.Target = None):
         var_renorm_prob: T.handle,
     ):
         T.func_attr({"tir.is_scheduled": 1, "tir.noalias": True})
-        B = T.int32()
-        N = T.int32()
+        B = T.int32(is_size_var=True)
+        N = T.int32(is_size_var=True)
         prob = T.match_buffer(var_prob, (B, N,), "float32")
         final_pivot = T.match_buffer(var_final_pivot, (B,), "float32")
         final_lsum = T.match_buffer(var_final_lsum, (B,), "float32")


### PR DESCRIPTION
This PR improves the RoPE embedding implementation:

* We adopt a better way for Llama3.1 RoPE scaling computation.
* We observed some overhead caused by the recomputation of a same expression in the RoPE kernel. Therefore, we explicitly apply some common-subexpression elimination (CSE) at the TIR level for the RoPE kernel.

In this PR, we also updates some `tir.Var` definition to `tir.SizeVar` which indicates that the variable is non-negative.