### PR TITLE
Add prefix-cache dataset in mlc bench

### DIFF
--- a/python/mlc_llm/bench/__main__.py
+++ b/python/mlc_llm/bench/__main__.py
@@ -101,15 +101,15 @@ def run_pipeline(
         args.output_len_std,
     )
     request_records = pipeline(request_records)
-    assert len(request_records) == args.num_requests
-    sorted_requests: List[RequestRecord] = [None] * args.num_requests
+    assert len(request_records) == args.num_requests * args.num_gpus
+    sorted_requests: List[RequestRecord] = [None] * args.num_requests * args.num_gpus
     for request_record in request_records:
         assert request_record.request_id is not None
         assert sorted_requests[request_record.request_id] is None
         sorted_requests[request_record.request_id] = request_record
 
     request_records = MetricAnalyzer(tokenizer)(request_records)
-    report = generate_metrics_summary(request_records, args.num_requests, args.num_gpus)
+    report = generate_metrics_summary(request_records, args.num_requests * args.num_gpus, args.num_gpus)
     return report, sorted_requests
 
 
@@ -135,7 +135,7 @@ def main(args: argparse.argparse.Namespace):
         tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
         dataset = create_dataset(args, tokenizer)
         f_create_api_endpoint = functools.partial(create_api_endpoint, args)
-        pipelines = create_pipelines(args, f_create_api_endpoint)
+        pipelines = create_pipelines(args, f_create_api_endpoint, dataset)
         reports = []
         alltime_records = {}
         for i, pipeline in enumerate(pipelines):
@@ -291,6 +291,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--timeout",
         type=float,
+        default=3 * 60 * 60,
         help="The timeout limit of each request.",
     )
     parser.add_argument(
@@ -378,6 +379,12 @@ if __name__ == "__main__":
         help="Whether to chat like mulit round conversion with history log each request. "
         "Only enabled when benchmarked with fixed concurrent request mode."
         "The --num-concurrent-requests should be provided when enabling this option.",
+    )
+
+    parser.add_argument(
+        "--testset-name",
+        type=str,
+        help="The name of the testset. Only used for Loogle dataset"
     )
 
     main(parser.parse_args())

--- a/python/mlc_llm/bench/__main__.py
+++ b/python/mlc_llm/bench/__main__.py
@@ -109,7 +109,9 @@ def run_pipeline(
         sorted_requests[request_record.request_id] = request_record
 
     request_records = MetricAnalyzer(tokenizer)(request_records)
-    report = generate_metrics_summary(request_records, args.num_requests * args.num_gpus, args.num_gpus)
+    report = generate_metrics_summary(
+        request_records, args.num_requests * args.num_gpus, args.num_gpus
+    )
     return report, sorted_requests
 
 
@@ -382,9 +384,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--testset-name",
-        type=str,
-        help="The name of the testset. Only used for Loogle dataset"
+        "--testset-name", type=str, help="The name of the testset. Only used for Loogle dataset"
     )
 
     main(parser.parse_args())

--- a/python/mlc_llm/bench/api_endpoint.py
+++ b/python/mlc_llm/bench/api_endpoint.py
@@ -58,7 +58,7 @@ class OpenAIChatEndPoint(APIEndPoint):
     async def __aenter__(self) -> Self:
         import aiohttp  # pylint: disable=import-outside-toplevel,import-error
 
-        self.client = aiohttp.ClientSession()
+        self.client = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(self.timeout))
         return self
 
     async def __aexit__(self, exc_type, exc_value, tb) -> None:
@@ -250,7 +250,7 @@ class OpenAIEndPoint(APIEndPoint):
         start_time = time.monotonic()
 
         try:
-            async with self.client.post(self.url, json=payload, headers=self.headers) as response:
+            async with self.client.post(self.url, json=payload, headers=self.headers, timeout=3600) as response:
                 assert response.status == 200, await response.text()
                 if payload["stream"]:
                     async for chunk in response.content:

--- a/python/mlc_llm/bench/api_endpoint.py
+++ b/python/mlc_llm/bench/api_endpoint.py
@@ -250,7 +250,9 @@ class OpenAIEndPoint(APIEndPoint):
         start_time = time.monotonic()
 
         try:
-            async with self.client.post(self.url, json=payload, headers=self.headers, timeout=3600) as response:
+            async with self.client.post(
+                self.url, json=payload, headers=self.headers, timeout=3600
+            ) as response:
                 assert response.status == 200, await response.text()
                 if payload["stream"]:
                     async for chunk in response.content:

--- a/python/mlc_llm/bench/dataset.py
+++ b/python/mlc_llm/bench/dataset.py
@@ -164,13 +164,14 @@ class ShareGPTDataset(Dataset):  # pylint: disable=too-few-public-methods
 class LoogleDataset(Dataset):  # pylint: disable=too-few-public-methods
     """The dataset class for Loogle dataset."""
 
