### PR TITLE
[Model] Fix cached buffer allocation and fix dynamic shape in Phi3v

### DIFF
--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -321,6 +321,13 @@ ObjectRef FunctionTable::CopyToWorker0(const NDArray& host_array, String buffer_
     NDArray buffer{nullptr};
     if (it != this->cached_buffers.end()) {
       buffer = Downcast<NDArray>((*it).second);
+      if (buffer_cache_key == "image") {
+        if (runtime::GetDataSize(*buffer.operator->()) <
+            runtime::GetDataSize(*host_array.operator->())) {
+          buffer = NDArray::Empty(max_reserved_shape, host_array->dtype, local_gpu_device);
+          this->cached_buffers.Set(buffer_cache_key, buffer);
+        }
+      }
     } else {
       buffer = NDArray::Empty(max_reserved_shape, host_array->dtype, local_gpu_device);
       this->cached_buffers.Set(buffer_cache_key, buffer);

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -116,11 +116,11 @@ class ModelImpl : public ModelObj {
     CHECK(ft_.image_embed_func_.defined()) << "`image_embed` function is not found in the model. ";
 
     int tmp_h = 0, tmp_w = 0;
-    CalculateResizeShape(image, this->model_type_, tmp_h, tmp_w);
+    CalculateResizeShape(image, this->model_type_, &tmp_h, &tmp_w);
     ShapeTuple resize_h = {tmp_h};
     ShapeTuple resize_w = {tmp_w};
 
-    CalculateCropShape(image, this->model_type_, tmp_h, tmp_w);
+    CalculateCropShape(image, this->model_type_, &tmp_h, &tmp_w);
     ShapeTuple crop_h = {tmp_h};
     ShapeTuple crop_w = {tmp_w};
 

--- a/cpp/support/vlm_utils.cc
+++ b/cpp/support/vlm_utils.cc
@@ -10,7 +10,7 @@ namespace mlc {
 namespace llm {
 
 void CalculateResizeShape(tvm::runtime::NDArray image_data, std::string model_type,
-                          int& target_height, int& target_width) {
+                          int* p_target_height, int* p_target_width) {
   ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
   int height = image_data->shape[1];
   int width = image_data->shape[2];
@@ -23,34 +23,34 @@ void CalculateResizeShape(tvm::runtime::NDArray image_data, std::string model_ty
       scale += 1;
     }
     scale -= 1;
-    target_width = static_cast<int>(scale * 336);
-    target_height = static_cast<int>(target_width / ratio);
+    *p_target_width = static_cast<int>(scale * 336);
+    *p_target_height = static_cast<int>(*p_target_width / ratio);
   }
 }
 
-void CalculatePadShape(tvm::runtime::NDArray image_data, std::string model_type, int& pad_height,
-                       int& pad_width) {
+void CalculatePadShape(tvm::runtime::NDArray image_data, std::string model_type, int* p_pad_height,
+                       int* p_pad_width) {
   ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
   if ("phi3_v" == model_type) {
     int resized_height = 0, resized_width = 0;
-    CalculateResizeShape(image_data, model_type, resized_height, resized_width);
+    CalculateResizeShape(image_data, model_type, &resized_height, &resized_width);
     int tar = (int)(ceil(resized_height / 336.0) * 336);
     int top_padding = (int)((tar - resized_height) / 2);
     int bottom_padding = tar - resized_height - top_padding;
     ICHECK_EQ(tar, resized_height + top_padding + bottom_padding) << "Padding size not equal!";
-    pad_height = tar;
-    pad_width = resized_width;
+    *p_pad_height = tar;
+    *p_pad_width = resized_width;
   }
 }
 
-void CalculateCropShape(tvm::runtime::NDArray image_data, std::string model_type, int& crop_height,
-                        int& crop_width) {
+void CalculateCropShape(tvm::runtime::NDArray image_data, std::string model_type,
+                        int* p_crop_height, int* p_crop_width) {
   ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
   if ("phi3_v" == model_type) {
     int pad_h = 0, pad_w = 0;
-    CalculatePadShape(image_data, model_type, pad_h, pad_w);
-    crop_height = pad_h / 336;
-    crop_width = pad_w / 336;
+    CalculatePadShape(image_data, model_type, &pad_h, &pad_w);
+    *p_crop_height = pad_h / 336;
+    *p_crop_width = pad_w / 336;
   }
 }
 

--- a/cpp/support/vlm_utils.cc
+++ b/cpp/support/vlm_utils.cc
@@ -1,0 +1,58 @@
+/*!
+ *  Copyright (c) 2023-2024 by Contributors
+ * \file support/image_utils.cc
+ */
+#include "vlm_utils.h"
+
+#include <cmath>
+
+namespace mlc {
+namespace llm {
+
+void CalculateResizeShape(tvm::runtime::NDArray image_data, std::string model_type,
+                          int& target_height, int& target_width) {
+  ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
+  int height = image_data->shape[1];
+  int width = image_data->shape[2];
+
+  if ("phi3_v" == model_type) {
+    const int hd_num = 4;
+    double ratio = static_cast<double>(width) / height;
+    int scale = 1;
+    while (scale * std::ceil(scale / ratio) <= hd_num) {
+      scale += 1;
+    }
+    scale -= 1;
+    target_width = static_cast<int>(scale * 336);
+    target_height = static_cast<int>(target_width / ratio);
+  }
+}
+
+void CalculatePadShape(tvm::runtime::NDArray image_data, std::string model_type, int& pad_height,
+                       int& pad_width) {
+  ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
+  if ("phi3_v" == model_type) {
+    int resized_height = 0, resized_width = 0;
+    CalculateResizeShape(image_data, model_type, resized_height, resized_width);
+    int tar = (int)(ceil(resized_height / 336.0) * 336);
+    int top_padding = (int)((tar - resized_height) / 2);
+    int bottom_padding = tar - resized_height - top_padding;
+    ICHECK_EQ(tar, resized_height + top_padding + bottom_padding) << "Padding size not equal!";
+    pad_height = tar;
+    pad_width = resized_width;
+  }
+}
+
+void CalculateCropShape(tvm::runtime::NDArray image_data, std::string model_type, int& crop_height,
+                        int& crop_width) {
+  ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
+  if ("phi3_v" == model_type) {
+    int pad_h = 0, pad_w = 0;
+    CalculatePadShape(image_data, model_type, pad_h, pad_w);
+    crop_height = pad_h / 336;
+    crop_width = pad_w / 336;
+  }
+}
+
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/support/vlm_utils.h
+++ b/cpp/support/vlm_utils.h
@@ -21,7 +21,7 @@ namespace llm {
  * the variable where the calculated target width will be stored.
  */
 void CalculateResizeShape(tvm::runtime::NDArray image_data, std::string model_type,
-                          int& target_height, int& target_width);
+                          int* p_target_height, int* p_target_width);
 /*!
  * \brief Calculate the padding height and width for an image based on the input data and model
  * type. \param image_data The input image data as a TVM NDArray. \param model_type The type of the
@@ -29,8 +29,8 @@ void CalculateResizeShape(tvm::runtime::NDArray image_data, std::string model_ty
  * variable where the calculated padding height will be stored. \param pad_width Reference to the
  * variable where the calculated padding width will be stored.
  */
-void CalculatePadShape(tvm::runtime::NDArray image_data, std::string model_type, int& pad_height,
-                       int& pad_width);
+void CalculatePadShape(tvm::runtime::NDArray image_data, std::string model_type, int* p_pad_height,
+                       int* p_pad_width);
 
 /*!
  * \brief Calculate the cropping height and width for an image based on the input data and model
@@ -39,8 +39,8 @@ void CalculatePadShape(tvm::runtime::NDArray image_data, std::string model_type,
  * variable where the calculated cropping height will be stored. \param crop_width Reference to the
  * variable where the calculated cropping width will be stored.
  */
-void CalculateCropShape(tvm::runtime::NDArray image_data, std::string model_type, int& crop_height,
-                        int& crop_width);
+void CalculateCropShape(tvm::runtime::NDArray image_data, std::string model_type,
+                        int* p_crop_height, int* p_crop_width);
 
 }  // namespace llm
 }  // namespace mlc

--- a/cpp/support/vlm_utils.h
+++ b/cpp/support/vlm_utils.h
@@ -1,0 +1,48 @@
+/*!
+ *  Copyright (c) 2023-2024 by Contributors
+ * \file support/vlm_utils.h
+ * \brief Tools for debug purposes.
+ */
+#ifndef MLC_LLM_SUPPORT_VLM_UTILS_H_
+#define MLC_LLM_SUPPORT_VLM_UTILS_H_
+
+#include <tvm/runtime/ndarray.h>
+
+#include <string>
+
+namespace mlc {
+namespace llm {
+
+/*!
+ * \brief Calculate the target height and width for resizing an image based on the input data and
+ * model type. \param image_data The input image data as a TVM NDArray. \param model_type The type
+ * of the model influencing the resizing parameters (e.g., phi3v). \param target_height Reference to
+ * the variable where the calculated target height will be stored. \param target_width Reference to
+ * the variable where the calculated target width will be stored.
+ */
+void CalculateResizeShape(tvm::runtime::NDArray image_data, std::string model_type,
+                          int& target_height, int& target_width);
+/*!
+ * \brief Calculate the padding height and width for an image based on the input data and model
+ * type. \param image_data The input image data as a TVM NDArray. \param model_type The type of the
+ * model influencing the padding parameters (e.g., phi3v). \param pad_height Reference to the
+ * variable where the calculated padding height will be stored. \param pad_width Reference to the
+ * variable where the calculated padding width will be stored.
+ */
+void CalculatePadShape(tvm::runtime::NDArray image_data, std::string model_type, int& pad_height,
+                       int& pad_width);
+
+/*!
+ * \brief Calculate the cropping height and width for an image based on the input data and model
+ * type. \param image_data The input image data as a TVM NDArray. \param model_type The type of the
+ * model influencing the cropping parameters (e.g., phi3v). \param crop_height Reference to the
+ * variable where the calculated cropping height will be stored. \param crop_width Reference to the
+ * variable where the calculated cropping width will be stored.
+ */
+void CalculateCropShape(tvm::runtime::NDArray image_data, std::string model_type, int& crop_height,
+                        int& crop_width);
+
+}  // namespace llm
+}  // namespace mlc
+
+#endif  // MLC_LLM_SUPPORT_IMAGE_UTILS_H_

--- a/python/mlc_llm/compiler_pass/low_batch_specialization.py
+++ b/python/mlc_llm/compiler_pass/low_batch_specialization.py
@@ -40,7 +40,8 @@ class LowBatchGemvSpecialize:  # pylint: disable=too-few-public-methods
                 symbolic_vars = set(
                     expr for shape in shapes for expr in shape if isinstance(expr, tir.Var)
                 )
-                assert len(symbolic_vars) == 1, symbolic_vars
+                if len(symbolic_vars) != 1:
+                    continue
                 gemm_mod = IRModule({})
                 gemm_mod["main"] = func
                 gemm_mod = dl.ApplyDefaultSchedule(

--- a/python/mlc_llm/model/phi3v/phi3v_image.py
+++ b/python/mlc_llm/model/phi3v/phi3v_image.py
@@ -2,8 +2,9 @@
 Implementation for Phi architecture.
 """
 
+from tvm import relax, tir
 from tvm.relax.frontend import nn
-from tvm.relax.frontend.nn import Module, Tensor
+from tvm.relax.frontend.nn import Module, Tensor, op
 from tvm.script import tir as T
 
 from mlc_llm.model.vision import CLIPVisionModel
@@ -22,7 +23,30 @@ class ImageProjection(Module):  # pylint: disable=too-many-instance-attributes
         self.linear_2 = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
 
     def forward(self, image_features: Tensor) -> Tensor:
+        shape_1 = tir.Var("shape_1", "int64")
+        image_features = op.wrap_nested(
+            relax.BlockBuilder()
+            .current()
+            .match_cast(
+                image_features._expr,  # pylint: disable=protected-access
+                relax.TensorStructInfo([shape_1, image_features.shape[1]], image_features.dtype),
+            ),
+            "image_features",
+        )
+
         hidden_states = self.linear_1(image_features)
+
+        shape_2 = tir.Var("shape_2", "int64")
+        hidden_states = op.wrap_nested(
+            relax.BlockBuilder()
+            .current()
+            .match_cast(
+                hidden_states._expr,  # pylint: disable=protected-access
+                relax.TensorStructInfo([shape_2, hidden_states.shape[1]], hidden_states.dtype),
+            ),
+            "hidden_states",
+        )
+
         hidden_states = self.act(hidden_states)
         hidden_states = self.linear_2(hidden_states)
         return hidden_states
@@ -41,50 +65,249 @@ class Phi3ImageEmbedding(Module):
         self.img_projection = ImageProjection(config)
         self.image_size = config.vision_config.image_size
 
+    # pylint: disable=dangerous-default-value
+    def apply_schedule(self, sch, block, bdx=32, tile=[32, 32]):
+        loop_x, loop_y = sch.get_loops(block)[-2:]
+        xo, xi = sch.split(loop_x, factors=[tile[0], None])
+        yo, yi = sch.split(loop_y, factors=[tile[1], None])
+        sch.reorder(xo, yo, xi, yi)
+        t = sch.fuse(xo, yo)
+        ty, tx = sch.split(t, factors=[None, bdx])
+        sch.bind(ty, "threadIdx.y")
+        sch.bind(tx, "threadIdx.x")
+
+    # pylint: disable=too-many-arguments,too-many-locals
+    def dyn_repeat_4d_tensor(self, input_tensor, r0, r1, r2, r3) -> Tensor:
+        assert 4 == input_tensor.ndim, "input_tensor should be 4D data tensor"
+
+        def create_dyn_repeat_func(dtype):
+            @T.prim_func
+            def dyn_repeat_4d_tensor_func(  # pylint disable=too-many-locals
+                input_tensor: T.handle,
+                output: T.handle,
+                ch0: T.int64(),
+                ch1: T.int64(),
+                ch2: T.int64(),
+                ch3: T.int64(),
+            ):
+                T.func_attr({"op_pattern": 8, "tir.noalias": True, "tir.is_scheduled": 1})
+                n, c, h, w = T.int64(), T.int64(), T.int64(), T.int64()
+                input_tensor_buf = T.match_buffer(input_tensor, (n, c, h, w), dtype=dtype)
+                out_buf = T.match_buffer(output, (n * ch0, c * ch1, h * ch2, w * ch3), dtype=dtype)
+
+                for n_idx in T.thread_binding(n * ch0, thread="blockIdx.x"):
+                    for c_idx in T.thread_binding(c * ch1, thread="blockIdx.y"):
+                        for h_idx, w_idx in T.grid(h * ch2, w * ch3):
+                            with T.block("dyn_repeat_4d_tensor"):
+                                T.reads(input_tensor_buf[n_idx, c_idx, h_idx, w_idx])
+                                T.writes(out_buf[n_idx, c_idx, h_idx, w_idx])
+                                out_buf[n_idx, c_idx, h_idx, w_idx] = input_tensor_buf[
+                                    n_idx % n, c_idx % c, h_idx % h, w_idx % w
+                                ]
+
+            return dyn_repeat_4d_tensor_func
+
+        n, c, h, w = input_tensor.shape
+        out = op.tensor_ir_op(
+            create_dyn_repeat_func(input_tensor.dtype),
+            "dyn_repeat_4d_tensor",
+            [input_tensor, r0, r1, r2, r3],
+            [Tensor.placeholder([n * r0, c * r1, h * r2, w * r3], input_tensor.dtype)],
+        )
+        return out
+
+    def dyn_concate_dim_2(self, input_1, input_2) -> Tensor:
+        def create_dyn_concate_func(dtype):
+            @T.prim_func
+            def dyn_concate_dim_2_func(input_1: T.handle, input_2: T.handle, output: T.handle):
+                T.func_attr({"op_pattern": 8, "tir.noalias": True, "tir.is_scheduled": 1})
+                n, c, h1, h2, w = T.int64(), T.int64(), T.int64(), T.int64(), T.int64()
+                input_1_buf = T.match_buffer(input_1, (n, c, h1, w), dtype=dtype)
+                input_2_buf = T.match_buffer(input_2, (n, c, h2, w), dtype=dtype)
+                out_buf = T.match_buffer(output, (n, c, h1 + h2, w), dtype=dtype)
+
+                for n_idx in T.thread_binding(n, thread="blockIdx.x"):
+                    for c_idx in T.thread_binding(c, thread="blockIdx.y"):
+                        for h_idx, w_idx in T.grid(h1 + h2, w):
+                            with T.block("dyn_concate_dim_2"):
+                                T.reads(input_1_buf[n_idx, c_idx, h_idx, w_idx])
+                                T.writes(out_buf[n_idx, c_idx, h_idx, w_idx])
+                                if h_idx < h1:
+                                    out_buf[n_idx, c_idx, h_idx, w_idx] = input_1_buf[
+                                        n_idx, c_idx, h_idx, w_idx
+                                    ]
+                                else:
+                                    out_buf[n_idx, c_idx, h_idx, w_idx] = input_2_buf[
+                                        n_idx, c_idx, h_idx - h1, w_idx
+                                    ]
+
+            return dyn_concate_dim_2_func
+
+        n1, c1, h1, w1 = input_1.shape
+        n2, c2, h2, w2 = input_2.shape
+        assert n1 == n2 and c1 == c2 and w1 == w2
+
+        out = op.tensor_ir_op(
+            create_dyn_concate_func(input_1.dtype),
+            "dyn_concate_dim_2",
+            [input_1, input_2],
+            [Tensor.placeholder([n1, c1, h1 + h2, w1], input_1.dtype)],
+        )
+        return out
+
+    def dyn_concate_dim_1(self, input_1, input_2) -> Tensor:
+        def create_dyn_concate_func(dtype):
+            @T.prim_func
+            def dyn_concate_dim_1_func(input_1: T.handle, input_2: T.handle, output: T.handle):
+                T.func_attr({"op_pattern": 8, "tir.noalias": True, "tir.is_scheduled": 1})
+                c, h1, h2, w = T.int64(), T.int64(), T.int64(), T.int64()
+                input_1_buf = T.match_buffer(input_1, (c, h1, w), dtype=dtype)
+                input_2_buf = T.match_buffer(input_2, (c, h2, w), dtype=dtype)
+                out_buf = T.match_buffer(output, (c, h1 + h2, w), dtype=dtype)
+
+                for c_idx in T.thread_binding(c, thread="blockIdx.y"):
+                    for h_idx, w_idx in T.grid(h1 + h2, w):
+                        with T.block("dyn_concate_dim_1"):
+                            T.reads(input_1_buf[c_idx, h_idx, w_idx])
+                            T.writes(out_buf[c_idx, h_idx, w_idx])
+                            if h_idx < h1:
+                                out_buf[c_idx, h_idx, w_idx] = input_1_buf[c_idx, h_idx, w_idx]
+                            else:
+                                out_buf[c_idx, h_idx, w_idx] = input_2_buf[c_idx, h_idx - h1, w_idx]
+
+            return dyn_concate_dim_1_func
+
+        c1, h1, w1 = input_1.shape
+        c2, h2, w2 = input_2.shape
+        assert c1 == c2 and w1 == w2
+
+        out = op.tensor_ir_op(
+            create_dyn_concate_func(input_1.dtype),
+            "dyn_concate",
+            [input_1, input_2],
+            [Tensor.placeholder([c1, h1 + h2, w1], input_1.dtype)],
+        )
+        return out
+
     def get_img_features(self, img_embeds: Tensor) -> Tensor:
         img_processor_output = self.img_processor(img_embeds)
         patch_feature = nn.op.split(img_processor_output, indices_or_sections=[1], axis=1)
         return patch_feature[1]
 
+    def reshape_hd_patches_2x2merge(self, image_features, h_crop, w_crop):
+        N, L, C = image_features.shape
+        num_images = 1
+        H = int(L**0.5)
+        image_features = nn.op.reshape(image_features, ([N, H, H, C]))  # N, 24, 24, 1024
+        image_features = nn.op.reshape(
+            image_features, ([N, H // 2, 2, H // 2, 2, C])
+        )  # N, 12, 2, 12, 2, 1024
+
+        new_s1 = tir.Var("new_s1", "int64")
+        new_s2 = tir.Var("new_s2", "int64")
+
+        image_features = op.wrap_nested(
+            relax.BlockBuilder()
+            .current()
+            .match_cast(
+                image_features._expr,  # pylint: disable=protected-access
+                relax.TensorStructInfo(
+                    [
+                        image_features.shape[0],
+                        new_s1,
+                        image_features.shape[2],
+                        new_s2,
+                        image_features.shape[4],
+                        image_features.shape[5],
+                    ],
+                    image_features.dtype,
+                ),
+            ),
+            "image_features_1",
+        )
+
+        image_features = nn.op.permute_dims(
+            image_features, axes=([0, 1, 3, 2, 4, 5])
+        )  # N, 12, 12, 2, 2, 1024
+        image_features = nn.op.reshape(image_features, ([N, -1, 4 * C]))  # N, 144, 4096
+        image_features = nn.op.reshape(
+            image_features, ([num_images, h_crop, w_crop, H // 2, H // 2, -1])
+        )
+
+        new_s3 = tir.Var("new_s3", "int64")
+        new_s4 = tir.Var("new_s4", "int64")
+
+        image_features = op.wrap_nested(
+            relax.BlockBuilder()
+            .current()
+            .match_cast(
+                image_features._expr,  # pylint: disable=protected-access
+                relax.TensorStructInfo(
+                    [
+                        image_features.shape[0],
+                        new_s3,
+                        image_features.shape[2],
+                        new_s4,
+                        image_features.shape[4],
+                        image_features.shape[5],
+                    ],
+                    image_features.dtype,
+                ),
+            ),
+            "image_features_2",
+        )
+
+        image_features = nn.op.permute_dims(image_features, axes=([0, 1, 3, 2, 4, 5]))
+        image_features_hd = nn.op.reshape(
+            image_features, ([num_images, h_crop * H // 2, w_crop * H // 2, 4 * C])
+        )
+
+        return image_features_hd
+
+    def add_image_newline(self, image_features_hd):
+        """
+        image_features_hd: (num_images, h_crop*12, w_crop*12, 4096)
+        output: (num_images, (h_crop*12) * (w_crop*12+1), 4096)
+        """
+        num_images, h, w, hid_dim = image_features_hd.shape  # pylint: disable=unused-variable
+        temp_sub_GN = self.dyn_repeat_4d_tensor(
+            self.sub_GN, T.int64(1), T.int64(h), T.int64(1), T.int64(1)
+        )
+        image_features_hd_newline = self.dyn_concate_dim_2(image_features_hd, temp_sub_GN)
+        image_features_hd_newline = nn.op.reshape(
+            image_features_hd_newline, ([num_images, -1, hid_dim])
+        )
+        return image_features_hd_newline
+
     # pylint: disable=too-many-locals,too-many-locals,unused-argument
-    def forward(self, pixel_values: Tensor, raw_image_h, raw_image_w) -> Tensor:
-        h = 3  # raw_image_h // self.image_size
-        w = 4  # raw_image_w // self.image_size
-        B_ = h * w
-        C = self.image_dim_out
-
-        # img_embeds = nn.op.squeeze(pixel_values, 0)
+    def forward(self, pixel_values: Tensor, h_crop, w_crop) -> Tensor:
         img_features = self.get_img_features(pixel_values)
-        H = T.int32((img_features.shape[1] ** 0.5))
         img_features = nn.op.split(img_features, indices_or_sections=[1], axis=0)
-        global_img_feature = img_features[0]
-        global_img_feature = nn.op.reshape(global_img_feature, ([1, H, H, C]))
-        global_img_feature = nn.op.reshape(global_img_feature, ([1, H // 2, 2, H // 2, 2, C]))
-        global_img_feature = nn.op.permute_dims(global_img_feature, axes=([0, 1, 3, 2, 4, 5]))
-        glb_img = nn.op.reshape(global_img_feature, ([1, H // 2, H // 2, 4 * C]))
 
-        temp_glb_GN = nn.op.repeat(self.sub_GN, int(H // 2), 1)
-        glb_img = nn.op.concat([glb_img, temp_glb_GN], dim=2)
-        glb_img = nn.op.reshape(glb_img, ([1, -1, 4 * C]))
+        global_image_features = img_features[0]
+        global_image_features_hd = self.reshape_hd_patches_2x2merge(global_image_features, 1, 1)
+        global_image_features_hd_newline = self.add_image_newline(global_image_features_hd)
 
-        sub_img = img_features[1]
-        sub_img = nn.op.split(sub_img, indices_or_sections=[12], axis=0)
-        sub_img = sub_img[0]
-        sub_img = nn.op.reshape(sub_img, ([B_, H, H, C]))
-        sub_img = nn.op.reshape(sub_img, ([B_, H // 2, 2, H // 2, 2, C]))
-        sub_img = nn.op.permute_dims(sub_img, axes=([0, 1, 3, 2, 4, 5]))
-        sub_img = nn.op.reshape(sub_img, ([B_, H // 2, 2, H // 2, 2, C]))
-        sub_img = nn.op.reshape(sub_img, ([B_, -1, 4 * C]))
-        sub_img = nn.op.reshape(sub_img, ([1, h, w, 12, 12, -1]))
-        sub_img = nn.op.permute_dims(sub_img, axes=([0, 1, 3, 2, 4, 5]))
-        sub_img = nn.op.reshape(sub_img, ([1, h * 12, w * 12, 4 * C]))
+        sub_image_features = img_features[1]
+        sub_image_features_hd = self.reshape_hd_patches_2x2merge(sub_image_features, h_crop, w_crop)
+        sub_image_features_hd_newline = self.add_image_newline(sub_image_features_hd)
 
-        temp_sub_GN = nn.op.repeat(self.sub_GN, h * 12, 1)
-        sub_img = nn.op.concat([sub_img, temp_sub_GN], dim=2)
-        sub_img = nn.op.reshape(sub_img, ([1, -1, 4 * C]))
+        global_image_features_hd = nn.op.squeeze(global_image_features_hd_newline, 0)
 
-        output_img = nn.op.concat([sub_img, self.glb_GN, glb_img], dim=1)
+        combined_image = self.dyn_concate_dim_1(sub_image_features_hd_newline, self.glb_GN)
+        combined_image = self.dyn_concate_dim_1(combined_image, global_image_features_hd_newline)
+        combined_image = nn.op.squeeze(combined_image, 0)
 
-        img_set_tensor = self.img_projection(output_img)
-        img_set_tensor = nn.op.squeeze(img_set_tensor, 0)
-        return img_set_tensor
+        new_s7 = tir.Var("new_s7", "int64")
+
+        combined_image = op.wrap_nested(
+            relax.BlockBuilder()
+            .current()
+            .match_cast(
+                combined_image._expr,  # pylint: disable=protected-access
+                relax.TensorStructInfo([new_s7, combined_image.shape[1]], combined_image.dtype),
+            ),
+            "combined_image",
+        )
+        output_image = self.img_projection(combined_image)
+        return output_image


### PR DESCRIPTION
This PR fixes the cached buffer allocation for larger new images and supports dynamic shapes in the vision encoder.