### PR TITLE
[Fix][Bench] Improve determinism and log dump

### DIFF
--- a/python/mlc_llm/bench/request_record.py
+++ b/python/mlc_llm/bench/request_record.py
@@ -46,11 +46,13 @@ class Metrics(BaseModel):
 class RequestRecord(BaseModel):
     """The request records collected from LLM inference requests."""
 
+    request_id: Optional[int] = None
     chat_cmpl: ChatCompletionRequest
     output_str: Optional[str] = None
     first_chunk_output_str: str = ""
     timestamp: Optional[float] = None
     metrics: Optional[Metrics] = None
+    error_msg: Optional[str] = None
 
 
 def generate_metrics_summary(
@@ -93,9 +95,12 @@ def generate_metrics_summary(
     if server_report is not None and len(server_report) > 0:
         report["server_metrics"] = server_report
 
-    report["exec_feature"] = (
-        request_records[0].metrics.exec_feature if num_completed_requests > 0 else None
-    )
+    report = {
+        "exec_feature": (
+            request_records[0].metrics.exec_feature if num_completed_requests > 0 else None
+        ),
+        **report,
+    }
     return report
 
 


### PR DESCRIPTION
This PR updates the benchmark with the following changes:

1. Fix the preprocessing of ShareGPT dataset. In ShareGPT dataset, sometimes a conversation entry starts with role GPT instead of role human, but previously the benchmark always selects the first message as the input and second as output. Therefore it might cause sending the GPT output in the dataset as a request input to benchmark servers. This does not align with the expectation and we thus fix it.

2. We make sure that for a given seed, given tokenizer and a given number of requests, the sampled requests are always the same across different runs. This improves the determinism and reproducibility.

3. Introduce logging raw request records into file. The raw request records include all information of a request, including its input prompt, measured metrics, error message, etc.