### PR TITLE
[Serve] MicroServing API refactor

### DIFF
--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -70,12 +70,12 @@ Result<DisaggConfig> DisaggConfig::FromJSON(const picojson::object& config) {
   DisaggConfig res;
   std::optional<std::string> kind = json::LookupOptional<std::string>(config, "kind");
   if (kind.has_value()) {
-    if (kind.value() == "prepare_prefill") {
-      res.kind = DisaggRequestKind::kPreparePrefill;
-    } else if (kind.value() == "remote_prefill") {
-      res.kind = DisaggRequestKind::kRemotePrefill;
-    } else if (kind.value() == "start_decode") {
-      res.kind = DisaggRequestKind::kStartDecode;
+    if (kind.value() == "prepare_receive") {
+      res.kind = DisaggRequestKind::kPrepareReceive;
+    } else if (kind.value() == "remote_send") {
+      res.kind = DisaggRequestKind::kRemoteSend;
+    } else if (kind.value() == "start_generation") {
+      res.kind = DisaggRequestKind::kStartGeneration;
     } else {
       return TResult::Error("Unknown disaggregation request kind " + kind.value());
     }
@@ -125,16 +125,16 @@ Result<DisaggConfig> DisaggConfig::FromJSON(const picojson::object& config) {
 picojson::object DisaggConfig::AsJSON() const {
   picojson::object config;
   switch (kind) {
-    case DisaggRequestKind::kPreparePrefill: {
-      config["kind"] = picojson::value("prepare_prefill");
+    case DisaggRequestKind::kPrepareReceive: {
+      config["kind"] = picojson::value("prepare_receive");
       break;
     }
-    case DisaggRequestKind::kRemotePrefill: {
-      config["kind"] = picojson::value("remote_prefill");
+    case DisaggRequestKind::kRemoteSend: {
+      config["kind"] = picojson::value("remote_send");
       break;
     }
-    case DisaggRequestKind::kStartDecode: {
-      config["kind"] = picojson::value("start_decode");
+    case DisaggRequestKind::kStartGeneration: {
+      config["kind"] = picojson::value("start_generation");
       break;
     }
     default:

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -48,9 +48,9 @@ enum class SpecialRequestKind : int {
 
 enum class DisaggRequestKind : int {
   kNone = 0,
-  kPreparePrefill = 1,
-  kRemotePrefill = 2,
-  kStartDecode = 3,
+  kPrepareReceive = 1,
+  kRemoteSend = 2,
+  kStartGeneration = 3,
 };
 
 /*! \brief Controls the behavior of inference with grammar constraint. */
@@ -70,11 +70,11 @@ class DisaggConfig {
   // "kv_window_begin" and "kv_window_end" denote the KV interval of interests.
   // "kv_window_end" supports Python style negative indexing.
   // The concrete meaning varies for different special request kind:
-  // - For "prepare_prefill", the begin is always 0, and "[0:end]" denotes
+  // - For "prepare_receive", the begin is always 0, and "[0:end]" denotes
   // the KV range to prefill on a prefill instance.
-  // - For "remote_prefill", "[begin:end]" means the KV range to compute prefill
+  // - For "remote_send", "[begin:end]" means the KV range to compute prefill
   // and send to the decode instance.
-  // - For "start_decode", the end is always nullopt, and "[begin:]" denotes
+  // - For "start_generation", the end is always nullopt, and "[begin:]" denotes
   // the KV range to prefill locally on the decode instance.
   std::optional<int> kv_window_begin = std::nullopt;
   std::optional<int> kv_window_end = std::nullopt;

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -548,10 +548,10 @@ class EngineImpl : public Engine {
   bool HandleDisaggRequest(Request request) {
     DisaggConfig disagg_config = request->generation_cfg->debug_config.disagg_config;
     DisaggRequestKind kind = disagg_config.kind;
-    if (kind == DisaggRequestKind::kPreparePrefill) {
+    if (kind == DisaggRequestKind::kPrepareReceive) {
       // No-op.
       return false;
-    } else if (kind == DisaggRequestKind::kRemotePrefill) {
+    } else if (kind == DisaggRequestKind::kRemoteSend) {
       int input_length = 0;
       for (Data input : request->inputs) {
         input_length += input->GetLength();
@@ -586,13 +586,13 @@ class EngineImpl : public Engine {
       updated_generation_cfg->n = 1;
       request->generation_cfg = GenerationConfig(updated_generation_cfg);
       return false;
-    } else if (kind == DisaggRequestKind::kStartDecode) {
+    } else if (kind == DisaggRequestKind::kStartGeneration) {
       auto it_rstate = estate_->request_states.find(request->id);
       CHECK(it_rstate != estate_->request_states.end());
       ICHECK(!it_rstate->second->entries.empty());
       request = it_rstate->second->entries[0]->request;
       CHECK(request->generation_cfg->debug_config.disagg_config.kind ==
-            DisaggRequestKind::kPreparePrefill);
+            DisaggRequestKind::kPrepareReceive);
       int input_length = 0;
       for (Data input : request->inputs) {
         input_length += input->GetLength();

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -220,7 +220,7 @@ class EngineAction : public ObjectRef {
    * matched length in the prefix cache.
    * \return The created action object.
    */
-  static EngineAction DisaggPreparePrefill(Array<Model> models, EngineConfig engine_config,
+  static EngineAction DisaggPrepareReceive(Array<Model> models, EngineConfig engine_config,
                                            std::vector<picojson::object> model_configs,
                                            Optional<EventTraceRecorder> trace_recorder,
                                            FRequestStreamCallback request_stream_callback);
@@ -238,7 +238,7 @@ class EngineAction : public ObjectRef {
    * \param device The device of the model for synchronization.
    * \return The created action object.
    */
-  static EngineAction NewRequestPrefillWithKVSend(
+  static EngineAction DisaggRemoteSend(
       Array<Model> models, std::vector<ModelWorkspace> model_workspaces, EngineConfig engine_config,
       std::vector<picojson::object> model_configs, Optional<EventTraceRecorder> trace_recorder,
       FRequestStreamCallback request_stream_callback, Device device);

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -122,11 +122,10 @@ Array<EngineAction> CreateEngineActions(
   if (model_metadata.disaggregation) {
     // Insert the disaggregation actions.
     Array<EngineAction> disaggregation_actions = {
-        EngineAction::DisaggPreparePrefill(models, engine_config, model_configs, trace_recorder,
+        EngineAction::DisaggPrepareReceive(models, engine_config, model_configs, trace_recorder,
                                            request_stream_callback),
-        EngineAction::NewRequestPrefillWithKVSend(models, model_workspaces, engine_config,
-                                                  model_configs, trace_recorder,
-                                                  request_stream_callback, device)};
+        EngineAction::DisaggRemoteSend(models, model_workspaces, engine_config, model_configs,
+                                       trace_recorder, request_stream_callback, device)};
     actions.insert(actions.begin(), disaggregation_actions.begin(), disaggregation_actions.end());
   }
   return actions;
@@ -302,11 +301,11 @@ void ActionStepPostProcess(Array<Request> requests, EngineState estate, const Ar
       }
     }
 
-    // - For all disaggregation requests with "remote_prefill",
+    // - For all disaggregation requests with "remote_send",
     // if it does not appear in the waiting queue, it means the prefill has been finished.
     // In this case, we mark the request as finished.
     if (request->generation_cfg->debug_config.disagg_config.kind ==
-        DisaggRequestKind::kRemotePrefill) {
+        DisaggRequestKind::kRemoteSend) {
       auto it = std::find(estate->waiting_queue.begin(), estate->waiting_queue.end(), request);
       if (it == estate->waiting_queue.end()) {
         CHECK_EQ(rstate->entries.size(), 1);

--- a/cpp/serve/engine_actions/disagg_prepare_recv.cc
+++ b/cpp/serve/engine_actions/disagg_prepare_recv.cc
@@ -18,9 +18,9 @@ namespace serve {
  * It picks a new request, reserve its KV data locations, and returns the
  * KV data locations and the matched prefix length in prefix cache.
  */
-class DisaggPreparePrefillActionObj : public BatchPrefillBaseActionObj {
+class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
  public:
-  explicit DisaggPreparePrefillActionObj(Array<Model> models, EngineConfig engine_config,
+  explicit DisaggPrepareReceiveActionObj(Array<Model> models, EngineConfig engine_config,
                                          std::vector<picojson::object> model_configs,
                                          Optional<EventTraceRecorder> trace_recorder,
                                          FRequestStreamCallback request_stream_callback)
@@ -51,7 +51,7 @@ class DisaggPreparePrefillActionObj : public BatchPrefillBaseActionObj {
       }
 
       {
-        NVTXScopedRange nvtx_scope("DisaggPreparePrefill matching prefix");
+        NVTXScopedRange nvtx_scope("DisaggPrepareReceive matching prefix");
         prefix_matched_length = MatchPrefixCache(estate, &prefill_input);
       }
 
@@ -199,7 +199,7 @@ class DisaggPreparePrefillActionObj : public BatchPrefillBaseActionObj {
     Request request{nullptr};
     for (const Request& request_candidate : estate->waiting_queue) {
       if (request_candidate->generation_cfg->debug_config.disagg_config.kind ==
-          DisaggRequestKind::kPreparePrefill) {
+          DisaggRequestKind::kPrepareReceive) {
         request = request_candidate;
         break;
       }
@@ -427,11 +427,11 @@ class DisaggPreparePrefillActionObj : public BatchPrefillBaseActionObj {
   FRequestStreamCallback request_stream_callback_;
 };
 
-EngineAction EngineAction::DisaggPreparePrefill(Array<Model> models, EngineConfig engine_config,
+EngineAction EngineAction::DisaggPrepareReceive(Array<Model> models, EngineConfig engine_config,
                                                 std::vector<picojson::object> model_configs,
                                                 Optional<EventTraceRecorder> trace_recorder,
                                                 FRequestStreamCallback request_stream_callback) {
-  return EngineAction(make_object<DisaggPreparePrefillActionObj>(
+  return EngineAction(make_object<DisaggPrepareReceiveActionObj>(
       std::move(models), std::move(engine_config), std::move(model_configs),
       std::move(trace_recorder), std::move(request_stream_callback)));
 }

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -11,6 +11,7 @@ from mlc_llm.serve import engine
 from mlc_llm.serve.entrypoints import (
     debug_entrypoints,
     metrics_entrypoints,
+    microserving_entrypoints,
     openai_entrypoints,
 )
 from mlc_llm.serve.server import ServerContext
@@ -95,6 +96,7 @@ def serve(
 
         app.include_router(openai_entrypoints.app)
         app.include_router(metrics_entrypoints.app)
+        app.include_router(microserving_entrypoints.app)
 
         server_context.enable_debug = enable_debug
 

--- a/python/mlc_llm/protocol/debug_protocol.py
+++ b/python/mlc_llm/protocol/debug_protocol.py
@@ -8,17 +8,17 @@ from pydantic import BaseModel
 class DisaggConfig(BaseModel):
     """The class of metadata used in microserving APIs."""
 
-    kind: Optional[Literal["prepare_prefill", "remote_prefill", "start_decode"]] = None
+    kind: Optional[Literal["prepare_receive", "remote_send", "start_generation"]] = None
     # "kv_append_metadata" is base64-encoded and is thus a string.
     kv_append_metadata: Optional[str] = None
     # "kv_window_begin" and "kv_window_end" denote the KV interval of interests.
     # "kv_window_end" supports Python style negative indexing.
     # The concrete meaning varies for different special request kind:
-    # - For "prepare_prefill", the begin is always 0, and "[0:end]" denotes
+    # - For "prepare_receive", the begin is always 0, and "[0:end]" denotes
     # the KV range to prefill on a prefill instance.
-    # - For "remote_prefill", "[begin:end]" means the KV range to compute prefill
+    # - For "remote_send", "[begin:end]" means the KV range to compute prefill
     # and send to the decode instance.
-    # - For "start_decode", the end is always None, and "[begin:]" denotes
+    # - For "start_generation", the end is always None, and "[begin:]" denotes
     # the KV range to prefill locally on the decode instance.
     kv_window_begin: Optional[int] = None
     kv_window_end: Optional[int] = None

--- a/python/mlc_llm/protocol/microserving_protocol.py
+++ b/python/mlc_llm/protocol/microserving_protocol.py
@@ -1,0 +1,76 @@
+"""Protocols in MLC LLM for MicroServing."""
+
+from pydantic import BaseModel
+
+from mlc_llm.protocol.openai_api_protocol import CompletionRequest
+
+
+class PrepRecvRequest(CompletionRequest):
+    """The extra request body for prep_recv request in MicroServing.
+
+    Attributes
+    ----------
+    kv_window_end : int
+        [0, kv_window_end] denotes the KV range of the prompt to prefill on
+        a prefill instance.
+        The entries of this KV range will be allocated on the decode instance.
+    """
+
+    kv_window_end: int
+
+
+class PrepRecvResponse(BaseModel):
+    """The response body for prep_recv request in MicroServing.
+
+    Attributes
+    ----------
+    prompt_length : int
+        The length of the request prompt in tokens.
+
+    prefix_matched_length : int
+        The matched common prefix length on the decode instance when
+        prefix cache is enabled, or 0 if there is no prefix cache.
+
+    kv_append_metadata : str
+        The metadata of the KV range on the destination decode instance.
+    """
+
+    prompt_length: int
+    prefix_matched_length: int
+    kv_append_metadata: str
+
+
+class RemoteSendRequest(CompletionRequest):
+    """The extra request body for remote_send request in MicroServing.
+
+    Attributes
+    ----------
+    kv_window_begin : int
+        Denote the start of the KV range to prefill.
+
+    kv_window_end : int
+        Denote the end of the KV range to prefill.
+
+    kv_append_metadata : str
+        The metadata of the KV range on the destination decode instance.
+
+    dst_group_offset : int
+        The node group offset of the destination decode instance.
+    """
+
+    kv_window_begin: int
+    kv_window_end: int
+    kv_append_metadata: str
+    dst_group_offset: int
+
+
+class StartGenerateRequest(CompletionRequest):
+    """The extra request body for start_generate request in MicroServing.
+
+    Attributes
+    ----------
+    kv_window_begin : int
+        Denote the start of the KV range to prefill on the decode instance.
+    """
+
+    kv_window_begin: int

--- a/python/mlc_llm/serve/entrypoints/__init__.py
+++ b/python/mlc_llm/serve/entrypoints/__init__.py
@@ -1,3 +1,8 @@
 """The entrypoints for MLC LLM server."""
 
-from . import debug_entrypoints, metrics_entrypoints, openai_entrypoints
+from . import (
+    debug_entrypoints,
+    metrics_entrypoints,
+    microserving_entrypoints,
+    openai_entrypoints,
+)

--- a/python/mlc_llm/serve/entrypoints/microserving_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/microserving_entrypoints.py
@@ -1,0 +1,75 @@
+"""MicroServing server entrypoints in MLC LLM"""
+
+import fastapi
+
+from mlc_llm.protocol.debug_protocol import DisaggConfig
+from mlc_llm.protocol.microserving_protocol import (
+    PrepRecvRequest,
+    PrepRecvResponse,
+    RemoteSendRequest,
+    StartGenerateRequest,
+)
+from mlc_llm.protocol.openai_api_protocol import StreamOptions
+
+from .openai_entrypoints import request_completion
+
+app = fastapi.APIRouter()
+
+
+################ MicroServing Endpoints ################
+
+
+@app.post("/microserving/prep_recv")
+async def prep_recv(request: PrepRecvRequest, raw_request: fastapi.Request) -> PrepRecvResponse:
+    """Handle the microserving request for receive preparation.
+    Match the prompt in the prefix cache (when enabled),
+    allocate entries in the KV cache to prepare receiving the KV data of the prompt.
+    Return the prompt length, matched prefix length and the allocated KV entry metadata.
+    """
+    request.debug_config.disagg_config = DisaggConfig(
+        kind="prepare_receive",
+        kv_window_begin=0,  # always zero for prepare_receive
+        kv_window_end=request.kv_window_end,
+    )
+    request.stream_options = StreamOptions(include_usage=True)
+    request.stream = False
+
+    response = await request_completion(request=request, raw_request=raw_request)
+    assert response.usage is not None
+    assert response.usage.extra is not None
+    assert "prompt_length" in response.usage.extra
+    assert "prefix_matched_length" in response.usage.extra
+    assert "kv_append_metadata" in response.usage.extra
+    return PrepRecvResponse(
+        prompt_length=response.usage.extra["prompt_length"],
+        prefix_matched_length=response.usage.extra["prefix_matched_length"],
+        kv_append_metadata=response.usage.extra["kv_append_metadata"],
+    )
+
+
+@app.post("/microserving/remote_send")
+async def remote_send(request: RemoteSendRequest, raw_request: fastapi.Request):
+    """Compute and generate the KV data of the prompt in the specified KV window.
+    Send the KV data to the destination server."""
+    request.debug_config.disagg_config = DisaggConfig(
+        kind="remote_send",
+        kv_window_begin=request.kv_window_begin,
+        kv_window_end=request.kv_window_end,
+        kv_append_metadata=request.kv_append_metadata,
+        dst_group_offset=request.dst_group_offset,
+    )
+    request.stream_options = StreamOptions(include_usage=True)
+    request.stream = False
+
+    await request_completion(request=request, raw_request=raw_request)
+    return {}
+
+
+@app.post("/microserving/start_generate")
+async def start_generate(request: StartGenerateRequest, raw_request: fastapi.Request):
+    """Prefill the prompt in the specified KV window, and start decode."""
+    request.debug_config.disagg_config = DisaggConfig(
+        kind="start_generation",
+        kv_window_begin=request.kv_window_begin,
+    )
+    return await request_completion(request=request, raw_request=raw_request)

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -113,7 +113,6 @@ async def request_completion(request: CompletionRequest, raw_request: fastapi.Re
             if choice.logprobs is not None:
                 logprob_results[choice.index] = choice.logprobs
 
-    assert all(finish_reason is not None for finish_reason in finish_reasons)
     return engine_base.wrap_completion_response(
         request_id=request_id,
         model=request.model,

--- a/python/mlc_llm/serve/server/popen_server.py
+++ b/python/mlc_llm/serve/server/popen_server.py
@@ -122,7 +122,6 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         final_env = os.environ.copy()
         for key, value in extra_env.items():
             final_env[key] = value
-        print(f"cmd = {cmd}")
         self._proc = subprocess.Popen(  # pylint: disable=consider-using-with
             cmd, cwd=process_path, env=final_env
         )


### PR DESCRIPTION
This PR refactors the MicroServing REST API. With this PR, we now have all the microserving REST APIs under file
`python/mlc_llm/serve/entrypoints/microserving_entrypoints.py`. And relative protocol data structures are placed under `python/mlc_llm/protocol/microserving_protocol.py`. These REST APIs essentially wrap and redirect to the OpenAI `v1/completions` API.

Besides, this PR applies some API name renaming to be consistent with writeups.