### PR TITLE
Repetition penalty calculation fix

### DIFF
--- a/python/mlc_llm/compiler_pass/attach_logit_processor.py
+++ b/python/mlc_llm/compiler_pass/attach_logit_processor.py
@@ -119,7 +119,7 @@ def _get_apply_penalty_inplace(target: tvm.target.Target):
                         penalties[pos2seq_id[vp], 0] + token_cnt[vp] * penalties[pos2seq_id[vp], 1]
                     )
                     logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] = T.if_then_else(
-                        logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] > 0,
+                        logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] < 0,
                         logits[seq_ids[pos2seq_id[vp]], token_ids[vp]]
                         * penalties[pos2seq_id[vp], 2],
                         logits[seq_ids[pos2seq_id[vp]], token_ids[vp]]


### PR DESCRIPTION
The PR contains typo fix in repetition penalty calculations.
The testing code is attached.
To test this fix it is necessary to add samplers_wrapper.cc and samplers_wrapper.h to <MLC-LLM>/cpp/serve/ folder and compile mlc-llm project. This wrappers allows to get access to "apply_penalty_inplace" kernel from python code.
After that it will be possible to run test_repetition_penalty.py which performs validation of "apply_penalty_inplace" kernel against transformers' RepetitionPenaltyLogitsProcessor.

[testing_code.zip](https://github.com/user-attachments/files/17110134/testing_code.zip)
