### PR TITLE
[Model] Update default prefill chunk size of Deepseek

### DIFF
--- a/python/mlc_llm/model/deepseek/deepseek_model.py
+++ b/python/mlc_llm/model/deepseek/deepseek_model.py
@@ -79,17 +79,17 @@ class DeepseekConfig(ConfigBase):  # pylint: disable=too-many-instance-attribute
             logger.info(
                 "%s defaults to %d",
                 bold("prefill_chunk_size"),
-                min(self.context_window_size, 2048),
+                min(self.context_window_size, 8192),
             )
-            self.prefill_chunk_size = min(self.context_window_size, 2048)
+            self.prefill_chunk_size = min(self.context_window_size, 8192)
         elif self.prefill_chunk_size > self.context_window_size:
             logger.info(
                 "Overriding %s from %d to %d",
                 bold("prefill_chunk_size"),
                 self.prefill_chunk_size,
-                min(self.context_window_size, 2048),
+                min(self.context_window_size, 8192),
             )
-            self.prefill_chunk_size = min(self.context_window_size, 2048)
+            self.prefill_chunk_size = min(self.context_window_size, 8192)
 
 
 # pylint: disable=invalid-name,missing-docstring


### PR DESCRIPTION
This PR updates the default prefill chunk size from 2048 to 8192 of Deepseek, just the same as other models.
