### PR TITLE
[Refactor] Rename `relax_vm` to `vm`

### DIFF
--- a/android/mlc4j/CMakeLists.txt
+++ b/android/mlc4j/CMakeLists.txt
@@ -66,10 +66,11 @@ target_include_directories(
          ${TVM_SOURCE_DIR}/ffi/include
          ${TVM_SOURCE_DIR}/ffi/src)
 target_compile_definitions(tvm4j_runtime_packed PUBLIC ${MLC_LLM_COMPILE_DEFS})
-target_compile_definitions(tvm4j_runtime_packed
-                           PUBLIC TVM_RELAX_VM_ENABLE_PROFILER=0
-                           PUBLIC TVM_FFI_USE_LIBBACKTRACE=0
-                           PUBLIC TVM_FFI_BACKTRACE_ON_SEGFAULT=0)
+target_compile_definitions(
+  tvm4j_runtime_packed
+  PUBLIC TVM_VM_ENABLE_PROFILER=0
+  PUBLIC TVM_FFI_USE_LIBBACKTRACE=0
+  PUBLIC TVM_FFI_BACKTRACE_ON_SEGFAULT=0)
 
 set(MLC_ENABLE_SENTENCEPIECE_TOKENIZER OFF)
 target_link_libraries(

--- a/android/mlc4j/src/cpp/tvm_runtime.h
+++ b/android/mlc4j/src/cpp/tvm_runtime.h
@@ -25,19 +25,19 @@
 #include <runtime/opencl/opencl_module.cc>
 #include <runtime/opencl/opencl_wrapper/opencl_wrapper.cc>
 #include <runtime/profiling.cc>
-#include <runtime/relax_vm/attn_backend.cc>
-#include <runtime/relax_vm/builtin.cc>
-#include <runtime/relax_vm/bytecode.cc>
-#include <runtime/relax_vm/executable.cc>
-#include <runtime/relax_vm/kv_state.cc>
-#include <runtime/relax_vm/ndarray_cache_support.cc>
-#include <runtime/relax_vm/paged_kv_cache.cc>
-#include <runtime/relax_vm/rnn_state.cc>
-#include <runtime/relax_vm/vm.cc>
 #include <runtime/source_utils.cc>
 #include <runtime/system_library.cc>
 #include <runtime/thread_pool.cc>
 #include <runtime/threading_backend.cc>
+#include <runtime/vm/attn_backend.cc>
+#include <runtime/vm/builtin.cc>
+#include <runtime/vm/bytecode.cc>
+#include <runtime/vm/executable.cc>
+#include <runtime/vm/kv_state.cc>
+#include <runtime/vm/ndarray_cache_support.cc>
+#include <runtime/vm/paged_kv_cache.cc>
+#include <runtime/vm/rnn_state.cc>
+#include <runtime/vm/vm.cc>
 #include <runtime/workspace_pool.cc>
 
 static_assert(TVM_LOG_CUSTOMIZE == 1, "TVM_LOG_CUSTOMIZE must be 1");

--- a/cpp/multi_gpu/builtin.cc
+++ b/cpp/multi_gpu/builtin.cc
@@ -11,7 +11,7 @@
 #include <tvm/runtime/disco/builtin.h>
 #include <tvm/runtime/disco/disco_worker.h>
 #include <tvm/runtime/ndarray.h>
-#include <tvm/runtime/relax_vm/vm.h>
+#include <tvm/runtime/vm/vm.h>
 
 namespace mlc {
 namespace llm {
@@ -24,7 +24,7 @@ using tvm::ffi::Shape;
 
 ObjectRef DispatchFunctionByGroup(tvm::ffi::AnyView vm_arg,
                                   Array<Array<ObjectRef>> funcs_and_args) {
-  using namespace relax_vm;
+  using namespace vm;
   VirtualMachine* vm = VirtualMachine::GetContextPtr(vm_arg);
   DiscoWorker* worker = DiscoWorker::ThreadLocal();
   int world_size = worker->num_workers;

--- a/cpp/serve/sampler/cpu_sampler.cc
+++ b/cpp/serve/sampler/cpu_sampler.cc
@@ -328,8 +328,7 @@ TVM_REGISTER_OBJECT_TYPE(SamplerObj);
 class CPUSampler : public SamplerObj {
  public:
   explicit CPUSampler(Optional<EventTraceRecorder> trace_recorder)
-      : trace_recorder_(std::move(trace_recorder)) {
-  }
+      : trace_recorder_(std::move(trace_recorder)) {}
 
   NDArray BatchRenormalizeProbsByTopP(NDArray probs_on_device,                 //
                                       const std::vector<int>& sample_indices,  //

--- a/python/mlc_llm/cli/model_metadata.py
+++ b/python/mlc_llm/cli/model_metadata.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def _extract_metadata(model_lib: Path) -> Dict[str, Any]:
     # pylint: disable=import-outside-toplevel
     from tvm.runtime import device, load_module
-    from tvm.runtime.relax_vm import VirtualMachine
+    from tvm.runtime.vm import VirtualMachine
 
     # pylint: enable=import-outside-toplevel
 

--- a/python/mlc_llm/contrib/embeddings/embeddings.py
+++ b/python/mlc_llm/contrib/embeddings/embeddings.py
@@ -9,7 +9,7 @@ import tvm
 from tvm import relax
 from tvm.contrib import tvmjs
 from tvm.runtime import Device, Module
-from tvm.runtime.relax_vm import VirtualMachine
+from tvm.runtime.vm import VirtualMachine
 
 from mlc_llm.serve import engine_utils
 from mlc_llm.support.auto_device import detect_device

--- a/python/mlc_llm/testing/debug_chat.py
+++ b/python/mlc_llm/testing/debug_chat.py
@@ -11,7 +11,7 @@ import tvm
 from tvm import DataType, relax
 from tvm.contrib import tvmjs
 from tvm.runtime import Device, Module, Object, ShapeTuple
-from tvm.runtime.relax_vm import VirtualMachine
+from tvm.runtime.vm import VirtualMachine
 
 from mlc_llm.conversation_template import ConvTemplateRegistry
 from mlc_llm.interface.help import HELP


### PR DESCRIPTION
Following recent upstream changes that rename `relax_vm` to `vm`, we update the MLC side accordingly with the rename.