### PR TITLE
[Model] Support weight absorption for DeepSeek-v2

### DIFF
--- a/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
+++ b/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
@@ -1,7 +1,7 @@
 """A pass that rewrites KV cache creation functions in IRModule."""
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Literal, Tuple
 
 import tvm
 from tvm import IRModule, relax
@@ -9,7 +9,7 @@ from tvm.relax.frontend.nn.llm import kv_cache
 from tvm.relax.frontend.nn.llm.kv_cache import RopeMode
 
 
-def extract_creation_args(func: relax.Function) -> Dict[str, Any]:
+def extract_creation_args(func: relax.Function) -> Tuple[Literal["mha", "mla"], Dict[str, Any]]:
     """Extract the KV cache creation args from the given generic creation func."""
     assert isinstance(func.body, relax.SeqExpr)
     assert len(func.body.blocks) == 1
@@ -17,43 +17,75 @@ def extract_creation_args(func: relax.Function) -> Dict[str, Any]:
     assert isinstance(func.body.blocks[0].bindings[0], relax.VarBinding)
     assert isinstance(func.body.blocks[0].bindings[0].value, relax.Call)
     assert func.body.blocks[0].bindings[0].value.op == tvm.ir.Op.get("relax.call_pure_packed")
-    args = func.body.blocks[0].bindings[0].value.args
-    assert isinstance(args[0], relax.ExternFunc)
-    assert args[0].global_symbol == "mlc.create_paged_kv_cache_generic"
+    call_args = func.body.blocks[0].bindings[0].value.args
+    assert isinstance(call_args[0], relax.ExternFunc)
+    assert call_args[0].global_symbol == "mlc.create_paged_kv_cache_generic"
+    assert isinstance(call_args[1], relax.StringImm)
 
-    assert len(args) == 15
-    assert isinstance(args[1], relax.ShapeExpr)
-    assert len(args[1].values) == 5
-    assert isinstance(args[2], relax.ShapeExpr)
-    for i in range(3, 14):
-        if i in [10, 11]:
-            continue
-        assert isinstance(args[i], relax.PrimValue)
-        assert isinstance(args[i].value, (tvm.tir.IntImm, tvm.tir.FloatImm))
-    assert isinstance(args[10], relax.StringImm)
-    assert isinstance(args[11], (relax.Constant, relax.PrimValue))
-    assert isinstance(args[14], relax.DataTypeImm)
+    args = call_args[1:]
+    if args[0].value == "mha":
+        assert len(args) == 15
+        assert isinstance(args[1], relax.ShapeExpr)
+        assert len(args[1].values) == 5
+        assert isinstance(args[2], relax.ShapeExpr)
+        for i in range(3, 14):
+            if i in [10, 11]:
+                continue
+            assert isinstance(args[i], relax.PrimValue)
+            assert isinstance(args[i].value, (tvm.tir.IntImm, tvm.tir.FloatImm))
+        assert isinstance(args[10], relax.StringImm)
+        assert isinstance(args[11], (relax.Constant, relax.PrimValue))
+        assert isinstance(args[14], relax.DataTypeImm)
 
