### PR TITLE
[CI][Fix] Temp fix for Windows CI error

### DIFF
--- a/ci/build-environment.yaml
+++ b/ci/build-environment.yaml
@@ -11,5 +11,5 @@ dependencies:
   - spirv-tools
   - spirv-headers
   - git
-  - cmake
+  - cmake<4.0
   - bzip2


### PR DESCRIPTION
The Windows CI error `Compatibility with CMake < 3.5 has been removed from CMake.` is caused because CMake 4.0 has removed compatibility with versions of CMake older than 3.5.
The proper fix would be to upgrade msgpack-c version in tokenizers-cpp.

CMake: https://www.kitware.com/cmake-4-0-0-available-for-download/
CI failure: https://github.com/mlc-ai/mlc-llm/actions/runs/14776403076/job/41485528478
