### PR TITLE
[Bench] Use OpenAI v1/completions as default

### DIFF
--- a/python/mlc_llm/bench/__main__.py
+++ b/python/mlc_llm/bench/__main__.py
@@ -110,7 +110,8 @@ def query_mlc_server_metrics(host: str, port: int):
     """Try to get the MLC server metrics whenever it exists."""
     try:
         r = requests.post(f"http://{host}:{port}/debug/dump_engine_metrics", json={}, timeout=10)
-        print(f"MLC server metrics: {r.json()}")
+        if r.status_code == 200:
+            print(f"MLC server metrics: {r.json()}")
     except Exception:  # pylint: disable=broad-exception-caught
         pass
 

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -144,7 +144,10 @@ class MetricAnalyzer(RequestProcessor):  # pylint: disable=too-few-public-method
                 continue
 
             metrics.output_tokens = len(self.tokenizer.encode(request_record.output_str))
-            if metrics.output_tokens < 2:
+            first_chunk_output_tokens = len(
+                self.tokenizer.encode(request_record.first_chunk_output_str)
+            )
+            if metrics.output_tokens <= first_chunk_output_tokens:
                 metrics.success = False
                 continue
             assert metrics.input_tokens > 0, "Invalid prompt tokens"
@@ -153,7 +156,7 @@ class MetricAnalyzer(RequestProcessor):  # pylint: disable=too-few-public-method
                 metrics.time_to_first_token_s = 0
             metrics.time_per_output_token_s = (
                 metrics.end_to_end_latency_s - metrics.time_to_first_token_s
-            ) / (metrics.output_tokens - 1)
+            ) / (metrics.output_tokens - first_chunk_output_tokens)
             updated_records.append(request_record)
         return updated_records
 

--- a/python/mlc_llm/bench/request_record.py
+++ b/python/mlc_llm/bench/request_record.py
@@ -48,6 +48,7 @@ class RequestRecord(BaseModel):
 
     chat_cmpl: ChatCompletionRequest
     output_str: Optional[str] = None
+    first_chunk_output_str: str = ""
     timestamp: Optional[float] = None
     metrics: Optional[Metrics] = None
 


### PR DESCRIPTION
This PR updates the benchmark to use OpenAI entrypoint `v1/completions` as the default to remove the impact of `v1/chat/completions` on conversation template and system prompt. The previous endpoint is renamed to `openai-chat`, and the naming here is aligned with vLLM.

This PR also fixes the TPOT calculation. Previously it used "number of output tokens - 1" as the divisor, and this PR changes "1" to the number of tokens in the first output chunk.