### PR TITLE
[Docs] Revert the `--no-index` changes in instalation commands

### DIFF
--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -30,35 +30,35 @@ Select your operating system/compute platform and run the command in your termin
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
 
             .. tab:: CUDA 12.2
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu122 mlc-ai-nightly-cu122
 
             .. tab:: CUDA 12.3
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cu123 mlc-ai-nightly-cu123
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cu123 mlc-ai-nightly-cu123
 
             .. tab:: ROCm 6.1
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-rocm61 mlc-ai-nightly-rocm61
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm61 mlc-ai-nightly-rocm61
 
             .. tab:: ROCm 6.2
 
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-rocm62 mlc-ai-nightly-rocm62
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-rocm62 mlc-ai-nightly-rocm62
 
             .. tab:: Vulkan
 
@@ -98,7 +98,7 @@ Select your operating system/compute platform and run the command in your termin
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
 
         .. note::
 
@@ -124,7 +124,7 @@ Select your operating system/compute platform and run the command in your termin
                 .. code-block:: bash
 
                     conda activate your-environment
-                    python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
+                    python -m pip install --pre -U -f https://mlc.ai/wheels mlc-llm-nightly-cpu mlc-ai-nightly-cpu
 
         .. note::
             Please make sure your conda environment comes with python and pip.

--- a/docs/install/tvm.rst
+++ b/docs/install/tvm.rst
@@ -37,35 +37,35 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
          .. tab:: CUDA 12.2
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu122
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu122
 
          .. tab:: CUDA 12.3
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu123
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cu123
 
          .. tab:: ROCm 6.1
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-rocm61
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm61
 
          .. tab:: ROCm 6.2
 
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-rocm62
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-rocm62
 
          .. tab:: Vulkan
 
@@ -88,7 +88,7 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
         .. note::
 
@@ -109,7 +109,7 @@ A nightly prebuilt Python package of Apache TVM Unity is provided.
             .. code-block:: bash
 
               conda activate your-environment
-              python -m pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+              python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
       .. note::
         Make sure you also install vulkan loader and clang to avoid vulkan


### PR DESCRIPTION
This PR reverts the `--no-index` introduced earlier in the installation commands, as with `--no-index`, dependency packages cannot be downloaded from PyPI.