### PR TITLE
[Fix] Remove the type index defined for RadixTree and PrefixCache

### DIFF
--- a/cpp/serve/prefix_cache.h
+++ b/cpp/serve/prefix_cache.h
@@ -123,7 +123,6 @@ class PrefixCacheObj : public Object {
   /*! \brief Return the prefix cache mode. */
   virtual PrefixCacheMode Mode() = 0;
 
-  static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "mlc.serve.PrefixCache";
   TVM_DECLARE_BASE_OBJECT_INFO(PrefixCacheObj, Object)
 };

--- a/cpp/serve/radix_tree.h
+++ b/cpp/serve/radix_tree.h
@@ -106,7 +106,6 @@ class PagedRadixTreeObj : public Object {
    */
   virtual void Reset() = 0;
 
-  static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "mlc.serve.PagedRadixTree";
   TVM_DECLARE_BASE_OBJECT_INFO(PagedRadixTreeObj, Object)
 };


### PR DESCRIPTION
This PR removes the `type_index` for `PrefixCache` and `PagedRadixTree`. The type index may case import error.