### PR TITLE
[Config] Print the overriden config during model compilation

### DIFF
--- a/python/mlc_llm/compiler_pass/blas_dispatch.py
+++ b/python/mlc_llm/compiler_pass/blas_dispatch.py
@@ -1,10 +1,16 @@
 """A compiler pass that dispatches patterns to CUBLAS."""
 
 import tvm
-import tvm.relax.backend.contrib.cublas as _cublas
-import tvm.relax.backend.contrib.hipblas as _hipblas
 from tvm import IRModule, relax
 from tvm.relax.backend import get_patterns_with_prefix
+
+try:
+    import tvm.relax.backend.cuda.cublas as _cublas
+    import tvm.relax.backend.rocm.hipblas as _hipblas
+except ImportError:
+    # Note: legacy path of cublas/hipblas for backward compatibility
+    import tvm.relax.backend.contrib.cublas as _cublas
+    import tvm.relax.backend.contrib.hipblas as _hipblas
 
 
 @tvm.transform.module_pass(opt_level=0, name="BLASDispatch")

--- a/python/mlc_llm/interface/compile.py
+++ b/python/mlc_llm/interface/compile.py
@@ -137,7 +137,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
             cutlass=args.opt.cutlass,
         )
         # Step 1. Create the quantized model
-        logger.info("Creating model from: %s", args.config)
+        logger.info("Creating model from: %s", model_config)
         if (
             args.quantization.kind == "ft-quant"
             and hasattr(model_config, "tensor_parallel_shards")


### PR DESCRIPTION
This PR fixes a minor place which didn't print out the overriden model config during model compilation.

It also updates the Python import path subject to the latest TVM changes.