### PR TITLE
[Sampler] Fix CPU sampler for speculative decoding

### DIFF
--- a/cpp/serve/sampler/cpu_sampler.cc
+++ b/cpp/serve/sampler/cpu_sampler.cc
@@ -437,7 +437,7 @@ class CPUSampler : public SamplerObj {
 
           CHECK_EQ(token_tree_parent_ptr[verify_start], -1);
           for (int j = verify_start + 1; j < verify_end; ++j) {
-            CHECK_EQ(token_tree_parent_ptr[j], j - verify_start)
+            CHECK_EQ(token_tree_parent_ptr[j], j - verify_start - 1)
                 << "CPU sampler only supports chain-style draft tokens.";
           }
 


### PR DESCRIPTION
The CPU sampler has typo which prevents from running speculative decoding. This PR fixes the bug.