### PR TITLE
Add API Key Authentication For openai_entrypoints

### DIFF
--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -194,6 +194,12 @@ def main(argv):
         default=["*"],
         help="allowed headers" + ' (default: "%(default)s")',
     )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for authentication. If not provided, authentication is disabled."
+    )
     parsed = parser.parse_args(argv)
 
     additional_models = []
@@ -236,4 +242,5 @@ def main(argv):
         allow_origins=parsed.allow_origins,
         allow_methods=parsed.allow_methods,
         allow_headers=parsed.allow_headers,
+        api_key=parsed.api_key,
     )

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -51,6 +51,7 @@ def serve(
     allow_origins: Any,
     allow_methods: Any,
     allow_headers: Any,
+    api_key: Optional[str] = None,
 ):  # pylint: disable=too-many-arguments, too-many-locals
     """Serve the model with the specified configuration."""
     # Create engine and start the background loop
@@ -84,6 +85,7 @@ def serve(
 
     with ServerContext() as server_context:
         server_context.add_model(model, async_engine)
+        server_context.api_key = api_key
 
         app = fastapi.FastAPI()
         app.add_middleware(

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -18,7 +18,18 @@ from mlc_llm.protocol.openai_api_protocol import (
 from mlc_llm.serve import engine_base, engine_utils
 from mlc_llm.serve.server import ServerContext
 
-app = fastapi.APIRouter()
+def verify_api_key(request: fastapi.Request):
+    """Function to verify API key"""
+    server_context = ServerContext.current()
+    # Only perform verification when API key is configured
+    if server_context is not None and server_context.api_key is not None:
+        provided_key = request.headers.get("Authorization", "").replace("Bearer ", "")
+        if provided_key != server_context.api_key:
+            raise fastapi.HTTPException(status_code=401, detail="Invalid API Key")
+    # Skip verification if no API key is configured
+
+app = fastapi.APIRouter(dependencies=[fastapi.Depends(verify_api_key)])
+
 ################ v1/models ################
 
 

--- a/python/mlc_llm/serve/server/server_context.py
+++ b/python/mlc_llm/serve/server/server_context.py
@@ -15,6 +15,7 @@ class ServerContext:
 
     def __init__(self) -> None:
         self._models: Dict[str, AsyncMLCEngine] = {}
+        self.api_key: Optional[str] = None  # New API key property
 
     def __enter__(self):
         if ServerContext.server_context is not None:


### PR DESCRIPTION
## Description

This PR adds API key authentication to the server. Now users can secure their endpoints with a simple API key.

Key features:
- API key is optional (disabled by default)
- API key is passed via `--api-key` command line argument (not hardcoded or using environment variables)
- Authentication follows OpenAI API standard (Bearer token in Authorization header)
- No breaking changes - existing functionality remains unchanged

## Changes

### 1. mlc_llm/serve/server/server_context.py
Added `api_key` property to store the API key in server context:
```python
def __init__(self) -> None:
    self._models: Dict[str, AsyncMLCEngine] = {}
    self.api_key: Optional[str] = None  # New line
```

### 2. mlc_llm/interface/serve.py
Added `api_key` parameter to the serve function:
```python
def serve(
    # ... existing parameters ...
    api_key: Optional[str] = None,  # New parameter
):
    # ...
    with ServerContext() as server_context:
        server_context.add_model(model, async_engine)
        server_context.api_key = api_key  # Set API key in context
```

### 3. mlc_llm/cli/serve.py
Added command line argument for API key:
```python
parser.add_argument(
    "--api-key",
    type=str,
    default=None,
    help="API key for authentication. If not provided, authentication is disabled."
)

# Pass the API key to serve function
serve(
    # ... existing parameters ...
    api_key=parsed.api_key,  # New line
)
```

### 4. mlc_llm/serve/entrypoints/openai_entrypoints.py
Added API key verification middleware:
```python
def verify_api_key(request: fastapi.Request):
    server_context = ServerContext.current()
    if server_context.api_key is not None:
        provided_key = request.headers.get("Authorization", "").replace("Bearer ", "")
        if provided_key != server_context.api_key:
            raise fastapi.HTTPException(status_code=401, detail="Invalid API Key")

# Apply middleware to all OpenAI API endpoints
app = fastapi.APIRouter(dependencies=[fastapi.Depends(verify_api_key)])
```

## How to Test

1. Start server with API key:
   ```bash
   python -m mlc_llm.serve --model your-model --api-key "mlc-ai-is-awesome"
   ```

2. Test with correct key (should succeed):
   ```bash
   curl http://localhost:8000/v1/models -H "Authorization: Bearer mlc-ai-is-awesome"
   ```

3. Test with incorrect key (should return 401):
   ```bash
   curl http://localhost:8000/v1/models -H "Authorization: Bearer wrong-key"
   ```

4. Test without key (should return 401):
   ```bash
   curl http://localhost:8000/v1/models
   ```

5. Start server without API key (all requests should work without authentication):
   ```bash
   python -m mlc_llm.serve --model your-model
   ```

This change follows the minimal modification principle and keeps the API simple and secure.