### PR TITLE
[Fix] Fix deepseek r1 stop tokens

### DIFF
--- a/python/mlc_llm/conversation_template/deepseek.py
+++ b/python/mlc_llm/conversation_template/deepseek.py
@@ -36,10 +36,10 @@ ConvTemplateRegistry.register_conv_template(
     )
 )
 
-# Deepseek V3
+# DeepSeek-R1-Distill-Qwen
 ConvTemplateRegistry.register_conv_template(
     Conversation(
-        name="deepseek_v3",
+        name="deepseek_r1_qwen",
         system_template=f"<｜begin▁of▁sentence｜>{MessagePlaceholders.SYSTEM.value}",
         system_message="You are a helpful assistant.",
         roles={"user": "<｜User｜>", "assistant": "<｜Assistant｜>"},
@@ -47,5 +47,19 @@ ConvTemplateRegistry.register_conv_template(
         role_content_sep="",
         role_empty_sep="",
         stop_token_ids=[151643],
+    )
+)
+
+# DeepSeek-R1-Distill-Llama, exactly the same as DeepSeek-R1-Distill-Qwen, but different stop token
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="deepseek_r1_llama",
+        system_template=f"<｜begin▁of▁sentence｜>{MessagePlaceholders.SYSTEM.value}",
+        system_message="You are a helpful assistant.",
+        roles={"user": "<｜User｜>", "assistant": "<｜Assistant｜>"},
+        seps=["", "<｜end▁of▁sentence｜>"],
+        role_content_sep="",
+        role_empty_sep="",
+        stop_token_ids=[128001],
     )
 )

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -309,7 +309,8 @@ CONV_TEMPLATES = {
     "aya-23",
     "deepseek",
     "deepseek_v2",
-    "deepseek_v3",
+    "deepseek_r1_qwen",
+    "deepseek_r1_llama",
     "olmo",
     "nemotron",
 }


### PR DESCRIPTION
This PR removes `deepseek_v3` conversation template, and adds `deepseek_r1_qwen` and `deepseek_r1_llama`, which only differ by the stop token. Note that DeepSeek V3 has its own stop token id, different from the R1's.