### PR TITLE
Update the length of decode token in eagle mode

### DIFF
--- a/cpp/serve/engine_actions/eagle_batch_verify.cc
+++ b/cpp/serve/engine_actions/eagle_batch_verify.cc
@@ -179,6 +179,7 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
       // Metrics update
       // live update the output metrics
       rsentries[i]->rstate->metrics.completion_tokens += accept_length;
+      rsentries[i]->rstate->metrics.decode_tokens += accept_length;
       estate->metrics.spec_decode.Update(cum_verify_lengths[i + 1] - cum_verify_lengths[i],
                                          accept_length);
       // - Minus one because the last draft token has no kv cache entry


### PR DESCRIPTION
Update the length of decode token in eagle mode, so we can get the decode metrics, otherwise, it's always 0.

/metrics
decode_tokens_sum       73
decode_tokens_per_s     5.658155349407193

/stats
prefill: 1.0 tok/s, decode: 5.4 tok/s
