### PR TITLE
[Docs] Support CUDA 12.3 packages; deprecate 12.1 packages

### DIFF
--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -32,19 +32,19 @@ Select your operating system/compute platform and run the command in your termin
                     conda activate your-environment
                     python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
 
-            .. tab:: CUDA 12.1
-
-                .. code-block:: bash
-
-                    conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu121 mlc-ai-nightly-cu121
-
             .. tab:: CUDA 12.2
 
                 .. code-block:: bash
 
                     conda activate your-environment
                     python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122
+
+            .. tab:: CUDA 12.3
+
+                .. code-block:: bash
+
+                    conda activate your-environment
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu123 mlc-ai-nightly-cu123
 
             .. tab:: ROCm 6.1
 

--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -39,19 +39,19 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
               conda activate your-environment
               python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
-         .. tab:: CUDA 12.1
-
-            .. code-block:: bash
-
-              conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu121
-
          .. tab:: CUDA 12.2
 
             .. code-block:: bash
 
               conda activate your-environment
               python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu122
+
+         .. tab:: CUDA 12.3
+
+            .. code-block:: bash
+
+              conda activate your-environment
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu123
 
          .. tab:: ROCm 6.1
 


### PR DESCRIPTION
This PR updates documents to add the CUDA 12.3 packages and deprecate the 12.1 package support. We need CUDA 12.3 for some CUTLASS kernels in H100 GPUs.