### PR TITLE
[Compile] Reset custom allreduce flag in O2 mode to NONE

### DIFF
--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -210,7 +210,7 @@ OPT_FLAG_PRESET = {
         faster_transformer=False,
         cudagraph=True,
         cutlass=True,
-        ipc_allreduce_strategy=IPCAllReduceStrategyType.AUTO,
+        ipc_allreduce_strategy=IPCAllReduceStrategyType.NONE,
     ),
     "O3": OptimizationFlags(
         flashinfer=True,


### PR DESCRIPTION
This PR resets the default IPC allreduce strategy under O2 mode to NONE for platform compatability.