### PR TITLE
Fix supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ MLC LLM is a machine learning compiler and high-performance deployment engine fo
     </tr>
     <tr>
       <td>macOS</td>
-      <td>✅ Metal (dGPU)</td>
+      <td>❌ Metal (dGPU)</td>
       <td>N/A</td>
       <td>✅ Metal</td>
-      <td>✅ Metal (iGPU)</td>
+      <td>❌ Metal (iGPU)</td>
     </tr>
     <tr>
       <td>Web Browser</td>


### PR DESCRIPTION
mmc-llm is broken on Intel Macs for more than a year, and it seems there are no plans to fix it (see #3078).

Therefore, in order for users not to waste time, it is worth updating the list of supported platforms to the current state.