### PR TITLE
[Engine] Preparation for switching between spec-decode mode and normal mode

### DIFF
--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -240,6 +240,7 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
     mstate->inputs = std::move(inputs);
     mstate->prefilled_inputs.clear();
     mstate->cached_committed_tokens = 0;
+    mstate->num_tokens_for_next_decode = 0;
   }
   if (estate->prefix_cache->HasSequence(rsentry->mstates[0]->internal_id)) {
     estate->prefix_cache->RecycleSequence(rsentry->mstates[0]->internal_id, /*lazy=*/false);

--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -40,8 +40,8 @@ class BatchDecodeActionObj : public EngineActionObj {
         trace_recorder_(std::move(trace_recorder)) {}
 
   Array<Request> Step(EngineState estate) final {
-    // - Do not run decode when there are multiple models or no running requests.
-    if (models_.size() > 1 || estate->running_queue.empty()) {
+    // - Do not run decode when there is no running request.
+    if (estate->running_queue.empty()) {
       return {};
     }
 


### PR DESCRIPTION
This PR introduces some prerequisite operations to support automatic switching between speculative decoding mode and the normal batch decode mode.

Specifically, this PR
* removes the constraint that the BatchDecode action is applicable when there is only one model.
* enhances the BatchDraft action so whenever the committed tokens of a request in the draft model is lagging behind the committed tokens in the main model, the BatchDraft action will automatically prefill all the lagging-behind part into the draft model when generating the draft.

These changes are tested locally.