### PR TITLE
[KVCache] Refactor KV cache interface and DeepSeek-v2 modeling

### DIFF
--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -217,8 +217,10 @@ void FunctionTable::_InitFunctions() {
   this->image_embed_func_ = mod_get_func("image_embed");
   this->single_batch_prefill_func_ = mod_get_func("prefill");
   this->single_batch_decode_func_ = mod_get_func("decode");
+  this->single_batch_extend_func_ = mod_get_func("extend");
   this->prefill_func_ = mod_get_func("batch_prefill");
   this->decode_func_ = mod_get_func("batch_decode");
+  this->extend_func_ = mod_get_func("batch_extend");
   this->verify_func_ = mod_get_func("batch_verify");
   this->single_batch_prefill_to_last_hidden_func_ = mod_get_func("prefill_to_last_hidden_states");
   this->single_batch_decode_to_last_hidden_func_ = mod_get_func("decode_to_last_hidden_states");

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -82,8 +82,10 @@ struct FunctionTable {
   PackedFunc image_embed_func_;
   PackedFunc single_batch_prefill_func_;
   PackedFunc single_batch_decode_func_;
+  PackedFunc single_batch_extend_func_;
   PackedFunc prefill_func_;
   PackedFunc decode_func_;
+  PackedFunc extend_func_;
   PackedFunc verify_func_;
   PackedFunc single_batch_prefill_to_last_hidden_func_;
   PackedFunc single_batch_decode_to_last_hidden_func_;

--- a/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
+++ b/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
@@ -1,15 +1,19 @@
 """A pass that rewrites KV cache creation functions in IRModule."""
 
 import json
-from typing import Any, Dict, Literal, Tuple
+from typing import Any, Dict, List
 
 import tvm
 from tvm import IRModule, relax
 from tvm.relax.frontend.nn.llm import kv_cache
 from tvm.relax.frontend.nn.llm.kv_cache import RopeMode
 
+from mlc_llm.support import logging
 
-def extract_creation_args(func: relax.Function) -> Tuple[Literal["mha", "mla"], Dict[str, Any]]:
+logger = logging.getLogger(__name__)
+
+
+def extract_creation_args(func: relax.Function) -> Dict[str, Any]:
     """Extract the KV cache creation args from the given generic creation func."""
     assert isinstance(func.body, relax.SeqExpr)
     assert len(func.body.blocks) == 1
@@ -23,69 +27,45 @@ def extract_creation_args(func: relax.Function) -> Tuple[Literal["mha", "mla"], 
     assert isinstance(call_args[1], relax.StringImm)
 
     args = call_args[1:]
-    if args[0].value == "mha":
-        assert len(args) == 15
-        assert isinstance(args[1], relax.ShapeExpr)
-        assert len(args[1].values) == 5
-        assert isinstance(args[2], relax.ShapeExpr)
-        for i in range(3, 14):
-            if i in [10, 11]:
-                continue
-            assert isinstance(args[i], relax.PrimValue)
-            assert isinstance(args[i].value, (tvm.tir.IntImm, tvm.tir.FloatImm))
-        assert isinstance(args[10], relax.StringImm)
-        assert isinstance(args[11], (relax.Constant, relax.PrimValue))
-        assert isinstance(args[14], relax.DataTypeImm)
+    assert len(args) == 18
+    assert isinstance(args[0], relax.StringImm)
+    assert args[0].value in ["mha", "mla"]
+    assert isinstance(args[1], relax.ShapeExpr)
+    assert len(args[1].values) == 5
+    assert isinstance(args[2], relax.ShapeExpr)
+    for i in range(3, 18):
+        if i in [13, 14, 17]:
+            continue
+        assert isinstance(args[i], relax.PrimValue), f"args[{i}] is {type(args[i])}"
+        assert isinstance(args[i].value, (tvm.tir.IntImm, tvm.tir.FloatImm))
+    assert isinstance(args[13], relax.StringImm)
+    assert isinstance(args[16], (relax.Constant, relax.PrimValue))
+    assert isinstance(args[17], relax.DataTypeImm)
 
-        return "mha", {
-            "max_batch_size": args[1].values[0],
-            "max_total_seq_len": args[1].values[1],
-            "prefill_chunk_size": args[1].values[2],
-            "page_size": args[1].values[3],
-            "support_sliding_window": args[1].values[4],
-            "layer_partition": args[2],
-            "num_hidden_layers": args[3].value.value,
-            "num_attention_heads": args[4].value.value,
-            "num_key_value_heads": args[5].value.value,
-            "head_dim": args[6].value.value,
-            "rope_mode": args[7].value.value,
-            "rope_scale": args[8].value.value,
-            "rope_theta": args[9].value.value,
-            "rope_scaling": json.loads(args[10].value),
-            "rope_ext_factors": args[11],
-            "rotary_dim": args[12].value.value,
-            "enable_disaggregation": bool(args[13].value.value),
-            "dtype": args[14].value,
-        }
-    if call_args[1].value == "mla":
-        assert len(args) == 12
-        assert isinstance(args[1], relax.ShapeExpr)
-        assert len(args[1].values) == 5
-        assert isinstance(args[2], relax.ShapeExpr)
-        for i in range(3, 11):
-            assert isinstance(args[i], relax.PrimValue)
-            assert isinstance(args[i].value, tvm.tir.IntImm)
-        assert isinstance(args[11], relax.DataTypeImm)
-
-        return "mla", {
-            "max_batch_size": args[1].values[0],
-            "max_total_seq_len": args[1].values[1],
-            "prefill_chunk_size": args[1].values[2],
-            "page_size": args[1].values[3],
-            "support_sliding_window": args[1].values[4],
-            "layer_partition": args[2],
-            "num_hidden_layers": args[3].value.value,
-            "num_attention_heads": args[4].value.value,
-            "num_key_value_heads": args[5].value.value,
-            "qk_nope_head_dim": args[6].value.value,
-            "qk_rope_head_dim": args[7].value.value,
-            "v_head_dim": args[8].value.value,
-            "kv_lora_rank": args[9].value.value,
-            "enable_disaggregation": bool(args[10].value.value),
-            "dtype": args[11].value,
-        }
-
-    raise ValueError("Cannot reach here")
+    return {
+        "attn_kind": args[0].value,
+        "max_batch_size": args[1].values[0],
+        "max_total_seq_len": args[1].values[1],
+        "prefill_chunk_size": args[1].values[2],
+        "page_size": args[1].values[3],
+        "support_sliding_window": args[1].values[4],
+        "layer_partition": args[2],
+        "num_hidden_layers": args[3].value.value,
+        "num_attention_heads": args[4].value.value,
+        "num_key_value_heads": args[5].value.value,
+        "qk_head_dim": args[6].value.value,
+        "v_head_dim": args[7].value.value,
+        "mla_original_qk_head_dim": args[8].value.value,
+        "mla_original_v_head_dim": args[9].value.value,
+        "rope_mode": args[10].value.value,
+        "rope_scale": args[11].value.value,
+        "rope_theta": args[12].value.value,
+        "rope_scaling": json.loads(args[13].value),
+        "rope_ext_factors": args[14],
+        "rotary_dim": args[15].value.value,
+        "enable_disaggregation": bool(args[16].value.value),
+        "dtype": args[17].value,
+    }
 
 
 @tvm.transform.module_pass(opt_level=0, name="DispatchKVCacheCreation")
@@ -132,38 +112,31 @@ class DispatchKVCacheCreation:  # pylint: disable=too-many-instance-attributes
         if mod.attrs is not None:
             new_mod = new_mod.with_attrs(mod.attrs)
 
-        kv_cache_kind, kwargs = extract_creation_args(creation_func)
-        self.attach_kv_cache_metadata(kv_cache_kind, kwargs)
+        kwargs = extract_creation_args(creation_func)
+        self.attach_kv_cache_metadata(kwargs)
 
         bb = relax.BlockBuilder(new_mod)
-        self.create_tir_paged_kv_cache(bb, kv_cache_kind, kwargs)
-        self.create_flashinfer_paged_kv_cache(bb, kv_cache_kind, kwargs)
-        return bb.finalize()
+        extern_mods = []
+        extern_mods += self.create_tir_paged_kv_cache(bb, kwargs)
+        extern_mods += self.create_flashinfer_paged_kv_cache(bb, kwargs)
 
-    def attach_kv_cache_metadata(
-        self, kv_cache_kind: Literal["mha", "mla"], kwargs: Dict[str, Any]
-    ):
+        mod = bb.finalize()
+        mod_attrs = dict(mod.attrs) if mod.attrs else {}
+        mod = mod.with_attr("external_mods", mod_attrs.get("external_mods", []) + extern_mods)
+        return mod
+
+    def attach_kv_cache_metadata(self, kwargs: Dict[str, Any]):
         """Attach the KV cache metadata to model metadata."""
-        if kv_cache_kind == "mha":
-            self.metadata["kv_cache"] = {
-                "num_hidden_layers": kwargs["num_hidden_layers"],
-                "num_attention_heads": kwargs["num_attention_heads"],
-                "num_key_value_heads": kwargs["num_key_value_heads"],
-                "head_dim": kwargs["head_dim"],
-            }
-        elif kv_cache_kind == "mla":
-            self.metadata["kv_cache"] = {
-                "num_hidden_layers": kwargs["num_hidden_layers"],
-                "num_attention_heads": kwargs["num_attention_heads"],
-                "num_key_value_heads": 1,
-                "head_dim": kwargs["kv_lora_rank"] + kwargs["qk_rope_head_dim"],
-            }
-        else:
-            raise ValueError("Cannot reach here.")
+        self.metadata["kv_cache"] = {
+            "num_hidden_layers": kwargs["num_hidden_layers"],
+            "num_attention_heads": kwargs["num_attention_heads"],
+            "num_key_value_heads": kwargs["num_key_value_heads"],
+            "head_dim": kwargs["qk_head_dim"],
+        }
 
     def create_tir_paged_kv_cache(
-        self, bb: relax.BlockBuilder, kv_cache_kind: Literal["mha", "mla"], kwargs: Dict[str, Any]
-    ) -> None:
+        self, bb: relax.BlockBuilder, kwargs: Dict[str, Any]
+    ) -> List[tvm.runtime.Module]:
         """Create the TIR-based PagedKVCache"""
         max_batch_size = relax.Var(
             "max_batch_size_", relax.ShapeStructInfo([kwargs["max_batch_size"]])
@@ -189,37 +162,29 @@ class DispatchKVCacheCreation:  # pylint: disable=too-many-instance-attributes
                 support_sliding_window,
             ],
         ):
-            if kv_cache_kind == "mha":
-                cache = kv_cache.TIRPagedKVCache(target=self.target, **kwargs)
-            elif kv_cache_kind == "mla":
-                cache = kv_cache.TIRPagedKVCache.create_mla_kv_cache(target=self.target, **kwargs)
-            else:
-                raise ValueError("Cannot reach here")
+            cache = kv_cache.TIRPagedKVCache(target=self.target, **kwargs)
             bb.emit_func_output(cache._expr)  # pylint: disable=protected-access
 
+        return cache.extern_mods
+
     def create_flashinfer_paged_kv_cache(
-        self, bb: relax.BlockBuilder, kv_cache_kind: Literal["mha", "mla"], kwargs: Dict[str, Any]
-    ) -> None:
+        self, bb: relax.BlockBuilder, kwargs: Dict[str, Any]
+    ) -> List[tvm.runtime.Module]:
         """Create the FlashInfer-based PagedKVCache"""
         # Filter the cases which FlashInfer does not support.
         if (  # pylint: disable=too-many-boolean-expressions
             not self.flashinfer
-            or kv_cache_kind != "mha"
-            or str(kwargs["dtype"]) != "float16"
-            or kwargs["head_dim"] != 128
+            or self.target.kind.name != "cuda"
+            or str(kwargs["dtype"]) not in ["float16"]
             or (
                 kwargs["rope_mode"] == RopeMode.INLINE
-                and kwargs["rotary_dim"] != kwargs["head_dim"]
+                and (
+                    kwargs["rotary_dim"] != kwargs["qk_head_dim"]
+                    or kwargs["qk_head_dim"] != kwargs["v_head_dim"]
+                )
             )
-            or (
-                # bypass GPT-2 since it uses attn_score_scaling_factor
-                "gpt2"
-                in self.metadata["model_type"]
-            )
-            # filter by attention group size
-            or kwargs["num_attention_heads"] // kwargs["num_key_value_heads"] not in [1, 4, 8]
         ):
