### PR TITLE
[Python] Add flag to disable logging config

### DIFF
--- a/python/mlc_llm/bench/api_endpoint.py
+++ b/python/mlc_llm/bench/api_endpoint.py
@@ -12,7 +12,6 @@ from typing_extensions import Self
 from mlc_llm.bench.request_record import Metrics, RequestRecord, ServerMetrics
 from mlc_llm.support import logging
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -19,7 +19,6 @@ from mlc_llm.bench.request_record import RequestRecord
 from mlc_llm.protocol.openai_api_protocol import ChatCompletionMessage, DebugConfig
 from mlc_llm.support import logging
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/bench/request_record.py
+++ b/python/mlc_llm/bench/request_record.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 from mlc_llm.protocol.openai_api_protocol import ChatCompletionRequest
 from mlc_llm.support import logging
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/cli/delivery.py
+++ b/python/mlc_llm/cli/delivery.py
@@ -16,7 +16,6 @@ from mlc_llm.support import logging
 from mlc_llm.support.argparse import ArgumentParser
 from mlc_llm.support.style import bold, green, red
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 GEN_CONFIG_OPTIONAL_ARGS = [

--- a/python/mlc_llm/cli/lib_delivery.py
+++ b/python/mlc_llm/cli/lib_delivery.py
@@ -16,7 +16,6 @@ from mlc_llm.support.argparse import ArgumentParser
 from mlc_llm.support.constants import MLC_TEMP_DIR
 from mlc_llm.support.style import bold, green, red
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/cli/model_metadata.py
+++ b/python/mlc_llm/cli/model_metadata.py
@@ -13,7 +13,6 @@ from mlc_llm.support.argparse import ArgumentParser
 from mlc_llm.support.config import ConfigBase
 from mlc_llm.support.style import green, red
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/serve/engine.py
+++ b/python/mlc_llm/serve/engine.py
@@ -30,7 +30,6 @@ from mlc_llm.tokenizers import TextStreamer
 
 from . import engine_base
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/serve/engine_base.py
+++ b/python/mlc_llm/serve/engine_base.py
@@ -28,7 +28,6 @@ from mlc_llm.support.auto_device import detect_device
 from mlc_llm.support.style import green
 from mlc_llm.tokenizers import TextStreamer, Tokenizer
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/serve/sync_engine.py
+++ b/python/mlc_llm/serve/sync_engine.py
@@ -29,7 +29,6 @@ from mlc_llm.serve.request import Request
 from mlc_llm.support import logging
 from mlc_llm.tokenizers import TextStreamer, Tokenizer
 
-logging.enable_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/python/mlc_llm/support/logging.py
+++ b/python/mlc_llm/support/logging.py
@@ -3,8 +3,8 @@ Logging support for MLC. It derives from Python's logging module, and in the fut
 it can be easily replaced by other logging modules such as structlog.
 """
 
-import os
 import logging
+import os
 
 
 def enable_logging():

--- a/python/mlc_llm/support/logging.py
+++ b/python/mlc_llm/support/logging.py
@@ -9,7 +9,7 @@ import logging
 
 def enable_logging():
     """Enable MLC's default logging format"""
-    if os.getenv('MLC_UNSET_LOGGING'):
+    if os.getenv("MLC_UNSET_LOGGING"):
         return
     logging.basicConfig(
         level=logging.INFO,

--- a/python/mlc_llm/support/logging.py
+++ b/python/mlc_llm/support/logging.py
@@ -3,11 +3,14 @@ Logging support for MLC. It derives from Python's logging module, and in the fut
 it can be easily replaced by other logging modules such as structlog.
 """
 
+import os
 import logging
 
 
 def enable_logging():
     """Enable MLC's default logging format"""
+    if os.getenv('MLC_UNSET_LOGGING'):
+        return
     logging.basicConfig(
         level=logging.INFO,
         style="{",


### PR DESCRIPTION
Fixes #2780

This adds a environment variable `MLC_UNSET_LOGGING` to force the logging format to be disabled. It also removes `enable_logging` calls except for in MLC entrypoints (e.g. CLI main).