### PR TITLE
[Fix] Resolve TVM Compatibility Issue by Removing Unsupported Argument

### DIFF
--- a/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
+++ b/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
@@ -180,7 +180,7 @@ class DispatchKVCacheCreation:  # pylint: disable=too-many-instance-attributes
         )
 
         # Remove the 'enable_disaggregation' argument
-        kwargs.pop('enable_disaggregation', None)
+        kwargs.pop("enable_disaggregation", None)
 
         with bb.function(
             name="create_tir_paged_kv_cache",

--- a/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
+++ b/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
@@ -179,6 +179,9 @@ class DispatchKVCacheCreation:  # pylint: disable=too-many-instance-attributes
             "support_sliding_window_", relax.ShapeStructInfo([kwargs["support_sliding_window"]])
         )
 
+        # Remove the 'enable_disaggregation' argument
+        kwargs.pop('enable_disaggregation', None)
+
         with bb.function(
             name="create_tir_paged_kv_cache",
             params=[


### PR DESCRIPTION
This PR resolves a compatibility issue with the TVM library by removing an unsupported argument. The issue arose when the `TIRPagedKVCache` class was instantiated with an `enable\_disaggregation` argument, which is not recognized by the TVM library.

Changes Made
------------

*   Modified the `create\_tir\_paged\_kv\_cache` function to remove the `enable\_disaggregation` argument from the kwargs dictionary before passing it to the `TIRPagedKVCache` constructor.
    

Benefits
--------

*   Resolves the compatibility issue with the TVM library, ensuring that the codebase can work seamlessly with the library.
    
*   Prevents potential errors and exceptions that may arise due to the unsupported argument.
    

Testing
-------

*   Verified that the modified code compiles successfully without any errors.
    
*   Confirmed that the compatibility issue with the TVM library is resolved, and the codebase functions as expected.
    

Checklist
---------

*   \[x\]Code changes are properly documented.
    
*   \[x\]Code formatting and style adhere to the project's standards.
    
*   \[x\]Changes have been thoroughly tested and verified.