### PR TITLE
[Docs] Update installation instructions for ROCm

### DIFF
--- a/docs/install/gpu.rst
+++ b/docs/install/gpu.rst
@@ -31,14 +31,14 @@ ROCm is required to compile and run models with ROCm backend.
 Installation
 ^^^^^^^^^^^^
 
-Right now MLC LLM only supports ROCm 5.6.
+Right now MLC LLM only supports ROCm 6.1/6.2.
 If you have AMD GPU and you want to use models compiled with ROCm
-backend, you should install ROCm 5.6 from `here <https://docs.amd.com/en/docs-5.6.0/deploy/linux/installer/install.html>`__.
+backend, you should install ROCm from `here <https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.2.0/install/quick-start.html>`__.
 
 Validate Installation
 ^^^^^^^^^^^^^^^^^^^^^
 
-To verify you have correctly installed ROCm 5.6, run ``rocm-smi`` in command line.
+To verify you have correctly installed ROCm, run ``rocm-smi`` in command line.
 If you see the list of AMD devices printed out in a table, it means the ROCm is correctly installed.
 
 .. _vulkan_driver:

--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -46,19 +46,19 @@ Select your operating system/compute platform and run the command in your termin
                     conda activate your-environment
                     python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122
 
-            .. tab:: ROCm 5.6
+            .. tab:: ROCm 6.1
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm56 mlc-ai-nightly-rocm56
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm61 mlc-ai-nightly-rocm61
 
-            .. tab:: ROCm 5.7
+            .. tab:: ROCm 6.2
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm57 mlc-ai-nightly-rocm57
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm62 mlc-ai-nightly-rocm62
 
             .. tab:: Vulkan
 

--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -53,19 +53,19 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
               conda activate your-environment
               python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu122
 
-         .. tab:: ROCm 5.6
+         .. tab:: ROCm 6.1
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm56
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm61
 
-         .. tab:: ROCm 5.7
+         .. tab:: ROCm 6.2
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm57
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm62
 
          .. tab:: Vulkan
 
@@ -144,6 +144,7 @@ While it is generally recommended to always use the prebuilt TVM Unity, if you r
 
     - CMake >= 3.24
     - LLVM >= 15
+      - For please install LLVM>=17 for ROCm 6.1 and LLVM>=18 for ROCm 6.2.
     - Git
     - (Optional) CUDA >= 11.8 (targeting NVIDIA GPUs)
     - (Optional) Metal (targeting Apple GPUs such as M1 and M2)


### PR DESCRIPTION
This PR updates the installation instructions for ROCm after our ROCm support upgraded to ROCm 6.1/6.2.