-            return
+            return []
 
         max_batch_size = relax.Var(
             "max_batch_size_", relax.ShapeStructInfo([kwargs["max_batch_size"]])
@@ -235,15 +200,25 @@ class DispatchKVCacheCreation:  # pylint: disable=too-many-instance-attributes
             "support_sliding_window_", relax.ShapeStructInfo([kwargs["support_sliding_window"]])
         )
 
-        with bb.function(
-            name="create_flashinfer_paged_kv_cache",
-            params=[
-                max_batch_size,
-                max_total_seq_len,
-                prefill_chunk_size,
-                page_size,
-                support_sliding_window,
-            ],
-        ):
-            cache = kv_cache.FlashInferPagedKVCache(target=self.target, **kwargs)
-            bb.emit_func_output(cache._expr)  # pylint: disable=protected-access
+        try:
+            with bb.function(
+                name="create_flashinfer_paged_kv_cache",
+                params=[
+                    max_batch_size,
+                    max_total_seq_len,
+                    prefill_chunk_size,
+                    page_size,
+                    support_sliding_window,
+                ],
+            ):
+                cache = kv_cache.FlashInferPagedKVCache(target=self.target, **kwargs)
+                bb.emit_func_output(cache._expr)  # pylint: disable=protected-access
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.info(
+                "Error caught when creating FlashInfer PagedKVCache: %s\n"
+                "The model will fallback to TIR-based KV cache.",
+                e,
+            )
+            return []
+
+        return cache.extern_mods

