### PR TITLE
[Python] Add sentencepiece as installation requirement

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -104,6 +104,7 @@ def main():
             "safetensors",
             "requests",
             "tqdm",
+            "sentencepiece",
             "tiktoken",
             "prompt_toolkit",
             "openai",


### PR DESCRIPTION
This PR adds the sentencepiece package as a Python installation requirement for tokenizer coverage when running `gen_config`.