### PR TITLE
[Bench] Update API backend names

### DIFF
--- a/python/mlc_llm/bench/api_endpoint.py
+++ b/python/mlc_llm/bench/api_endpoint.py
@@ -436,19 +436,21 @@ class TensorRTLLMEndPoint(APIEndPoint):
 
 SUPPORTED_BACKENDS = [
     "openai",
-    "openai-no-debug-config",
     "openai-chat",
+    "mlc",
+    "sglang",
     "tensorrt-llm",
+    "vllm",
 ]
 
 
 def create_api_endpoint(args: argparse.Namespace) -> APIEndPoint:
     """Create an API endpoint instance with regard to the specified endpoint kind."""
-    if args.api_endpoint == "openai":
+    if args.api_endpoint in ["openai", "mlc", "sglang"]:
         return OpenAIEndPoint(args.host, args.port, args.timeout, args.include_server_metrics)
-    if args.api_endpoint == "openai-no-debug-config":
+    if args.api_endpoint == "vllm":
         return OpenAIEndPoint(
-            args.host, args.port, args.timeout, args.include_server_metrics, no_debug_config=True
+            args.host, args.port, args.timeout, include_server_metrics=False, no_debug_config=True
         )
     if args.api_endpoint == "openai-chat":
         return OpenAIChatEndPoint(args.host, args.port, args.timeout, args.include_server_metrics)


### PR DESCRIPTION
This PR updates the backend names, introducing one name per backend framework. These backends may refer to the same api endpoint.