-    return {
-        "max_batch_size": args[1].values[0],
-        "max_total_seq_len": args[1].values[1],
-        "prefill_chunk_size": args[1].values[2],
-        "page_size": args[1].values[3],
-        "support_sliding_window": args[1].values[4],
-        "layer_partition": args[2],
-        "num_hidden_layers": args[3].value.value,
-        "num_attention_heads": args[4].value.value,
-        "num_key_value_heads": args[5].value.value,
-        "head_dim": args[6].value.value,
-        "rope_mode": args[7].value.value,
-        "rope_scale": args[8].value.value,
-        "rope_theta": args[9].value.value,
-        "rope_scaling": json.loads(args[10].value),
-        "rope_ext_factors": args[11],
-        "rotary_dim": args[12].value.value,
-        "enable_disaggregation": bool(args[13].value.value),
-        "dtype": args[14].value,
-    }
+        return "mha", {
+            "max_batch_size": args[1].values[0],
+            "max_total_seq_len": args[1].values[1],
+            "prefill_chunk_size": args[1].values[2],
+            "page_size": args[1].values[3],
+            "support_sliding_window": args[1].values[4],
+            "layer_partition": args[2],
+            "num_hidden_layers": args[3].value.value,
+            "num_attention_heads": args[4].value.value,
+            "num_key_value_heads": args[5].value.value,
+            "head_dim": args[6].value.value,
+            "rope_mode": args[7].value.value,
+            "rope_scale": args[8].value.value,
+            "rope_theta": args[9].value.value,
+            "rope_scaling": json.loads(args[10].value),
+            "rope_ext_factors": args[11],
+            "rotary_dim": args[12].value.value,
+            "enable_disaggregation": bool(args[13].value.value),
+            "dtype": args[14].value,
+        }
+    if call_args[1].value == "mla":
+        assert len(args) == 12
+        assert isinstance(args[1], relax.ShapeExpr)
+        assert len(args[1].values) == 5
+        assert isinstance(args[2], relax.ShapeExpr)
+        for i in range(3, 11):
+            assert isinstance(args[i], relax.PrimValue)
+            assert isinstance(args[i].value, tvm.tir.IntImm)
+        assert isinstance(args[11], relax.DataTypeImm)
+
+        return "mla", {
+            "max_batch_size": args[1].values[0],
+            "max_total_seq_len": args[1].values[1],
+            "prefill_chunk_size": args[1].values[2],
+            "page_size": args[1].values[3],
+            "support_sliding_window": args[1].values[4],
+            "layer_partition": args[2],
+            "num_hidden_layers": args[3].value.value,
+            "num_attention_heads": args[4].value.value,
+            "num_key_value_heads": args[5].value.value,
+            "qk_nope_head_dim": args[6].value.value,
+            "qk_rope_head_dim": args[7].value.value,
+            "v_head_dim": args[8].value.value,
+            "kv_lora_rank": args[9].value.value,
+            "enable_disaggregation": bool(args[10].value.value),
+            "dtype": args[11].value,
+        }
+
+    raise ValueError("Cannot reach here")
 
 
 @tvm.transform.module_pass(opt_level=0, name="DispatchKVCacheCreation")
@@ -100,24 +132,38 @@ class DispatchKVCacheCreation:  # pylint: disable=too-many-instance-attributes
         if mod.attrs is not None:
             new_mod = new_mod.with_attrs(mod.attrs)
 
-        kwargs = extract_creation_args(creation_func)
-        self.attach_kv_cache_metadata(kwargs)
+        kv_cache_kind, kwargs = extract_creation_args(creation_func)
+        self.attach_kv_cache_metadata(kv_cache_kind, kwargs)
 
         bb = relax.BlockBuilder(new_mod)
-        self.create_tir_paged_kv_cache(bb, kwargs)
-        self.create_flashinfer_paged_kv_cache(bb, kwargs)
+        self.create_tir_paged_kv_cache(bb, kv_cache_kind, kwargs)
+        self.create_flashinfer_paged_kv_cache(bb, kv_cache_kind, kwargs)
         return bb.finalize()
 
-    def attach_kv_cache_metadata(self, kwargs: Dict[str, Any]):
+    def attach_kv_cache_metadata(
+        self, kv_cache_kind: Literal["mha", "mla"], kwargs: Dict[str, Any]
+    ):
         """Attach the KV cache metadata to model metadata."""
-        self.metadata["kv_cache"] = {
-            "num_hidden_layers": kwargs["num_hidden_layers"],
-            "num_attention_heads": kwargs["num_attention_heads"],
-            "num_key_value_heads": kwargs["num_key_value_heads"],
-            "head_dim": kwargs["head_dim"],
-        }
+        if kv_cache_kind == "mha":
+            self.metadata["kv_cache"] = {
+                "num_hidden_layers": kwargs["num_hidden_layers"],
+                "num_attention_heads": kwargs["num_attention_heads"],
+                "num_key_value_heads": kwargs["num_key_value_heads"],
+                "head_dim": kwargs["head_dim"],
+            }
+        elif kv_cache_kind == "mla":
+            self.metadata["kv_cache"] = {
+                "num_hidden_layers": kwargs["num_hidden_layers"],
+                "num_attention_heads": kwargs["num_attention_heads"],
+                "num_key_value_heads": 1,
+                "head_dim": kwargs["kv_lora_rank"] + kwargs["qk_rope_head_dim"],
+            }
+        else:
+            raise ValueError("Cannot reach here.")
 
