### PR TITLE
[Bench] Support applying chat template

### DIFF
--- a/python/mlc_llm/bench/__main__.py
+++ b/python/mlc_llm/bench/__main__.py
@@ -318,6 +318,13 @@ if __name__ == "__main__":
         help='Whether to set the "ignore_eos" field.',
     )
     parser.add_argument(
+        "--apply-chat-template",
+        default=False,
+        action="store_true",
+        help="Whether to apply chat template to the request input text. "
+        'It is not supported when "--input-len" is specified.',
+    )
+    parser.add_argument(
         "--num-process-workers",
         type=int,
         help="The number of parallel process workers to send the requests.",

--- a/python/mlc_llm/bench/request_record.py
+++ b/python/mlc_llm/bench/request_record.py
@@ -236,6 +236,8 @@ def pretty_print_report(report: Dict[str, Any]) -> None:  # pylint: disable=too-
 
         input_tokens = report["input_tokens"]
         print(" Input Tokens ".center(50, "-"))
+        print(f"{'Mean:':<40} {input_tokens['mean']:<1}")
+        print(f"{'Stddev:':<40} {input_tokens['stddev']:<1}")
         print(f"{'P25:':<40} {input_tokens['quantiles']['p25']:<1}")
         print(f"{'P50:':<40} {input_tokens['quantiles']['p50']:<1}")
         print(f"{'P95:':<40} {input_tokens['quantiles']['p95']:<1}")
@@ -244,11 +246,13 @@ def pretty_print_report(report: Dict[str, Any]) -> None:  # pylint: disable=too-
 
         output_tokens = report["output_tokens"]
         print(" Output Tokens ".center(50, "-"))
-        print(f"{'P25:':<40} {output_tokens['quantiles']['p25']:<10}")
-        print(f"{'P50:':<40} {output_tokens['quantiles']['p50']:<10}")
-        print(f"{'P95:':<40} {output_tokens['quantiles']['p95']:<10}")
-        print(f"{'Min:':<40} {output_tokens['min']:<10}")
-        print(f"{'Max:':<40} {output_tokens['max']:<10}")
+        print(f"{'Mean:':<40} {output_tokens['mean']:<1}")
+        print(f"{'Stddev:':<40} {output_tokens['stddev']:<1}")
+        print(f"{'P25:':<40} {output_tokens['quantiles']['p25']:<1}")
+        print(f"{'P50:':<40} {output_tokens['quantiles']['p50']:<1}")
+        print(f"{'P95:':<40} {output_tokens['quantiles']['p95']:<1}")
+        print(f"{'Min:':<40} {output_tokens['min']:<1}")
+        print(f"{'Max:':<40} {output_tokens['max']:<1}")
 
         print("=" * 50)
 


### PR DESCRIPTION
This PR supports applying tokenizer chat template in benchmarking. It needs to be manually specified via flag `--apply-chat-template`.

In the following cases `--apply-chat-template` is not supported:

* when `--input-len` is also specified, which means the input text needs truncation.
* when the dataset is not ShareGPT.
* when the tokenizer does not have `chat_template` defined.