### PR TITLE
[Python] Skip termination when engine is not initialized

### DIFF
--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -659,6 +659,8 @@ class MLCEngineBase:  # pylint: disable=too-many-instance-attributes,too-few-pub
         if hasattr(self, "_terminated") and self._terminated:
             return
         self._terminated = True
+        if not hasattr(self, "_ffi"):
+            return
         self._ffi["exit_background_loop"]()
         if hasattr(self, "_background_loop_thread"):
             self._background_loop_thread.join()


### PR DESCRIPTION
This PR skips the MLCEngine termination when the engine is not initialized at all (e.g., failed during JIT compilation). Previously there will be an extra error message saying `'MLCEngine' object has no attribute '_ffi'` which is confusing and misleading. Skipping the termination can eliminate this error message.