### PR TITLE
[Model] Deepseek-v3 support

### DIFF
--- a/ci/task/pylint.sh
+++ b/ci/task/pylint.sh
@@ -10,7 +10,7 @@ if [[ -n ${MLC_CI_SETUP_DEPS:-} ]]; then
     echo "MLC_CI_SETUP_DEPS=1 start setup deps"
     # TVM Unity is a dependency to this testing
     pip install --quiet --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
-    pip install requests
+    pip install requests triton
     pip install --quiet --pre -U cuda-python
 fi
 

--- a/python/mlc_llm/compiler_pass/dispatch_triton_kernel.py
+++ b/python/mlc_llm/compiler_pass/dispatch_triton_kernel.py
@@ -1,0 +1,174 @@
+"""A pass that dispatch generic calls of triton kernels to specific kernel implementations."""
+
+# pylint: disable=invalid-name
+
+from typing import List
+
+import tvm
+from tvm import IRModule, relax
+from tvm.relax.expr_functor import PyExprMutator, mutator
+
+from mlc_llm.op.triton import (
+    get_tir_w8a8_block_fp8_group_matmul,
+    get_tir_w8a8_block_fp8_matmul,
+)
+from mlc_llm.support import logging
+
+logger = logging.getLogger(__name__)
+
+
+@mutator
+class _Rewriter(PyExprMutator):  # pylint: disable=abstract-method
+    def __init__(self, mod: IRModule, target: tvm.target.Target) -> None:
+        super().__init__(mod)
+        self.mod = mod
+        self.target = target
+        self.extern_mods: List[tvm.runtime.Module] = []
+
+    def transform(self) -> tvm.IRModule:  # pylint: disable=too-many-locals
+        """Entry point of the transformation"""
+        for g_var, func in self.mod.functions_items():
+            if not isinstance(func, relax.Function):
+                continue
+            new_func = self.visit_expr(func)
+            # new_func = remove_all_unused(new_func)
+            self.builder_.update_func(g_var, new_func)
+
+        mod = self.builder_.finalize()
+        mod_attrs = dict(mod.attrs) if mod.attrs else {}
+        mod = mod.with_attr(
+            "external_mods", list(mod_attrs.get("external_mods", [])) + self.extern_mods
+        )
+        return mod
+
+    def visit_call_(self, call: relax.Call) -> relax.Expr:  # pylint: disable=arguments-renamed
+        call = super().visit_call_(call)
+
+        if (
+            call.op != tvm.ir.Op.get("relax.call_dps_packed")
+            or not isinstance(call.args[0], relax.ExternFunc)
+            or not str(call.args[0].global_symbol).startswith("mlc.triton.")
+        ):
+            return call
+
+        global_symbol = str(call.args[0].global_symbol)
+        assert isinstance(call.args[1], relax.Tuple)
+        if global_symbol == "mlc.triton.w8a8_block_fp8_matmul":
+            return self.w8a8_block_fp8_matmul(call.args[1].fields, call.struct_info)
+        if global_symbol == "mlc.triton.w8a8_block_fp8_group_matmul":
+            return self.w8a8_block_fp8_group_matmul(call.args[1].fields, call.struct_info)
+        raise ValueError(f"Unknown mlc.triton kernel identifier: {global_symbol}")
+
+    def w8a8_block_fp8_matmul(  # pylint: disable=too-many-locals
+        self, args: List[relax.Expr], out_sinfo: relax.StructInfo
+    ) -> relax.Expr:
+        """Emit the w8a8_block_fp8_matmul triton kernel."""
+        assert len(args) == 16
+        x, weight, x_scale, weight_scale = args[:4]
+        (
+            N,
+            K,
+            block_n,
+            block_k,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            GROUP_SIZE_M,
+            num_warps,
+            num_stages,
+        ) = [arg.value.value for arg in args[4:14]]
+        in_dtype, out_dtype = str(args[14].value), str(args[15].value)
+
+        prim_func, func_name = get_tir_w8a8_block_fp8_matmul(
+            N,
+            K,
+            block_n,
+            block_k,
+            in_dtype,  # type: ignore
+            out_dtype,  # type: ignore
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            GROUP_SIZE_M,
+            num_warps,
+            num_stages,
+            self.extern_mods,
+        )
+        if prim_func is None:
+            # The TIR function is already in the IRModule
+            gv = self.builder_.get().get_global_var(func_name)
+        else:
+            # Add the TIR function to the IRModule
+            gv = self.builder_.add_func(prim_func, func_name)
+
+        return relax.call_tir(gv, [x, weight, x_scale, weight_scale], out_sinfo=out_sinfo)
+
+    def w8a8_block_fp8_group_matmul(  # pylint: disable=too-many-locals
+        self, args: List[relax.Expr], out_sinfo: relax.StructInfo
+    ) -> relax.Expr:
+        """Emit the w8a8_block_fp8_group_matmul triton kernel."""
+        assert len(args) == 19
+        x, weight, x_scale, weight_scale, expert_ids, indptr = args[:6]
+        (
+            N,
+            K,
+            num_experts,
+            block_n,
+            block_k,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            GROUP_SIZE_M,
+            num_warps,
+            num_stages,
+        ) = [arg.value.value for arg in args[6:17]]
+        in_dtype, out_dtype = str(args[17].value), str(args[18].value)
+
+        prim_func, func_name = get_tir_w8a8_block_fp8_group_matmul(
+            N,
+            K,
+            num_experts,
+            block_n,
+            block_k,
+            in_dtype,  # type: ignore
+            out_dtype,  # type: ignore
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            GROUP_SIZE_M,
+            num_warps,
+            num_stages,
+            self.extern_mods,
+        )
+        if prim_func is None:
+            # The TIR function is already in the IRModule
+            gv = self.builder_.get().get_global_var(func_name)
+        else:
+            # Add the TIR function to the IRModule
+            gv = self.builder_.add_func(prim_func, func_name)
+
+        return relax.call_tir(
+            gv,
+            [x, weight, x_scale, weight_scale, expert_ids, indptr],
+            out_sinfo=out_sinfo,
+        )
+
+
+@tvm.transform.module_pass(opt_level=0, name="DispatchTritonKernel")
+class DispatchTritonKernel:  # pylint: disable=too-many-instance-attributes,too-few-public-methods
+    """Rewrite KV cache creation functions to IRModule."""
+
+    def __init__(self, target: tvm.target.Target) -> None:
+        """Initializer.
+
+        Parameters
+        ----------
+        """
+        self.target = target
+
+    def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:
+        """Entrypoint"""
+        if self.target.kind.name != "cuda":
+            return mod
+
+        return _Rewriter(mod, self.target).transform()

--- a/python/mlc_llm/compiler_pass/fuse_add_norm.py
+++ b/python/mlc_llm/compiler_pass/fuse_add_norm.py
@@ -182,6 +182,7 @@ class _FuseAddRMSNormRewriter(PyExprMutator):  # pylint: disable=abstract-method
         call = super().visit_call_(call)
 
         # Match the "rms_norm(add(x1, x2), w)" pattern
+        # Todo: support bf16  # pylint: disable=fixme
         if call.op != tvm.ir.Op.get("relax.nn.rms_norm") or call.struct_info.dtype != "float16":
             return call
         assert len(call.args) == 2

