### PR TITLE
[CI] Add conda TOS accept commands to allow inlined package installation

### DIFF
--- a/ci/task/build_lib.sh
+++ b/ci/task/build_lib.sh
@@ -9,6 +9,10 @@ export CCACHE_NOHASHDIR=1
 export CCACHE_DIR=/ccache
 
 # Temporary workaround to install ccache.
+if [[ ${GPU} != metal ]]; then
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+fi
 conda install -c conda-forge ccache
 
 if [[ ${GPU} != metal ]]; then


### PR DESCRIPTION
This PR adds the Terms-of-Service acceptance command to the CI script so that we can install conda packages in CI jobs.