### PR TITLE
[Vision][Fix] Follow phi3.5-vision prompt format for image

### DIFF
--- a/python/mlc_llm/protocol/conversation_protocol.py
+++ b/python/mlc_llm/protocol/conversation_protocol.py
@@ -177,6 +177,7 @@ class Conversation(BaseModel):
                     assert config is not None, "Model config is required"
                     image_url = _get_url_from_item(item)
                     message_list.append(data.ImageData.from_url(image_url, config))
+                    message_list.append("\n")
                 else:
                     raise ValueError(f"Unsupported content type: {item['type']}")
 


### PR DESCRIPTION
Phi3.5-vision has the following rules for formatting messages with images according to https://huggingface.co/microsoft/Phi-3.5-vision-instruct#input-formats:

- Single image: `<|user|>\n<|image_1|>\n{prompt}<|end|>\n<|assistant|>\n`
- Multi image: `<|user|>\n<|image_1|>\n<|image_2|>\n{prompt}<|end|>\n<|assistant|>\n`

Currently, our protocol misses the `\n` separator for the image.

In future when we support more vision models, how the image is formatted should be inside the conversation template rather than hardcoded.