### PR TITLE
[Model] Gemma3 Support

### DIFF
--- a/python/mlc_llm/model/gemma3/gemma3_loader.py
+++ b/python/mlc_llm/model/gemma3/gemma3_loader.py
@@ -1,0 +1,143 @@
+"""
+This file specifies how MLC's Gemma3 parameter maps from other formats, for example HuggingFace
+PyTorch, HuggingFace safetensors.
+"""
+
+import functools
+
+import numpy as np
+
+from mlc_llm.loader import ExternMapping
+from mlc_llm.quantization import Quantization
+
+from .gemma3_model import Gemma3Config, Gemma3ForCausalLM
+
+
+def huggingface(model_config: Gemma3Config, quantization: Quantization) -> ExternMapping:
+    """Returns a parameter mapping that maps from the names of MLC LLM parameters to
+    the names of HuggingFace PyTorch parameters.
+
+    Parameters
+    ----------
+    model_config : Gemma3Config
+        The configuration of the Gemma model.
+
+    quantization : Quantization
+        The quantization configuration.
+
+    Returns
+    -------
+    param_map : ExternMapping
+        The parameter mapping from MLC to HuggingFace PyTorch.
+    """
+    model = Gemma3ForCausalLM(model_config)
+    if quantization is not None:
+        model.to(quantization.model_dtype)
+    _, _named_params, _ = model.export_tvm(  # type: ignore[misc]
+        spec=model.get_default_spec(),
+        allow_extern=True,
+    )
+    named_parameters = dict(_named_params)
+
+    mapping = ExternMapping()
+
+    for i in range(model_config.text_config.num_hidden_layers):
+        # Add QKV in self attention
+        attn = f"language_model.model.layers.{i}.self_attn"
+        mlc_name = f"{attn}.qkv_proj.weight"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [
+                f"{attn}.q_proj.weight",
+                f"{attn}.k_proj.weight",
+                f"{attn}.v_proj.weight",
+            ],
+            functools.partial(
+                lambda q, k, v, dtype: np.concatenate([q, k, v], axis=0).astype(dtype),
+                dtype=mlc_param.dtype,
+            ),
+        )
+        # Add gates in MLP
+        mlp = f"language_model.model.layers.{i}.mlp"
+        mlc_name = f"{mlp}.gate_up_proj.weight"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [
+                f"{mlp}.gate_proj.weight",
+                f"{mlp}.up_proj.weight",
+            ],
+            functools.partial(
+                lambda gate, up, dtype: np.concatenate([gate, up], axis=0).astype(dtype),
+                dtype=mlc_param.dtype,
+            ),
+        )
+        # Modify RMS layernorm weights, since Gemma model adds 1 to the weights
+        # We add 1 to the weights here for efficiency purpose
+        mlc_name = f"language_model.model.layers.{i}.input_layernorm.weight"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [mlc_name],
+            functools.partial(
+                lambda x, dtype: (x + 1).astype(dtype),
+                dtype=named_parameters[mlc_name].dtype,
+            ),
+        )
+
+        mlc_name = f"language_model.model.layers.{i}.post_attention_layernorm.weight"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [mlc_name],
+            functools.partial(
+                lambda x, dtype: (x + 1).astype(dtype),
+                dtype=named_parameters[mlc_name].dtype,
+            ),
+        )
+
+        mlc_name = f"language_model.model.layers.{i}.pre_feedforward_layernorm.weight"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [mlc_name],
+            functools.partial(
+                lambda x, dtype: (x + 1).astype(dtype),
+                dtype=named_parameters[mlc_name].dtype,
+            ),
+        )
+
+        mlc_name = f"language_model.model.layers.{i}.post_feedforward_layernorm.weight"
+        mlc_param = named_parameters[mlc_name]
+        mapping.add_mapping(
+            mlc_name,
+            [mlc_name],
+            functools.partial(
+                lambda x, dtype: (x + 1).astype(dtype),
+                dtype=named_parameters[mlc_name].dtype,
+            ),
+        )
+
+    mlc_name = "language_model.model.norm.weight"
+    mlc_param = named_parameters[mlc_name]
+    mapping.add_mapping(
+        mlc_name,
+        [mlc_name],
+        functools.partial(
+            lambda x, dtype: (x + 1).astype(dtype),
+            dtype=named_parameters[mlc_name].dtype,
+        ),
+    )
+
+    for mlc_name, mlc_param in named_parameters.items():
+        if mlc_name not in mapping.param_map:
+            mapping.add_mapping(
+                mlc_name,
+                [mlc_name],
+                functools.partial(
+                    lambda x, dtype: x.astype(dtype),
+                    dtype=mlc_param.dtype,
+                ),
+            )
+    return mapping

