### PR TITLE
[Conv] Remove custom from gen_config CONV_TEMPLATES

### DIFF
--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -293,7 +293,6 @@ CONV_TEMPLATES = {
     "wizardlm_7b",
     "wizard_coder_or_math",
     "glm",
-    "custom",  # for web-llm only
     "phi-2",
     "phi-3",
     "phi-3-vision",


### PR DESCRIPTION
`"custom"` is added earlier for WebLLM, and it is no longer needed. Currently specifying as `"custom"` runs into error.