### PR TITLE
[C++] Fix the downcast use per latest refactor

### DIFF
--- a/cpp/multi_gpu/builtin.cc
+++ b/cpp/multi_gpu/builtin.cc
@@ -9,6 +9,7 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/reflection/registry.h>
+#include <tvm/node/cast.h>
 #include <tvm/runtime/disco/builtin.h>
 #include <tvm/runtime/disco/disco_worker.h>
 #include <tvm/runtime/ndarray.h>
@@ -19,6 +20,7 @@ namespace llm {
 namespace multi_gpu {
 
 using namespace tvm::runtime;
+using tvm::Downcast;
 using tvm::ffi::Array;
 using tvm::ffi::Optional;
 using tvm::ffi::Shape;

--- a/cpp/serve/data.h
+++ b/cpp/serve/data.h
@@ -9,6 +9,7 @@
 #include <tvm/ffi/container/shape.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/string.h>
+#include <tvm/node/cast.h>
 #include <tvm/runtime/int_tuple.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/object.h>


### PR DESCRIPTION
This PR fixes the use of `Downcast` in MLC and includes the `include/tvm/node/cast.h` header to adapt to the latest refactor.