### PR TITLE
[Optim] Enable cuBLAS GeMM for bfloat16

### DIFF
--- a/python/mlc_llm/interface/compiler_flags.py
+++ b/python/mlc_llm/interface/compiler_flags.py
@@ -101,7 +101,7 @@ class OptimizationFlags:
             if not target.kind.name in ["cuda", "rocm"]:
                 return False
             if not (
-                quantization.name in ["q0f16", "q0f32"]
+                quantization.name in ["q0f16", "q0bf16", "q0f32"]
                 or "e4m3" in quantization.name
                 or "e5m2" in quantization.name
             ):


### PR DESCRIPTION
This PR enables using cuBLAS GeMM dispatch for bfloat16 gemm.