### PR TITLE
[Fix] Deepcopy reqeust when sampling dataset

### DIFF
--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import concurrent.futures
+import copy
 import os
 import random
 import time
@@ -54,8 +55,9 @@ class SampleRequests(RequestProcessor):  # pylint: disable=too-few-public-method
         remaining_num_requests = self.num_requests
         while remaining_num_requests > 0:
             current_num_sample = min(remaining_num_requests, len(request_records))
-            sample += random.sample(request_records, current_num_sample)
+            sample += copy.deepcopy(random.sample(request_records, current_num_sample))
             remaining_num_requests -= current_num_sample
+
         return sample
 
 


### PR DESCRIPTION
This PR fixes the sampling of dataset in benchmark. Otherwise the sampled requests may refer to the same object and cause issues.