+    # pylint: disable=line-too-long
     task2prompt = {
         "shortdep_qa": "Please answer the question based on the long texts below. \n{input}\nQuestion: {Q}\nAnswer: ",
         "longdep_qa": "Please answer the question based on the long texts below. \n{input}\nQuestion: {Q}\nAnswer: ",
         "longdep_summarization": "Please generate a summary of the below paper. \n{input}\n Summarization: ",
         "shortdep_cloze": "Please fill in the clozes based on the given long texts below. Each of the placeholder '<mask-n>' in the question could be an entity of Person, Location or Organiocation. The same masks represent the same entity. Output a json format answer, for example: {{'<mask-0>': 'Bob', '<mask-1>': 'Gorrosion Magazine','<mask-2>': 'Bethel Horizon'}}\n{input}\n Question: {Q} What are the masked entities? \nAnswer:",
-        # pylint: disable=line-too-long
     }
+    # pylint: enable=line-too-long
     require_fake_warmup: bool = True
 
     def __init__(self, tokenizer: AutoTokenizer, testset_name) -> None:
@@ -405,7 +406,7 @@ class ReActDataset(Dataset):  # pylint: disable=too-few-public-methods
 
     _dataset: List[List[Tuple[str, int, int]]]
     require_fake_warmup: bool = True