--- a/python/mlc_llm/compiler_pass/fuse_dequantize_take.py
+++ b/python/mlc_llm/compiler_pass/fuse_dequantize_take.py
@@ -15,7 +15,7 @@ from tvm.relax.dpl.pattern import (
 class FuseDequantizeTake:  # pylint: disable=too-few-public-methods
     """A compiler pass that fuses dequantize + take."""
 
-    def transform_module(
+    def transform_module(  # pylint: disable=too-many-locals
         self,
         mod: IRModule,
         _ctx: tvm.transform.PassContext,

--- a/python/mlc_llm/conversation_template/deepseek.py
+++ b/python/mlc_llm/conversation_template/deepseek.py
@@ -36,6 +36,22 @@ ConvTemplateRegistry.register_conv_template(
     )
 )
 
+# DeepSeek-V3
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="deepseek_v3",
+        system_template=f"<｜begin▁of▁sentence｜>{MessagePlaceholders.SYSTEM.value}",
+        system_message="You are Deepseek-V3, an AI assistant created exclusively by the Chinese "
+        "Company DeepSeek. You'll provide helpful, harmless, and detailed responses to all "
+        "user inquiries.",
+        roles={"user": "<｜User｜>", "assistant": "<｜Assistant｜>"},
+        seps=["", "<｜end▁of▁sentence｜>"],
+        role_content_sep="",
+        role_empty_sep="",
+        stop_token_ids=[1],
+    )
+)
+
 # DeepSeek-R1-Distill-Qwen
 ConvTemplateRegistry.register_conv_template(
     Conversation(

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -309,6 +309,7 @@ CONV_TEMPLATES = {
     "aya-23",
     "deepseek",
     "deepseek_v2",
+    "deepseek_v3",
     "deepseek_r1_qwen",
     "deepseek_r1_llama",
     "olmo",

--- a/python/mlc_llm/model/deepseek_v2/deepseek_v2_loader.py
+++ b/python/mlc_llm/model/deepseek_v2/deepseek_v2_loader.py
@@ -4,16 +4,19 @@ PyTorch, HuggingFace safetensors.
 """
 
 import functools
+from typing import Callable, List
 
 import numpy as np
 
-from mlc_llm.loader import ExternMapping
-from mlc_llm.quantization import Quantization
+from mlc_llm.loader import ExternMapping, QuantizeMapping
+from mlc_llm.quantization import BlockScaleQuantize, Quantization
 
 from .deepseek_v2_model import DeepseekV2Config, DeepseekV2ForCausalLM
 
 
-def huggingface(model_config: DeepseekV2Config, quantization: Quantization) -> ExternMapping:
+def huggingface(  # pylint: disable=too-many-locals,too-many-statements
+    model_config: DeepseekV2Config, quantization: Quantization
+) -> ExternMapping:
     """Returns a parameter mapping that maps from the names of MLC LLM parameters to
     the names of HuggingFace PyTorch parameters.
 
@@ -33,6 +36,15 @@ def huggingface(model_config: DeepseekV2Config, quantization: Quantization) -> E
     model = DeepseekV2ForCausalLM(model_config)
     if quantization is not None:
         model.to(quantization.model_dtype)
+    if isinstance(quantization, BlockScaleQuantize):
+        # Convert the model to block-scale quantized model before loading parameters
+        model = quantization.quantize_model(model, QuantizeMapping({}, {}), "")
+        if model_config.weight_block_size is None:
+            raise ValueError(
+                "The input DeepSeek model is not fp8 block quantized. "
+                "Thus BlockScaleQuantize is not supported."
+            )
+
     _, _named_params, _ = model.export_tvm(  # type: ignore[misc]
         spec=model.get_default_spec(),
         allow_extern=True,
@@ -41,35 +53,62 @@ def huggingface(model_config: DeepseekV2Config, quantization: Quantization) -> E
 
     mapping = ExternMapping()
 
+    if (
+        not isinstance(quantization, BlockScaleQuantize)
+        and model_config.weight_block_size is not None
+    ):
+        raise ValueError(
+            "The input DeepSeek model is fp8 block quantized. "
+            "Please use BlockScaleQuantize for the model."
+        )
+
+    # Helper function to add both weight and scale mappings
+    def add_weight_and_scale_mapping(
+        weight_mlc_name: str,
+        weight_hf_names: List[str],
+        weight_transform_func: Callable,
+    ):
+        mlc_param = named_parameters[weight_mlc_name]
+        mapping.add_mapping(
+            weight_mlc_name,
+            weight_hf_names,
+            functools.partial(weight_transform_func, dtype=mlc_param.dtype),
+        )
+
+        if isinstance(quantization, BlockScaleQuantize):
+            scale_mlc_name = f"{weight_mlc_name}_scale_inv"
+            if scale_mlc_name in named_parameters:
+                scale_hf_names = [f"{name}_scale_inv" for name in weight_hf_names]
+                scale_param = named_parameters[scale_mlc_name]
+                mapping.add_mapping(
+                    scale_mlc_name,
+                    scale_hf_names,
+                    functools.partial(weight_transform_func, dtype=scale_param.dtype),
+                )
+
     for i in range(model_config.num_hidden_layers):
         if i >= model_config.first_k_dense_replace and i % model_config.moe_layer_freq == 0:
             # map mlp shared expert weight
             mlp = f"model.layers.{i}.mlp"
             shared_expert = f"{mlp}.shared_experts"
-            mlc_name = f"{shared_expert}.gate_up_proj.weight"
-            mlc_param = named_parameters[mlc_name]
-            mapping.add_mapping(
-                mlc_name,
+            add_weight_and_scale_mapping(
+                f"{shared_expert}.gate_up_proj.weight",
                 [
                     f"{shared_expert}.gate_proj.weight",
                     f"{shared_expert}.up_proj.weight",
                 ],
-                functools.partial(
-                    lambda gate, up, dtype: np.concatenate([gate, up], axis=0).astype(dtype),
-                    dtype=mlc_param.dtype,
-                ),
+                lambda gate, up, dtype: np.concatenate([gate, up], axis=0).astype(dtype),
             )
-            # map mlp moe gate and up weight
-            mlc_name = f"{mlp}.moe_gate_up_proj.weight"
 
+            # map mlp moe gate and up weight
             def combine_expert_gate_up(*hf_params, dtype):
                 stack = []
                 for i in range(0, len(hf_params), 2):
                     stack.append(np.concatenate([hf_params[i], hf_params[i + 1]], axis=0))
                 return np.stack(stack, axis=0).astype(dtype)
 
-            mapping.add_mapping(
-                mlc_name,
+            add_weight_and_scale_mapping(
+                f"{mlp}.moe_gate_up_proj.weight",
                 functools.reduce(
                     lambda a, b: a + b,
                     [
@@ -80,47 +119,49 @@ def huggingface(model_config: DeepseekV2Config, quantization: Quantization) -> E
                         for expert_id in range(model_config.n_routed_experts)
                     ],
                 ),
-                functools.partial(
-                    combine_expert_gate_up,
-                    dtype=mlc_param.dtype,
-                ),
+                combine_expert_gate_up,
             )
 
-            # map mlp moe gate and up weight
-            mlc_name = f"{mlp}.moe_down_proj.weight"
-            mlc_param = named_parameters[mlc_name]
-            mapping.add_mapping(
-                mlc_name,
+            # map mlp moe down projection weight
+            add_weight_and_scale_mapping(
+                f"{mlp}.moe_down_proj.weight",
                 [
                     f"{mlp}.experts.{expert_id}.down_proj.weight"
                     for expert_id in range(model_config.n_routed_experts)
                 ],
-                functools.partial(
-                    lambda *hf_params, dtype: np.stack(hf_params, axis=0).astype(dtype),
-                    dtype=mlc_param.dtype,
-                ),
+                lambda *hf_params, dtype: np.stack(hf_params, axis=0).astype(dtype),
             )
+
+            # map moe e_score_correction_bias
+            if model_config.topk_method == "noaux_tc":
+                mlc_name = f"{mlp}.e_score_correction_bias"
+                mlc_param = named_parameters[mlc_name]
+                mapping.add_mapping(
+                    mlc_name,
+                    [f"{mlp}.gate.e_score_correction_bias"],
+                    functools.partial(
+                        lambda x, dtype: x.astype(dtype),
+                        dtype=mlc_param.dtype,
+                    ),
+                )
         else:
             # map mlp weight
             mlp = f"model.layers.{i}.mlp"
-            mlc_name = f"{mlp}.gate_up_proj.weight"
-            mlc_param = named_parameters[mlc_name]
-            mapping.add_mapping(
-                mlc_name,
+            add_weight_and_scale_mapping(
+                f"{mlp}.gate_up_proj.weight",
                 [
                     f"{mlp}.gate_proj.weight",
                     f"{mlp}.up_proj.weight",
                 ],
-                functools.partial(
-                    lambda gate, up, dtype: np.concatenate([gate, up], axis=0).astype(dtype),
-                    dtype=mlc_param.dtype,
-                ),
+                lambda gate, up, dtype: np.concatenate([gate, up], axis=0).astype(dtype),
             )
 
         # map MLA kv_b_proj weight
         attn = f"model.layers.{i}.self_attn"
+        mlc_name = f"{attn}.w_uk"
+        mlc_param = named_parameters[mlc_name]
         mapping.add_mapping(
-            f"{attn}.w_uk",
+            mlc_name,
             [f"{attn}.kv_b_proj.weight"],
             functools.partial(
                 lambda kv_b_proj, dtype: np.split(
@@ -137,8 +178,34 @@ def huggingface(model_config: DeepseekV2Config, quantization: Quantization) -> E
                 dtype=mlc_param.dtype,
             ),
         )
+        if isinstance(quantization, BlockScaleQuantize):
+            scale_mlc_name = f"{attn}.w_uk_scale_inv"
+            mlc_param = named_parameters[scale_mlc_name]
+            mapping.add_mapping(
+                scale_mlc_name,
+                [f"{attn}.kv_b_proj.weight_scale_inv"],
+                functools.partial(
+                    lambda kv_b_proj, dtype: np.split(
+                        kv_b_proj.reshape(
+                            model_config.num_key_value_heads,
+                            (model_config.qk_nope_head_dim + model_config.v_head_dim)
+                            // quantization.weight_block_size[0],
+                            model_config.kv_lora_rank // quantization.weight_block_size[1],
+                        ),
+                        indices_or_sections=[
+                            model_config.qk_nope_head_dim // quantization.weight_block_size[0]
+                        ],
+                        axis=1,
+                    )[0]
+                    .transpose(0, 2, 1)
+                    .astype(dtype),
+                    dtype=mlc_param.dtype,
+                ),
+            )
+        mlc_name = f"{attn}.w_uv"
+        mlc_param = named_parameters[mlc_name]
         mapping.add_mapping(
-            f"{attn}.w_uv",
+            mlc_name,
             [f"{attn}.kv_b_proj.weight"],
             functools.partial(
                 lambda kv_b_proj, dtype: np.split(
@@ -153,6 +220,28 @@ def huggingface(model_config: DeepseekV2Config, quantization: Quantization) -> E
                 dtype=mlc_param.dtype,
             ),
         )
+        if isinstance(quantization, BlockScaleQuantize):
+            scale_mlc_name = f"{attn}.w_uv_scale_inv"
+            mlc_param = named_parameters[scale_mlc_name]
+            mapping.add_mapping(
+                scale_mlc_name,
+                [f"{attn}.kv_b_proj.weight_scale_inv"],
+                functools.partial(
+                    lambda kv_b_proj, dtype: np.split(
+                        kv_b_proj.reshape(
+                            model_config.num_key_value_heads,
+                            (model_config.qk_nope_head_dim + model_config.v_head_dim)
+                            // quantization.weight_block_size[0],
+                            model_config.kv_lora_rank // quantization.weight_block_size[1],
+                        ),
+                        indices_or_sections=[
+                            model_config.qk_nope_head_dim // quantization.weight_block_size[0]
+                        ],
+                        axis=1,
+                    )[1].astype(dtype),
+                    dtype=mlc_param.dtype,
+                ),
+            )
 
     for mlc_name, mlc_param in named_parameters.items():
         if mlc_name not in mapping.param_map:

--- a/python/mlc_llm/model/deepseek_v2/deepseek_v2_quantization.py
+++ b/python/mlc_llm/model/deepseek_v2/deepseek_v2_quantization.py
@@ -6,7 +6,12 @@ from typing import Tuple
 from tvm.relax.frontend import nn
 
 from mlc_llm.loader import QuantizeMapping
-from mlc_llm.quantization import FTQuantize, GroupQuantize, NoQuantize
+from mlc_llm.quantization import (
+    BlockScaleQuantize,
+    FTQuantize,
+    GroupQuantize,
+    NoQuantize,
+)
 
 from .deepseek_v2_model import DeepseekV2Config, DeepseekV2ForCausalLM
 
@@ -44,4 +49,16 @@ def no_quant(
     model: nn.Module = DeepseekV2ForCausalLM(model_config)
     model.to(quantization.model_dtype)
     quant_map = QuantizeMapping({}, {})
+    return model, quant_map
+
+
+def block_scale_quant(
+    model_config: DeepseekV2Config,
+    quantization: BlockScaleQuantize,
+) -> Tuple[nn.Module, QuantizeMapping]:
+    """Quantize a DeepseekV2 model using block-scale quantization."""
+    model: nn.Module = DeepseekV2ForCausalLM(model_config)
+    model.to(quantization.model_dtype)
+    quant_map = QuantizeMapping({}, {})
+    model = quantization.quantize_model(model, quant_map, "")
     return model, quant_map

--- a/python/mlc_llm/model/gemma3/gemma3_model.py
+++ b/python/mlc_llm/model/gemma3/gemma3_model.py
@@ -110,7 +110,7 @@ class Gemma3Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
             self.is_text_model = True
             self.text_config = Gemma3TextConfig.from_dict(self.kwargs)
 
-        text_config_dict: Dict[str, Any]
+        text_config_dict: Dict[str, Any]  # type: ignore
         if isinstance(self.text_config, Gemma3TextConfig):
             text_config_dict = dataclasses.asdict(self.text_config)
         else:

--- a/python/mlc_llm/model/model.py
+++ b/python/mlc_llm/model/model.py
@@ -340,6 +340,21 @@ MODELS: Dict[str, Model] = {
             "ft-quant": deepseek_v2_quantization.ft_quant,
         },
     ),
+    "deepseek_v3": Model(
+        name="deepseek_v3",
+        model=deepseek_v2_model.DeepseekV2ForCausalLM,
+        config=deepseek_v2_model.DeepseekV2Config,
+        source={
+            "huggingface-torch": deepseek_v2_loader.huggingface,
+            "huggingface-safetensor": deepseek_v2_loader.huggingface,
+        },
+        quantize={
+            "no-quant": deepseek_v2_quantization.no_quant,
+            "group-quant": deepseek_v2_quantization.group_quant,
+            "ft-quant": deepseek_v2_quantization.ft_quant,
+            "block-scale-quant": deepseek_v2_quantization.block_scale_quant,
+        },
+    ),
     "stablelm": Model(
         name="stablelm",
         model=stablelm_model.StableLmForCausalLM,

--- a/python/mlc_llm/model/model_preset.py
+++ b/python/mlc_llm/model/model_preset.py
@@ -886,6 +886,7 @@ MODEL_PRESETS: Dict[str, Any] = {
         },
         "rope_theta": 10000,
         "routed_scaling_factor": 1.0,
+        "scoring_func": "softmax",
         "topk_group": 1,
         "topk_method": "greedy",
         "torch_dtype": "bfloat16",

--- a/python/mlc_llm/op/batch_matmul.py
+++ b/python/mlc_llm/op/batch_matmul.py
@@ -1,0 +1,42 @@
+"""Batch matmul operators"""
+
+from typing import Tuple
+
+from tvm.relax.frontend import nn
+
+from mlc_llm.op import cutlass
+from mlc_llm.quantization.block_scale_quantization import rowwise_group_quant_fp8
+
+
+def quantized_bmm(
+    x: nn.Tensor,
+    w: nn.Tensor,
+    w_scale: nn.Tensor,
+    block_size: Tuple[int, int],
+) -> nn.Tensor:
+    """Quantized batch matmul.
+    Currently only support CUDA backend (by using CUTLASS).
+
+    Parameters
+    ----------
+    x : nn.Tensor
+        The input tensor, with shape of [b, m, k].
+
+    w : nn.Tensor
+        The weight tensor, with shape of [b, n, k] (column major).
+
+    w_scale : nn.Tensor
+        The scale tensor, with shape of [b, n // block_size[0], k // block_size[1]].
+
+    block_size : Tuple[int, int]
+        The block size.
+
+    Returns
+    -------
+    ret : nn.Tensor
+        The output tensor, with shape of [b, m, n].
+    """
+    x_fp8, x_scale = rowwise_group_quant_fp8(
+        x, block_size[1], w.dtype, transpose_scale=True, keep_first_batch_dim=True
+    )
+    return cutlass.fp8_block_scale_bmm(x_fp8, x_scale, w, w_scale, block_size, out_dtype=x.dtype)

--- a/python/mlc_llm/op/cutlass.py
+++ b/python/mlc_llm/op/cutlass.py
@@ -1,6 +1,6 @@
 """Operators enabled by external modules."""
 
-from typing import Optional
+from typing import Optional, Tuple
 
 from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import op
@@ -130,4 +130,131 @@ def fp8_gemm(
         func_name,
         args=[x, weight, workspace, scale],
         out=nn.Tensor.placeholder((*x.shape[:-1], weight.shape[0]), dtype=out_dtype),
+    )
+
+
+def fp8_block_scale_gemm(  # pylint: disable=too-many-arguments
+    x: nn.Tensor,
+    x_scale: nn.Tensor,
+    weight: nn.Tensor,
+    weight_scale: nn.Tensor,
+    block_size: Tuple[int, int],
+    out_dtype: str,
+):
+    """Cutlass block-scale fp8 gemm operator.
+
+    Parameters
+    ----------
+    x : nn.Tensor
+        The input tensor, with shape of [m, k].
+
+    x_scale : nn.Tensor
+        The scale tensor, with shape of [k // block_size, m].
+
+    weight : nn.Tensor
+        The weight tensor, with shape of [n, k].
+
+    weight_scale : nn.Tensor
+        The scale tensor, with shape of [n // block_size, k // block_size].
+
+    block_size : Tuple[int, int]
+        The block size.
+
+    out_dtype : str
+        The data type of the output tensor.
+
+    Returns
+    -------
+    out : nn.Tensor
+        The output tensor, with shape of [m, n] and dtype of `out_dtype`.
+    """
+    assert x.ndim >= 2
+    assert weight.ndim == 2
+    assert x_scale.ndim == x.ndim
+    assert weight_scale.ndim == weight.ndim
+
+    if block_size[0] != 128 or block_size[1] != 128:
+        raise ValueError(f"block_size must be (128, 128), but got {block_size}")
+    if x.dtype != "float8_e4m3fn" or weight.dtype != "float8_e4m3fn":
+        raise ValueError(
+            f"x and weight must be float8_e4m3fn, but got x={x.dtype}, weight={weight.dtype}"
+        )
+    if x_scale.dtype != "float32" and weight_scale.dtype != "float32":
+        raise ValueError(
+            "x_scale and weight_scale must be float32, but got "
+            f"x_scale={x_scale.dtype}, weight_scale={weight_scale.dtype}"
+        )
+    if out_dtype not in ["float16", "bfloat16"]:
+        raise ValueError(f"out_dtype must be float16 or bfloat16, but got {out_dtype}")
+
+    func_name = "cutlass.blockwise_scaled_gemm_e4m3fn_e4m3fn"
+    workspace = op.empty((4096 * 1024,), dtype="uint8", name="workspace")
+    return op.extern(
+        func_name,
+        args=[x, weight, x_scale, weight_scale, workspace, block_size[0], block_size[1]],
+        out=nn.Tensor.placeholder((*x.shape[:-1], weight.shape[0]), dtype=out_dtype),
+    )
+
+
+def fp8_block_scale_bmm(  # pylint: disable=too-many-arguments
+    x: nn.Tensor,
+    x_scale: nn.Tensor,
+    weight: nn.Tensor,
+    weight_scale: nn.Tensor,
+    block_size: Tuple[int, int],
+    out_dtype: str,
+):
+    """Cutlass block-scale fp8 gemm operator.
+
+    Parameters
+    ----------
+    x : nn.Tensor
+        The input tensor, with shape of [b, m, k].
+
+    x_scale : nn.Tensor
+        The scale tensor, with shape of [b, k // block_size, m].
+
+    weight : nn.Tensor
+        The weight tensor, with shape of [b, n, k].
+
+    weight_scale : nn.Tensor
+        The scale tensor, with shape of [b, n // block_size, k // block_size].
+
+    block_size : Tuple[int, int]
+        The block size.
+
+    out_dtype : str
+        The data type of the output tensor.
+
+    Returns
+    -------
+    out : nn.Tensor
+        The output tensor, with shape of [m, n] and dtype of `out_dtype`.
+    """
+    assert x.ndim == 3
+    assert weight.ndim == 3
+    assert x_scale.ndim == x.ndim
+    assert weight_scale.ndim == weight.ndim
+    assert x.shape[0] == x_scale.shape[0] == weight.shape[0] == weight_scale.shape[0]
+
+    if block_size[0] != 128 or block_size[1] != 128:
+        raise ValueError(f"block_size must be (128, 128), but got {block_size}")
+    if x.dtype != "float8_e4m3fn" or weight.dtype != "float8_e4m3fn":
+        raise ValueError(
+            f"x and weight must be float8_e4m3fn, but got x={x.dtype}, weight={weight.dtype}"
+        )
+    if x_scale.dtype != "float32" and weight_scale.dtype != "float32":
+        raise ValueError(
+            "x_scale and weight_scale must be float32, but got "
+            f"x_scale={x_scale.dtype}, weight_scale={weight_scale.dtype}"
+        )
+    if out_dtype not in ["float16", "bfloat16"]:
+        raise ValueError(f"out_dtype must be float16 or bfloat16, but got {out_dtype}")
+
+    func_name = "cutlass.blockwise_scaled_bmm_e4m3fn_e4m3fn"
+    workspace = op.empty((4096 * 1024,), dtype="uint8", name="workspace")
+    return op.extern(
+        func_name,
+        args=[x, weight, x_scale, weight_scale, workspace, block_size[0], block_size[1]],
+        out=nn.Tensor.placeholder((x.shape[0], x.shape[1], weight.shape[1]), dtype=out_dtype),
     )

--- a/python/mlc_llm/op/moe_matmul.py
+++ b/python/mlc_llm/op/moe_matmul.py
@@ -1,6 +1,6 @@
 """Mixture of Experts operators"""
 
-from typing import Literal, Optional
+from typing import Literal, Optional, Tuple
 
 from tvm import DataType, DataTypeCode, tir
 from tvm.relax.frontend.nn import Tensor, op
@@ -293,6 +293,88 @@ def dequantize_float8_gemv(
         "moe_dequantize_gemv",
         args=[x, w, indptr],
         out=Tensor.placeholder([experts_per_tok, out_features], model_dtype),
+    )
+
+
+def dequantize_block_scale_float8_gemv(
+    x: Tensor,
+    w: Tensor,
+    w_scale: Tensor,
+    expert_indices: Tensor,
+    block_size: Tuple[int, int],
+    out_dtype: str,
+) -> Tensor:
+    """GEMV for project-in (e1-e3) or project-out (e2) in MLP but the weight is quantized in
+    fp8 e5m2 or e4m3. It needs to be dequantized before the GEMV computation.
+
+    Parameters
+    ----------
+    x : Tensor
+        For project-in, the input tensor of shape (1, in_features); and for project-out, the input
+        shape is (experts_per_tok, in_features), where `experts_per_tok` is the number of activated
+        experts per token.
+
+    w : Tensor
+        The quantized weight tensor of shape (local_experts, out_features, in_features)
+
+    scale : Optional[Tensor]
+        The optional scale tensor of shape (1,)
+
+    indptr : Tensor
+        The index pointer tensor of shape (1, experts_per_tok), where `experts_per_tok` is the
+        number of activated experts per token.
+
+    quantize_dtype : Literal["float8_e5m2", "float8_e4m3fn"]
+        The quantize dtype of the weight tensor, which is either float8_e5m2 or float8_e4m3fn.
+    """
+    x_leading_dim, in_features = x.shape
+    local_experts, out_features, k = w.shape
+    _, experts_per_tok = expert_indices.shape
+    model_dtype = x.dtype
+    quantize_dtype = w.dtype
+
+    assert out_features % block_size[0] == 0
+    assert k % block_size[1] == 0
+
+    def _dequantize(w, s, e, i, j):
+        return w[e, i, j].astype(model_dtype) * s[e, i // block_size[0], j // block_size[1]].astype(
+            model_dtype
+        )
+
+    def load_x(x, e, j):
+        return x[0, j] if x_leading_dim == 1 else x[e, j]
+
+    @T.prim_func(private=True)
+    def _func(
+        x: T.Buffer((x_leading_dim, in_features), model_dtype),
+        w: T.Buffer((local_experts, out_features, k), quantize_dtype),
+        w_scale: T.Buffer(
+            (local_experts, out_features // block_size[0], k // block_size[1]), "float32"
+        ),
+        expert_indices: T.Buffer((1, experts_per_tok), "int32"),
+        o: T.Buffer((experts_per_tok, out_features), out_dtype),
+    ):
+        T.func_attr({"op_pattern": 4, "tir.noalias": True})  # kOutEWiseFusable
+        for expert_id in T.thread_binding(experts_per_tok, thread="blockIdx.y"):
+            with T.block("gemv_o"):
+                e = T.axis.spatial(experts_per_tok, expert_id)
+                y = T.alloc_buffer((out_features, in_features), model_dtype)
+                for i1, i2 in T.grid(out_features, in_features):
+                    with T.block("dequantize"):
+                        i, j = T.axis.remap("SS", [i1, i2])
+                        y[i, j] = _dequantize(w, w_scale, expert_indices[0, e], i, j)
+                for i1, i2 in T.grid(out_features, in_features):
+                    with T.block("gemv"):
+                        i, j = T.axis.remap("SR", [i1, i2])
+                        with T.init():
+                            o[e, i] = T.cast(T.float16(0), out_dtype)
+                        o[e, i] += (load_x(x, e, j) * y[i, j]).astype(out_dtype)
+
+    return op.tensor_ir_op(
+        _func,
+        "moe_dequantize_gemv",
+        args=[x, w, w_scale, expert_indices],
+        out=Tensor.placeholder([experts_per_tok, out_features], out_dtype),
     )
 
 

--- a/python/mlc_llm/op/moe_misc.py
+++ b/python/mlc_llm/op/moe_misc.py
@@ -1,10 +1,11 @@
 """Mixture of Experts operators"""
 
 from functools import reduce
-from typing import Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
+import numpy as np
 from tvm import te, tir
-from tvm.relax.frontend.nn import Tensor, op
+from tvm.relax.frontend.nn import IntExpr, Tensor, op
 from tvm.script import tir as T
 
 # mypy: disable-error-code="attr-defined,name-defined"
@@ -26,6 +27,100 @@ def moe_sum(x: Tensor, dim: int) -> Tensor:
             args=[x],
         )
     return op.sum(x, axis=dim)
+
+
+def gating_topk(scores: Tensor, k: int) -> Tuple[Tensor, Tensor]:
+    """Compute the top-k experts and their scores.
+
+    Parameters
+    ----------
+    scores : Tensor
+        The input tensor with shape [batch_size, num_local_experts].
+
+    k : int
+        The number of top elements to be selected, which is `num_experts_per_tok` in MoE.
+
+    Returns
+    -------
+    expert_weights: Tensor
+        The top-k expert scores with shape [batch_size, k].
+
+    expert_indices: Tensor
+        The top-k expert indices with shape [batch_size, k].
+    """
+    (batch_size, num_local_experts), dtype = scores.shape, scores.dtype
+    index_dtype = "int32"
+
+    TX = 1024
+
+    def _get_topk_func(k_val: int):
+        def _init_local_top_k(local_top_k, local_top_k_index):
+            for t in range(k_val):
+                T.buffer_store(local_top_k, T.min_value(dtype), indices=[t])
+            for t in range(k_val):
+                T.buffer_store(local_top_k_index, t, indices=[-1])
+
+        def _process_value(x, local_top_k, local_top_k_index, vi, vk):
+            if_frames = [T.If(x[vi, vk] > local_top_k[i]) for i in range(k_val)]
+            then_frames = [T.Then() for _ in range(k_val)]
+            else_frames = [T.Else() for _ in range(k_val - 1)]
+            for i in range(k_val):
+                if_frames[i].__enter__()  # pylint: disable=unnecessary-dunder-call
+                with then_frames[i]:
+                    for j in range(k_val - 1, i, -1):
+                        T.buffer_store(local_top_k, local_top_k[j - 1], indices=[j])
+                        T.buffer_store(local_top_k_index, local_top_k_index[j - 1], indices=[j])
+                    T.buffer_store(local_top_k, x[vi, vk], indices=[i])
+                    T.buffer_store(local_top_k_index, vk, indices=[i])
+                if i != k_val - 1:
+                    else_frames[i].__enter__()  # pylint: disable=unnecessary-dunder-call
+
+            for i in range(k_val - 1, -1, -1):
+                if i != k_val - 1:
+                    else_frames[i].__exit__(None, None, None)
+                if_frames[i].__exit__(None, None, None)
+
+        @T.prim_func(private=True)
+        def topk_func(
+            var_x: T.handle,
+            var_out: T.handle,
+            var_out_index: T.handle,
+        ) -> None:
+            T.func_attr({"tir.noalias": True, "tir.is_scheduled": True})
+            batch_size = T.int64()
+            x = T.match_buffer(var_x, (batch_size, num_local_experts), dtype)
+            out = T.match_buffer(var_out, (batch_size, k_val), dtype)
+            out_index = T.match_buffer(var_out_index, (batch_size, k_val), index_dtype)
+            local_top_k = T.alloc_buffer((k_val,), dtype=dtype, scope="local")
+            local_top_k_index = T.alloc_buffer((k_val,), dtype=index_dtype, scope="local")
+            for io in T.thread_binding(0, T.ceildiv(batch_size, TX), "blockIdx.x"):
+                for ii in T.thread_binding(0, TX, "threadIdx.x"):
+                    with T.block("top_k"):
+                        vi = T.axis.spatial(batch_size, io * TX + ii)
+                        T.where(io * TX + ii < batch_size)
+                        with T.block("init"):
+                            _init_local_top_k(local_top_k, local_top_k_index)
+                        for k in range(num_local_experts):
+                            with T.block("update"):
+                                vk = T.axis.remap("S", [k])
+                                _process_value(x, local_top_k, local_top_k_index, vi, vk)
+                        for j in T.unroll(k_val):
+                            with T.block("output"):
+                                vj = T.axis.remap("S", [j])
+                                out[vi, vj] = local_top_k[vj]
+                                out_index[vi, vj] = local_top_k_index[vj]
+
+        return topk_func
+
+    return op.tensor_ir_op(
+        _get_topk_func(k),
+        f"top{k}",
+        args=[scores],
+        out=(
+            Tensor.placeholder([batch_size, k], dtype),
+            Tensor.placeholder([batch_size, k], index_dtype),
+        ),
+    )
 
 
 def gating_softmax_topk(  # pylint: disable=too-many-statements
@@ -62,7 +157,7 @@ def gating_softmax_topk(  # pylint: disable=too-many-statements
             for t in range(k_val):
                 T.buffer_store(local_top_k, T.min_value(dtype), indices=[t])
             for t in range(k_val):
-                T.buffer_store(local_top_k_index, t, indices=[t])
+                T.buffer_store(local_top_k_index, t, indices=[-1])
 
         def _process_value(x, local_top_k, local_top_k_index, vi, vk):
             if_frames = [T.If(x[vi, vk] > local_top_k[i]) for i in range(k_val)]
@@ -108,6 +203,7 @@ def gating_softmax_topk(  # pylint: disable=too-many-statements
                             with T.block("update"):
                                 vk = T.axis.remap("S", [k])
                                 _process_value(x, local_top_k, local_top_k_index, vi, vk)
+                        # Todo: fix softmax when norm_topk_prob is True  # pylint: disable=fixme
                         for j in T.unroll(k_val):
                             with T.block("output"):
                                 vj = T.axis.remap("S", [j])
@@ -137,6 +233,137 @@ def gating_softmax_topk(  # pylint: disable=too-many-statements
             Tensor.placeholder([batch_size, k], index_dtype),
         ),
     )
+
+
+def group_limited_greedy_topk(  # pylint: disable=too-many-arguments
+    scores: Tensor,  # (num_tokens, num_routed_experts)
+    top_k: int,
+    num_routed_experts: int,
+    n_group: int,
+    topk_group: int,
+    topk_method: Literal["group_limited_greedy", "noaux_tc"],
+    num_tokens: IntExpr,
+    e_score_correction_bias: Optional[Tensor],
+) -> Tuple[Tensor, Tensor]:
+    """Group-limited greedy top-k expert selection.
+
+    Parameters
+    ----------
+    scores : Tensor
+        The input tensor with shape [num_tokens, num_routed_experts].
+
+    top_k : int
+        The number of top elements to be selected, which is `num_experts_per_tok` in MoE.
+
+    num_routed_experts : int
+        The number of routed experts.
+
+    n_group : int
+        The number of groups.
+
+    topk_group : int
+        The number of top-k groups to be selected.
+
+    topk_method : Literal["group_limited_greedy", "noaux_tc"]
+        The method to select the top-k groups.
+
+    num_tokens : IntExpr
+        The number of tokens.
+
+    e_score_correction_bias : Optional[Tensor]
+        The bias of the expert scores. Only available for "noaux_tc".
+
+    Returns
+    -------
+    expert_weights : Tensor
+        The top-k expert scores with shape [num_tokens, top_k].
+
+    expert_indices : Tensor
+        The top-k expert indices with shape [num_tokens, top_k].
+    """
+    assert scores.dtype == "float32"
+    scores_for_choice = scores
+    if topk_method == "noaux_tc":
+        assert e_score_correction_bias is not None
+        assert e_score_correction_bias.dtype == "float32"
+        scores_for_choice = scores + e_score_correction_bias
+    group_size = num_routed_experts // n_group
+    if topk_method == "noaux_tc":
+        group_scores = op.sum(
+            gating_topk(
+                scores_for_choice.reshape(num_tokens * n_group, group_size),
+                2,
+            )[0],
+            axis=-1,
+        ).reshape(num_tokens, n_group)
+    else:
+        group_scores = op.max(
+            scores_for_choice.reshape(num_tokens * n_group, group_size), axis=-1
+        ).reshape(num_tokens, n_group)
+    group_idx = gating_topk(group_scores, topk_group)[1]  # (num_tokens, top_k_group)
+
+    @T.prim_func(private=True)
+    def group_limited_mask_scores(
+        var_scores: T.handle, var_group_idx: T.handle, var_output: T.handle
+    ):
+        T.func_attr({"tir.noalias": True})
+        scores = T.match_buffer(
+            var_scores, (num_tokens, num_routed_experts), dtype=scores_for_choice.dtype
+        )
+        group_idx_tir = T.match_buffer(
+            var_group_idx, (num_tokens, topk_group), dtype=group_idx.dtype
+        )
+        output = T.match_buffer(
+            var_output, (num_tokens, num_routed_experts), dtype=scores_for_choice.dtype
+        )
+        for i, j, k in T.grid(num_tokens, topk_group, group_size):
+            with T.block("mask_scores"):
+                vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                output[vi, group_idx_tir[vi, vj] * group_size + vk] = scores[
+                    vi, group_idx_tir[vi, vj] * group_size + vk
+                ]
+
+    tmp_scores = op.tensor_ir_inplace_op(
+        group_limited_mask_scores,
+        "group_limited_mask_scores",
+        args=[
+            scores_for_choice,
+            group_idx,
+            op.full(
+                scores_for_choice.shape,
+                float(np.finfo("float32").min),
+                dtype=scores_for_choice.dtype,
+            ),
+        ],
+        inplace_indices=[2],
+        out=Tensor.placeholder(scores_for_choice.shape, scores_for_choice.dtype),
+    )
+
+    expert_weights, expert_indices = gating_topk(tmp_scores, top_k)
+    if topk_method == "noaux_tc":
+
+        @T.prim_func(private=True)
+        def gather_scores(var_scores: T.handle, var_expert_indices: T.handle, var_output: T.handle):
+            T.func_attr({"tir.noalias": True})
+            scores = T.match_buffer(
+                var_scores, (num_tokens, num_routed_experts), dtype=scores_for_choice.dtype
+            )
+            expert_indices_tir = T.match_buffer(
+                var_expert_indices, (num_tokens, top_k), dtype=expert_indices.dtype
+            )
+            output = T.match_buffer(var_output, (num_tokens, top_k), dtype=scores_for_choice.dtype)
+            for i, j in T.grid(num_tokens, top_k):
+                with T.block("gather_scores"):
+                    vi, vj = T.axis.remap("SS", [i, j])
+                    output[vi, vj] = scores[vi, expert_indices_tir[vi, vj]]
+
+        expert_weights = op.tensor_ir_op(
+            gather_scores,
+            "gather_scores",
+            args=[scores, expert_indices],
+            out=Tensor.placeholder((num_tokens, top_k), scores_for_choice.dtype),
+        )
+    return expert_weights, expert_indices
 
 
 def moe_cumsum(expert_indices: Tensor, num_local_experts: int) -> Tensor:

--- a/python/mlc_llm/op/triton.py
+++ b/python/mlc_llm/op/triton.py
@@ -1,0 +1,751 @@
+"""Operators enabled by external modules."""
+
+# pylint: disable=invalid-name
+
+from typing import List, Literal, Tuple
+
+import tvm
+from tvm.relax.frontend import nn
+from tvm.script import ir as I
+from tvm.script import tir as T
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+# We use a wrapper function to avoid type annotation issue of "tl.constexpr" when
+# triton is not installed.
+def _get_triton_w8a8_block_fp8_gemm():
+    # Triton kernel adapted from SGLang project
+    # https://github.com/sgl-project/sglang/blob/v0.4.4/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py  # pylint: disable=line-too-long
+    def _triton_w8a8_block_fp8_gemm(  # pylint: disable=too-many-arguments,too-many-locals
+        # Pointers to inputs and output
+        A,
+        B,
+        C,
+        As,
+        Bs,
+        # Shape for matmul
+        M,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        # Stride for inputs and output
+        stride_am: tl.constexpr,
+        stride_ak: tl.constexpr,
+        stride_bk: tl.constexpr,
+        stride_bn: tl.constexpr,
+        stride_cm: tl.constexpr,
+        stride_cn: tl.constexpr,
+        stride_As_m: tl.constexpr,
+        stride_As_k: tl.constexpr,
+        stride_Bs_k: tl.constexpr,
+        stride_Bs_n: tl.constexpr,
+        # Block size for block-wise quantization
+        group_n: tl.constexpr,
+        group_k: tl.constexpr,
+        # Meta-parameters
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+        GROUP_SIZE_M: tl.constexpr,
+    ):
+        """Triton-accelerated function used to perform linear operations (dot
+        product) on input tensors `A` and `B` with block-wise quantization,
+        and store the result in output tensor `C`.
+        """
+
+        pid = tl.program_id(axis=0).to(tl.int64)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + (pid % group_size_m)
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+        offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+        offs_k = tl.arange(0, BLOCK_SIZE_K)
+        a_ptrs = A + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+        b_ptrs = B + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+        As_ptrs = As + offs_am * stride_As_m
+        offs_bsn = offs_bn // group_n
+        Bs_ptrs = Bs + offs_bsn * stride_Bs_n
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+
+            k_start = k * BLOCK_SIZE_K
+            offs_ks = k_start // group_k
+            a_s = tl.load(As_ptrs + offs_ks * stride_As_k)
+            b_s = tl.load(Bs_ptrs + offs_ks * stride_Bs_k)
+
+            accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+        if C.dtype.element_ty == tl.bfloat16:
+            c = accumulator.to(tl.bfloat16)
+        elif C.dtype.element_ty == tl.float16:
+            c = accumulator.to(tl.float16)
+        else:
+            c = accumulator.to(tl.float32)
+
+        offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_ptrs = C + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, c, mask=c_mask)
+
+    return _triton_w8a8_block_fp8_gemm
+
+
+# We use a wrapper function to avoid type annotation issue of "tl.constexpr" when
+# triton is not installed.
+def _get_triton_w8a8_block_fp8_group_gemm():
+    # Triton kernel adapted from SGLang project
+    # https://github.com/sgl-project/sglang/blob/v0.4.4/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py  # pylint: disable=line-too-long
+    def _triton_w8a8_block_fp8_group_gemm(  # pylint: disable=too-many-arguments,too-many-locals
+        # Pointers to matrices
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        a_scale_ptr,
+        b_scale_ptr,
+        expert_ids_ptr,
+        indptr_ptr,
+        # Matrix dimensions
+        EM,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        num_experts: tl.constexpr,
+        # The stride variables represent how much to increase the ptr by when
+        # moving by 1 element in a particular dimension. E.g. `stride_am` is
+        # how much to increase `a_ptr` by to get the element one row down
+        # (A has M rows).
+        stride_am: tl.constexpr,
+        stride_ak: tl.constexpr,
+        stride_be: tl.constexpr,
+        stride_bk: tl.constexpr,
+        stride_bn: tl.constexpr,
+        stride_cm: tl.constexpr,
+        stride_cn: tl.constexpr,
+        stride_asm: tl.constexpr,
+        stride_ask: tl.constexpr,
+        stride_bse: tl.constexpr,
+        stride_bsk: tl.constexpr,
+        stride_bsn: tl.constexpr,
+        # Block size for block-wise quantization
+        group_n: tl.constexpr,
+        group_k: tl.constexpr,
+        # Meta-parameters
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+        GROUP_SIZE_M: tl.constexpr,
+        even_Ks: tl.constexpr,
+    ):
+        """
+        Implements the fused computation for a Mixture of Experts (MOE) using
+        token and expert matrices.
+
+        Key Parameters:
+        - A: The input tensor representing tokens with shape (*, K), where '*' can
+            be any shape representing batches and K is the feature dimension of
+            each token.
+        - B: The stacked MOE weight tensor with shape (E, N, K), where E is
+            the number of experts, K is the input feature dimension, and N is
+            the output feature dimension.
+        - C: The output cache tensor with shape (*, N), where '*' means the
+            same shape as the input tensor A, and N is the output feature dimension.
+        - expert_ids: A tensor containing the indices of the expert for each
+            block. It determines which expert matrix from B should be used for
+            each block in A.
+        This kernel performs the multiplication of a token by its corresponding
+        expert matrix as determined by `expert_ids`.
+        """
+        # -----------------------------------------------------------
+        # Map program ids `pid` to the block of C it should compute.
+        # This is done in a grouped ordering to promote L2 data reuse.
+        pid = tl.program_id(axis=0).to(tl.int64)
+        num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M) + num_experts
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+        # ----------------------------------------------------------
+        # Create pointers for the first blocks of A and B.
+        # We will advance this pointer as we move in the K direction
+        # and accumulate
+        # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+        # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+        expert_id = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+        if expert_id == -1:
+            return
+
+        token_begin = tl.load(indptr_ptr + expert_id)
+        token_end = tl.load(indptr_ptr + expert_id + 1)
+        start_pid_m = tl.cdiv(token_begin, BLOCK_SIZE_M) + expert_id
+        offs_token_id = (
+            token_begin + (pid_m - start_pid_m) * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        )
+        token_mask = offs_token_id < token_end
+
+        offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+        offs_k = tl.arange(0, BLOCK_SIZE_K)
+        a_ptrs = a_ptr + offs_token_id[:, None] * stride_am + offs_k[None, :] * stride_ak
+
+        b_ptrs = (
+            b_ptr
+            + expert_id * stride_be
+            + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+        )
+
+        a_scale_ptrs = a_scale_ptr + offs_token_id * stride_asm
+        offs_bsn = offs_bn // group_n
+        b_scale_ptrs = b_scale_ptr + expert_id * stride_bse + offs_bsn * stride_bsn
+
+        # -----------------------------------------------------------
+        # Iterate to compute a block of the C matrix.
+        # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+        # of fp32 values for higher accuracy.
+        # `accumulator` will be converted back to fp16 after the loop.
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            # Load the next block of A and B, generate a mask by checking the
+            # K dimension.
+            if even_Ks:
+                a = tl.load(
+                    a_ptrs,
+                    mask=token_mask[:, None],
+                    other=0.0,
+                )
+                b = tl.load(b_ptrs)
+            else:
+                a = tl.load(
+                    a_ptrs,
+                    mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                    other=0.0,
+                )
+                b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+
+            # We accumulate along the K dimension.
+            k_start = k * BLOCK_SIZE_K
+            offs_ks = k_start // group_k
+            a_scale = tl.load(a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0)
+            b_scale = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
+
+            accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
+            # Advance the ptrs to the next K block.
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+        if c_ptr.dtype.element_ty == tl.bfloat16:
+            accumulator = accumulator.to(tl.bfloat16)
+        elif c_ptr.dtype.element_ty == tl.float16:
+            accumulator = accumulator.to(tl.float16)
+        else:
+            accumulator = accumulator.to(tl.float32)
+
+        # -----------------------------------------------------------
+        # Write back the block of the output
+        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_ptrs = c_ptr + stride_cm * offs_token_id[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
+
+    return _triton_w8a8_block_fp8_group_gemm
+
+
+def get_tir_w8a8_block_fp8_matmul(  # pylint: disable=too-many-arguments,too-many-locals
+    N: int,
+    K: int,
+    block_n: int,
+    block_k: int,
+    in_dtype: Literal["float8_e4m3fn"],
+    out_dtype: Literal["float16", "bfloat16"],
+    BLOCK_SIZE_M: int,
+    BLOCK_SIZE_N: int,
+    BLOCK_SIZE_K: int,
+    GROUP_SIZE_M: int,
+    num_warps: int,
+    num_stages: int,
+    extern_mods: List[tvm.runtime.Module],
+):
+    """Get the TIR function for the w8a8_block_fp8_matmul kernel."""
+    # NOTE: adding the type annotation of " -> Tuple[Optional[tvm.tir.PrimFunc], str]"
+    # will cause the failure of the type resolution in mypy.
+    if triton is None:
+        raise RuntimeError("Triton is not installed. Please install it with `pip install triton`.")
+
+    name_suffix = f"_N{N}_K{K}_block_n{block_n}_block_k{block_k}_in{in_dtype}_out{out_dtype}"
+    kernel_name = f"triton_w8a8_block_fp8_gemm{name_suffix}"
+    tir_name = f"tir_w8a8_block_fp8_matmul{name_suffix}"
+    for ext_mod in extern_mods:
+        if ext_mod.implements_function(kernel_name):
+            return [None, tir_name]
+
+    triton_kernel = _get_triton_w8a8_block_fp8_gemm()
+    triton_kernel.__name__ = kernel_name
+
+    @I.ir_module
+    class BlockFP8Matmul:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        @T.prim_func(private=True)
+        def tir_w8a8_block_fp8_matmul(  # pylint: disable=missing-function-docstring
+            var_A: T.handle,
+            var_B: T.handle,
+            var_As: T.handle,
+            var_Bs: T.handle,
+            var_C: T.handle,
+        ):
+            T.func_attr({"op_pattern": 8, "tir.is_scheduled": 1})
+            M = T.SizeVar("M", "int32")
+            A = T.match_buffer(var_A, (M, K), dtype=in_dtype)
+            B = T.match_buffer(var_B, (N, K), dtype=in_dtype)
+            As = T.match_buffer(var_As, (M, (K + block_k - 1) // block_k), "float32")
+            Bs = T.match_buffer(
+                var_Bs, ((N + block_n - 1) // block_n, (K + block_k - 1) // block_k), "float32"
+            )
+            C = T.match_buffer(var_C, (M, N), dtype=out_dtype)
+            with T.block("root"):
+                T.reads(
+                    A[0:M, 0:K],
+                    B[0:N, 0:K],
+                    As[0:M, 0 : (K + block_k - 1) // block_k],
+                    Bs[0 : (N + block_n - 1) // block_n, 0 : (K + block_k - 1) // block_k],
+                )
+                T.writes(C[0:M, 0:N])
+                T.call_kernel(
+                    triton.jit(triton_kernel),
+                    (T.ceildiv(M, BLOCK_SIZE_M) * T.ceildiv(N, BLOCK_SIZE_N),),
+                    A.data,
+                    B.data,
+                    C.data,
+                    As.data,
+                    Bs.data,
+                    M,
+                    N,
+                    K,
+                    K,  # stride_am
+                    1,  # stride_ak
+                    1,  # stride_bk
+                    K,  # stride_bn
+                    N,  # stride_cm
+                    1,  # stride_cn
+                    (K + block_k - 1) // block_k,  # stride_As_m
+                    1,  # stride_As_k
+                    1,  # stride_Bs_k
+                    (K + block_k - 1) // block_k,  # stride_Bs_n
+                    block_n,
+                    block_k,
+                    BLOCK_SIZE_M,
+                    BLOCK_SIZE_N,
+                    BLOCK_SIZE_K,
+                    GROUP_SIZE_M,
+                    num_warps=num_warps,
+                    num_stages=num_stages,
+                )
+
+    new_ext_mods = BlockFP8Matmul.attrs["external_mods"]  # type: ignore  # pylint: disable=no-member
+    assert len(new_ext_mods) == 1
+    extern_mods.append(new_ext_mods[0])
+    return BlockFP8Matmul["tir_w8a8_block_fp8_matmul"], tir_name  # type: ignore
+
+
+def get_tir_w8a8_block_fp8_group_matmul(  # pylint: disable=too-many-arguments,too-many-locals
+    N: int,
+    K: int,
+    num_experts: int,
+    block_n: int,
+    block_k: int,
+    in_dtype: Literal["float8_e4m3fn"],
+    out_dtype: Literal["float16", "bfloat16"],
+    BLOCK_SIZE_M: int,
+    BLOCK_SIZE_N: int,
+    BLOCK_SIZE_K: int,
+    GROUP_SIZE_M: int,
+    num_warps: int,
+    num_stages: int,
+    extern_mods: List[tvm.runtime.Module],
+):
+    """Get the TIR function for the w8a8_block_fp8_group_gemm kernel."""
+    if triton is None:
+        raise RuntimeError("Triton is not installed. Please install it with `pip install triton`.")
+
+    name_suffix = (
+        f"_N{N}_K{K}_num_experts{num_experts}_block_n{block_n}"
+        f"_block_k{block_k}_in{in_dtype}_out{out_dtype}"
+    )
+    kernel_name = f"triton_w8a8_block_fp8_group_gemm{name_suffix}"
+    tir_name = f"tir_w8a8_block_fp8_group_gemm{name_suffix}"
+    for ext_mod in extern_mods:
+        if ext_mod.implements_function(kernel_name):
+            return [None, tir_name]
+
+    triton_kernel = _get_triton_w8a8_block_fp8_group_gemm()
+    triton_kernel.__name__ = kernel_name
+
+    @I.ir_module
+    class BlockFP8GroupMatmul:  # pylint: disable=missing-class-docstring,too-few-public-methods
+        @T.prim_func(private=True)
+        def tir_w8a8_block_fp8_group_gemm(  # pylint: disable=missing-function-docstring,too-many-arguments
+            var_A: T.handle,
+            var_B: T.handle,
+            var_As: T.handle,
+            var_Bs: T.handle,
+            var_expert_ids: T.handle,
+            var_indptr: T.handle,
+            var_C: T.handle,
+        ):
+            T.func_attr({"op_pattern": 8, "tir.is_scheduled": 1})
+            EM = T.SizeVar("EM", "int32")
+            A = T.match_buffer(var_A, (EM, K), dtype=in_dtype)
+            B = T.match_buffer(var_B, (num_experts, N, K), dtype=in_dtype)
+            As = T.match_buffer(var_As, (EM, (K + block_k - 1) // block_k), "float32")
+            Bs = T.match_buffer(
+                var_Bs,
+                (num_experts, (N + block_n - 1) // block_n, (K + block_k - 1) // block_k),
+                "float32",
+            )
+            expert_ids = T.match_buffer(
+                var_expert_ids, ((EM + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + num_experts,), "int32"
+            )
+            indptr = T.match_buffer(var_indptr, (num_experts + 1,), "int32")
+            C = T.match_buffer(var_C, (EM, N), dtype=out_dtype)
+
+            with T.block("root"):
+                T.reads(
+                    A[0:EM, 0:K],
+                    B[0:num_experts, 0:N, 0:K],
+                    As[0:EM, 0 : (K + block_k - 1) // block_k],
+                    Bs[
+                        0:num_experts,
+                        0 : (N + block_n - 1) // block_n,
+                        0 : (K + block_k - 1) // block_k,
+                    ],
+                    expert_ids[0 : (EM + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + num_experts],
+                    indptr[0 : num_experts + 1],
+                )
+                T.writes(C[0:EM, 0:N])
+                T.call_kernel(
+                    triton.jit(triton_kernel),
+                    ((T.ceildiv(EM, BLOCK_SIZE_M) + num_experts) * T.ceildiv(N, BLOCK_SIZE_N),),
+                    A.data,
+                    B.data,
+                    C.data,
+                    As.data,
+                    Bs.data,
+                    expert_ids.data,
+                    indptr.data,
+                    EM,
+                    N,
+                    K,
+                    num_experts,
+                    K,  # stride_am
+                    1,  # stride_ak
+                    N * K,  # stride_be
+                    1,  # stride_bk
+                    K,  # stride_bn
+                    N,  # stride_cm
+                    1,  # stride_cn
+                    (K + block_k - 1) // block_k,  # stride_asm
+                    1,  # stride_ask
+                    ((N + block_n - 1) // block_n) * ((K + block_k - 1) // block_k),  # stride_bse
+                    1,  # stride_bsk
+                    (K + block_k - 1) // block_k,  # stride_Bs_n
+                    block_n,
+                    block_k,
+                    BLOCK_SIZE_M,
+                    BLOCK_SIZE_N,
+                    BLOCK_SIZE_K,
+                    GROUP_SIZE_M,
+                    K % BLOCK_SIZE_K == 0,
+                    num_warps=num_warps,
+                    num_stages=num_stages,
+                )
+
+    new_ext_mods = BlockFP8GroupMatmul.attrs["external_mods"]  # type: ignore  # pylint: disable=no-member
+    assert len(new_ext_mods) == 1
+    extern_mods.append(new_ext_mods[0])
+    return BlockFP8GroupMatmul["tir_w8a8_block_fp8_group_gemm"], tir_name  # type: ignore
+
+
+def _compute_expert_id_per_block(
+    indptr: nn.Tensor,
+    num_experts: int,
+    M: nn.IntExpr,
+    BLOCK_SIZE_M: int,
+) -> nn.Tensor:
+    """Compute the expert id for each threadblock (CTA).
+    We assign an expert id to each threadblock, and the threadblock will
+    compute the gemm with regard to the specified expert.
+
+    Parameters
+    ----------
+    indptr : nn.Tensor
+        The indptr tensor of group gemm, with shape of [num_experts + 1,].
+
+    num_experts : int
+        The number of total experts.
+
+    M : nn.IntExpr
+        The number of tokens.
+
+    BLOCK_SIZE_M : int
+        The block size of the threadblock along the batch dimension.
+
+    Returns
+    -------
+    expert_ids : nn.Tensor
+        The expert id for each threadblock, with shape of
+        [(M + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + num_experts,].
+    """
+
+    @T.prim_func
+    def tir_compute_expert_id_per_block(
+        var_indptr: T.handle,
+        var_expert_ids: T.handle,
+        M: T.int64,
+    ):
+        T.func_attr({"op_pattern": 8, "tir.is_scheduled": 1})
+        indptr = T.match_buffer(var_indptr, (num_experts + 1,), "int32")
+        expert_ids = T.match_buffer(
+            var_expert_ids, ((M + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + num_experts,), "int32"
+        )
+        with T.block("root"):
+            for eid in T.thread_binding(0, num_experts, thread="threadIdx.x"):
+                start_block_id: T.int32 = (indptr[eid] + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + eid
+                num_blocks: T.int32 = (
+                    indptr[eid + 1] - indptr[eid] + BLOCK_SIZE_M - 1
+                ) // BLOCK_SIZE_M
+                start_block_id_next_expert: T.int32 = (
+                    (indptr[eid + 1] + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + eid + 1
+                )
+                for block_id in T.serial(num_blocks):
+                    expert_ids[start_block_id + block_id] = eid
+                for block_id in T.serial(
+                    start_block_id_next_expert - (start_block_id + num_blocks)
+                ):
+                    expert_ids[start_block_id + num_blocks + block_id] = -1
+
+    assert num_experts <= 1024
+    return nn.tensor_ir_op(
+        tir_compute_expert_id_per_block,
+        "tir_compute_expert_id_per_block",
+        args=[indptr, M],
+        out=nn.Tensor.placeholder(
+            ((M + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + num_experts,), dtype="int32"
+        ),
+    )
+
+
+def fp8_block_scale_gemm(  # pylint: disable=too-many-arguments,too-many-locals
+    x: nn.Tensor,
+    x_scale: nn.Tensor,
+    weight: nn.Tensor,
+    weight_scale: nn.Tensor,
+    block_size: Tuple[int, int],
+    out_dtype: str,
+) -> nn.Tensor:
+    """Triton block-scale fp8 gemm operator.
+
+    Parameters
+    ----------
+    x : nn.Tensor
+        The input tensor, with shape of [m, k].
+
+    x_scale : nn.Tensor
+        The scale tensor, with shape of [m, k // block_size].
+
+    weight : nn.Tensor
+        The weight tensor, with shape of [n, k].
+
+    weight_scale : nn.Tensor
+        The scale tensor, with shape of [n // block_size, k // block_size].
+
+    block_size : Tuple[int, int]
+        The block size.
+
+    out_dtype : str
+        The data type of the output tensor.
+
+    Returns
+    -------
+    out : nn.Tensor
+        The output tensor, with shape of [m, n] and dtype of `out_dtype`.
+    """
+    assert x.ndim >= 2
+    assert weight.ndim == 2
+    assert x_scale.ndim == x.ndim
+    assert weight_scale.ndim == weight.ndim
+    assert x.shape[-1] == weight.shape[1]
+    assert x.shape[:-1] == x_scale.shape[:-1]
+    assert (x.shape[-1] + block_size[1] - 1) // block_size[1] == x_scale.shape[-1]
+    assert (weight.shape[1] + block_size[1] - 1) // block_size[1] == weight_scale.shape[1]
+    assert (weight.shape[0] + block_size[0] - 1) // block_size[0] == weight_scale.shape[0]
+
+    if x.dtype != "float8_e4m3fn" or weight.dtype != "float8_e4m3fn":
+        raise ValueError(
+            f"x and weight must be float8_e4m3fn, but got x={x.dtype}, weight={weight.dtype}"
+        )
+    if x_scale.dtype != "float32" and weight_scale.dtype != "float32":
+        raise ValueError(
+            "x_scale and weight_scale must be float32, but got "
+            f"x_scale={x_scale.dtype}, weight_scale={weight_scale.dtype}"
+        )
+    if out_dtype not in ["float16", "bfloat16"]:
+        raise ValueError(f"out_dtype must be float16 or bfloat16, but got {out_dtype}")
+
+    M = x.shape[0]
+    for i in range(1, x.ndim - 1):
+        M *= x.shape[i]
+    N = weight.shape[0]
+    K = x.shape[-1]
+
+    BLOCK_SIZE_M = 64
+    BLOCK_SIZE_N = block_size[0]
+    BLOCK_SIZE_K = block_size[1]
+    GROUP_SIZE_M = 32
+    num_warps = 4
+    num_stages = 3
+
+    x_shape = x.shape
+    if x.ndim > 2:
+        x = x.reshape(M, K)
+    x_scale = x_scale.reshape(M, x_scale.shape[-1])
+
+    out = nn.extern(
+        "mlc.triton.w8a8_block_fp8_matmul",
+        args=[
+            x,
+            weight,
+            x_scale,
+            weight_scale,
+            N,
+            K,
+            block_size[0],
+            block_size[1],
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            GROUP_SIZE_M,
+            num_warps,
+            num_stages,
+            x.dtype,
+            out_dtype,
+        ],
+        out=nn.Tensor.placeholder((M, N), dtype=out_dtype),
+    )
+    return out.reshape(*x_shape[:-1], N) if len(x_shape) > 2 else out
+
+
+def fp8_block_scale_group_gemm(  # pylint: disable=too-many-arguments,too-many-locals
+    x: nn.Tensor,
+    x_scale: nn.Tensor,
+    weight: nn.Tensor,
+    weight_scale: nn.Tensor,
+    indptr: nn.Tensor,
+    block_size: Tuple[int, int],
+    out_dtype: str,
+):
+    """Triton block-scale fp8 group gemm operator.
+
+    Parameters
+    ----------
+    x : nn.Tensor
+        The input tensor, with shape of [m, k].
+
+    x_scale : nn.Tensor
+        The scale tensor, with shape of [m, k // block_size].
+
+    weight : nn.Tensor
+        The weight tensor, with shape of [num_experts, n, k].
+
+    weight_scale : nn.Tensor
+        The scale tensor, with shape of [num_experts, n // block_size, k // block_size].
+
+    indptr : nn.Tensor
+        The indptr tensor of group gemm, with shape of [num_experts + 1,].
+
+    block_size : Tuple[int, int]
+        The block size.
+
+    out_dtype : str
+        The data type of the output tensor.
+
+    Returns
+    -------
+    out : nn.Tensor
+        The output tensor, with shape of [m, n] and dtype of `out_dtype`.
+    """
+    assert x.ndim >= 2
+    assert weight.ndim == 3
+    assert x_scale.ndim == x.ndim
+    assert weight_scale.ndim == weight.ndim
+    assert x.shape[-1] == weight.shape[2]
+    assert (x.shape[-1] + block_size[1] - 1) // block_size[1] == x_scale.shape[-1]
+    assert (weight.shape[2] + block_size[1] - 1) // block_size[1] == weight_scale.shape[2]
+    assert (weight.shape[1] + block_size[0] - 1) // block_size[0] == weight_scale.shape[1]
+
+    num_experts = weight.shape[0]
+    M = x.shape[0]
+    for i in range(1, x.ndim - 1):
+        M *= x.shape[i]
+    N = weight.shape[1]
+    K = x.shape[-1]
+    assert weight_scale.shape[0] == num_experts
+    assert indptr.ndim == 1
+    assert indptr.shape[0] == num_experts + 1
+
+    BLOCK_SIZE_M = 64
+    BLOCK_SIZE_N = block_size[0]
+    BLOCK_SIZE_K = block_size[1]
+    GROUP_SIZE_M = 32
+    num_warps = 4
+    num_stages = 3
+
+    x_shape = x.shape
+    if x.ndim > 2:
+        x = x.reshape(M, K)
+    x_scale = x_scale.reshape(M, x_scale.shape[-1])
+    expert_ids = _compute_expert_id_per_block(indptr, num_experts, M, BLOCK_SIZE_M)
+
+    out = nn.extern(
+        "mlc.triton.w8a8_block_fp8_group_matmul",
+        args=[
+            x,
+            weight,
+            x_scale,
+            weight_scale,
+            expert_ids,
+            indptr,
+            N,
+            K,
+            num_experts,
+            block_size[0],
+            block_size[1],
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            GROUP_SIZE_M,
+            num_warps,
+            num_stages,
+            x.dtype,
+            out_dtype,
+        ],
+        out=nn.Tensor.placeholder((M, N), dtype=out_dtype),
+    )
+    return out.reshape(*x_shape[:-1], N) if len(x_shape) > 2 else out

--- a/python/mlc_llm/quantization/__init__.py
+++ b/python/mlc_llm/quantization/__init__.py
@@ -1,6 +1,7 @@
 """A subpackage for quantization and dequantization algorithms"""
 
 from .awq_quantization import AWQQuantize
+from .block_scale_quantization import BlockScaleQuantize
 from .fp8_quantization import FP8PerTensorQuantizeMixtralExperts
 from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize

--- a/python/mlc_llm/quantization/block_scale_quantization.py
+++ b/python/mlc_llm/quantization/block_scale_quantization.py
@@ -1,0 +1,523 @@
+"""The block-scale quantization config"""
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional, Tuple
+
+from tvm import DataType, DataTypeCode, te, tir
+from tvm.relax.frontend import nn
+
+from mlc_llm.loader import QuantizeMapping
+from mlc_llm.nn import MixtralExperts
+from mlc_llm.op import cutlass, extern, moe_matmul, triton
+from mlc_llm.support import logging
+from mlc_llm.support import tensor_parallel as tp
+
+from .utils import apply_sharding, is_final_fc, is_moe_gate
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BlockScaleQuantize:  # pylint: disable=too-many-instance-attributes
+    """Configuration for block-scale quantization"""
+
+    name: str
+    kind: str = "block-scale"
+    weight_dtype: Literal["float8_e4m3fn", "float8_e5m2"] = "float8_e4m3fn"
+    model_dtype: Literal["float16", "bfloat16"] = "bfloat16"
+    quantize_linear: bool = True
+    weight_block_size: Optional[Tuple[int, int]] = None
+
+    def __post_init__(self):
+        assert self.kind == "block-scale-quant"
+        weight_dtype = DataType(self.weight_dtype)
+        model_dtype = DataType(self.model_dtype)
+        assert weight_dtype.type_code in [
+            DataTypeCode.Float8E4M3FN,
+            DataTypeCode.Float8E5M2,
+        ]
+        assert model_dtype.type_code in [
+            DataTypeCode.FLOAT,
+            DataTypeCode.BFLOAT,
+        ]
+
+    def quantize_model(
+        self,
+        model: nn.Module,
+        quant_map: QuantizeMapping,
+        name_prefix: str,
+    ) -> nn.Module:
+        """Quantize model with block-scale quantization
+
+        Parameters
+        ----------
+        model : nn.Module
+            The non-quantized nn.Module.
+
+        quant_map : QuantizeMapping
+            The quantize mapping with name mapping and func mapping.
+
+        name_prefix : str
+            The name prefix for visited weight.
+
+        Returns
+        -------
+        ret : nn.Module
+            The quantized nn.Module.
+        """
+
+        weight_block_size = model.weight_block_size
+
+        class _Mutator(nn.Mutator):
+            def __init__(self, config: BlockScaleQuantize, quant_map: QuantizeMapping) -> None:
+                super().__init__()
+                self.config = config
+                self.quant_map = quant_map
+
+            def visit_module(self, name: str, node: nn.Module) -> Any:
+                """The visiting method for block-scale quantization of nn.Module nodes.
+
+                Parameters
+                ----------
+                name : str
+                    The name of the current node.
+
+                node : nn.Module
+                    The current node of nn.Module to mutate.
+
+                Returns
+                ------
+                ret : Any
+                """
+                if getattr(node, "no_quantization", False):
+                    return node
+
+                if hasattr(node, "w_uk"):
+                    assert hasattr(node, "w_uv")
+                    assert node.block_size == weight_block_size
+                    if (
+                        node.qk_nope_head_dim % node.block_size[0] != 0
+                        or node.v_head_dim % node.block_size[1] != 0
+                    ):
+                        raise ValueError(
+                            "Invalid DeepSeek model config: "
+                            "qk_nope_head_dim must be multiple of weight_block_size[0], and "
+                            "v_head_dim must be multiple of weight_block_size[1]. "
+                            f"However, qk_nope_head_dim is {node.qk_nope_head_dim}, "
+                            f"v_head_dim is {node.v_head_dim}, "
+                            f"weight_block_size is {node.block_size}."
+                        )
+                    w_uk_shard_strategy = node.w_uk.attrs.get("shard_strategy", None)
+                    w_uv_shard_strategy = node.w_uv.attrs.get("shard_strategy", None)
+                    node.w_uk = nn.Parameter(
+                        (node.num_heads, node.kv_lora_rank, node.qk_nope_head_dim),
+                        self.config.weight_dtype,
+                    )
+                    node.w_uv = nn.Parameter(
+                        (node.num_heads, node.v_head_dim, node.kv_lora_rank),
+                        self.config.weight_dtype,
+                    )
+                    node.w_uk_scale_inv = nn.Parameter(
+                        (
+                            node.num_heads,
+                            node.kv_lora_rank // node.block_size[1],
+                            node.qk_nope_head_dim // node.block_size[0],
+                        ),
+                        "float32",
+                    )
+                    node.w_uv_scale_inv = nn.Parameter(
+                        (
+                            node.num_heads,
+                            node.v_head_dim // node.block_size[0],
+                            node.kv_lora_rank // node.block_size[1],
+                        ),
+                        "float32",
+                    )
+                    if w_uk_shard_strategy is not None:
+                        assert w_uk_shard_strategy.segs is None
+                        apply_sharding(w_uk_shard_strategy, w_uk_shard_strategy.name, node.w_uk)
+                        apply_sharding(
+                            w_uk_shard_strategy,
+                            f"{w_uk_shard_strategy.name}_scale_inv",
+                            node.w_uk_scale_inv,
+                        )
+                    if w_uv_shard_strategy is not None:
+                        assert w_uv_shard_strategy.segs is None
+                        apply_sharding(w_uv_shard_strategy, w_uv_shard_strategy.name, node.w_uv)
+                        apply_sharding(
+                            w_uv_shard_strategy,
+                            f"{w_uv_shard_strategy.name}_scale_inv",
+                            node.w_uv_scale_inv,
+                        )
+
+                if (
+                    isinstance(node, nn.Linear)
+                    and not is_final_fc(name)
+                    and not is_moe_gate(name, node)
+                ):
+                    return BlockScaleQuantizeLinear.from_linear(
+                        node, self.config, weight_block_size
+                    )
+                if isinstance(node, MixtralExperts):
+                    return BlockScaleQuantizeMixtralExperts.from_mixtral_experts(
+                        node, self.config, weight_block_size
+                    )
+                return self.visit(name, node)
+
+        model.to(dtype=self.model_dtype)
+        mutator = _Mutator(self, quant_map)
+        model = mutator.visit(name_prefix, model)
+        self.weight_block_size = weight_block_size
+        return model
+
+
+class BlockScaleQuantizeLinear(nn.Module):  # pylint: disable=too-many-instance-attributes
+    """Block-scale quantization for Linear"""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        in_features: int,
+        out_features: int,
+        weight_dtype: Literal["float8_e4m3fn", "float8_e5m2"],
+        block_size: Tuple[int, int],
+        bias: bool = True,
+        dtype: Optional[str] = None,
+        out_dtype: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.out_dtype = out_dtype
+        self.weight = nn.Parameter((out_features, in_features), weight_dtype)
+        self.weight_scale_inv = nn.Parameter(
+            (
+                (out_features + block_size[0] - 1) // block_size[0],
+                (in_features + block_size[1] - 1) // block_size[1],
+            ),
+            "float32",
+        )
+        self.weight_dtype = weight_dtype
+        self.block_size = block_size
+        if bias:
+            self.bias = nn.Parameter((out_features,), dtype if out_dtype is None else out_dtype)
+        else:
+            self.bias = None
+
+    @staticmethod
+    def from_linear(
+        src: nn.Linear, config: BlockScaleQuantize, weight_block_size: Optional[Tuple[int, int]]
+    ) -> "BlockScaleQuantizeLinear":
+        """
+        Converts a non-quantized nn.Linear to a block-scale quantized BlockScaleQuantizeLinear
+
+        Parameters
+        ----------
+        src : nn.Linear
+            The non-quantized nn.Linear.
+
+        config : BlockScaleQuantize
+            The block-scale quantization config.
+
+        weight_block_size : Optional[Tuple[int, int]]
+            The weight block size.
+
+        Returns
+        -------
+        ret : BlockScaleQuantizeLinear
+            The block-scale quantized BlockScaleQuantizeLinear.
+        """
+        assert weight_block_size is not None
+        out_features, in_features = src.weight.shape
+        quantized_linear = BlockScaleQuantizeLinear(
+            in_features=in_features,
+            out_features=out_features,
+            weight_dtype=config.weight_dtype,
+            block_size=weight_block_size,
+            bias=getattr(src, "bias", None) is not None,
+            dtype=config.model_dtype,
+            out_dtype=src.out_dtype,
+        )
+        if quantized_linear.bias is not None:
+            quantized_linear.bias.attrs = src.bias.attrs
+        if "shard_strategy" in src.weight.attrs:
+            shard = src.weight.attrs["shard_strategy"]
+            apply_sharding(shard, shard.name, quantized_linear.weight)
+            if isinstance(shard, tp.ShardSingleDim) and shard.segs is not None:
+                shard.segs = [x // weight_block_size[shard.dim] for x in shard.segs]
+            apply_sharding(shard, f"{shard.name}_scale_inv", quantized_linear.weight_scale_inv)
+        return quantized_linear
+
+    def forward(self, x: nn.Tensor) -> nn.Tensor:
+        """Forward pass of the block-scale quantized linear layer.
+
+        Parameters
+        ----------
+        x : nn.Tensor
+            The input tensor.
+
+        Returns
+        -------
+        ret : nn.Tensor
+            The output tensor.
+        """
+        shape_supported_by_cutlass = (
+            self.weight.shape[0] % 128 == 0 and self.weight.shape[1] % 128 == 0
+        )
+        if extern.get_store().cutlass_gemm and shape_supported_by_cutlass:
+            x_fp8, x_scale = rowwise_group_quant_fp8(
+                x, self.block_size[1], self.weight_dtype, transpose_scale=True
+            )
+            x = cutlass.fp8_block_scale_gemm(
+                x_fp8,
+                x_scale,
+                self.weight,
+                self.weight_scale_inv,
+                self.block_size,
+                self.out_dtype if self.out_dtype is not None else x.dtype,
+            )
+        else:
+            x_fp8, x_scale = rowwise_group_quant_fp8(
+                x, self.block_size[1], self.weight_dtype, transpose_scale=False
+            )
+            x = triton.fp8_block_scale_gemm(
+                x_fp8,
+                x_scale,
+                self.weight,
+                self.weight_scale_inv,
+                self.block_size,
+                self.out_dtype if self.out_dtype is not None else x.dtype,
+            )
+        if self.bias is not None:
+            x = x + self.bias
+        return x
+
+    def to(self, dtype: Optional[str] = None) -> None:
+        """
+        Override to() such that we do not convert bias if there is an out_dtype.
+        Otherwise, we might run into dtype mismatch when computing x + self.bias.
+        """
+        if self.bias is not None and self.out_dtype is None:
+            self.bias.to(dtype=dtype)
+        if dtype is not None and isinstance(getattr(self, "dtype", None), str):
+            self.dtype = dtype  # pylint: disable=attribute-defined-outside-init
+
+
+class BlockScaleQuantizeMixtralExperts(nn.Module):  # pylint: disable=too-many-instance-attributes
+    """Block-scale quantization for MoE experts"""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        num_local_experts: int,
+        in_features: int,
+        out_features: int,
+        weight_dtype: Literal["float8_e4m3fn", "float8_e5m2"],
+        block_size: Tuple[int, int],
+    ) -> None:
+        super().__init__()
+        self.num_local_experts = num_local_experts
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter((num_local_experts, out_features, in_features), weight_dtype)
+        self.weight_scale_inv = nn.Parameter(
+            (
+                num_local_experts,
+                (out_features + block_size[0] - 1) // block_size[0],
+                (in_features + block_size[1] - 1) // block_size[1],
+            ),
+            "float32",
+        )
+        self.weight_dtype = weight_dtype
+        self.block_size = block_size
+
+    @staticmethod
+    def from_mixtral_experts(
+        src: "MixtralExperts",
+        config: BlockScaleQuantize,
+        weight_block_size: Optional[Tuple[int, int]],
+    ) -> "BlockScaleQuantizeMixtralExperts":
+        """
+        Converts a non-quantized MixtralExperts to a block-scale
+        quantized BlockScaleQuantizeMixtralExperts
+
+        Parameters
+        ----------
+        src : MixtralExperts
+            The non-quantized MixtralExperts
+
+        config : BlockScaleQuantize
+            The block-scale quantization config.
+
+        weight_block_size : Optional[Tuple[int, int]]
+            The weight block size.
+
+        Returns
+        -------
+        ret : BlockScaleQuantizeMixtralExperts
+            The block-scale quantized BlockScaleQuantizeMixtralExperts layer.
+        """
+        assert weight_block_size is not None
+        quantized_mistral_experts = BlockScaleQuantizeMixtralExperts(
+            num_local_experts=src.num_local_experts,
+            in_features=src.in_features,
+            out_features=src.out_features,
+            weight_dtype=config.weight_dtype,
+            block_size=weight_block_size,
+        )
+        if "shard_strategy" in src.weight.attrs:
+            shard = src.weight.attrs["shard_strategy"]
+            apply_sharding(shard, shard.name, quantized_mistral_experts.weight)
+            if isinstance(shard, tp.ShardSingleDim) and shard.segs is not None:
+                shard.segs = [x // weight_block_size[shard.dim - 1] for x in shard.segs]
+            apply_sharding(
+                shard, f"{shard.name}_scale_inv", quantized_mistral_experts.weight_scale_inv
+            )
+        return quantized_mistral_experts
+
+    def forward(self, x: nn.Tensor, indptr: nn.Tensor) -> nn.Tensor:
+        """Forward pass of the block-scale quantized MixtralExperts.
+
+        Parameters
+        ----------
+        x : nn.Tensor
+            The input tensor.
+
+        indptr : nn.Tensor
+            The indptr tensor of group gemm, with shape of [num_experts + 1,].
+
+        Returns
+        -------
+        ret : nn.Tensor
+            The output tensor.
+        """
+        if indptr.ndim == 2:
+            # The input is for single token, which does not need group gemm
+            # and can be specialized.
+            expert_indices = indptr
+            assert expert_indices.shape[0] == 1
+            return moe_matmul.dequantize_block_scale_float8_gemv(
+                x,
+                self.weight,
+                self.weight_scale_inv,
+                expert_indices,
+                self.block_size,
+                x.dtype,
+            )
+
+        x_fp8, x_scale = rowwise_group_quant_fp8(
+            x, self.block_size[1], self.weight_dtype, transpose_scale=False
+        )
+        x = triton.fp8_block_scale_group_gemm(
+            x_fp8,
+            x_scale,
+            self.weight,
+            self.weight_scale_inv,
+            indptr,
+            self.block_size,
+            x.dtype,
+        )
+        return x
+
+    def to(self, dtype: Optional[str] = None) -> None:
+        """
+        Override to() such that we do not convert bias if there is an out_dtype.
+        Otherwise, we might run into dtype mismatch when computing x + self.bias.
+        """
+        if dtype is not None and isinstance(getattr(self, "dtype", None), str):
+            self.dtype = dtype  # pylint: disable=attribute-defined-outside-init
+
+
+def rowwise_group_quant_fp8(  # pylint: disable=too-many-arguments
+    x: nn.Tensor,
+    group_size: int,
+    dtype: Literal["float8_e4m3fn", "float8_e5m2"],
+    transpose_scale: bool,
+    eps: float = 1e-10,
+    keep_first_batch_dim: bool = False,
+) -> Tuple[nn.Tensor, nn.Tensor]:
+    """Rowwise group quantization of fp8 tensor.
+
+    Parameters
+    ----------
+    x : nn.Tensor
+        The input tensor.
+
+    group_size : int
+        The group size per row for quantization.
+
+    transpose_scale : bool
+        Whether return the transposed scales or not.
+
+    Returns
+    -------
+    x_fp8 : nn.Tensor
+        The quantized tensor.
+
+    x_scale : nn.Tensor
+        The scales of the quantized tensor.
+        If transpose_scale is True, the shape is
+        (*x.shape[:-2], ceildiv(x.shape[-1], group_size), x.shape[-2]).
+        Otherwise, the shape is (*x.shape[:-1], ceildiv(x.shape[-1], group_size)).
+    """
+    assert x.ndim >= 2
+    assert group_size > 0
+
+    def quantize(x: te.Tensor):
+        num_group = tir.ceildiv(x.shape[-1], group_size)
+        max_abs_shape = (*x.shape[:-1], num_group)
+        max_abs_reduce_axis = te.reduce_axis((0, group_size), name="r")
+        scale_dtype = "float32"
+        max_abs = te.compute(
+            shape=max_abs_shape,
+            fcompute=lambda *idx: te.max(
+                tir.if_then_else(
+                    idx[-1] * group_size + max_abs_reduce_axis < x.shape[-1],
+                    tir.Max(
+                        te.abs(
+                            x(*idx[:-1], idx[-1] * group_size + max_abs_reduce_axis).astype(
+                                scale_dtype
+                            )
+                        ),
+                        eps,
+                    ),
+                    tir.min_value(scale_dtype),
+                ),
+                axis=max_abs_reduce_axis,
+            ),
+            name="max_abs",
+        )
+        assert dtype in ["float8_e4m3fn", "float8_e5m2"]
+        fp8_max = 448.0 if dtype == "float8_e4m3fn" else 57344.0
+        fp8_min = -fp8_max
+        scale = te.compute(
+            shape=max_abs_shape,
+            fcompute=lambda *idx: max_abs(*idx) / tir.const(fp8_max, scale_dtype),
+            name="scale",
+        )
+        x_quantized = te.compute(
+            shape=x.shape,
+            fcompute=lambda *idx: tir.max(
+                tir.min(
+                    x(*idx).astype(scale_dtype) / scale(*idx[:-1], idx[-1] // group_size), fp8_max
+                ),
+                fp8_min,
+            ).astype(dtype),
+            name="x_quantized",
+        )
+        if transpose_scale:
+            if not keep_first_batch_dim:
+                scale = te.compute(
+                    shape=(num_group, *x.shape[:-1]),
+                    fcompute=lambda *idx: scale(*idx[1:], idx[0]),
+                    name="scale",
+                )
+            else:
+                assert len(x.shape) > 2
+                scale = te.compute(
+                    shape=(x.shape[0], num_group, *x.shape[1:-1]),
+                    fcompute=lambda *idx: scale(idx[0], *idx[2:], idx[1]),
+                    name="scale",
+                )
+        return x_quantized, scale
+
+    x_quantized, scale = nn.tensor_expr_op(quantize, name_hint="rowwise_group_quant_fp8", args=[x])
+    return x_quantized, scale

--- a/python/mlc_llm/quantization/quantization.py
+++ b/python/mlc_llm/quantization/quantization.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict
 
 from .awq_quantization import AWQQuantize
+from .block_scale_quantization import BlockScaleQuantize
 from .ft_quantization import FTQuantize
 from .group_quantization import GroupQuantize
 from .no_quantization import NoQuantize
@@ -183,5 +184,11 @@ QUANTIZATION: Dict[str, Quantization] = {
         quantize_linear=True,
         use_scale=True,
         calibration_mode="max",
+    ),
+    "fp8_e4m3fn_bf16_block_scale": BlockScaleQuantize(
+        name="fp8_e4m3fn_bf16_block_scale",
+        kind="block-scale-quant",
+        weight_dtype="float8_e4m3fn",
+        model_dtype="bfloat16",
     ),
 }

--- a/python/mlc_llm/quantization/utils.py
+++ b/python/mlc_llm/quantization/utils.py
@@ -56,7 +56,7 @@ def is_final_fc(name: str) -> bool:
 
 def is_moe_gate(name: str, node: nn.Linear) -> bool:
     """Check whether the parameter is the MoE gate layer."""
-    return name.endswith("gate") and isinstance(node.out_features, int) and node.out_features <= 64
+    return name.endswith("gate") and isinstance(node.out_features, int) and node.out_features <= 256
 
 
 def compile_quantize_func(mod: IRModule, device) -> Callable:

--- a/tests/python/op/test_fp8_block_matmul.py
+++ b/tests/python/op/test_fp8_block_matmul.py
@@ -1,0 +1,833 @@
+from itertools import product
+from typing import Tuple
+
+import ml_dtypes
+import numpy as np
+import pytest
+import torch
+import tvm
+from tvm import dlight as dl
+from tvm import relax
+from tvm.relax.frontend import nn
+from tvm.relax.frontend.nn import spec
+
+from mlc_llm.compiler_pass.dispatch_triton_kernel import DispatchTritonKernel
+from mlc_llm.op import batch_matmul, cutlass, moe_matmul, triton
+from mlc_llm.quantization.block_scale_quantization import rowwise_group_quant_fp8
+
+# test category "op_correctness"
+pytestmark = [pytest.mark.op_correctness]
+
+block_size = (128, 128)
+fp8_dtype = "float8_e4m3fn"
+
+torch_fp8_dtype = torch.float8_e4m3fn
+torch_device = torch.device("cuda")
+
+torch.set_grad_enabled(False)
+
+
+def test_fp8_block_matmul_cutlass(M: int, N: int, K: int, dtype: str):
+    class TestModule(nn.Module):
+        def __init__(self):
+            pass
+
+        def cutlass_gemm(self, x: nn.Tensor, w: nn.Tensor, w_scale: nn.Tensor):
+            n, k = w.shape
+            m = x.shape[0]
+            assert n % block_size[0] == 0
+            assert k % block_size[1] == 0
+            assert n // block_size[0] == w_scale.shape[0]
+            assert k // block_size[1] == w_scale.shape[1]
+            assert x.shape[1] == k
+            x_fp8, x_scale = rowwise_group_quant_fp8(
+                x, block_size[1], w.dtype, transpose_scale=True
+            )
+            assert x_fp8.dtype == w.dtype
+            assert x_scale.dtype == "float32"
+            o = cutlass.fp8_block_scale_gemm(x_fp8, x_scale, w, w_scale, block_size, x.dtype)
+            return x_fp8, x_scale, o
+
+    mod, _, ext_mods = TestModule().export_tvm(
+        spec={
+            "cutlass_gemm": {
+                "x": spec.Tensor(("m", K), dtype),
+                "w": spec.Tensor((N, K), fp8_dtype),
+                "w_scale": spec.Tensor(
+                    (
+                        (N + block_size[0] - 1) // block_size[0],
+                        (K + block_size[1] - 1) // block_size[1],
+                    ),
+                    "float32",
+                ),
+            },
+        },
+        allow_extern=True,
+    )
+    device = tvm.cuda()
+    target = tvm.target.Target.from_device(device)
+    exec = relax.build(
+        mod, target=target, relax_pipeline=relax.backend.cuda.get_default_pipeline(target)
+    )
+    vm = relax.VirtualMachine(exec, device)
+
+    x_torch = torch.rand(M, K, dtype=getattr(torch, dtype), device=torch_device) * 2 - 1
+    w_full_torch = torch.rand(N, K, dtype=getattr(torch, dtype), device=torch_device) * 2 - 1
+    w_torch, w_scale_torch = blockwise_quant_fp8(w_full_torch, block_size, torch_fp8_dtype)
+    x_torch, x_fp8_torch, x_scale_torch = rowwise_quant_fp8(x_torch, block_size, torch_fp8_dtype)
+    o_torch = blockwise_matmul(x_fp8_torch, x_scale_torch, w_torch, w_scale_torch, x_torch.dtype)
+    x_tvm = tvm.nd.array(x_torch.view(torch.float16).cpu().numpy().view(dtype), device=device)
+    w_tvm = tvm.nd.array(w_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype), device=device)
+    w_scale_tvm = tvm.nd.array(w_scale_torch.cpu().numpy(), device=device)
+    x_fp8_tvm, x_scale_tvm, o_tvm = vm["cutlass_gemm"](x_tvm, w_tvm, w_scale_tvm)
+    x_fp8_tvm = x_fp8_tvm.numpy()
+    x_scale_tvm = x_scale_tvm.numpy()
+    o_tvm = o_tvm.numpy()
+
+    np.testing.assert_allclose(
+        x_fp8_tvm,
+        x_fp8_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype),
+        atol=1e-1,
+        rtol=1e-1,
+    )
+    np.testing.assert_allclose(x_scale_tvm.T, x_scale_torch.cpu().numpy(), atol=1e-5, rtol=1e-5)
+    atol = 0.5
+    rtol = 1e-4
+    o_tvm_flat = o_tvm.flatten()
+    o_torch_flat = o_torch.view(torch.float16).cpu().numpy().view(dtype).flatten()
+    failed_indices = np.where(
+        np.abs(o_tvm_flat - o_torch_flat) > (atol + rtol * np.abs(o_torch_flat))
+    )[0]
+    if len(failed_indices) > 0:
+        print(f"failed_indices: {failed_indices}, size: {len(failed_indices)}")
+        print(f"o_tvm_flat[failed_indices]: {o_tvm_flat[failed_indices]}")
+        print(f"o_torch_flat[failed_indices]: {o_torch_flat[failed_indices]}")
+    np.testing.assert_allclose(
+        o_tvm, o_torch.view(torch.float16).cpu().numpy().view(dtype), atol=atol, rtol=rtol
+    )
+
+
+def test_fp8_block_matmul_triton(M: int, N: int, K: int, dtype: str):
+    device = tvm.cuda()
+    target = tvm.target.Target.from_device(device)
+
+    class TestModule(nn.Module):
+        def __init__(self):
+            pass
+
+        def triton_gemm(self, x: nn.Tensor, w: nn.Tensor, w_scale: nn.Tensor):
+            n, k = w.shape
+            m = x.shape[0]
+            assert (n + block_size[0] - 1) // block_size[0] == w_scale.shape[0]
+            assert (k + block_size[1] - 1) // block_size[1] == w_scale.shape[1]
+            assert x.shape[1] == k
+            x_fp8, x_scale = rowwise_group_quant_fp8(
+                x, block_size[1], w.dtype, transpose_scale=False
+            )
+            assert x_fp8.dtype == w.dtype
+            assert x_scale.dtype == "float32"
+            o = triton.fp8_block_scale_gemm(
+                x_fp8,
+                x_scale,
+                w,
+                w_scale,
+                block_size,
+                x.dtype,
+            )
+            return x_fp8, x_scale, o
+
+    mod, _, ext_mods = TestModule().export_tvm(
+        spec={
+            "triton_gemm": {
+                "x": spec.Tensor(("m", K), dtype),
+                "w": spec.Tensor((N, K), fp8_dtype),
+                "w_scale": spec.Tensor(
+                    (
+                        (N + block_size[0] - 1) // block_size[0],
+                        (K + block_size[1] - 1) // block_size[1],
+                    ),
+                    "float32",
+                ),
+            },
+        },
+        allow_extern=True,
+    )
+    mod = DispatchTritonKernel(target)(mod)  # type: ignore
+    exec = relax.build(
+        mod, target=target, relax_pipeline=relax.backend.cuda.get_default_pipeline(target)
+    )
+    vm = relax.VirtualMachine(exec, device)
+
+    x_torch = torch.randn(M, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_full_torch = torch.randn(N, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_torch, w_scale_torch = blockwise_quant_fp8(w_full_torch, block_size, torch_fp8_dtype)
+    x_torch, x_fp8_torch, x_scale_torch = rowwise_quant_fp8(x_torch, block_size, torch_fp8_dtype)
+    o_torch = blockwise_matmul(x_fp8_torch, x_scale_torch, w_torch, w_scale_torch, x_torch.dtype)
+    x_tvm = tvm.nd.array(x_torch.view(torch.float16).cpu().numpy().view(dtype), device=device)
+    w_tvm = tvm.nd.array(w_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype), device=device)
+    w_scale_tvm = tvm.nd.array(w_scale_torch.cpu().numpy(), device=device)
+    x_fp8_tvm, x_scale_tvm, o_tvm = vm["triton_gemm"](x_tvm, w_tvm, w_scale_tvm)
+    x_fp8_tvm = x_fp8_tvm.numpy()
+    x_scale_tvm = x_scale_tvm.numpy()
+    o_tvm = o_tvm.numpy()
+    np.testing.assert_allclose(
+        x_fp8_tvm,
+        x_fp8_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype),
+        atol=1e-1,
+        rtol=1e-1,
+    )
+    np.testing.assert_allclose(x_scale_tvm, x_scale_torch.cpu().numpy(), atol=1e-5, rtol=1e-5)
+    atol = 0.5
+    rtol = 1e-4
+    o_tvm_flat = o_tvm.flatten()
+    o_torch_flat = o_torch.view(torch.float16).cpu().numpy().view(dtype).flatten()
+    failed_indices = np.where(
+        np.abs(o_tvm_flat - o_torch_flat) > (atol + rtol * np.abs(o_torch_flat))
+    )[0]
+    if len(failed_indices) > 0:
+        print(f"failed_indices: {failed_indices}, size: {len(failed_indices)}")
+        print(f"o_tvm_flat[failed_indices]: {o_tvm_flat[failed_indices]}")
+        print(f"o_torch_flat[failed_indices]: {o_torch_flat[failed_indices]}")
+    np.testing.assert_allclose(
+        o_tvm, o_torch.view(torch.float16).cpu().numpy().view(dtype), atol=atol, rtol=rtol
+    )
+
+
+def test_fp8_block_group_matmul_triton(M: int, N: int, K: int, dtype: str):
+    num_experts = 256
+    top_k = 8
+
+    device = tvm.cuda()
+    target = tvm.target.Target.from_device(device)
+
+    class TestModule(nn.Module):
+        def __init__(self):
+            pass
+
+        def triton_group_gemm(
+            self,
+            x: nn.Tensor,
+            w: nn.Tensor,
+            w_scale: nn.Tensor,
+            indptr: nn.Tensor,
+        ):
+            e, n, k = w.shape
+            m = x.shape[0]
+            assert e == num_experts
+            assert (n + block_size[0] - 1) // block_size[0] == w_scale.shape[1]
+            assert (k + block_size[1] - 1) // block_size[1] == w_scale.shape[2]
+            assert x.shape[1] == k
+            x_fp8, x_scale = rowwise_group_quant_fp8(
+                x, block_size[1], w.dtype, transpose_scale=False
+            )
+            assert x_fp8.dtype == w.dtype
+            assert x_scale.dtype == "float32"
+            o = triton.fp8_block_scale_group_gemm(
+                x_fp8,
+                x_scale,
+                w,
+                w_scale,
+                indptr,
+                block_size,
+                x.dtype,
+            )
+            return x_fp8, x_scale, o
+
+    mod, _, ext_mods = TestModule().export_tvm(
+        spec={
+            "triton_group_gemm": {
+                "x": spec.Tensor(("m", K), dtype),
+                "w": spec.Tensor((num_experts, N, K), fp8_dtype),
+                "w_scale": spec.Tensor(
+                    (
+                        num_experts,
+                        (N + block_size[0] - 1) // block_size[0],
+                        (K + block_size[1] - 1) // block_size[1],
+                    ),
+                    "float32",
+                ),
+                "indptr": spec.Tensor((num_experts + 1,), "int32"),
+            },
+        },
+        allow_extern=True,
+    )
+    mod = DispatchTritonKernel(target)(mod)  # type: ignore
+    exec = relax.build(
+        mod, target=target, relax_pipeline=relax.backend.cuda.get_default_pipeline(target)
+    )
+    vm = relax.VirtualMachine(exec, device)
+
+    # Randomly sample `top_k` experts for each token with pytorch
+    expert_choices = torch.randint(
+        0, num_experts, (M * top_k,), device=torch_device, dtype=torch.int32
+    )
+
+    indptr = torch.zeros(num_experts + 1, device=torch_device, dtype=torch.int32)
+    for i in range(num_experts):
+        indptr[i + 1] = indptr[i] + (expert_choices == i).sum()
+    token_ids_list = []
+    for i in range(num_experts):
+        # Get the indices of the tokens that belong to the i-th expert
+        token_ids = torch.where(expert_choices == i)[0]
+        token_ids_list.append(token_ids)
+
+    x_torch = torch.randn(M * top_k, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_full_torch = torch.randn(num_experts, N, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_torch, w_scale_torch = blockwise_quant_fp8(w_full_torch, block_size, torch_fp8_dtype)
+    x_torch, x_fp8_torch, x_scale_torch = rowwise_quant_fp8(x_torch, block_size, torch_fp8_dtype)
+    o_torch = blockwise_group_matmul(
+        x_fp8_torch,
+        x_scale_torch,
+        w_torch,
+        w_scale_torch,
+        indptr,
+        x_torch.dtype,
+    )
+    x_tvm = tvm.nd.array(x_torch.view(torch.float16).cpu().numpy().view(dtype), device=device)
+    w_tvm = tvm.nd.array(w_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype), device=device)
+    w_scale_tvm = tvm.nd.array(w_scale_torch.cpu().numpy(), device=device)
+    indptr_tvm = tvm.nd.array(indptr.cpu().numpy(), device=device)
+    x_fp8_tvm, x_scale_tvm, o_tvm = vm["triton_group_gemm"](
+        x_tvm,
+        w_tvm,
+        w_scale_tvm,
+        indptr_tvm,
+    )
+    x_fp8_tvm = x_fp8_tvm.numpy()
+    x_scale_tvm = x_scale_tvm.numpy()
+    o_tvm = o_tvm.numpy()
+    np.testing.assert_allclose(
+        x_fp8_tvm,
+        x_fp8_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype),
+        atol=1e-1,
+        rtol=1e-1,
+    )
+    np.testing.assert_allclose(x_scale_tvm, x_scale_torch.cpu().numpy(), atol=1e-5, rtol=1e-5)
+    atol = 0.5
+    rtol = 1e-4
+    o_tvm_flat = o_tvm.flatten()
+    o_torch_flat = o_torch.view(torch.float16).cpu().numpy().view(dtype).flatten()
+    failed_indices = np.where(
+        np.abs(o_tvm_flat - o_torch_flat) > (atol + rtol * np.abs(o_torch_flat))
+    )[0]
+    if len(failed_indices) > 0:
+        print(f"failed_indices: {failed_indices}, size: {len(failed_indices)}")
+        print(f"o_tvm_flat[failed_indices]: {o_tvm_flat[failed_indices]}")
+        print(f"o_torch_flat[failed_indices]: {o_torch_flat[failed_indices]}")
+    np.testing.assert_allclose(
+        o_tvm, o_torch.view(torch.float16).cpu().numpy().view(dtype), atol=atol, rtol=rtol
+    )
+
+
+def test_fp8_block_bmm_cutlass(M: int, N: int, K: int, H: int, dtype: str):
+    class TestModule(nn.Module):
+        def __init__(self):
+            pass
+
+        def cutlass_bmm(self, x: nn.Tensor, w: nn.Tensor, w_scale: nn.Tensor):
+            _, n, k = w.shape
+            assert w.shape[0] == x.shape[0] == H
+            assert n % block_size[0] == 0
+            assert k % block_size[1] == 0
+            assert n // block_size[0] == w_scale.shape[1]
+            assert k // block_size[1] == w_scale.shape[2]
+            assert x.shape[2] == k
+            o = batch_matmul.quantized_bmm(x, w, w_scale, block_size)
+            return o
+
+    mod, _, ext_mods = TestModule().export_tvm(
+        spec={
+            "cutlass_bmm": {
+                "x": spec.Tensor((H, "m", K), dtype),
+                "w": spec.Tensor((H, N, K), fp8_dtype),
+                "w_scale": spec.Tensor(
+                    (
+                        H,
+                        (N + block_size[0] - 1) // block_size[0],
+                        (K + block_size[1] - 1) // block_size[1],
+                    ),
+                    "float32",
+                ),
+            },
+        },
+        allow_extern=True,
+    )
+    device = tvm.cuda()
+    target = tvm.target.Target.from_device(device)
+    exec = relax.build(
+        mod, target=target, relax_pipeline=relax.backend.cuda.get_default_pipeline(target)
+    )
+    vm = relax.VirtualMachine(exec, device)
+
+    x_torch = torch.randn(H, M, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_full_torch = torch.randn(H, N, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_torch, w_scale_torch = blockwise_quant_fp8(w_full_torch, block_size, torch_fp8_dtype)
+    x_torch, x_fp8_torch, x_scale_torch = rowwise_quant_fp8(x_torch, block_size, torch_fp8_dtype)
+    o_torch = blockwise_bmm(x_fp8_torch, x_scale_torch, w_torch, w_scale_torch, x_torch.dtype)
+    x_tvm = tvm.nd.array(x_torch.view(torch.float16).cpu().numpy().view(dtype), device=device)
+    w_tvm = tvm.nd.array(w_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype), device=device)
+    w_scale_tvm = tvm.nd.array(w_scale_torch.cpu().numpy(), device=device)
+    o_tvm = vm["cutlass_bmm"](x_tvm, w_tvm, w_scale_tvm)
+    o_tvm = o_tvm.numpy()
+    atol = 0.5
+    rtol = 1e-4
+    o_tvm_flat = o_tvm.flatten()
+    o_torch_flat = o_torch.view(torch.float16).cpu().numpy().view(dtype).flatten()
+    failed_indices = np.where(
+        np.abs(o_tvm_flat - o_torch_flat) > (atol + rtol * np.abs(o_torch_flat))
+    )[0]
+    if len(failed_indices) > 0:
+        print(f"failed_indices: {failed_indices}, size: {len(failed_indices)}")
+        print(f"o_tvm_flat[failed_indices]: {o_tvm_flat[failed_indices]}")
+        print(f"o_torch_flat[failed_indices]: {o_torch_flat[failed_indices]}")
+    np.testing.assert_allclose(
+        o_tvm, o_torch.view(torch.float16).cpu().numpy().view(dtype), atol=atol, rtol=rtol
+    )
+
+
+def test_fp8_block_gemv_tir(N: int, K: int, up: bool, dtype: str):
+    num_experts = 256
+    top_k = 8
+    M = 1 if up else top_k
+
+    device = tvm.cuda()
+    target = tvm.target.Target.from_device(device)
+
+    class TestModule(nn.Module):
+        def __init__(self):
+            pass
+
+        def tir_moe_gemv(
+            self,
+            x: nn.Tensor,
+            w: nn.Tensor,
+            w_scale: nn.Tensor,
+            expert_indices: nn.Tensor,
+        ):
+            e, n, k = w.shape
+            m = x.shape[0]
+            assert e == num_experts
+            assert (n + block_size[0] - 1) // block_size[0] == w_scale.shape[1]
+            assert (k + block_size[1] - 1) // block_size[1] == w_scale.shape[2]
+            assert x.shape[1] == k
+            o = moe_matmul.dequantize_block_scale_float8_gemv(
+                x, w, w_scale, expert_indices, block_size, x.dtype
+            )
+            return o
+
+    mod, _, ext_mods = TestModule().export_tvm(
+        spec={
+            "tir_moe_gemv": {
+                "x": spec.Tensor((M, K), dtype),
+                "w": spec.Tensor((num_experts, N, K), fp8_dtype),
+                "w_scale": spec.Tensor(
+                    (
+                        num_experts,
+                        (N + block_size[0] - 1) // block_size[0],
+                        (K + block_size[1] - 1) // block_size[1],
+                    ),
+                    "float32",
+                ),
+                "expert_indices": spec.Tensor((1, top_k), "int32"),
+            },
+        },
+        allow_extern=True,
+    )
+    with target:
+        mod = dl.ApplyDefaultSchedule(
+            dl.gpu.Matmul(),
+            dl.gpu.GEMV(),
+            dl.gpu.Reduction(),
+            dl.gpu.GeneralReduction(),
+            dl.gpu.Fallback(),
+        )(mod)
+    exec = relax.build(
+        mod, target=target, relax_pipeline=relax.backend.cuda.get_default_pipeline(target)
+    )
+    vm = relax.VirtualMachine(exec, device)
+
+    # Randomly sample `top_k` experts for each token with pytorch
+    expert_choices = torch.randint(0, num_experts, (top_k,), device=torch_device, dtype=torch.int32)
+    indptr = torch.zeros(num_experts + 1, device=torch_device, dtype=torch.int32)
+    for i in range(num_experts):
+        indptr[i + 1] = indptr[i] + (expert_choices == i).sum()
+    token_ids_list = []
+    for i in range(num_experts):
+        # Get the indices of the tokens that belong to the i-th expert
+        token_ids = torch.where(expert_choices == i)[0]
+        token_ids_list.append(token_ids)
+
+    x_torch = torch.randn(M, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_full_torch = torch.randn(num_experts, N, K, dtype=getattr(torch, dtype), device=torch_device)
+    w_torch, w_scale_torch = blockwise_quant_fp8(w_full_torch, block_size, torch_fp8_dtype)
+    x_input_torch = torch.repeat_interleave(x_torch, top_k, dim=0) if up else x_torch
+    o_torch = blockwise_group_matmul_unquantized(
+        x_input_torch, w_torch, w_scale_torch, expert_choices
+    )
+    x_tvm = tvm.nd.array(x_torch.view(torch.float16).cpu().numpy().view(dtype), device=device)
+    w_tvm = tvm.nd.array(w_torch.view(torch.uint8).cpu().numpy().view(fp8_dtype), device=device)
+    w_scale_tvm = tvm.nd.array(w_scale_torch.cpu().numpy(), device=device)
+    expert_choices = tvm.nd.array(expert_choices.reshape(1, top_k).cpu().numpy(), device=device)
+    o_tvm = vm["tir_moe_gemv"](x_tvm, w_tvm, w_scale_tvm, expert_choices)
+    o_tvm = o_tvm.numpy()
+    atol = 0.5
+    rtol = 1e-4
+    o_tvm_flat = o_tvm.flatten()
+    o_torch_flat = o_torch.view(torch.float16).cpu().numpy().view(dtype).flatten()
+    failed_indices = np.where(
+        np.abs(o_tvm_flat - o_torch_flat) > (atol + rtol * np.abs(o_torch_flat))
+    )[0]
+    if len(failed_indices) > 0:
+        print(f"failed_indices: {failed_indices}, size: {len(failed_indices)}")
+        print(f"o_tvm_flat[failed_indices]: {o_tvm_flat[failed_indices]}")
+        print(f"o_torch_flat[failed_indices]: {o_torch_flat[failed_indices]}")
+    np.testing.assert_allclose(
+        o_tvm, o_torch.view(torch.float16).cpu().numpy().view(dtype), atol=atol, rtol=rtol
+    )
+
+
+def blockwise_matmul(
+    x_fp8_torch: torch.Tensor,
+    x_scale_torch: torch.Tensor,
+    w_torch: torch.Tensor,
+    w_scale_torch: torch.Tensor,
+    dtype,
+):
+    o_torch = torch.zeros(
+        (x_fp8_torch.shape[0], w_torch.shape[0]), dtype=dtype, device=torch_device
+    )
+    for j in range(w_scale_torch.shape[0]):
+        for k in range(w_scale_torch.shape[1]):
+            o_torch[
+                :,
+                j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[0]),
+            ] += (
+                torch.matmul(
+                    x_fp8_torch[
+                        :, k * block_size[1] : min((k + 1) * block_size[1], x_fp8_torch.shape[1])
+                    ].to(dtype),
+                    w_torch[
+                        j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[0]),
+                        k * block_size[1] : min((k + 1) * block_size[1], w_torch.shape[1]),
+                    ].T.to(dtype),
+                )
+                * x_scale_torch[:, k : k + 1]
+                * w_scale_torch[j, k]
+            )
+    return o_torch
+
+
+def blockwise_group_matmul(
+    x_fp8_torch: torch.Tensor,
+    x_scale_torch: torch.Tensor,
+    w_torch: torch.Tensor,
+    w_scale_torch: torch.Tensor,
+    indptr: torch.Tensor,
+    dtype,
+):
+    o_torch = torch.zeros(
+        (x_fp8_torch.shape[0], w_torch.shape[1]), dtype=dtype, device=torch_device
+    )
+    for e in range(w_scale_torch.shape[0]):
+        if indptr[e + 1] - indptr[e] == 0:
+            continue
+        indices = slice(indptr[e], indptr[e + 1])
+        for j in range(w_scale_torch.shape[1]):
+            for k in range(w_scale_torch.shape[2]):
+                o_torch[
+                    indices,
+                    j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[1]),
+                ] += (
+                    torch.matmul(
+                        x_fp8_torch.to(dtype)[
+                            indices,
+                            k * block_size[1] : min((k + 1) * block_size[1], x_fp8_torch.shape[1]),
+                        ],
+                        w_torch[
+                            e,
+                            j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[1]),
+                            k * block_size[1] : min((k + 1) * block_size[1], w_torch.shape[2]),
+                        ].T.to(dtype),
+                    )
+                    * x_scale_torch[indices, k : k + 1]
+                    * w_scale_torch[e, j, k]
+                )
+    return o_torch
+
+
+def blockwise_group_matmul_unquantized(
+    x_torch: torch.Tensor,
+    w_torch: torch.Tensor,
+    w_scale_torch: torch.Tensor,
+    expert_choices: torch.Tensor,
+):
+    o_torch = torch.zeros(
+        (x_torch.shape[0], w_torch.shape[1]), dtype=x_torch.dtype, device=torch_device
+    )
+    for i, e in enumerate(expert_choices):
+        for j in range(w_scale_torch.shape[1]):
+            for k in range(w_scale_torch.shape[2]):
+                o_torch[
+                    i,
+                    j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[1]),
+                ] += torch.matmul(
+                    x_torch[i, k * block_size[1] : min((k + 1) * block_size[1], x_torch.shape[1])],
+                    w_torch[
+                        e,
+                        j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[1]),
+                        k * block_size[1] : min((k + 1) * block_size[1], w_torch.shape[2]),
+                    ].T.to(x_torch.dtype)
+                    * w_scale_torch[e, j, k].to(x_torch.dtype),
+                )
+    return o_torch
+
+
+def blockwise_bmm(
+    x_fp8_torch: torch.Tensor,
+    x_scale_torch: torch.Tensor,
+    w_torch: torch.Tensor,
+    w_scale_torch: torch.Tensor,
+    dtype,
+):
+    o_torch = torch.zeros(
+        (x_fp8_torch.shape[0], x_fp8_torch.shape[1], w_torch.shape[1]),
+        dtype=dtype,
+        device=torch_device,
+    )
+    for j in range(w_scale_torch.shape[1]):
+        for k in range(w_scale_torch.shape[2]):
+            o_torch[
+                ...,
+                j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[1]),
+            ] += (
+                torch.bmm(
+                    x_fp8_torch[
+                        ...,
+                        k * block_size[1] : min((k + 1) * block_size[1], x_fp8_torch.shape[2]),
+                    ].to(dtype),
+                    w_torch[
+                        ...,
+                        j * block_size[0] : min((j + 1) * block_size[0], w_torch.shape[1]),
+                        k * block_size[1] : min((k + 1) * block_size[1], w_torch.shape[2]),
+                    ]
+                    .transpose(1, 2)
+                    .to(dtype),
+                )
+                * x_scale_torch[..., k : k + 1]
+                * w_scale_torch[..., j : j + 1, k : k + 1]
+            )
+    return o_torch
+
+
+def blockwise_quant_fp8(
+    w_full_torch: torch.Tensor, block_size: Tuple[int, int], quant_dtype: torch.dtype
+):
+    w_scale_shape = (
+        *w_full_torch.shape[:-2],
+        (w_full_torch.shape[-2] + block_size[0] - 1) // block_size[0],
+        (w_full_torch.shape[-1] + block_size[1] - 1) // block_size[1],
+    )
+    # For each (block_size[0], block_size[1]) block, compute the max abs value of `w_full_torch`
+    w_max_abs_torch = torch.zeros(w_scale_shape, dtype=torch.float32, device=torch_device)
+    for i in range(w_scale_shape[-2]):
+        for j in range(w_scale_shape[-1]):
+            w_max_abs_torch[..., i, j] = torch.max(
+                torch.abs(
+                    w_full_torch[
+                        ...,
+                        i * block_size[0] : min((i + 1) * block_size[0], w_full_torch.shape[-2]),
+                        j * block_size[1] : min((j + 1) * block_size[1], w_full_torch.shape[-1]),
+                    ]
+                ).flatten(-2, -1),
+                dim=-1,
+            )[0]
+    # Scale is the `w_max_abs_torch` divided by the max value of quant_dtype in ml_dtypes
+    fp8_max = float(ml_dtypes.finfo(fp8_dtype).max)
+    w_scale_torch = w_max_abs_torch / fp8_max
+    # `w_torch` is the `w_full_torch` divided by the `w_scale_torch` (with block awareness),
+    # clamped to (-fp8_max, fp8_max), and cast to `quant_dtype`
+    w_torch = torch.zeros_like(w_full_torch, dtype=quant_dtype, device=torch_device)
+    if len(w_scale_shape) == 2:
+        for i in range(w_scale_shape[-2]):
+            for j in range(w_scale_shape[-1]):
+                w_torch[
+                    i * block_size[0] : min((i + 1) * block_size[0], w_full_torch.shape[-2]),
+                    j * block_size[1] : min((j + 1) * block_size[1], w_full_torch.shape[-1]),
+                ] = torch.clamp(
+                    w_full_torch[
+                        i * block_size[0] : min((i + 1) * block_size[0], w_full_torch.shape[-2]),
+                        j * block_size[1] : min((j + 1) * block_size[1], w_full_torch.shape[-1]),
+                    ]
+                    / w_scale_torch[..., i, j],
+                    -fp8_max,
+                    fp8_max,
+                )
+    else:
+        for e in range(w_scale_shape[0]):
+            for i in range(w_scale_shape[-2]):
+                for j in range(w_scale_shape[-1]):
+                    w_torch[
+                        e,
+                        i * block_size[0] : min((i + 1) * block_size[0], w_full_torch.shape[-2]),
+                        j * block_size[1] : min((j + 1) * block_size[1], w_full_torch.shape[-1]),
+                    ] = torch.clamp(
+                        w_full_torch[
+                            e,
+                            i
+                            * block_size[0] : min((i + 1) * block_size[0], w_full_torch.shape[-2]),
+                            j
+                            * block_size[1] : min((j + 1) * block_size[1], w_full_torch.shape[-1]),
+                        ]
+                        / w_scale_torch[e, i, j],
+                        -fp8_max,
+                        fp8_max,
+                    )
+
+    w_scale_torch = (
+        torch.rand(w_scale_torch.shape, dtype=torch.float32, device=torch_device) / fp8_max
+    )
+    return w_torch, w_scale_torch
+
+
+def rowwise_quant_fp8(
+    x_full_torch: torch.Tensor, block_size: Tuple[int, int], quant_dtype: torch.dtype
+):
+    x_scale_shape = (
+        *x_full_torch.shape[:-1],
+        (x_full_torch.shape[-1] + block_size[1] - 1) // block_size[1],
+    )
+    # For each (block_size[1]) block, compute the max abs value of `w_full_torch`
+    x_max_abs_torch = torch.zeros(x_scale_shape, dtype=torch.float32, device=torch_device)
+    for i in range(x_scale_shape[-1]):
+        x_max_abs_torch[..., i] = torch.max(
+            torch.abs(
+                x_full_torch[
+                    ...,
+                    i * block_size[1] : min((i + 1) * block_size[1], x_full_torch.shape[-1]),
+                ]
+            ),
+            dim=-1,
+        )[0]
+    # Scale is the `x_max_abs_torch` divided by the max value of quant_dtype in ml_dtypes
+    fp8_max = float(ml_dtypes.finfo(fp8_dtype).max)
+    x_scale_torch = x_max_abs_torch / fp8_max
+    # `x_torch` is the `x_full_torch` divided by the `x_scale_torch` (with block awareness),
+    # clamped to (-fp8_max, fp8_max), and cast to `quant_dtype`
+    x_torch = torch.zeros_like(x_full_torch, dtype=quant_dtype, device=torch_device)
+    for i in range(x_scale_shape[-1]):
+        x_torch[
+            ...,
+            i * block_size[1] : min((i + 1) * block_size[1], x_full_torch.shape[-1]),
+        ] = torch.clamp(
+            x_full_torch[
+                ...,
+                i * block_size[1] : min((i + 1) * block_size[1], x_full_torch.shape[-1]),
+            ]
+            / x_scale_torch[..., i : i + 1],
+            -fp8_max,
+            fp8_max,
+        )
+
+    x_scale_torch = (
+        torch.rand(x_scale_torch.shape, dtype=torch.float32, device=torch_device) / fp8_max
+    )
+    for i in range(x_scale_shape[-1]):
+        x_full_torch[
+            ...,
+            i * block_size[1] : min((i + 1) * block_size[1], x_full_torch.shape[-1]),
+        ] = (
+            x_torch[
+                ...,
+                i * block_size[1] : min((i + 1) * block_size[1], x_full_torch.shape[-1]),
+            ].to(x_scale_torch.dtype)
+            * x_scale_torch[..., i : i + 1]
+        )
+    return x_full_torch, x_torch, x_scale_torch
+
+
+@pytest.mark.skip(reason="Test requiring SM90a")
+def test_cutlass_gemm():
+    # Cutlass GEMM
+    for M, (N, K), dtype in product(
+        [1, 128, 256, 1024, 2111],
+        [
+            (4608, 896),
+            (896, 2304),
+            (3072, 896),
+            (512, 896),
+            (3072, 512),
+            (4096, 512),
+            (896, 2048),
+            (129280, 896),
+        ],
+        ["bfloat16"],
+    ):
+        print(f"Cutlass, M: {M}, N: {N}, K: {K}, dtype: {dtype}")
+        test_fp8_block_matmul_cutlass(M, N, K, dtype)
+
+
+@pytest.mark.skip(reason="Test requiring SM90a")
+def test_triton_gemm():
+    # Triton GEMM
+    for M, (N, K), dtype in product(
+        [1, 128, 256, 1024, 2111],
+        [
+            (4608, 896),
+            (896, 576),
+            (896, 2304),
+        ],
+        ["bfloat16"],
+    ):
+        print(f"Triton, M: {M}, N: {N}, K: {K}, dtype: {dtype}")
+        test_fp8_block_matmul_triton(M, N, K, dtype)
+
+
+@pytest.mark.skip(reason="Test requiring SM90a")
+def test_triton_group_gemm():
+    # Triton group GEMM
+    for M, (N, K), dtype in product(
+        [1, 128, 256, 1024, 2111],
+        [
+            (512, 896),
+            (896, 256),
+        ],
+        ["bfloat16"],
+    ):
+        print(f"Triton group gemm, M: {M}, N: {N}, K: {K}, dtype: {dtype}")
+        test_fp8_block_group_matmul_triton(M, N, K, dtype)
+
+
+@pytest.mark.skip(reason="Test requiring SM90a")
+def test_cutlass_bmm():
+    # Cutlass BMM
+    for M, H, (N, K), dtype in product(
+        [1, 128, 256, 1024, 2111],
+        [16, 64, 128],
+        [
+            (512, 128),
+            (128, 512),
+        ],
+        ["bfloat16"],
+    ):
+        print(f"Cutlass BMM, M: {M}, N: {N}, K: {K}, H: {H}, dtype: {dtype}")
+        test_fp8_block_bmm_cutlass(M, N, K, H, dtype)
+
+
+@pytest.mark.skip(reason="Test requiring SM90a")
+def test_tir_moe_gemv():
+    # TIR MoE GEMV
+    for (N, K), up, dtype in product(
+        [(512, 896), (896, 256)],
+        [True, False],
+        ["bfloat16"],
+    ):
+        print(f"TIR MoE GEMV, N: {N}, K: {K}, up: {up}, dtype: {dtype}")
+        test_fp8_block_gemv_tir(N, K, up, dtype)
+
+
+if __name__ == "__main__":
+    test_cutlass_gemm()
+    test_triton_gemm()
+    test_triton_group_gemm()
+    test_cutlass_bmm()
+    test_tir_moe_gemv()


### PR DESCRIPTION
This PR introduces the Deepseek-v3 support with blockwise scale quantization. Deepseek-V3-0324 is also supported. R1 will be supported after a followup PR with the conversation template update.

More bfloat16 related optimizations will be added in the future for performance.

Some blockwise scale matmul kernels are adapted from SGLang project (http://github.com/sgl-project/sglang).