### PR TITLE
[Model] Keep vision encoder weights unquantized to maintain accuracy

### DIFF
--- a/python/mlc_llm/model/vision/clip_vision.py
+++ b/python/mlc_llm/model/vision/clip_vision.py
@@ -218,6 +218,8 @@ class CLIPVisionTransformer(Module):
 
 
 class CLIPVisionModel(Module):
+    no_quantization: bool = True
+
     def __init__(self, config: CLIPVisionConfig):
         super().__init__()
         self.vision_model = CLIPVisionTransformer(config)

--- a/python/mlc_llm/quantization/group_quantization.py
+++ b/python/mlc_llm/quantization/group_quantization.py
@@ -111,6 +111,9 @@ class GroupQuantize:  # pylint: disable=too-many-instance-attributes
                 ret_node: Any
                     The new node to replace current node.
                 """
+                if getattr(node, "no_quantization", False):
+                    return node
+
                 if (
                     isinstance(node, nn.Linear)
                     and (not is_final_fc(name) or self.config.quantize_final_fc)


### PR DESCRIPTION
This PR ensures that vision encoder layers are excluded from quantization, improving accuracy for models with vision components.