### PR TITLE
[KVCache] Adjust KV cache interface for RoPE ext factors

### DIFF
--- a/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
+++ b/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
@@ -21,17 +21,18 @@ def extract_creation_args(func: relax.Function) -> Dict[str, Any]:
     assert isinstance(args[0], relax.ExternFunc)
     assert args[0].global_symbol == "mlc.create_paged_kv_cache_generic"
 
-    assert len(args) == 13
+    assert len(args) == 14
     assert isinstance(args[1], relax.ShapeExpr)
     assert len(args[1].values) == 5
     assert isinstance(args[2], relax.ShapeExpr)
-    for i in range(3, 12):
-        if i == 10:
+    for i in range(3, 13):
+        if i in [10, 11]:
             continue
         assert isinstance(args[i], relax.PrimValue)
         assert isinstance(args[i].value, (tvm.tir.IntImm, tvm.tir.FloatImm))
     assert isinstance(args[10], relax.StringImm)
-    assert isinstance(args[12], relax.DataTypeImm)
+    assert isinstance(args[11], (relax.Constant, relax.PrimValue))
+    assert isinstance(args[13], relax.DataTypeImm)
 
     return {
         "max_batch_size": args[1].values[0],
@@ -48,8 +49,9 @@ def extract_creation_args(func: relax.Function) -> Dict[str, Any]:
         "rope_scale": args[8].value.value,
         "rope_theta": args[9].value.value,
         "rope_scaling": json.loads(args[10].value),
-        "rotary_dim": args[11].value.value,
-        "dtype": args[12].value,
+        "rope_ext_factors": args[11],
+        "rotary_dim": args[12].value.value,
+        "dtype": args[13].value,
     }
 
 


### PR DESCRIPTION
This PR adjusts the KV cache interface to better support the RoPE extension factors introduced for Phi3.5 model. The intention is to keep the attention interface unchanged, and it is more allowed to update the KV cache constructor interface.