### PR TITLE
Add support for gemma3_instruction to genconfig

### DIFF
--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -301,6 +301,7 @@ CONV_TEMPLATES = {
     "phi-3-vision",
     "stablelm-2",
     "gemma_instruction",
+    "gemma3_instruction",
     "orion",
     "llava",
     "hermes2_pro_llama3",


### PR DESCRIPTION
This PR adds `gemma3_instruction` as a valid conversation template in `gen_config.py`, enabling the generation of config and manual compilation for the Gemma3 instruction model.