--- a/python/mlc_llm/model/gemma3/gemma3_model.py
+++ b/python/mlc_llm/model/gemma3/gemma3_model.py
@@ -3,18 +3,17 @@
 import dataclasses
 from typing import Any, Dict, Optional
 
+from tvm import te, tir
+from tvm.relax.frontend import nn
+from tvm.relax.frontend.nn import Tensor, op
+
 from mlc_llm import op as op_ext
 from mlc_llm.model.gemma.gemma_model import GemmaEmbedding
 from mlc_llm.nn import PagedKVCache, RopeMode
 from mlc_llm.support import logging
 from mlc_llm.support import tensor_parallel as tp
+from mlc_llm.support.config import ConfigBase
 from mlc_llm.support.style import bold
-
-from tvm import te, tir
-from tvm.relax.frontend import nn
-from tvm.relax.frontend.nn import Tensor, op
-
-from ...support.config import ConfigBase
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +193,7 @@ class Gemma3Attention(nn.Module):  # pylint: disable=too-many-instance-attribute
         self.k_norm = nn.RMSNorm(
             config.text_config.head_dim, -1, config.text_config.rms_norm_eps, bias=False
         )
-        # self.scaling_factor = (config.text_config.head_dim / config.text_config.query_pre_attn_scalar) ** 0.5
+        # self.scaling_factor = (self.head_dim / config.text_config.query_pre_attn_scalar) ** 0.5
         self.scaling = config.text_config.query_pre_attn_scalar**-0.5
 
     def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):

--- a/python/mlc_llm/model/gemma3/gemma3_model.py
+++ b/python/mlc_llm/model/gemma3/gemma3_model.py
@@ -127,7 +127,7 @@ class Gemma3Config(ConfigBase):
 
         if getattr(self, "sliding_window_size") <= 0:
             if hasattr(self.text_config, "sliding_window"):
-                setattr(self, k, getattr(self.text_config, "sliding_window"))
+                setattr(self, "sliding_window_size", getattr(self.text_config, "sliding_window"))
 
 
 class Gemma3MLP(nn.Module):

--- a/python/mlc_llm/model/gemma3/gemma3_model.py
+++ b/python/mlc_llm/model/gemma3/gemma3_model.py
@@ -7,12 +7,9 @@ from tvm import te, tir
 from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import Tensor, op
 
