### PR TITLE
[iOS] Add Phi3.5 into `mlc-package-config.json`

### DIFF
--- a/ios/MLCChat/mlc-package-config.json
+++ b/ios/MLCChat/mlc-package-config.json
@@ -11,8 +11,8 @@
             }
         },
         {
-            "model": "HF://mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
-            "model_id": "Phi-3-mini-4k-instruct-q4f16_1-MLC",
+            "model": "HF://mlc-ai/Phi-3.5-mini-instruct-q4f16_1-MLC",
+            "model_id": "Phi-3.5-mini-instruct-q4f16_1-MLC",
             "estimated_vram_bytes": 3043000000,
             "overrides": {
                 "prefill_chunk_size": 128


### PR DESCRIPTION
This PR adds the Phi3.5 model into the iOS `mlc-package-config.json`.