### PR TITLE
[Bench] Specialize OpenAI endpoint for backends not supporting debug config

### DIFF
--- a/python/mlc_llm/bench/dataset.py
+++ b/python/mlc_llm/bench/dataset.py
@@ -85,8 +85,13 @@ class ShareGPTDataset(Dataset):  # pylint: disable=too-few-public-methods
         ).input_ids
         self._tokenized_dataset: List[Tuple[str, List[int], int]] = []
         for i in range(len(_dataset)):
-            if len(prompt_token_ids[i]) < 4:
-                # Filter out sequences that are too short
+            if (
+                len(prompt_token_ids[i]) < 4
+                or len(completion_token_ids[i]) < 4
+                or len(prompt_token_ids[i]) + len(completion_token_ids[i])
+                >= min(tokenizer.model_max_length, 8192)
+            ):
+                # Filter out sequences that are too short or too long
                 continue
             self._tokenized_dataset.append(
                 (prompts[i], prompt_token_ids[i], len(completion_token_ids[i]))

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -151,9 +151,13 @@ class MetricAnalyzer(RequestProcessor):  # pylint: disable=too-few-public-method
                 assert request_record.error_msg is not None
                 continue
 
-            metrics.output_tokens = len(self.tokenizer.encode(request_record.output_str))
+            metrics.output_tokens = len(
+                self.tokenizer.encode(request_record.output_str, add_special_tokens=False)
+            )
             first_chunk_output_tokens = len(
-                self.tokenizer.encode(request_record.first_chunk_output_str)
+                self.tokenizer.encode(
+                    request_record.first_chunk_output_str, add_special_tokens=False
+                )
             )
             if metrics.output_tokens <= first_chunk_output_tokens:
                 metrics.success = False


### PR DESCRIPTION
This PR specializes the OpenAI endpoint with the option of "not attaching `debug_config`". Prior to this PR, when `--ignore-eos` is enabled, a `debug_config` field is included in the payload for MLC to recognize. However, some backend servers (e.g., vLLM) do not support this `debug_config` field. So we need to manually specify not attaching this field when benchmarking these backends.