### PR TITLE
[Engine][Spec] Initiali adaptive speculative decoding

### DIFF
--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -249,8 +249,12 @@ class EngineConfigNode : public Object {
 
   /*! \brief The speculative mode. */
   SpeculativeMode speculative_mode = SpeculativeMode::kDisable;
-  /*! \brief The number of tokens to generate in speculative proposal (draft). */
-  int spec_draft_length = 4;
+  /*!
+   * \brief The number of tokens to generate in speculative proposal (draft).
+   * Being 0 means to enable adaptive speculative mode, where the draft length
+   * will be automatically adjusted based on engine state.
+   */
+  int spec_draft_length = 0;
   /*! \brief The number of tokens to generate in speculative tree decoding */
   int spec_tree_width = 1;
 

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -117,14 +117,13 @@ class EngineAction : public ObjectRef {
    * \param draft_token_workspace_manager The draft token workspace manager.
    * \param engine_config The engine config.
    * \param trace_recorder The event trace recorder for requests.
-   * \param draft_length The number of draft proposal rounds.
    * \return The created action object.
    */
   static EngineAction BatchDraft(Array<Model> models, LogitProcessor logit_processor,
                                  Sampler sampler, std::vector<ModelWorkspace> model_workspaces,
                                  DraftTokenWorkspaceManager draft_token_workspace_manager,
                                  EngineConfig engine_config,
-                                 Optional<EventTraceRecorder> trace_recorder, int draft_length);
+                                 Optional<EventTraceRecorder> trace_recorder);
 
   /*!
    * \brief Create the action that runs one-step speculative draft proposal for
@@ -137,15 +136,13 @@ class EngineAction : public ObjectRef {
    * \param draft_token_workspace_manager The draft token workspace manager.
    * \param engine_config The engine config.
    * \param trace_recorder The event trace recorder for requests.
-   * \param draft_length The number of draft proposal rounds.
    * \return The created action object.
    */
   static EngineAction EagleBatchDraft(Array<Model> models, LogitProcessor logit_processor,
                                       Sampler sampler, std::vector<ModelWorkspace> model_workspaces,
                                       DraftTokenWorkspaceManager draft_token_workspace_manager,
                                       EngineConfig engine_config,
-                                      Optional<EventTraceRecorder> trace_recorder,
-                                      int draft_length = 4);
+                                      Optional<EventTraceRecorder> trace_recorder);
 
   /*!
    * \brief Create the action that runs one-step speculative verification for requests in the
@@ -198,6 +195,18 @@ class EngineAction : public ObjectRef {
    */
   static EngineAction BatchJumpForward(Array<Model> models, Tokenizer tokenizer,
                                        Optional<EventTraceRecorder> trace_recorder);
+
+  /*!
+   * \brief Create the action that first makes a decision on whether to run speculative
+   * decoding or normal mode batch decode, and then runs the selected actions.
+   * \param spec_decode_actions The actions for speculative decoding.
+   * \param batch_decode_actions The actions for normal mode batch decoding.
+   * \param engine_config The engine config.
+   * \return The created action object
+   */
+  static EngineAction AutoSpecDecode(std::vector<EngineAction> spec_decode_actions,
+                                     std::vector<EngineAction> batch_decode_actions,
+                                     EngineConfig engine_config);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(EngineAction, ObjectRef, EngineActionObj);
 };

--- a/cpp/serve/engine_actions/action_commons.h
+++ b/cpp/serve/engine_actions/action_commons.h
@@ -6,18 +6,30 @@
 #ifndef MLC_LLM_SERVE_ENGINE_ACTIONS_ACTION_COMMONS_H_
 #define MLC_LLM_SERVE_ENGINE_ACTIONS_ACTION_COMMONS_H_
 
+#include <tvm/runtime/container/array.h>
+
 #include "../../tokenizers/tokenizers.h"
 #include "../draft_token_workspace_manager.h"
 #include "../engine.h"
 #include "../engine_state.h"
 #include "../event_trace_recorder.h"
 #include "../model.h"