-from mlc_llm.model.gemma2.gemma2_model import (
-    Gemma2Attention,
-    Gemma2Config,
-    Gemma2DecoderLayer,
-    Gemma2ForCausalLM,
-    Gemma2Model,
+from mlc_llm.model.gemma.gemma_model import (
+    GemmaConfig,
+    GemmaEmbedding,
 )
 from mlc_llm import op as op_ext
 from mlc_llm.nn import PagedKVCache, RopeMode
@@ -44,7 +41,6 @@ class Gemma3TextConfig(ConfigBase):
     context_window_size: int = 131_072
     prefill_chunk_size: int = 0
 
-    attn_logit_softcapping: float = None
     final_logit_softcapping: float = None
     query_pre_attn_scalar: int = 256
     sliding_window: int = None
@@ -99,7 +95,6 @@ class Gemma3TextConfig(ConfigBase):
         # as the sliding window attention every other layer is yet to be supported.
         self.context_window_size = self.sliding_window
 
-
 @dataclasses.dataclass
 class Gemma3Config(ConfigBase):
     """Configuration of the Gemma3 model"""
@@ -134,36 +129,330 @@ class Gemma3Config(ConfigBase):
             if hasattr(self.text_config, "sliding_window"):
                 setattr(self, k, getattr(self.text_config, "sliding_window"))
 
-    def toGemma2Config(self):
-        return Gemma2Config(**self.text_config.__dict__, vocab_size=self.vocab_size)
-
-
-# pylint: disable=invalid-name,missing-docstring
-
-
-class Gemma3Attention(Gemma2Attention):
+class Gemma3MLP(nn.Module):
     def __init__(self, config: Gemma3Config):
-        super().__init__(config.toGemma2Config())
+        super().__init__()
+        if config.text_config.intermediate_size % config.tensor_parallel_shards != 0:
+            raise ValueError(
+                f"Cannot split MLP intermediate size {config.text_config.intermediate_size} "
+                f"evenly to {config.tensor_parallel_shards} GPUs."
+            )
+        self.intermediate_size = config.text_config.intermediate_size // config.tensor_parallel_shards
+        self.gate_up_proj = nn.Linear(
+            in_features=config.text_config.hidden_size,
+            out_features=2 * self.intermediate_size,
+            bias=False,
+        )
+        self.down_proj = nn.Linear(self.intermediate_size, config.text_config.hidden_size, bias=False)
 
+    def forward(self, x: Tensor):
+        concat_x1_x2 = self.gate_up_proj(x)
+        x1, x2 = op.split(concat_x1_x2, 2, axis=-1)
+        return self.down_proj(op.gelu(x1, approximate="tanh") * x2)
 
-class Gemma3DecoderLayer(Gemma2DecoderLayer):
+class Gemma3Attention(nn.Module):  # pylint: disable=too-many-instance-attributes
     def __init__(self, config: Gemma3Config):
-        super().__init__(config.toGemma2Config())
+        self.head_dim = config.text_config.head_dim
+        self.num_q_heads = config.text_config.num_attention_heads // config.tensor_parallel_shards
+        assert (
+            config.text_config.num_key_value_heads % config.tensor_parallel_shards == 0
+        ), f"num_kv_heads({config.text_config.num_key_value_heads}) must be divisible by tensor_parallel_shards"
+        assert (
+            config.text_config.num_key_value_heads >= config.tensor_parallel_shards
+        ), f"Too large tensor_parallel_shards, must be smaller than {config.text_config.num_key_value_heads}"
+        self.num_kv_heads = config.text_config.num_key_value_heads // config.tensor_parallel_shards
+        self.q_proj = nn.Linear(
+            in_features=config.text_config.hidden_size,
+            out_features=self.num_q_heads * self.head_dim,
+            bias=config.text_config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            in_features=config.text_config.hidden_size,
+            out_features=self.num_kv_heads * self.head_dim,
+            bias=config.text_config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            in_features=config.text_config.hidden_size,
+            out_features=self.num_kv_heads * self.head_dim,
+            bias=config.text_config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            in_features=self.num_q_heads * self.head_dim,
+            out_features=config.text_config.hidden_size,
+            bias=config.text_config.attention_bias,
+        )
+        self.q_norm = nn.RMSNorm(config.text_config.head_dim, -1, config.text_config.rms_norm_eps, bias=False)
+        self.k_norm = nn.RMSNorm(config.text_config.head_dim, -1, config.text_config.rms_norm_eps, bias=False)
+        self.scaling_factor = (config.text_config.head_dim / config.text_config.query_pre_attn_scalar) ** 0.5
+
+    def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
+        d, h_q, h_kv = self.head_dim, self.num_q_heads, self.num_kv_heads
+        b, s, _ = hidden_states.shape
+        # QKV Projection
+        q_proj = op.reshape(self.q_proj(hidden_states), (b, s, -1, d))
+        k_proj = op.reshape(self.k_proj(hidden_states), (b, s, -1, d))
+        v_proj = op.reshape(self.v_proj(hidden_states), (b, s, -1, d))
+
+        q_norm = self.q_norm(q_proj)
+        k_norm = self.k_norm(k_proj)
+
+        qkv = op.concat([q_norm, k_norm, v_proj], dim=2)
+
+        # Attention
+        output = op.reshape(
+            paged_kv_cache.attention_with_fused_qkv(
+                layer_id, qkv, self.num_q_heads, sm_scale=self.head_dim**-0.5
+            ),
+            (b, s, h_q * d),
+        )
+        return self.o_proj(output)
 
 
-class Gemma3Model(Gemma2Model):
+class Gemma3DecoderLayer(nn.Module):
     def __init__(self, config: Gemma3Config):
-        super().__init__(config.toGemma2Config())
+        rms_norm_eps = config.text_config.rms_norm_eps
+        self.self_attn = Gemma3Attention(config)
+        self.mlp = Gemma3MLP(config)
+        # Gemma RMSNorm adds 1 to the weights. It is already fused in the loader
+        self.input_layernorm = nn.RMSNorm(config.text_config.hidden_size, -1, rms_norm_eps, bias=False)
+        self.post_attention_layernorm = nn.RMSNorm(config.text_config.hidden_size, -1, rms_norm_eps, bias=False)
+        self.pre_feedforward_layernorm = nn.RMSNorm(
+            config.text_config.hidden_size, -1, rms_norm_eps, bias=False
+        )
+        self.post_feedforward_layernorm = nn.RMSNorm(
+            config.text_config.hidden_size, -1, rms_norm_eps, bias=False
+        )
+
+        def _set_tp():
+            def _set(layer, hint):
+                layer.weight.attrs["shard_strategy"] = hint
+
+            i = self.mlp.intermediate_size
+            _set(self.self_attn.q_proj, tp.ShardSingleDim("_shard_q", dim=1))
+            _set(self.self_attn.k_proj, tp.ShardSingleDim("_shard_k", dim=1))
+            _set(self.self_attn.v_proj, tp.ShardSingleDim("_shard_v", dim=1))
+            _set(self.self_attn.o_proj, tp.ShardSingleDim("_shard_o", dim=1))
+            _set(self.mlp.gate_up_proj, tp.ShardSingleDim("_shard_mlp_up", segs=[i, i], dim=0))
+            _set(self.mlp.down_proj, tp.ShardSingleDim("_shard_mlp_down", dim=1))
+
+        self.tensor_parallel_shards = config.tensor_parallel_shards
+        _set_tp()
+
+    def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
+        out = self.self_attn(self.input_layernorm(hidden_states), paged_kv_cache, layer_id)
+        out = self._apply_post_matmul_norm(out, norm=self.post_attention_layernorm)
+        hidden_states = out + hidden_states
+
+        out = self.pre_feedforward_layernorm(hidden_states)
+        out = self.mlp(out)
+        out = self._apply_post_matmul_norm(out, norm=self.post_feedforward_layernorm)
+        hidden_states = out + hidden_states
+
+        return hidden_states
+
+    def _apply_post_matmul_norm(self, out: Tensor, norm: nn.Tensor):
+        if self.tensor_parallel_shards > 1:
+            return norm(op.ccl_allreduce(out, "sum"))
+        return norm(out)
+
+
+class Gemma3TextModel(nn.Module):
+    def __init__(self, config: Gemma3Config):
+        self.hidden_size = config.text_config.hidden_size
+        assert config.text_config.hidden_size % config.text_config.num_attention_heads == 0
+        self.embed_tokens = GemmaEmbedding("vocab_size", config.text_config.hidden_size)
+        self.layers = nn.ModuleList(
+            [Gemma3DecoderLayer(config) for _ in range(config.text_config.num_hidden_layers)]
+        )
+        self.norm = nn.RMSNorm(config.text_config.hidden_size, -1, config.text_config.rms_norm_eps, bias=False)
+
+    def forward(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
+        hidden_states = input_embed
+        hidden_states = hidden_states * (self.hidden_size**0.5)
+        for layer_id, layer in enumerate(self.layers):
+            hidden_states = layer(hidden_states, paged_kv_cache, layer_id)
+        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class Gemma3LanguageModel(nn.Module):  # pylint: disable=too-many-instance-attributes
+    def __init__(self, config: Gemma3Config):
+        self.model = Gemma3TextModel(config)
+        self.num_hidden_layers = config.text_config.num_hidden_layers
+        self.num_attention_heads = config.text_config.num_attention_heads
+        self.num_key_value_heads = config.text_config.num_key_value_heads
+        self.head_dim = config.text_config.head_dim
+        self.hidden_size = config.text_config.hidden_size
+        self.vocab_size = config.vocab_size
+        self.rope_theta = config.text_config.position_embedding_base
+        self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.dtype = "float32"
+
+    def to(self, dtype: Optional[str] = None):
+        super().to(dtype=dtype)
+        if dtype is not None:
+            self.dtype = dtype
+
+    def get_logits(self, hidden_states: Tensor):
+        logits = self.model.embed_tokens.lm_head_forward(hidden_states)
+        if logits.dtype != "float32":
+            logits = logits.astype("float32")
+        return logits
+
+    def batch_forward(
+        self,
+        input_embeds: Tensor,
+        paged_kv_cache: PagedKVCache,
+        logit_positions: Optional[Tensor] = None,
+    ):
+        op_ext.configure()
+
+        hidden_states = self.model(input_embeds, paged_kv_cache)
+        if logit_positions is not None:
+            hidden_states = op.take(hidden_states, logit_positions, axis=1)
+        logits = self.get_logits(hidden_states)
+        return logits
+
+    def embed(self, input_ids: Tensor):
+        if self.tensor_parallel_shards > 1:
+            input_ids = op.ccl_broadcast_from_worker0(input_ids)
+        return self.model.embed_tokens(input_ids)
+
+    def prefill(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
+        op_ext.configure()
+
+        def _index(x: te.Tensor):  # x[:-1,:]
+            b, s, d = x.shape
+            return te.compute((b, 1, d), lambda i, _, k: x[i, s - 1, k], name="index")
+
+        hidden_states = self.model(input_embed, paged_kv_cache)
+        hidden_states = op.tensor_expr_op(_index, name_hint="index", args=[hidden_states])
+        logits = self.get_logits(hidden_states)
+        return logits, paged_kv_cache
+
+    def decode(self, input_embed: Tensor, paged_kv_cache: PagedKVCache):
+        op_ext.configure()
+
+        hidden_states = self.model(input_embed, paged_kv_cache)
+        logits = self.get_logits(hidden_states)
+        return logits, paged_kv_cache
+
+    def batch_prefill(
+        self, input_embeds: Tensor, logit_positions: Tensor, paged_kv_cache: PagedKVCache
+    ):
+        if self.tensor_parallel_shards > 1:
+            logit_positions = op.ccl_broadcast_from_worker0(logit_positions)
+        logits = self.batch_forward(input_embeds, paged_kv_cache, logit_positions)
+        return logits, paged_kv_cache
+
+    def batch_decode(self, input_embeds: Tensor, paged_kv_cache: PagedKVCache):
+        logits = self.batch_forward(input_embeds, paged_kv_cache)
+        return logits, paged_kv_cache
+
+    def batch_verify(self, input_embeds: Tensor, paged_kv_cache: PagedKVCache):
+        logits = self.batch_forward(input_embeds, paged_kv_cache)
+        return logits, paged_kv_cache
+
+    def create_paged_kv_cache(  # pylint: disable=too-many-arguments
+        self,
+        max_batch_size: tir.Var,
+        max_total_seq_len: tir.Var,
+        prefill_chunk_size: tir.Var,
+        page_size: tir.Var,
+        support_sliding_window: tir.Var,
+    ) -> PagedKVCache:
+        return PagedKVCache.create_generic(
+            attn_kind="mha",
+            max_batch_size=max_batch_size,
+            max_total_seq_len=max_total_seq_len,
+            prefill_chunk_size=prefill_chunk_size,
+            page_size=page_size,
+            support_sliding_window=support_sliding_window,
+            num_hidden_layers=self.num_hidden_layers,
+            num_attention_heads=self.num_attention_heads // self.tensor_parallel_shards,
+            num_key_value_heads=self.num_key_value_heads // self.tensor_parallel_shards,
+            qk_head_dim=self.head_dim,
+            v_head_dim=self.head_dim,
+            rope_mode=RopeMode.NORMAL,
+            rope_scale=1,
+            rope_theta=self.rope_theta,
+            dtype=self.dtype,
+        )
+
+    def get_default_spec(self):
+        mod_spec = {
+            "embed": {
+                "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "prefill": {
+                "input_embed": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "decode": {
+                "input_embed": nn.spec.Tensor([1, 1, self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "batch_prefill": {
+                "input_embeds": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
+                "logit_positions": nn.spec.Tensor(["batch_size"], "int32"),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "batch_decode": {
+                "input_embeds": nn.spec.Tensor(["batch_size", 1, self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "batch_verify": {
+                "input_embeds": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "create_paged_kv_cache": {
+                "max_batch_size": int,
+                "max_total_seq_len": int,
+                "prefill_chunk_size": int,
+                "page_size": int,
+                "support_sliding_window": int,
+                "$": {
+                    "param_mode": "none",
+                    "effect_mode": "none",
+                },
+            },
+        }
+        return nn.spec.ModuleSpec.from_raw(mod_spec, self)
 
 
 class Gemma3ForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attributes
     def __init__(self, config: Gemma3Config):
         super().__init__()
         self.config = config
-        self.language_model = Gemma2ForCausalLM(Gemma2Config(**config.text_config.__dict__, vocab_size=config.vocab_size))
+        self.language_model = Gemma3LanguageModel(config)
         self.vocab_size = config.vocab_size
         self.dtype = "bfloat16"
         self.tensor_parallel_shards = config.tensor_parallel_shards
+        self.final_logit_softcapping = config.text_config.final_logit_softcapping
 
     def to(self, dtype: Optional[str] = None):
         super().to(dtype=dtype)
@@ -175,6 +464,8 @@ class Gemma3ForCausalLM(nn.Module):  # pylint: disable=too-many-instance-attribu
         logits = self.language_model.model.embed_tokens.lm_head_forward(hidden_states)
         if logits.dtype != "float32":
             logits = logits.astype("float32")
+        if self.final_logit_softcapping is not None:
+            logits = op.tanh(logits / self.final_logit_softcapping) * self.final_logit_softcapping
         return logits
 
     def batch_forward(

--- a/python/mlc_llm/model/gemma3/gemma3_quantization.py
+++ b/python/mlc_llm/model/gemma3/gemma3_quantization.py
@@ -1,0 +1,39 @@
+"""This file specifies how MLC's Gemma parameters are quantized using group quantization
+or other formats."""
+
+from typing import Tuple
+
+from tvm.relax.frontend import nn
+
+from mlc_llm.loader import QuantizeMapping
+from mlc_llm.quantization import GroupQuantize, NoQuantize
+
+from .gemma3_model import Gemma3Config, Gemma3ForCausalLM
+
+
+def group_quant(
+    model_config: Gemma3Config,
+    quantization: GroupQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a Gemma-architecture model using group quantization."""
+    model: nn.Module = Gemma3ForCausalLM(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    quantization.tensor_parallel_shards = model_config.tensor_parallel_shards
+    model = quantization.quantize_model(
+        model,
+        quant_map,
+        "",
+    )
+    return model, quant_map
+
+
+def no_quant(
+    model_config: Gemma3Config,
+    quantization: NoQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a Llama2 model without quantization."""
+    model: nn.Module = Gemma3ForCausalLM(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    return model, quant_map

--- a/python/mlc_llm/model/model.py
+++ b/python/mlc_llm/model/model.py
@@ -17,6 +17,7 @@ from .deepseek_v2 import deepseek_v2_loader, deepseek_v2_model, deepseek_v2_quan
 from .eagle import eagle_loader, eagle_model, eagle_quantization
 from .gemma import gemma_loader, gemma_model, gemma_quantization
 from .gemma2 import gemma2_loader, gemma2_model, gemma2_quantization
+from .gemma3 import gemma3_loader, gemma3_model, gemma3_quantization
 from .gpt2 import gpt2_loader, gpt2_model, gpt2_quantization
 from .gpt_bigcode import gpt_bigcode_loader, gpt_bigcode_model, gpt_bigcode_quantization
 from .gpt_j import gpt_j_loader, gpt_j_model, gpt_j_quantization
@@ -142,6 +143,19 @@ MODELS: Dict[str, Model] = {
         quantize={
             "no-quant": gemma2_quantization.no_quant,
             "group-quant": gemma2_quantization.group_quant,
+        },
+    ),
+    "gemma3": Model(
+        name="gemma3",
+        model=gemma3_model.Gemma3ForCausalLM,
+        config=gemma3_model.Gemma3Config,
+        source={
+            "huggingface-torch": gemma3_loader.huggingface,
+            "huggingface-safetensor": gemma3_loader.huggingface,
+        },
+        quantize={
+            "no-quant": gemma3_quantization.no_quant,
+            "group-quant": gemma3_quantization.group_quant,
         },
     ),
     "gpt2": Model(


### PR DESCRIPTION
Adds model support for Gemma3, currently in progress. QK normalization has been added as described in the technical documentation for Gemma3, but current there is an issue with short/truncated generation and significant slowdown after the first few prompts.

Additionally, there is also a lack of local/global attention layer interweaving, similar to Gemma2 in MLC-LLM, as well as support for the multimodal capabilities of Gemma3