### PR TITLE
[Bench] Support multi round conversation

### DIFF
--- a/python/mlc_llm/bench/__main__.py
+++ b/python/mlc_llm/bench/__main__.py
@@ -317,5 +317,13 @@ if __name__ == "__main__":
         help="Whether to enable cuda profile on server. "
         "The --mlc-model-lib path should be provided when enabling this option.",
     )
+    parser.add_argument(
+        "--multi-round",
+        default=False,
+        action="store_true",
+        help="Whether to chat like mulit round conversion with history log each request. "
+        "Only enabled when benchmarked with fixed concurrent request mode."
+        "The --num-concurrent-requests should be provided when enabling this option.",
+    )
 
     main(parser.parse_args())

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -250,7 +250,7 @@ class Executor(RequestProcessor):  # pylint: disable=too-few-public-methods
 class FixedConcurrentRequestExecutor(Executor):  # pylint: disable=too-few-public-methods
     """The benchmark executor of fixing the number of concurrent requests."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         f_create_api_endpoint: Callable[[], APIEndPoint],
         num_processes: Optional[int],


### PR DESCRIPTION
This PR adds the support of multi round conversation when benchmarked with fixed concurrent request mode. When enabled, the chat history will be logged and appended during benchmark.