### PR TITLE
Update mlc_llm.rst correcting for mlc from mlc_llm

### DIFF
--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -153,8 +153,8 @@ Then you can verify installation in command line:
 
 .. code-block:: bash
 
-    python -c "import mlc_llm; print(mlc_llm)"
-    # Prints out: <module 'mlc_llm' from '/path-to-env/lib/python3.11/site-packages/mlc_llm/__init__.py'>
+    python -c "import mlc; print(mlc)"
+    # Prints out: <module 'mlc' from '/path-to-env/lib/python3.11/site-packages/mlc/__init__.py'>
 
 |
 


### PR DESCRIPTION
Fixed verify installation command line from mlc_llm to mlc (fails when attempting to use mlc_llm).  Verified actual installed module is mlc as shown below. 

```
(mlc-prebuilt) agrajag@tor-orin:/opt/miniconda3/envs/mlc-prebuilt/lib/python3.11/site-packages/mlc$ ls -la
total 16
drwxrwxr-x  3 agrajag agrajag 4096 Apr  6 20:59 .
drwxrwxr-x 13 agrajag agrajag 4096 Apr  6 20:59 ..
-rw-rw-r--  1 agrajag agrajag   15 Apr  6 20:59 __init__.py
drwxrwxr-x  2 agrajag agrajag 4096 Apr  6 20:59 __pycache__
(mlc-prebuilt) agrajag@tor-orin:/opt/miniconda3/envs/mlc-prebuilt/lib/python3.11/site-packages/mlc$ python -c "import mlc; print(mlc)"
<module 'mlc' from '/opt/miniconda3/envs/mlc-prebuilt/lib/python3.11/site-packages/mlc/__init__.py'>
```