-    def create_tir_paged_kv_cache(self, bb: relax.BlockBuilder, kwargs: Dict[str, Any]) -> None:
+    def create_tir_paged_kv_cache(
+        self, bb: relax.BlockBuilder, kv_cache_kind: Literal["mha", "mla"], kwargs: Dict[str, Any]
+    ) -> None:
         """Create the TIR-based PagedKVCache"""
         max_batch_size = relax.Var(
             "max_batch_size_", relax.ShapeStructInfo([kwargs["max_batch_size"]])
@@ -143,16 +189,22 @@ class DispatchKVCacheCreation:  # pylint: disable=too-many-instance-attributes
                 support_sliding_window,
             ],
         ):
-            cache = kv_cache.TIRPagedKVCache(target=self.target, **kwargs)
+            if kv_cache_kind == "mha":
+                cache = kv_cache.TIRPagedKVCache(target=self.target, **kwargs)
+            elif kv_cache_kind == "mla":
+                cache = kv_cache.TIRPagedKVCache.create_mla_kv_cache(target=self.target, **kwargs)
+            else:
+                raise ValueError("Cannot reach here")
             bb.emit_func_output(cache._expr)  # pylint: disable=protected-access
 
     def create_flashinfer_paged_kv_cache(
-        self, bb: relax.BlockBuilder, kwargs: Dict[str, Any]
+        self, bb: relax.BlockBuilder, kv_cache_kind: Literal["mha", "mla"], kwargs: Dict[str, Any]
     ) -> None:
         """Create the FlashInfer-based PagedKVCache"""
         # Filter the cases which FlashInfer does not support.
         if (  # pylint: disable=too-many-boolean-expressions
             not self.flashinfer
+            or kv_cache_kind != "mha"
             or str(kwargs["dtype"]) != "float16"
             or kwargs["head_dim"] != 128
             or (

--- a/python/mlc_llm/model/baichuan/baichuan_model.py
+++ b/python/mlc_llm/model/baichuan/baichuan_model.py
@@ -277,7 +277,7 @@ class BaichuanForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/chatglm3/chatglm3_model.py
+++ b/python/mlc_llm/model/chatglm3/chatglm3_model.py
@@ -353,7 +353,7 @@ class ChatGLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/cohere/cohere_model.py
+++ b/python/mlc_llm/model/cohere/cohere_model.py
@@ -322,7 +322,7 @@ class CohereForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/deepseek/deepseek_model.py
+++ b/python/mlc_llm/model/deepseek/deepseek_model.py
@@ -428,7 +428,7 @@ class DeepseekForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/eagle/eagle_model.py
+++ b/python/mlc_llm/model/eagle/eagle_model.py
@@ -164,7 +164,7 @@ class EagleForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/gemma/gemma_model.py
+++ b/python/mlc_llm/model/gemma/gemma_model.py
@@ -306,7 +306,7 @@ class GemmaForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/gpt2/gpt2_model.py
+++ b/python/mlc_llm/model/gpt2/gpt2_model.py
@@ -297,7 +297,7 @@ class GPT2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/gpt_bigcode/gpt_bigcode_model.py
+++ b/python/mlc_llm/model/gpt_bigcode/gpt_bigcode_model.py
@@ -264,7 +264,7 @@ class GPTBigCodeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/gpt_j/gpt_j_model.py
+++ b/python/mlc_llm/model/gpt_j/gpt_j_model.py
@@ -285,7 +285,7 @@ class GPTJForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribute
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/gpt_neox/gpt_neox_model.py
+++ b/python/mlc_llm/model/gpt_neox/gpt_neox_model.py
@@ -328,7 +328,7 @@ class GPTNeoXForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/internlm/internlm_model.py
+++ b/python/mlc_llm/model/internlm/internlm_model.py
@@ -288,7 +288,7 @@ class InternLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/internlm2/internlm2_model.py
+++ b/python/mlc_llm/model/internlm2/internlm2_model.py
@@ -295,7 +295,7 @@ class InternLM2ForCausalLM(nn.Module):  # pylint: disable=R0902
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/llama/llama_model.py
+++ b/python/mlc_llm/model/llama/llama_model.py
@@ -396,7 +396,7 @@ class LlamaForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/llava/llava_model.py
+++ b/python/mlc_llm/model/llava/llava_model.py
@@ -229,7 +229,7 @@ class LlavaForCasualLM(Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/minicpm/minicpm_model.py
+++ b/python/mlc_llm/model/minicpm/minicpm_model.py
@@ -428,7 +428,7 @@ class MiniCPMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/mistral/mistral_model.py
+++ b/python/mlc_llm/model/mistral/mistral_model.py
@@ -302,7 +302,7 @@ class MistralForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/nemotron/nemotron_model.py
+++ b/python/mlc_llm/model/nemotron/nemotron_model.py
@@ -378,7 +378,7 @@ class NemotronForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/olmo/olmo_model.py
+++ b/python/mlc_llm/model/olmo/olmo_model.py
@@ -450,7 +450,7 @@ class OLMoForCausalLM(  # pylint: disable=missing-class-docstring,too-many-insta
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/orion/orion_model.py
+++ b/python/mlc_llm/model/orion/orion_model.py
@@ -284,7 +284,7 @@ class OrionForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/phi/phi_model.py
+++ b/python/mlc_llm/model/phi/phi_model.py
@@ -406,7 +406,7 @@ class PhiForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/phi3/phi3_model.py
+++ b/python/mlc_llm/model/phi3/phi3_model.py
@@ -302,7 +302,7 @@ class Phi3ForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/phi3v/phi3v_model.py
+++ b/python/mlc_llm/model/phi3v/phi3v_model.py
@@ -282,7 +282,7 @@ class Phi3VForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/qwen/qwen_model.py
+++ b/python/mlc_llm/model/qwen/qwen_model.py
@@ -283,7 +283,7 @@ class QWenLMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/qwen2/qwen2_model.py
+++ b/python/mlc_llm/model/qwen2/qwen2_model.py
@@ -324,7 +324,7 @@ class QWen2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/qwen2_moe/qwen2_moe_model.py
+++ b/python/mlc_llm/model/qwen2_moe/qwen2_moe_model.py
@@ -307,7 +307,7 @@ class Qwen2MoeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/stable_lm/stablelm_model.py
+++ b/python/mlc_llm/model/stable_lm/stablelm_model.py
@@ -292,7 +292,7 @@ class StableLmForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/python/mlc_llm/model/starcoder2/starcoder2_model.py
+++ b/python/mlc_llm/model/starcoder2/starcoder2_model.py
@@ -310,7 +310,7 @@ class Starcoder2ForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic(
+        return PagedKVCache.create_generic_mha(
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,

--- a/tests/python/model/test_kv_cache.py
+++ b/tests/python/model/test_kv_cache.py
@@ -74,7 +74,7 @@ def test_nn_module_paged_kv_cache():
             page_size: tir.Var,
             support_sliding_window: tir.Var,
         ) -> PagedKVCache:
-            return PagedKVCache.create_generic(
+            return PagedKVCache.create_generic_mha(
                 max_batch_size=max_batch_size,
                 max_total_seq_len=max_total_seq_len,
                 prefill_chunk_size=prefill_chunk_size,


### PR DESCRIPTION
This PR supports the weight absorption for DeepSeek-v2/v3 models.

At this moment, absorption is enabled by default, while for the first prefill, computing without weight absorption is usually more efficient. The logic that switches between weight absorption and normal computation is still in progress.