--- a/python/mlc_llm/model/baichuan/baichuan_model.py
+++ b/python/mlc_llm/model/baichuan/baichuan_model.py
@@ -102,7 +102,10 @@ class BaichuanAttention(nn.Module):  # pylint: disable=too-many-instance-attribu
         qkv = self.W_pack(hidden_states)
         qkv = op.reshape(qkv, (b, s, 3 * h, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads), (b, s, h * d)
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
+            (b, s, h * d),
         )
         attn_output = self.o_proj(output)
         return attn_output
@@ -277,7 +280,8 @@ class BaichuanForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -286,7 +290,8 @@ class BaichuanForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_attention_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/chatglm3/chatglm3_model.py
+++ b/python/mlc_llm/model/chatglm3/chatglm3_model.py
@@ -120,7 +120,9 @@ class GLMAttention(nn.Module):  # pylint: disable=too-many-instance-attributes
         qkv = self.query_key_value(hidden_states)
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, h_q),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, h_q, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         attn_output = self.dense(output)
@@ -353,7 +355,8 @@ class ChatGLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -362,7 +365,8 @@ class ChatGLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/cohere/cohere_model.py
+++ b/python/mlc_llm/model/cohere/cohere_model.py
@@ -140,7 +140,9 @@ class CohereAttention(nn.Module):
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         # Attention
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_q_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         return self.out_proj(output)
@@ -322,7 +324,8 @@ class CohereForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -331,7 +334,8 @@ class CohereForCausalLM(nn.Module):
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/deepseek/deepseek_model.py
+++ b/python/mlc_llm/model/deepseek/deepseek_model.py
@@ -128,7 +128,9 @@ class DeepseekAttention(nn.Module):  # pylint: disable=too-many-instance-attribu
         qkv = self.wqkv_pack(hidden_states)
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         attn_output = self.o_proj(output)
@@ -428,7 +430,8 @@ class DeepseekForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -437,7 +440,8 @@ class DeepseekForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/eagle/eagle_model.py
+++ b/python/mlc_llm/model/eagle/eagle_model.py
@@ -164,7 +164,8 @@ class EagleForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -173,7 +174,8 @@ class EagleForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/gpt_j/gpt_j_model.py
+++ b/python/mlc_llm/model/gpt_j/gpt_j_model.py
@@ -109,7 +109,10 @@ class GPTJAttention(nn.Module):  # pylint: disable=too-many-instance-attributes
         qkv = self.c_attn(hidden_states)
         qkv = op.reshape(qkv, (b, s, 3 * h, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads), (b, s, h * d)
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
+            (b, s, h * d),
         )
         return self.out_proj(output)
 