+#include "action.h"
 
 namespace mlc {
 namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+
+/*! \brief Create the engine actions based on engine config. */
+Array<EngineAction> CreateEngineActions(Array<Model> models, EngineConfig engine_config,
+                                        std::vector<picojson::object> model_configs,
+                                        std::vector<ModelWorkspace> model_workspaces,
+                                        LogitProcessor logit_processor, Sampler sampler,
+                                        DraftTokenWorkspaceManager draft_token_workspace_manager,
+                                        Tokenizer tokenizer,
+                                        Optional<EventTraceRecorder> trace_recorder);
 
 /*!
  * \brief Remove the given request from models.

--- a/cpp/serve/engine_actions/auto_spec_decode.cc
+++ b/cpp/serve/engine_actions/auto_spec_decode.cc
@@ -1,0 +1,86 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file serve/engine_actions/auto_spec_decode.cc
+ */
+
+#include <tvm/runtime/nvtx.h>
+
+#include <numeric>
+
+#include "../config.h"
+#include "action.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+/*!
+ * \brief The action that first makes a decision on whether to run speculative
+ * decoding or normal mode batch decode, and then runs the selected actions.
+ */
+class AutoSpecDecodeActionObj : public EngineActionObj {
+ public:
+  explicit AutoSpecDecodeActionObj(Array<EngineAction> spec_decode_actions,
+                                   Array<EngineAction> batch_decode_actions,
+                                   EngineConfig engine_config)
+      : spec_decode_actions_(std::move(spec_decode_actions)),
+        batch_decode_actions_(std::move(batch_decode_actions)),
+        engine_config_(std::move(engine_config)) {}
+
+  Array<Request> Step(EngineState estate) final {
+    int num_running_rsentries = estate->GetRunningRequestStateEntries().size();
+    if (num_running_rsentries == 0) {
+      return {};
+    }
+
+    // Calculate the draft length to use for the next round decode.
+    estate->spec_draft_length = CalculateDraftLength(estate, num_running_rsentries);
+    ICHECK_GE(estate->spec_draft_length, 0);
+    Array<Request> processed_requests;
+    // Use speculative decoding when the computed draft length is positive.
+    // Otherwise use normal mode batch decode.
+    Array<EngineAction> actions =
+        estate->spec_draft_length > 0 ? spec_decode_actions_ : batch_decode_actions_;
+    for (EngineAction action : actions) {
+      processed_requests = action->Step(estate);
+    }
+
+    // Reset the draft length.
+    estate->spec_draft_length = 0;
+    return processed_requests;
+  }
+
+ private:
+  int CalculateDraftLength(EngineState estate, int num_running_rsentries) {
+    // Right now we use the fixed table to select the draft length (only based on
+    // the batch size). We will follow up to adopt powerful draft length selection.
+    if (num_running_rsentries < 10) {
+      return 4;
+    } else if (num_running_rsentries < 20) {
+      return 3;
+    } else if (num_running_rsentries < 30) {
+      return 2;
+    } else {
+      return 0;
+    }
+  }
+
+  /*! \brief The speculative decode actions. */
+  Array<EngineAction> spec_decode_actions_;
+  /*! \brief The normal mode decode actions. */
+  Array<EngineAction> batch_decode_actions_;
+  /*! \brief The engine config. */
+  EngineConfig engine_config_;
+};
+
+EngineAction EngineAction::AutoSpecDecode(std::vector<EngineAction> spec_decode_actions_,
+                                          std::vector<EngineAction> batch_decode_actions_,
+                                          EngineConfig engine_config) {
+  return EngineAction(make_object<AutoSpecDecodeActionObj>(
+      Array<EngineAction>(spec_decode_actions_), Array<EngineAction>(batch_decode_actions_),
+      std::move(engine_config)));
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -277,7 +277,7 @@ bool BatchPrefillBaseActionObj::CanPrefill(EngineState estate, int num_prefill_r
   // No exceeding of the maximum allowed requests that can
   // run simultaneously.
   int spec_factor = engine_config_->speculative_mode != SpeculativeMode::kDisable
-                        ? (engine_config_->spec_draft_length + 1)
+                        ? (estate->spec_draft_length + 1)
                         : 1;
   if ((num_running_rsentries + num_prefill_rsentries) * spec_factor >
       std::min(static_cast<int64_t>(engine_config_->max_num_sequence),

--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -202,8 +202,10 @@ class BatchVerifyActionObj : public EngineActionObj {
         verify_model_seq_internal_ids,
         std::vector<int64_t>{last_accepted_tree_node_verify_model.begin(),
                              last_accepted_tree_node_verify_model.end()});
-    models_[draft_model_id_]->CommitAcceptedTokenTreeNodesToKVCache(
-        draft_model_seq_internal_ids, last_accepted_tree_node_draft_model);
+    if (engine_config_->spec_tree_width > 1) {
+      models_[draft_model_id_]->CommitAcceptedTokenTreeNodesToKVCache(
+          draft_model_seq_internal_ids, last_accepted_tree_node_draft_model);
+    }
 
     if (!fully_accepted_rsentries.empty()) {
       // - Run a step of batch decode for requests whose drafts are fully accepted.
@@ -244,7 +246,7 @@ class BatchVerifyActionObj : public EngineActionObj {
       rsentries[i]->mstates[draft_model_id_]->RemoveAllDraftTokens(&draft_token_slots_);
       draft_token_workspace_manager_->FreeSlots(draft_token_slots_);
       // reset num_tokens_for_next_decode to 1
-      rsentries[i]->mstates[verify_model_id_]->num_tokens_for_next_decode = 0;
+      rsentries[i]->mstates[verify_model_id_]->num_tokens_for_next_decode = 1;
       rsentries[i]->mstates[draft_model_id_]->num_tokens_for_next_decode = 1;
     }
 

--- a/cpp/serve/engine_actions/eagle_batch_draft.cc
+++ b/cpp/serve/engine_actions/eagle_batch_draft.cc
@@ -26,17 +26,14 @@ class EagleBatchDraftActionObj : public EngineActionObj {
                                     Sampler sampler, std::vector<ModelWorkspace> model_workspaces,
                                     DraftTokenWorkspaceManager draft_token_workspace_manager,
                                     EngineConfig engine_config,
-                                    Optional<EventTraceRecorder> trace_recorder, int draft_length)
+                                    Optional<EventTraceRecorder> trace_recorder)
       : models_(std::move(models)),
         logit_processor_(std::move(logit_processor)),
         sampler_(std::move(sampler)),
         model_workspaces_(std::move(model_workspaces)),
         draft_token_workspace_manager_(std::move(draft_token_workspace_manager)),
         engine_config_(std::move(engine_config)),
-        trace_recorder_(std::move(trace_recorder)),
-        draft_length_(draft_length) {
-    ICHECK_GT(draft_length_, 0);
-  }
+        trace_recorder_(std::move(trace_recorder)) {}
 
   Array<Request> Step(EngineState estate) final {
     // - Only run spec decode when there are two models (llm+ssm) and >=1 running requests.
@@ -82,6 +79,8 @@ class EagleBatchDraftActionObj : public EngineActionObj {
       rngs.push_back(&rsentry->rng);
     }
 
+    ICHECK_GT(estate->spec_draft_length, 0)
+        << "The speculative decoding draft length must be positive.";
     // The first model doesn't get involved in draft proposal.
     for (int model_id = 1; model_id < static_cast<int>(models_.size()); ++model_id) {
       // Collect
@@ -99,7 +98,7 @@ class EagleBatchDraftActionObj : public EngineActionObj {
       ObjectRef hidden_states = model_workspaces_[model_id].hidden_states;
       // Concat last hidden_states
       draft_token_slots_.clear();
-      if (draft_length_ > 1) {
+      if (estate->spec_draft_length > 1) {
         for (int i = 0; i < num_rsentries; ++i) {
           draft_token_slots_.push_back(mstates[i]->draft_token_slots.back());
         }
@@ -107,7 +106,7 @@ class EagleBatchDraftActionObj : public EngineActionObj {
             model_workspaces_[0].draft_hidden_states_storage, draft_token_slots_, &hidden_states);
       }
       // The first draft token has been generated in prefill/verify stage
-      for (int draft_id = 1; draft_id < draft_length_; ++draft_id) {
+      for (int draft_id = 1; draft_id < estate->spec_draft_length; ++draft_id) {
         auto tdraft_start = std::chrono::high_resolution_clock::now();
         // prepare new input tokens
         input_tokens.clear();
@@ -213,8 +212,6 @@ class EagleBatchDraftActionObj : public EngineActionObj {
   EngineConfig engine_config_;
   /*! \brief Event trace recorder. */
   Optional<EventTraceRecorder> trace_recorder_;
-  /*! \brief Draft proposal length */
-  int draft_length_;
   /*! \brief Temporary buffer to store the slots of the current draft tokens */
   std::vector<int> draft_token_slots_;
 };
@@ -224,12 +221,11 @@ EngineAction EngineAction::EagleBatchDraft(Array<Model> models, LogitProcessor l
                                            std::vector<ModelWorkspace> model_workspaces,
                                            DraftTokenWorkspaceManager draft_token_workspace_manager,
                                            EngineConfig engine_config,
-                                           Optional<EventTraceRecorder> trace_recorder,
-                                           int draft_length) {
+                                           Optional<EventTraceRecorder> trace_recorder) {
   return EngineAction(make_object<EagleBatchDraftActionObj>(
       std::move(models), std::move(logit_processor), std::move(sampler),
       std::move(model_workspaces), std::move(draft_token_workspace_manager),
-      std::move(engine_config), std::move(trace_recorder), draft_length));
+      std::move(engine_config), std::move(trace_recorder)));
 }
 
 }  // namespace serve

--- a/cpp/serve/engine_actions/eagle_batch_verify.cc
+++ b/cpp/serve/engine_actions/eagle_batch_verify.cc
@@ -320,7 +320,8 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
         UpdateRequestStatesWithDraftProposals(mstates, sample_results, draft_model_id_,
                                               renormalized_probs, hidden_states, estate);
       } else if (engine_config_->speculative_mode == SpeculativeMode::kMedusa) {
-        for (int draft_id = 0; draft_id < engine_config_->spec_draft_length; draft_id++) {
+        ICHECK_NE(estate->spec_draft_length, 0);
+        for (int draft_id = 0; draft_id < estate->spec_draft_length; draft_id++) {
           const auto& [renormalized_probs, sample_results] = ApplyLogitProcessorAndSample(
               logit_processor_, sampler_, multi_step_logits[draft_id], generation_cfg, request_ids,
               mstates, rngs, sample_indices, generation_cfg, request_ids, sample_indices);
@@ -407,7 +408,7 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
     models_[0]->ScatterDraftProbs(renormalized_probs, draft_token_slots_,
                                   &model_workspaces_[0].draft_probs_storage);
     if (engine_config_->speculative_mode == SpeculativeMode::kEagle &&
-        engine_config_->spec_draft_length > 1) {
+        estate->spec_draft_length > 1) {
       models_[0]->ScatterHiddenStates(hidden_states_for_sample, draft_token_slots_,
                                       &model_workspaces_[0].draft_hidden_states_storage);
     }

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -318,7 +318,8 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
                                                 estate, child_sample_indices);
         }
       } else if (engine_config_->speculative_mode == SpeculativeMode::kMedusa) {
-        for (int draft_id = 0; draft_id < engine_config_->spec_draft_length; ++draft_id) {
+        ICHECK_NE(estate->spec_draft_length, 0);
+        for (int draft_id = 0; draft_id < estate->spec_draft_length; ++draft_id) {
           const auto& [renormalized_probs, sample_results] = ApplyLogitProcessorAndSample(
               logit_processor_, sampler_, multi_step_logits[draft_id], generation_cfg, request_ids,
               mstates_for_logitproc, rngs, sample_indices, child_generation_cfg, child_request_ids,
@@ -356,7 +357,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
     models_[0]->ScatterDraftProbs(renormalized_probs, draft_token_slots_,
                                   &model_workspaces_[0].draft_probs_storage);
     if (engine_config_->speculative_mode == SpeculativeMode::kEagle &&
-        engine_config_->spec_draft_length > 1) {
+        estate->spec_draft_length > 1) {
       models_[0]->ScatterHiddenStates(hidden_states_for_sample, draft_token_slots_,
                                       &model_workspaces_[0].draft_hidden_states_storage);
     }

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -73,6 +73,13 @@ class EngineStateObj : public Object {
   /*! \brief A boolean flag denoting whether the running request state entry list has changed. */
   bool running_rsentries_changed = true;
   /*!
+   * \brief The current engine speculative decoding draft length.
+   * The length may change across time under the auto speculative decoding mode.
+   * Value 0 means undefined. It must have a positive value for speculative decoding to
+   * properly work.
+   */
+  int spec_draft_length = 0;
+  /*!
    * \brief The post-process data structures.
    * We make it a workspace to avoid repetitive memory allocation/free in the action post process.
    */

--- a/cpp/serve/metrics.h
+++ b/cpp/serve/metrics.h
@@ -7,6 +7,7 @@
 #define MLC_LLM_SERVE_METRICS_H_
 
 #include <picojson.h>
+#include <tvm/runtime/logging.h>
 
 #include <chrono>
 #include <string>
@@ -68,6 +69,7 @@ struct SpecDecodeMetrics {
    * \param accept_length The number of accepted tokens in the speculative decoding.
    */
   void Update(int draft_length, int accept_length) {
+    ICHECK_GE(accept_length, 1);
     if (accept_count.size() < draft_length) {
       this->accept_count.resize(draft_length, 0);
       this->draft_count.resize(draft_length, 0);

--- a/python/mlc_llm/interface/help.py
+++ b/python/mlc_llm/interface/help.py
@@ -210,7 +210,9 @@ The speculative decoding mode. Right now four options are supported:
 The default mode is "disable".
 """.strip(),
     "spec_draft_length_serve": """
-The number of draft tokens to generate in speculative proposal. The default values is 4.
+The number of draft tokens to generate in speculative proposal.
+Being 0 means to enable adaptive speculative mode, where the draft length will be
+automatically adjusted based on engine state. The default values is 0.
 """.strip(),
     "prefix_cache_mode_serve": """
 The prefix cache mode. Right now two options are supported:

--- a/python/mlc_llm/serve/config.py
+++ b/python/mlc_llm/serve/config.py
@@ -96,6 +96,8 @@ class EngineConfig:  # pylint: disable=too-many-instance-attributes
 
     spec_draft_length : int
         The number of tokens to generate in speculative proposal (draft).
+        Being 0 means to enable adaptive speculative mode, where the draft length
+        will be automatically adjusted based on engine state.
 
     spec_tree_width : int
         The width of the speculative decoding tree.
@@ -136,7 +138,7 @@ class EngineConfig:  # pylint: disable=too-many-instance-attributes
     max_history_size: Optional[int] = None
     kv_state_kind: Optional[Literal["kv_cache", "rnn_state"]] = None
     speculative_mode: Literal["disable", "small_draft", "eagle", "medusa"] = "disable"
-    spec_draft_length: int = 4
+    spec_draft_length: int = 0
     spec_tree_width: int = 1
     prefix_cache_mode: Literal["disable", "radix"] = "radix"
     prefix_cache_max_num_recycling_seqs: Optional[int] = None


### PR DESCRIPTION
This PR introduces the initial support of speculative decoding, which is enabled when the `spec_draft_length` is 0 (its default value is also changed to 0 in this PR so that the adaptive mode is enabled by default).

The goal of adaptive speculative decoding is to dynamically adjust the draft length depending on the engine's running state. For the initial version, we use a fixed table for the draft length selection. We will follow up with more powerful draft length selection.

This PR also fixes a few bugs after the introduction of tree draft.