### PR TITLE
[Serving] Remove draft tokens after finishing request

### DIFF
--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -406,6 +406,7 @@ class EngineImpl : public Engine {
     n->actions_ = CreateEngineActions(
         n->models_, engine_config, model_configs, n->model_workspaces_, logit_processor, sampler,
         draft_token_workspace_manager, n->tokenizer_, n->trace_recorder_);
+    n->draft_token_workspace_manager_ = draft_token_workspace_manager;
     // - Automatically set the threading backend max concurrency.
     n->engine_config_ = engine_config;
     n->SetThreadMaxConcurrency();
@@ -595,7 +596,7 @@ class EngineImpl : public Engine {
       if (!processed_requests.empty()) {
         ActionStepPostProcess(processed_requests, estate_, models_, tokenizer_,
                               request_stream_callback_, engine_config_->max_single_sequence_length,
-                              trace_recorder_);
+                              draft_token_workspace_manager_, trace_recorder_);
         return;
       }
     }
@@ -844,6 +845,8 @@ class EngineImpl : public Engine {
   FRequestStreamCallback request_stream_callback_;
   // Engine actions.
   Array<EngineAction> actions_;
+  // Draft token workspace manager for speculative decoding.
+  Optional<DraftTokenWorkspaceManager> draft_token_workspace_manager_;
   // Event trace recorder.
   Optional<EventTraceRecorder> trace_recorder_;
 };

--- a/cpp/serve/engine_actions/action_commons.h
+++ b/cpp/serve/engine_actions/action_commons.h
@@ -52,6 +52,7 @@ void RemoveRequestFromModel(EngineState estate, int64_t req_internal_id,
  * \param tokenizer The tokenizer for logprob process.
  * \param request_stream_callback The request stream callback function.
  * \param max_single_sequence_length The max single sequence length to help decide
+ * \param draft_token_workspace_manager The draft token workspace manager.
  * \param trace_recorder The event trace recorder for requests.
  * if a request is finished.
  */
@@ -59,6 +60,7 @@ void ActionStepPostProcess(Array<Request> requests, EngineState estate, const Ar
                            const Tokenizer& tokenizer,
                            FRequestStreamCallback request_stream_callback,
                            int64_t max_single_sequence_length,
+                           Optional<DraftTokenWorkspaceManager> draft_token_workspace_manager,
                            Optional<EventTraceRecorder> trace_recorder);
 
 /*!


### PR DESCRIPTION
Fixed a leak of draft token slots because they are not released when requests are finished