@@ -285,7 +288,8 @@ class GPTJForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribute
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -294,7 +298,8 @@ class GPTJForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribute
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_attention_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/internlm/internlm_model.py
+++ b/python/mlc_llm/model/internlm/internlm_model.py
@@ -105,7 +105,10 @@ class InternLMAttention(nn.Module):  # pylint: disable=too-many-instance-attribu
         qkv = self.wqkv_pack(hidden_states)
         qkv = op.reshape(qkv, (b, s, 3 * h, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads), (b, s, h * d)
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
+            (b, s, h * d),
         )
         attn_output = self.o_proj(output)
         return attn_output
@@ -288,7 +291,8 @@ class InternLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -297,7 +301,8 @@ class InternLMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_attention_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/internlm2/internlm2_model.py
+++ b/python/mlc_llm/model/internlm2/internlm2_model.py
@@ -111,7 +111,9 @@ class InternLM2Attention(nn.Module):  # pylint: disable=too-many-instance-attrib
         qkv = self.wqkv(hidden_states)
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         attn_output = self.wo(output)
@@ -295,7 +297,8 @@ class InternLM2ForCausalLM(nn.Module):  # pylint: disable=R0902
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -304,7 +307,8 @@ class InternLM2ForCausalLM(nn.Module):  # pylint: disable=R0902
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/llava/llava_model.py
+++ b/python/mlc_llm/model/llava/llava_model.py
@@ -229,7 +229,8 @@ class LlavaForCasualLM(Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -240,7 +241,8 @@ class LlavaForCasualLM(Module):
             // self.config.tensor_parallel_shards,
             num_key_value_heads=self.config.text_config.num_key_value_heads
             // self.config.tensor_parallel_shards,
-            head_dim=self.config.text_config.head_dim,
+            qk_head_dim=self.config.text_config.head_dim,
+            v_head_dim=self.config.text_config.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.language_model.rope_theta,

--- a/python/mlc_llm/model/minicpm/minicpm_model.py
+++ b/python/mlc_llm/model/minicpm/minicpm_model.py
@@ -123,7 +123,9 @@ class MiniCPMAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         qkv = self.wqkv_pack(hidden_states)
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         attn_output = self.o_proj(output)
@@ -428,7 +430,8 @@ class MiniCPMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -437,7 +440,8 @@ class MiniCPMForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attrib
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/mistral/mistral_model.py
+++ b/python/mlc_llm/model/mistral/mistral_model.py
@@ -146,7 +146,9 @@ class MistralAttention(nn.Module):  # pylint: disable=too-many-instance-attribut
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         # Attention
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_q_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         return self.o_proj(output)
@@ -302,7 +304,8 @@ class MistralForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attrib
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -311,7 +314,8 @@ class MistralForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attrib
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/nemotron/nemotron_model.py
+++ b/python/mlc_llm/model/nemotron/nemotron_model.py
@@ -147,7 +147,9 @@ class NemotronAttention(nn.Module):  # pylint: disable=too-many-instance-attribu
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         # Attention
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_q_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         return self.o_proj(output)
@@ -378,7 +380,8 @@ class NemotronForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -387,7 +390,8 @@ class NemotronForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/olmo/olmo_model.py
+++ b/python/mlc_llm/model/olmo/olmo_model.py
@@ -152,7 +152,9 @@ class OLMoAttention(nn.Module):  # pylint: disable=missing-class-docstring
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         # Attention
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_q_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         return self.o_proj(output)
@@ -450,7 +452,8 @@ class OLMoForCausalLM(  # pylint: disable=missing-class-docstring,too-many-insta
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -459,7 +462,8 @@ class OLMoForCausalLM(  # pylint: disable=missing-class-docstring,too-many-insta
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/orion/orion_model.py
+++ b/python/mlc_llm/model/orion/orion_model.py
@@ -135,7 +135,9 @@ class OrionAttention(nn.Module):  # pylint: disable=too-many-instance-attributes
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         # Attention
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_q_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         return self.o_proj(output)
@@ -284,7 +286,8 @@ class OrionForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -293,7 +296,8 @@ class OrionForCasualLM(nn.Module):  # pylint: disable=too-many-instance-attribut
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/phi/phi_model.py
+++ b/python/mlc_llm/model/phi/phi_model.py
@@ -217,7 +217,9 @@ class PhiMHA(nn.Module):  # pylint: disable=too-many-instance-attributes
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         # Attention
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_q_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         return self.out_proj(output)
@@ -406,7 +408,8 @@ class PhiForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -415,7 +418,8 @@ class PhiForCausalLM(nn.Module):
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/phi3/phi3_model.py
+++ b/python/mlc_llm/model/phi3/phi3_model.py
@@ -142,7 +142,9 @@ class PhiMHA(nn.Module):  # pylint: disable=too-many-instance-attributes
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         # Attention
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_q_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         return self.out_proj(output)
@@ -302,7 +304,8 @@ class Phi3ForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -311,7 +314,8 @@ class Phi3ForCausalLM(nn.Module):
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scaling=self.rope_scaling,
             rope_scale=1,

--- a/python/mlc_llm/model/phi3v/phi3v_model.py
+++ b/python/mlc_llm/model/phi3v/phi3v_model.py
@@ -282,7 +282,8 @@ class Phi3VForCausalLM(nn.Module):
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -291,7 +292,8 @@ class Phi3VForCausalLM(nn.Module):
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scaling=self.rope_scaling,
             rope_scale=1,

--- a/python/mlc_llm/model/qwen/qwen_model.py
+++ b/python/mlc_llm/model/qwen/qwen_model.py
@@ -107,7 +107,10 @@ class QWenAttention(nn.Module):  # pylint: disable=too-many-instance-attributes
         qkv = self.c_attn(hidden_states)
         qkv = op.reshape(qkv, (b, s, 3 * h, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads), (b, s, h * d)
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
+            (b, s, h * d),
         )
         return self.c_proj(output)
 
@@ -283,7 +286,8 @@ class QWenLMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -292,7 +296,8 @@ class QWenLMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribute
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_attention_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rotary_emb_base,

--- a/python/mlc_llm/model/qwen2/qwen2_model.py
+++ b/python/mlc_llm/model/qwen2/qwen2_model.py
@@ -110,7 +110,9 @@ class QWen2Attention(nn.Module):  # pylint: disable=too-many-instance-attributes
         qkv = self.c_attn(hidden_states)
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_attention_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_attention_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         attn_output = self.o_proj(output)
@@ -324,7 +326,8 @@ class QWen2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribut
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -333,7 +336,8 @@ class QWen2LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribut
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/qwen2_moe/qwen2_moe_model.py
+++ b/python/mlc_llm/model/qwen2_moe/qwen2_moe_model.py
@@ -307,7 +307,8 @@ class Qwen2MoeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -316,7 +317,8 @@ class Qwen2MoeForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attri
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/model/starcoder2/starcoder2_model.py
+++ b/python/mlc_llm/model/starcoder2/starcoder2_model.py
@@ -118,7 +118,9 @@ class Starcoder2Attention(nn.Module):  # pylint: disable=too-many-instance-attri
         qkv = self.wqkv_pack(hidden_states)
         qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
         output = op.reshape(
-            paged_kv_cache.attention_with_fused_qkv(layer_id, qkv, self.num_heads),
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_heads, sm_scale=self.head_dim**-0.5
+            ),
             (b, s, h_q * d),
         )
         attn_output = self.o_proj(output)
@@ -310,7 +312,8 @@ class Starcoder2ForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
         page_size: tir.Var,
         support_sliding_window: tir.Var,
     ) -> PagedKVCache:
-        return PagedKVCache.create_generic_mha(
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
             max_batch_size=max_batch_size,
             max_total_seq_len=max_total_seq_len,
             prefill_chunk_size=prefill_chunk_size,
@@ -319,7 +322,8 @@ class Starcoder2ForCausalLM(nn.Module):  # pylint: disable=too-many-instance-att
             num_hidden_layers=self.num_hidden_layers,
             num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
             num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
-            head_dim=self.head_dim,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
             rope_mode=RopeMode.NORMAL,
             rope_scale=1,
             rope_theta=self.rope_theta,

--- a/python/mlc_llm/nn/kv_cache.py
+++ b/python/mlc_llm/nn/kv_cache.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=too-many-statements,too-many-lines,too-many-arguments
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import numpy as np
 from tvm import relax as rx
@@ -15,7 +15,8 @@ class PagedKVCache(TVMPagedKVCache):  # pylint: disable=too-few-public-methods
     """The Paged KV Cache used in LLM batching for efficient attention computation."""
 
     @staticmethod
-    def create_generic_mha(  # pylint: disable=too-many-locals
+    def create_generic(  # pylint: disable=too-many-locals
+        attn_kind: Literal["mha", "mla"],
         max_batch_size: tir.Var,
         max_total_seq_len: tir.Var,
         prefill_chunk_size: tir.Var,
@@ -24,11 +25,14 @@ class PagedKVCache(TVMPagedKVCache):  # pylint: disable=too-few-public-methods
         num_hidden_layers: int,
         num_attention_heads: int,
         num_key_value_heads: int,
-        head_dim: int,
+        qk_head_dim: int,
+        v_head_dim: int,
         rope_mode: RopeMode,
         rope_scale: int,
         rope_theta: int,
         dtype: str,
+        mla_original_qk_head_dim: int = 0,
+        mla_original_v_head_dim: int = 0,
         rotary_dim: Optional[int] = None,
         rope_scaling: Optional[Dict[str, Any]] = None,
         rope_ext_factors: Optional[List[int]] = None,
@@ -40,7 +44,7 @@ class PagedKVCache(TVMPagedKVCache):  # pylint: disable=too-few-public-methods
         which will be rewritten by functions in compilation pipeline.
         """
         if rotary_dim is None:
-            rotary_dim = head_dim
+            rotary_dim = qk_head_dim
         if rope_scaling is None:
             rope_scaling = {}
         if layer_partition is None:
@@ -48,7 +52,7 @@ class PagedKVCache(TVMPagedKVCache):  # pylint: disable=too-few-public-methods
         return PagedKVCache(
             _expr=rx.call_pure_packed(
                 "mlc.create_paged_kv_cache_generic",
-                rx.StringImm("mha"),
+                rx.StringImm(attn_kind),
                 rx.ShapeExpr(
                     [
                         max_batch_size,
@@ -62,7 +66,10 @@ class PagedKVCache(TVMPagedKVCache):  # pylint: disable=too-few-public-methods
                 rx.PrimValue(num_hidden_layers),
                 rx.PrimValue(num_attention_heads),
                 rx.PrimValue(num_key_value_heads),
-                rx.PrimValue(head_dim),
+                rx.PrimValue(qk_head_dim),
+                rx.PrimValue(v_head_dim),
+                rx.PrimValue(mla_original_qk_head_dim),
+                rx.PrimValue(mla_original_v_head_dim),
                 rx.PrimValue(rope_mode),
                 rx.PrimValue(rope_scale),
                 rx.PrimValue(rope_theta),
@@ -75,58 +82,6 @@ class PagedKVCache(TVMPagedKVCache):  # pylint: disable=too-few-public-methods
                     # to represent "undefined".
                 ),
                 rx.PrimValue(rotary_dim),
-                rx.PrimValue(int(enable_disaggregation)),
-                rx.DataTypeImm(dtype),
-                sinfo_args=rx.ObjectStructInfo(),
-            ),
-            _name=name,
-        )
-
-    @staticmethod
-    def create_generic_mla(  # pylint: disable=too-many-locals
-        max_batch_size: tir.Var,
-        max_total_seq_len: tir.Var,
-        prefill_chunk_size: tir.Var,
-        page_size: tir.Var,
-        support_sliding_window: tir.Var,
-        num_hidden_layers: int,
-        num_attention_heads: int,
-        num_key_value_heads: int,
-        qk_nope_head_dim: int,
-        qk_rope_head_dim: int,
-        v_head_dim: int,
-        kv_lora_rank: int,
-        dtype: str,
-        layer_partition: Optional[List[int]] = None,
-        enable_disaggregation: bool = False,
-        name: str = "paged_kv_cache",
-    ) -> "PagedKVCache":
-        """The generic function of creating a multi-head latent attn PagedKVCache,
-        which will be rewritten by functions in compilation pipeline.
-        """
-        if layer_partition is None:
-            layer_partition = [0, num_hidden_layers]
-        return PagedKVCache(
-            _expr=rx.call_pure_packed(
-                "mlc.create_paged_kv_cache_generic",
-                rx.StringImm("mla"),
-                rx.ShapeExpr(
-                    [
-                        max_batch_size,
-                        max_total_seq_len,
-                        prefill_chunk_size,
-                        page_size,
-                        support_sliding_window,
-                    ]
-                ),
-                rx.ShapeExpr(layer_partition),
-                rx.PrimValue(num_hidden_layers),
-                rx.PrimValue(num_attention_heads),
-                rx.PrimValue(num_key_value_heads),
-                rx.PrimValue(qk_nope_head_dim),
-                rx.PrimValue(qk_rope_head_dim),
-                rx.PrimValue(v_head_dim),
-                rx.PrimValue(kv_lora_rank),
                 rx.PrimValue(int(enable_disaggregation)),
                 rx.DataTypeImm(dtype),
                 sinfo_args=rx.ObjectStructInfo(),

--- a/python/setup.py
+++ b/python/setup.py
@@ -111,6 +111,7 @@ def main():
             "transformers",
             "pandas",
             "datasets",
+            "flashinfer-python==0.2.2",
         ],
         distclass=BinaryDistribution,
         **setup_kwargs,

--- a/tests/python/model/test_kv_cache.py
+++ b/tests/python/model/test_kv_cache.py
@@ -64,7 +64,7 @@ def test_nn_module_paged_kv_cache():
             cache: PagedKVCache,
             qkv: core.Tensor,
         ) -> core.Tensor:
-            return cache.attention_with_fused_qkv(0, qkv, num_qo_heads=32)
+            return cache.attention_with_fused_qkv(0, qkv, num_qo_heads=32, sm_scale=128**-0.5)
 
         def create_paged_kv_cache(
             self,
@@ -74,7 +74,8 @@ def test_nn_module_paged_kv_cache():
             page_size: tir.Var,
             support_sliding_window: tir.Var,
         ) -> PagedKVCache:
-            return PagedKVCache.create_generic_mha(
+            return PagedKVCache.create_generic(
+                attn_kind="mha",
                 max_batch_size=max_batch_size,
                 max_total_seq_len=max_total_seq_len,
                 prefill_chunk_size=prefill_chunk_size,
@@ -83,7 +84,8 @@ def test_nn_module_paged_kv_cache():
                 num_hidden_layers=32,
                 num_attention_heads=32,
                 num_key_value_heads=32,
-                head_dim=128,
+                qk_head_dim=128,
+                v_head_dim=128,
                 rope_mode=RopeMode.NORMAL,
                 rope_scale=1,
                 rope_theta=10000,


### PR DESCRIPTION
This PR updates the KV cache interface following a recent refactor in apache/tvm. We also update the DeepSeek-v2 modeling to use the new KV cache interface.