### PR TITLE
[Fix] Add `--no-index` to pip install commands

### DIFF
--- a/ci/task/pylint.sh
+++ b/ci/task/pylint.sh
@@ -9,7 +9,7 @@ export PYTHONPATH="./python":${PYTHONPATH:-""}
 if [[ -n ${MLC_CI_SETUP_DEPS:-} ]]; then
     echo "MLC_CI_SETUP_DEPS=1 start setup deps"
     # TVM Unity is a dependency to this testing
-    pip install --quiet --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+    pip install --quiet --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
     pip install --quiet --pre -U cuda-python
 fi
 

--- a/ci/task/test_model_compile.sh
+++ b/ci/task/test_model_compile.sh
@@ -9,17 +9,17 @@ pip install --force-reinstall wheels/*.whl
 
 if [[ ${GPU} == cuda* ]]; then
     TARGET=cuda
-    pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu123
+    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu123
     export LD_LIBRARY_PATH=/usr/local/cuda/compat/:$LD_LIBRARY_PATH
 elif [[ ${GPU} == rocm* ]]; then
     TARGET=rocm
-    pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm57
+    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-rocm57
 elif [[ ${GPU} == metal ]]; then
     TARGET=metal
-    pip install --pre -U --force-reinstal -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+    pip install --pre -U --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 elif [[ ${GPU} == wasm* ]]; then
     TARGET=wasm
-    pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
     export TVM_SOURCE_DIR=$(dirname $(python -c 'import tvm; print(tvm.__file__)'))
     export TVM_HOME=${TVM_SOURCE_DIR}
     export MLC_LLM_SOURCE_DIR=$(pwd)
@@ -27,14 +27,14 @@ elif [[ ${GPU} == wasm* ]]; then
     cd $MLC_LLM_SOURCE_DIR/web/ && make -j${NUM_THREADS} && cd -
 elif [[ ${GPU} == ios ]]; then
     TARGET=ios
-    pip install --pre -U --force-reinstal -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+    pip install --pre -U --force-reinstall -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 elif [[ ${GPU} == android* ]]; then
     TARGET=android
-    pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
     source /android_env_vars.sh
 else
     TARGET=vulkan
-    pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 fi
 
 python tests/python/integration/test_model_compile.py $TARGET $NUM_THREADS

--- a/ci/task/test_unittest.sh
+++ b/ci/task/test_unittest.sh
@@ -8,7 +8,7 @@ if [[ -n ${MLC_CI_SETUP_DEPS:-} ]]; then
     # Install dependency
     pip install --force-reinstall wheels/*.whl
     pip install --quiet pytest
-    pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu123
+    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu123
     export LD_LIBRARY_PATH=/usr/local/cuda/compat/:$LD_LIBRARY_PATH
 fi
 

--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -30,35 +30,35 @@ Select your operating system/compute platform and run the command in your termin
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
+                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
 
             .. tab:: CUDA 12.2
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122
+                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122
 
             .. tab:: CUDA 12.3
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu123 mlc-ai-nightly-cu123
+                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cu123 mlc-ai-nightly-cu123
 
             .. tab:: ROCm 6.1
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm61 mlc-ai-nightly-rocm61
+                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-rocm61 mlc-ai-nightly-rocm61
 
             .. tab:: ROCm 6.2
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm62 mlc-ai-nightly-rocm62
+                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-rocm62 mlc-ai-nightly-rocm62
 
             .. tab:: Vulkan
 
@@ -98,7 +98,7 @@ Select your operating system/compute platform and run the command in your termin
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
+                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
 
         .. note::
 
@@ -124,7 +124,7 @@ Select your operating system/compute platform and run the command in your termin
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
+                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
 
         .. note::
             Please make sure your conda environment comes with python and pip.

--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -37,35 +37,35 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
          .. tab:: CUDA 12.2
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu122
+              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu122
 
          .. tab:: CUDA 12.3
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu123
+              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu123
 
          .. tab:: ROCm 6.1
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm61
+              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-rocm61
 
          .. tab:: ROCm 6.2
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm62
+              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-rocm62
 
          .. tab:: Vulkan
 
@@ -88,7 +88,7 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
         .. note::
 
@@ -109,7 +109,7 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
       .. note::
         Make sure you also install vulkan loader and clang to avoid vulkan


### PR DESCRIPTION
This PR adds the field `--no-index` to mlc-ai/mlc-llm pip install commands to bypass PyPI.