-
+    # pylint: disable=line-too-long
     prefix: str = """Solve a question answering task with interleaving Thought, Action, Observation steps. Thought can reason about the current situation, and Action can be three types:
 (1) Search[entity], which searches the exact entity on Wikipedia and returns the first paragraph if it exists. If not, it will return some similar entities to search.
 (2) Lookup[keyword], which returns the next sentence containing keyword in the current passage.
@@ -472,11 +473,12 @@ Action 2: Search[Leonid Levin]
 Observation 2: Leonid Anatolievich Levin is a Soviet-American mathematician and computer scientist.
 Thought 3: Leonid Levin is a mathematician and computer scientist. So Pavel Urysohn and Leonid Levin have the same type of work.
 Action 3: Finish[yes]
-"""  # pylint: disable=line-too-long
+"""
 
-    def __init__(
+    # pylint: enable=line-too-long
+    def __init__(  # pylint: disable=too-many-locals
         self, dataset_path: str, tokenizer: AutoTokenizer
-    ) -> None:  # pylint: disable=too-many-locals
+    ) -> None:
         raw_entries: List[Dict] = []
         with open(dataset_path) as fin:  # pylint: disable=unspecified-encoding
             for line in fin:

--- a/python/mlc_llm/bench/dataset.py
+++ b/python/mlc_llm/bench/dataset.py
@@ -161,13 +161,15 @@ class ShareGPTDataset(Dataset):  # pylint: disable=too-few-public-methods
         return request_records
 
 
-class LoogleDataset(Dataset):
-    # task2maxlen = {"shortdep_qa": 300, "longdep_qa": 500, "longdep_summarization": 500, "shortdep_cloze": 50}
+class LoogleDataset(Dataset):  # pylint: disable=too-few-public-methods
+    """The dataset class for Loogle dataset."""
+
     task2prompt = {
         "shortdep_qa": "Please answer the question based on the long texts below. \n{input}\nQuestion: {Q}\nAnswer: ",
         "longdep_qa": "Please answer the question based on the long texts below. \n{input}\nQuestion: {Q}\nAnswer: ",
         "longdep_summarization": "Please generate a summary of the below paper. \n{input}\n Summarization: ",
         "shortdep_cloze": "Please fill in the clozes based on the given long texts below. Each of the placeholder '<mask-n>' in the question could be an entity of Person, Location or Organiocation. The same masks represent the same entity. Output a json format answer, for example: {{'<mask-0>': 'Bob', '<mask-1>': 'Gorrosion Magazine','<mask-2>': 'Bethel Horizon'}}\n{input}\n Question: {Q} What are the masked entities? \nAnswer:",
+        # pylint: disable=line-too-long
     }
     require_fake_warmup: bool = True
 
@@ -183,7 +185,7 @@ class LoogleDataset(Dataset):
         for data in raw_dataset:
             prompt = data["input"]
             prompts.append(prompt)
-            qa_pairs = eval(data["qa_pairs"])
+            qa_pairs = eval(data["qa_pairs"])  # pylint: disable=eval-used
             questions.append([j["Q"] for j in qa_pairs])
             generate_lens.append(
                 [len(tokenizer.encode(j["A"], add_special_tokens=False)) for j in qa_pairs]
@@ -194,10 +196,12 @@ class LoogleDataset(Dataset):
             max_length=min(tokenizer.model_max_length, self.truncate_length),
             add_special_tokens=False,
         ).input_ids
-        for i in range(len(prompts)):
-            self.dataset.append((prompts[i], prompt_token_ids[i], questions[i], generate_lens[i]))
+        for prompt, prompt_token_id, question, generate_len in zip(
+            prompts, prompt_token_ids, questions, generate_lens
+        ):
+            self.dataset.append((prompt, prompt_token_id, question, generate_len))
 
-    def generate_request_records(
+    def generate_request_records(  # pylint: disable=too-many-locals
         self,
         input_len: Optional[int],
         output_len: Optional[int],
@@ -285,7 +289,6 @@ class LLMPerfDataset(Dataset):  # pylint: disable=too-few-public-methods
             output_len = 150
 
         request_records = []
-        original_dataset = self.dataset.copy()
         for _ in range(self.num_requests):
             input_length = round(float(np.random.normal(loc=input_len, scale=input_len_std)))
             output_length = round(float(np.random.normal(loc=output_len, scale=output_len_std)))
@@ -469,11 +472,13 @@ Action 2: Search[Leonid Levin]
 Observation 2: Leonid Anatolievich Levin is a Soviet-American mathematician and computer scientist.
 Thought 3: Leonid Levin is a mathematician and computer scientist. So Pavel Urysohn and Leonid Levin have the same type of work.
 Action 3: Finish[yes]
-"""
+"""  # pylint: disable=line-too-long
 
-    def __init__(self, dataset_path: str, tokenizer: AutoTokenizer) -> None:
+    def __init__(
+        self, dataset_path: str, tokenizer: AutoTokenizer
+    ) -> None:  # pylint: disable=too-many-locals
         raw_entries: List[Dict] = []
-        with open(dataset_path) as fin:
+        with open(dataset_path) as fin:  # pylint: disable=unspecified-encoding
             for line in fin:
                 line_content = json.loads(line)
                 raw_entries += list({"question": k, "triplets": v} for k, v in line_content.items())

--- a/python/mlc_llm/bench/dataset.py
+++ b/python/mlc_llm/bench/dataset.py
@@ -162,7 +162,6 @@ class ShareGPTDataset(Dataset):  # pylint: disable=too-few-public-methods
 
 
 class LoogleDataset(Dataset):
-
     # task2maxlen = {"shortdep_qa": 300, "longdep_qa": 500, "longdep_summarization": 500, "shortdep_cloze": 50}
     task2prompt = {
         "shortdep_qa": "Please answer the question based on the long texts below. \n{input}\nQuestion: {Q}\nAnswer: ",

--- a/python/mlc_llm/bench/dataset.py
+++ b/python/mlc_llm/bench/dataset.py
@@ -3,13 +3,13 @@
 import argparse
 import json
 import random
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from datasets import load_dataset  # pylint: disable=import-error
 from transformers import AutoTokenizer  # pylint: disable=import-error
 
-from mlc_llm.bench.request_record import Metrics, RequestRecord
+from mlc_llm.bench.request_record import GroupedRequestRecord, Metrics, RequestRecord
 from mlc_llm.protocol.openai_api_protocol import (
     ChatCompletionMessage,
     ChatCompletionRequest,
@@ -22,6 +22,9 @@ class Dataset:  # pylint: disable=too-few-public-methods
 
     # We set a truncation limit of 100k.
     truncate_length = int(1e5)
+    # For some that datasets (e.g., dataset that has shared common prefix),
+    # we need fake warmup requests to avoid prefilling common prefixes to the engine.
+    require_fake_warmup: bool = False
 
     def generate_request_records(
         self,
@@ -158,6 +161,97 @@ class ShareGPTDataset(Dataset):  # pylint: disable=too-few-public-methods
         return request_records
 
 
+class LoogleDataset(Dataset):
+
+    # task2maxlen = {"shortdep_qa": 300, "longdep_qa": 500, "longdep_summarization": 500, "shortdep_cloze": 50}
+    task2prompt = {
+        "shortdep_qa": "Please answer the question based on the long texts below. \n{input}\nQuestion: {Q}\nAnswer: ",
+        "longdep_qa": "Please answer the question based on the long texts below. \n{input}\nQuestion: {Q}\nAnswer: ",
+        "longdep_summarization": "Please generate a summary of the below paper. \n{input}\n Summarization: ",
+        "shortdep_cloze": "Please fill in the clozes based on the given long texts below. Each of the placeholder '<mask-n>' in the question could be an entity of Person, Location or Organiocation. The same masks represent the same entity. Output a json format answer, for example: {{'<mask-0>': 'Bob', '<mask-1>': 'Gorrosion Magazine','<mask-2>': 'Bethel Horizon'}}\n{input}\n Question: {Q} What are the masked entities? \nAnswer:",
+    }
+    require_fake_warmup: bool = True
+
+    def __init__(self, tokenizer: AutoTokenizer, testset_name) -> None:
+        raw_dataset = load_dataset("bigainlco/LooGLE", testset_name, split="test")
+        self.tokenizer = tokenizer
+        self.dataset = []
+        self.prompt_format = self.task2prompt[testset_name]
+        # self.max_gen = self.task2maxlen[testset_name]
+        prompts = []
+        generate_lens = []
+        questions = []
+        for data in raw_dataset:
+            prompt = data["input"]
+            prompts.append(prompt)
+            qa_pairs = eval(data["qa_pairs"])
+            questions.append([j["Q"] for j in qa_pairs])
+            generate_lens.append(
+                [len(tokenizer.encode(j["A"], add_special_tokens=False)) for j in qa_pairs]
+            )
+        prompt_token_ids = tokenizer(
+            prompts,
+            truncation=True,
+            max_length=min(tokenizer.model_max_length, self.truncate_length),
+            add_special_tokens=False,
+        ).input_ids
+        for i in range(len(prompts)):
+            self.dataset.append((prompts[i], prompt_token_ids[i], questions[i], generate_lens[i]))
+
+    def generate_request_records(
+        self,
+        input_len: Optional[int],
+        output_len: Optional[int],
+        input_len_std: float = 0.0,
+        output_len_std: float = 0.0,
+    ) -> List[RequestRecord]:
+        request_records = []
+        for prompt, input_token_ids, questions, generate_lens in self.dataset:
+            input_length = round(float(np.random.normal(loc=input_len, scale=input_len_std)))
+            if len(input_token_ids) > input_length:
+                input_token_ids = input_token_ids[:input_length]
+                prompt = self.tokenizer.decode(input_token_ids)
+            grouped_request_records = []
+            for question, generate_len in zip(questions, generate_lens):
+                json_obj = {"input": prompt, "Q": question}
+                full_prompt = self.prompt_format.format(**json_obj)
+
+                output_length = (
+                    round(float(np.random.normal(loc=output_len, scale=output_len_std, size=1)[0]))
+                    if output_len is not None
+                    else generate_len
+                )
+                grouped_request_records.append(
+                    RequestRecord(
+                        chat_cmpl=ChatCompletionRequest(
+                            messages=[
+                                {
+                                    "role": "user",
+                                    "content": full_prompt,
+                                }
+                            ],
+                            model="",
+                            max_tokens=output_length,
+                        ),
+                        metrics=Metrics(
+                            success=False,
+                            start_time=0,
+                            finish_time=0,
+                            end_to_end_latency_s=0,
+                            input_tokens=len(input_token_ids),
+                        ),
+                    )
+                )
+            request_records.append(
+                GroupedRequestRecord(
+                    # Create a dummy ChatCompletionRequest.
+                    chat_cmpl=ChatCompletionRequest(messages=[]),
+                    records=grouped_request_records,
+                )
+            )
+        return request_records
+
+
 class LLMPerfDataset(Dataset):  # pylint: disable=too-few-public-methods
     """The dataset class for LLMPerf dataset."""
 
@@ -192,6 +286,7 @@ class LLMPerfDataset(Dataset):  # pylint: disable=too-few-public-methods
             output_len = 150
 
         request_records = []
+        original_dataset = self.dataset.copy()
         for _ in range(self.num_requests):
             input_length = round(float(np.random.normal(loc=input_len, scale=input_len_std)))
             output_length = round(float(np.random.normal(loc=output_len, scale=output_len_std)))
@@ -296,6 +391,186 @@ class JSONModeEvalDataset(Dataset):  # pylint: disable=too-few-public-methods
                         end_to_end_latency_s=0,
                         input_tokens=num_tokens,
                     ),
+                )
+            )
+        return request_records
+
+
+class ReActDataset(Dataset):  # pylint: disable=too-few-public-methods
+    """The dataset class for replaying a given ReAct trace for benchmark purpose.
+    It is not an actual ReAct agent implementation.
+    """
+
+    _dataset: List[List[Tuple[str, int, int]]]
+    require_fake_warmup: bool = True
+
+    prefix: str = """Solve a question answering task with interleaving Thought, Action, Observation steps. Thought can reason about the current situation, and Action can be three types:
+(1) Search[entity], which searches the exact entity on Wikipedia and returns the first paragraph if it exists. If not, it will return some similar entities to search.
+(2) Lookup[keyword], which returns the next sentence containing keyword in the current passage.
+(3) Finish[answer], which returns the answer and finishes the task.
+Here are some examples.
+Question: What is the elevation range for the area that the eastern sector of the Colorado orogeny extends into?
+Thought 1: I need to search Colorado orogeny, find the area that the eastern sector of the Colorado orogeny extends into, then find the elevation range of the area.
+Action 1: Search[Colorado orogeny]
+Observation 1: The Colorado orogeny was an episode of mountain building (an orogeny) in Colorado and surrounding areas.
+Thought 2: It does not mention the eastern sector. So I need to look up eastern sector.
+Action 2: Lookup[eastern sector]
+Observation 2: (Result 1 / 1) The eastern sector extends into the High Plains and is called the Central Plains orogeny.
+Thought 3: The eastern sector of Colorado orogeny extends into the High Plains. So I need to search High Plains and find its elevation range.
+Action 3: Search[High Plains]
+Observation 3: High Plains refers to one of two distinct land regions:
+Thought 4: I need to instead search High Plains (United States).
+Action 4: Search[High Plains (United States)]
+Observation 4: The High Plains are a subregion of the Great Plains. From east to west, the High Plains rise in elevation from around 1,800 to 7,000 ft (550 to 2,130 m).[3]
+Thought 5: High Plains rise in elevation from around 1,800 to 7,000 ft, so the answer is 1,800 to 7,000 ft.
+Action 5: Finish[1,800 to 7,000 ft]
+Question: Musician and satirist Allie Goertz wrote a song about the "The Simpsons" character Milhouse, who Matt Groening named after who?
+Thought 1: The question simplifies to "The Simpsons" character Milhouse is named after who. I only need to search Milhouse and find who it is named after.
+Action 1: Search[Milhouse]
+Observation 1: Milhouse Mussolini Van Houten is a recurring character in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt Groening.
+Thought 2: The paragraph does not tell who Milhouse is named after, maybe I can look up "named after".
+Action 2: Lookup[named after]
+Observation 2: (Result 1 / 1) Milhouse was named after U.S. president Richard Nixon, whose middle name was Milhous.
+Thought 3: Milhouse was named after U.S. president Richard Nixon, so the answer is Richard Nixon.
+Action 3: Finish[Richard Nixon]
+Question: Which documentary is about Finnish rock groups, Adam Clayton Powell or The Saimaa Gesture?
+Thought 1: I need to search Adam Clayton Powell and The Saimaa Gesture, and find which documentary is about Finnish rock groups.
+Action 1: Search[Adam Clayton Powell]
+Observation 1: Could not find [Adam Clayton Powell]. Similar: ['Adam Clayton Powell III', 'Seventh Avenue (Manhattan)', 'Adam Clayton Powell Jr. State Office Building', 'Isabel Washington Powell', 'Adam Powell', 'Adam Clayton Powell (film)', 'Giancarlo Esposito'].
+Thought 2: To find the documentary, I can search Adam Clayton Powell (film).
+Action 2: Search[Adam Clayton Powell (film)]
+Observation 2: Adam Clayton Powell is a 1989 American documentary film directed by Richard Kilberg.
+The film is about the rise and fall of influential African-American politician Adam Clayton Powell Jr.[3][4] It was later aired as part of the PBS series The American Experience.
+Thought 3: Adam Clayton Powell (film) is a documentary about an African-American politician, not Finnish rock groups. So the documentary about Finnish rock groups must instead be The Saimaa Gesture.
+Action 3: Finish[The Saimaa Gesture]
+Question: What profession does Nicholas Ray and Elia Kazan have in common?
+Thought 1: I need to search Nicholas Ray and Elia Kazan, find their professions, then find the profession they have in common.
+Action 1: Search[Nicholas Ray]
+Observation 1: Nicholas Ray (born Raymond Nicholas Kienzle Jr., August 7, 1911 – June 16, 1979) was an American film director, screenwriter, and actor best known for the 1955 film Rebel Without a Cause.
+Thought 2: Professions of Nicholas Ray are director, screenwriter, and actor. I need to search Elia Kazan next and find his professions.
+Action 2: Search[Elia Kazan]
+Observation 2: Elia Kazan was an American film and theatre director, producer, screenwriter and actor.
+Thought 3: Professions of Elia Kazan are director, producer, screenwriter, and actor. So profession Nicholas Ray and Elia Kazan have in common is director, screenwriter, and actor.
+Action 3: Finish[director, screenwriter, actor]
+Question: Which magazine was started first Arthur's Magazine or First for Women?
+Thought 1: I need to search Arthur's Magazine and First for Women, and find which was started first.
+Action 1: Search[Arthur's Magazine]
+Observation 1: Arthur's Magazine (1844-1846) was an American literary periodical published in Philadelphia in the 19th century.
+Thought 2: Arthur's Magazine was started in 1844. I need to search First for Women next.
+Action 2: Search[First for Women]
+Observation 2: First for Women is a woman's magazine published by Bauer Media Group in the USA.[1] The magazine was started in 1989.
+Thought 3: First for Women was started in 1989. 1844 (Arthur's Magazine) < 1989 (First for Women), so Arthur's Magazine was started first.
+Action 3: Finish[Arthur's Magazine]
+Question: Were Pavel Urysohn and Leonid Levin known for the same type of work?
+Thought 1: I need to search Pavel Urysohn and Leonid Levin, find their types of work, then find if they are the same.
+Action 1: Search[Pavel Urysohn]
+Observation 1: Pavel Samuilovich Urysohn (February 3, 1898 â August 17, 1924) was a Soviet mathematician who is best known for his contributions in dimension theory.
+Thought 2: Pavel Urysohn is a mathematician. I need to search Leonid Levin next and find its type of work.
+Action 2: Search[Leonid Levin]
+Observation 2: Leonid Anatolievich Levin is a Soviet-American mathematician and computer scientist.
+Thought 3: Leonid Levin is a mathematician and computer scientist. So Pavel Urysohn and Leonid Levin have the same type of work.
+Action 3: Finish[yes]
+"""
+
+    def __init__(self, dataset_path: str, tokenizer: AutoTokenizer) -> None:
+        raw_entries: List[Dict] = []
+        with open(dataset_path) as fin:
+            for line in fin:
+                line_content = json.loads(line)
+                raw_entries += list({"question": k, "triplets": v} for k, v in line_content.items())
+
+        self._dataset = []
+        max_rounds = 0
+        for raw_entry in raw_entries:
+            processed_entry = []
+            question = raw_entry["question"]
+            triplets = raw_entry["triplets"]
+            seq = self.prefix + question
+            max_rounds = max(max_rounds, len(triplets) + 1)
+            output_lengths: List[int] = []
+            for i, triplet in enumerate(triplets):
+                output_lengths.append(
+                    len(
+                        tokenizer(
+                            triplet["thought"]
+                            + "\nAction "
+                            + str(i + 1)
+                            + ": "
+                            + triplet["action"]
+                            + "\n",
+                            truncation=True,
+                            max_length=min(tokenizer.model_max_length, self.truncate_length),
+                            add_special_tokens=False,
+                        ).input_ids
+                    )
+                )
+
+            for i in range(1, len(triplets) + 2):
+                seq += "Thought " + str(i) + ":"
+                input_len = len(
+                    tokenizer(
+                        seq,
+                        truncation=True,
+                        max_length=min(tokenizer.model_max_length, self.truncate_length),
+                        add_special_tokens=False,
+                    ).input_ids
+                )
+                output_length = (
+                    output_lengths[i - 1]
+                    if i <= len(triplets)
+                    else int(sum(output_lengths) / len(triplets))
+                )
+                processed_entry.append((seq, input_len, output_length))
+                if i != len(triplets) + 1:
+                    seq += (
+                        triplets[i - 1]["thought"]
+                        + "\nAction "
+                        + str(i)
+                        + ": "
+                        + triplets[i - 1]["action"]
+                        + "\nObservation "
+                        + str(i)
+                        + ": "
+                        + triplets[i - 1]["observation"]
+                        + "\n"
+                    )
+            self._dataset.append(processed_entry)
+
+    def generate_request_records(
+        self,
+        input_len: Optional[int],
+        output_len: Optional[int],
+        input_len_std: float = 0.0,
+        output_len_std: float = 0.0,
+    ) -> List[RequestRecord]:
+        if input_len is not None or output_len is not None:
+            raise ValueError("ReAct dataset does not support specifying input/output length.")
+
+        request_records = []
+        for processed_entries in self._dataset:
+            grouped_request_records = []
+            for prompt, input_length, output_length in processed_entries:
+                grouped_request_records.append(
+                    RequestRecord(
+                        chat_cmpl=ChatCompletionRequest(
+                            messages=[{"role": "user", "content": prompt}],
+                            model="",
+                            max_tokens=output_length,
+                        ),
+                        metrics=Metrics(
+                            success=False,
+                            start_time=0,
+                            finish_time=0,
+                            end_to_end_latency_s=0,
+                            input_tokens=input_length,
+                        ),
+                    )
+                )
+            request_records.append(
+                GroupedRequestRecord(
+                    # Create a dummy ChatCompletionRequest.
+                    chat_cmpl=ChatCompletionRequest(messages=[]),
+                    records=grouped_request_records,
                 )
             )
         return request_records
@@ -491,6 +766,8 @@ SUPPORTED_DATASET = [
     "sharegpt",
     "llmperf",
     "json-mode-eval",
+    "loogle",
+    "react",
 ]
 
 
@@ -511,10 +788,22 @@ def create_dataset(args: argparse.Namespace, tokenizer: AutoTokenizer) -> "Datas
         assert (
             args.apply_chat_template is False
         ), "LLMPerf dataset does not support applying chat template"
-        return LLMPerfDataset(args.dataset_path, args.num_requests * 4, tokenizer)
+        return LLMPerfDataset(
+            args.dataset_path, (args.num_requests + args.num_warmup_requests) * 4, tokenizer
+        )
     if args.dataset == "json-mode-eval":
         assert (
             args.apply_chat_template is False
         ), "JSON mode evaluation does not support applying chat template"
         return JSONModeEvalDataset(tokenizer)
+    if args.dataset == "loogle":
+        assert (
+            args.apply_chat_template is False
+        ), "Loogle dataset does not support applying chat template"
+        return LoogleDataset(tokenizer, args.testset_name)
+    if args.dataset == "react":
+        assert (
+            args.apply_chat_template is False
+        ), "ReAct dataset does not support applying chat template"
+        return ReActDataset(args.dataset_path, tokenizer)
     raise ValueError(f"Unrecognized dataset {args.dataset}")

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -225,10 +225,10 @@ class MetricAnalyzer(RequestProcessor):  # pylint: disable=too-few-public-method
         return updated_records
 
 
-class WarmupAndRun(RequestProcessor):  # pylint: disable=too-few-public-methods
+class WarmupAndRun(RequestProcessor):  # pylint: disable=too-few-public-methods,line-too-long
     """The processor that runs warmup first and then runs the benchmark with the given pipeline."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         num_warmup_requests: int,
         num_benchmark_requests: int,
@@ -242,12 +242,12 @@ class WarmupAndRun(RequestProcessor):  # pylint: disable=too-few-public-methods
         self.cuda_profile_url = cuda_profile_url
         self.fake_warmup = fake_warmup
 
-    def generate_fake_warmup_requests(
+    def generate_fake_warmup_requests(  # pylint: disable=missing-function-docstring
         self, num_warmup_requests: int, example_request: RequestRecord
     ) -> List[RequestRecord]:
         records = []
-        for i in range(num_warmup_requests):
-            record = example_request.__deepcopy__()
+        for _ in range(num_warmup_requests):
+            record = copy.deepcopy(example_request)
             record.chat_cmpl = ChatCompletionRequest(
                 messages=[
                     {

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -263,7 +263,6 @@ class WarmupAndRun(RequestProcessor):  # pylint: disable=too-few-public-methods
 
     def __call__(self, request_records: List[RequestRecord]) -> List[RequestRecord]:
 
-
         # Warmup
         if self.fake_warmup:
             assert len(request_records) == self.num_benchmark_requests
@@ -628,7 +627,7 @@ def create_pipelines(
         if args.fake_warmup:
             num_samples = int(args.num_requests * args.num_gpus)
         else:
-            num_samples = int(args.num_requests * args.num_gpus)  + args.num_warmup_requests
+            num_samples = int(args.num_requests * args.num_gpus) + args.num_warmup_requests
         return [
             SequentialProcessor(
                 LogMessage(f"Fixing request rate: {request_rate}"),

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -15,8 +15,13 @@ from tqdm import tqdm
 from transformers import AutoTokenizer  # pylint: disable=import-error
 
 from mlc_llm.bench.api_endpoint import APIEndPoint
-from mlc_llm.bench.request_record import RequestRecord
-from mlc_llm.protocol.openai_api_protocol import ChatCompletionMessage, DebugConfig
+from mlc_llm.bench.dataset import Dataset
+from mlc_llm.bench.request_record import GroupedRequestRecord, RequestRecord
+from mlc_llm.protocol.openai_api_protocol import (
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    DebugConfig,
+)
 from mlc_llm.support import logging
 
 logging.enable_logging()
@@ -51,6 +56,19 @@ class SampleRequests(RequestProcessor):  # pylint: disable=too-few-public-method
         self.num_requests = num_requests
 
     def __call__(self, request_records: List[RequestRecord]) -> List[RequestRecord]:
+        assert len(request_records) > 0, "Empty input request record."
+
+        # We expect the input request records to be all grouped or all plain.
+        if isinstance(request_records[0], GroupedRequestRecord):
+            assert all(isinstance(record, GroupedRequestRecord) for record in request_records)
+            return self._sample_from_grouped_request_records(request_records)
+
+        assert all(not isinstance(record, GroupedRequestRecord) for record in request_records)
+        return self._sample_from_plain_request_records(request_records)
+
+    def _sample_from_plain_request_records(
+        self, request_records: List[RequestRecord]
+    ) -> List[RequestRecord]:
         samples: List[RequestRecord] = []
         while len(samples) < self.num_requests:
             # Create a new list so that the in-place shuffle does not mutate the input list.
@@ -58,6 +76,35 @@ class SampleRequests(RequestProcessor):  # pylint: disable=too-few-public-method
             random.shuffle(records)
             samples += copy.deepcopy(records)
         samples = samples[: self.num_requests]
+        for i, record in enumerate(samples):
+            record.request_id = i
+        return samples
+
+    def _sample_from_grouped_request_records(
+        self, grouped_request_records: List[GroupedRequestRecord]
+    ) -> List[RequestRecord]:
+        num_total_available_requests = sum(
+            len(record.records) for record in grouped_request_records
+        )
+        if self.num_requests > num_total_available_requests:
+            raise ValueError(
+                "Due to the existence of shared common prefixes, we do not allow "
+                "benchmarking with requests more than the available requests in the dataset. "
+                f"The required number of requests {self.num_requests} exceeds the "
+                f"number of total available requests {num_total_available_requests}."
+            )
+
+        # Create a new list so that the in-place shuffle does not mutate the input list.
+        records = list(grouped_request_records)
+        random.shuffle(records)
+        remaining = self.num_requests
+        samples: List[RequestRecord] = []
+        for grouped_request_record in grouped_request_records:
+            num_used_requests = min(len(grouped_request_record.records), remaining)
+            samples += grouped_request_record.records[:num_used_requests]
+            remaining -= num_used_requests
+            if remaining == 0:
+                break
         for i, record in enumerate(samples):
             record.request_id = i
         return samples
@@ -187,20 +234,50 @@ class WarmupAndRun(RequestProcessor):  # pylint: disable=too-few-public-methods
         num_benchmark_requests: int,
         pipeline: RequestProcessor,
         cuda_profile_url: Optional[str],
+        fake_warmup: bool = False,
     ) -> None:
         self.num_warmup_requests = num_warmup_requests
         self.num_benchmark_requests = num_benchmark_requests
         self.pipeline = pipeline
         self.cuda_profile_url = cuda_profile_url
+        self.fake_warmup = fake_warmup
+
+    def generate_fake_warmup_requests(
+        self, num_warmup_requests: int, example_request: RequestRecord
+    ) -> List[RequestRecord]:
+        records = []
+        for i in range(num_warmup_requests):
+            record = example_request.__deepcopy__()
+            record.chat_cmpl = ChatCompletionRequest(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Please output arbitrary coherent sentences. Do not output eos token.",
+                    }
+                ],
+                model="",
+                max_tokens=128,
+            )
+            records.append(record)
+        return records
 
     def __call__(self, request_records: List[RequestRecord]) -> List[RequestRecord]:
-        assert len(request_records) == self.num_warmup_requests + self.num_benchmark_requests
-        warmup_requests = request_records[-self.num_warmup_requests :]
-        benchmark_requests = request_records[: -self.num_warmup_requests]
-        for request_record in warmup_requests:
-            request_record.timestamp = 0 if request_record.timestamp is not None else None
+
 
         # Warmup
+        if self.fake_warmup:
+            assert len(request_records) == self.num_benchmark_requests
+            benchmark_requests = request_records
+            example_request = benchmark_requests[0]
+            warmup_requests = self.generate_fake_warmup_requests(
+                self.num_warmup_requests, example_request=example_request
+            )
+        else:
+            assert len(request_records) == self.num_warmup_requests + self.num_benchmark_requests
+            benchmark_requests = request_records[: -self.num_warmup_requests]
+            warmup_requests = request_records[-self.num_warmup_requests :]
+        for request_record in warmup_requests:
+            request_record.timestamp = 0 if request_record.timestamp is not None else None
         warmup_requests = self._process_warmup_requests(warmup_requests)
         logger.info("Warmup with %d request(s)...", self.num_warmup_requests)
         self.pipeline(warmup_requests)
@@ -501,7 +578,7 @@ class FixTimestampExecutor(Executor):  # pylint: disable=too-few-public-methods
 
 
 def create_pipelines(
-    args: argparse.Namespace, f_create_api_endpoint: Callable[[], APIEndPoint]
+    args: argparse.Namespace, f_create_api_endpoint: Callable[[], APIEndPoint], dataset: Dataset
 ) -> List[RequestProcessor]:
     """Creating request processing pipelines with regard to the specified args."""
     cuda_profile_url = f"http://{args.host}:{args.port}" if args.cuda_profile else None
@@ -537,6 +614,7 @@ def create_pipelines(
                             args.multi_round,
                         ),
                         cuda_profile_url=cuda_profile_url,
+                        fake_warmup=dataset.require_fake_warmup,
                     ),
                 )
             )
@@ -547,19 +625,22 @@ def create_pipelines(
                 "Please specify the number of warmup requests via "
                 '"--num-warmup-requests" when fixing request rate.'
             )
-        # for request_rate in args.request_rate:
+        if args.fake_warmup:
+            num_samples = int(args.num_requests * args.num_gpus)
+        else:
+            num_samples = int(args.num_requests * args.num_gpus)  + args.num_warmup_requests
         return [
             SequentialProcessor(
                 LogMessage(f"Fixing request rate: {request_rate}"),
-                SampleRequests(args.num_requests + args.num_warmup_requests),
+                SampleRequests(num_samples),
                 AttachModelName(args.tokenizer),
-                AttachRequestRateTimestamp(request_rate),
+                AttachRequestRateTimestamp(request_rate * args.num_gpus),
                 AttachStreamFlag(args.stream),
                 AttachSamplingOptions(args.temperature, args.top_p, args.ignore_eos),
                 AttachExecutionFeature({"request_rate": float(request_rate)}),
                 WarmupAndRun(
                     num_warmup_requests=args.num_warmup_requests,
-                    num_benchmark_requests=args.num_requests,
+                    num_benchmark_requests=int(args.num_requests * args.num_gpus),
                     pipeline=FixTimestampExecutor(
                         f_create_api_endpoint,
                         args.num_process_workers,
@@ -569,6 +650,7 @@ def create_pipelines(
                         request_rate,
                     ),
                     cuda_profile_url=cuda_profile_url,
+                    fake_warmup=dataset.require_fake_warmup,
                 ),
             )
             for request_rate in args.request_rate

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -262,7 +262,6 @@ class WarmupAndRun(RequestProcessor):  # pylint: disable=too-few-public-methods
         return records
 
     def __call__(self, request_records: List[RequestRecord]) -> List[RequestRecord]:
-
         # Warmup
         if self.fake_warmup:
             assert len(request_records) == self.num_benchmark_requests

--- a/python/mlc_llm/bench/request_processor.py
+++ b/python/mlc_llm/bench/request_processor.py
@@ -252,7 +252,7 @@ class WarmupAndRun(RequestProcessor):  # pylint: disable=too-few-public-methods,
                 messages=[
                     {
                         "role": "user",
-                        "content": "Please output arbitrary coherent sentences. Do not output eos token.",
+                        "content": "Please output arbitrary coherent sentences. Do not output eos token.",  # pylint: disable=line-too-long
                     }
                 ],
                 model="",

--- a/python/mlc_llm/bench/request_record.py
+++ b/python/mlc_llm/bench/request_record.py
@@ -55,6 +55,16 @@ class RequestRecord(BaseModel):
     error_msg: Optional[str] = None
 
 
+class GroupedRequestRecord(RequestRecord):
+    """The data structure for request record groups.
+    For datasets that have common prefix sharing, the request records
+    that share a same common prefix will be wrapped in a GroupedRequestRecord
+    at the beginning.
+    """
+
+    records: List[RequestRecord]
+
+
 def generate_metrics_summary(
     request_records: List[RequestRecord],
     num_total_requests: int,


### PR DESCRIPTION
Add Loogle and React dataset. Add fake warmup option to avoid initalizing prefix cache.

