### PR TITLE
[FFI] `Module` update in accordance with recent refactor

### DIFF
--- a/cpp/json_ffi/json_ffi_engine.cc
+++ b/cpp/json_ffi/json_ffi_engine.cc
@@ -151,7 +151,7 @@ void JSONFFIEngine::ExitBackgroundLoop() { this->engine_->ExitBackgroundLoop(); 
 
 JSONFFIEngine::~JSONFFIEngine() { this->ExitBackgroundLoop(); }
 
-class JSONFFIEngineImpl : public JSONFFIEngine, public ModuleNode {
+class JSONFFIEngineImpl : public JSONFFIEngine, public ffi::ModuleObj {
  public:
   TVM_MODULE_VTABLE_BEGIN("mlc.json_ffi");
   TVM_MODULE_VTABLE_ENTRY("init_background_engine", &JSONFFIEngineImpl::InitBackgroundEngine);
@@ -299,7 +299,7 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ModuleNode {
 TVM_FFI_STATIC_INIT_BLOCK({
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("mlc.json_ffi.CreateJSONFFIEngine",
-                        []() { return Module(make_object<JSONFFIEngineImpl>()); });
+                        []() { return ffi::Module(make_object<JSONFFIEngineImpl>()); });
 });
 
 }  // namespace json_ffi

--- a/cpp/metadata/model.h
+++ b/cpp/metadata/model.h
@@ -7,6 +7,7 @@
 
 #include <picojson.h>
 #include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/string.h>
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/module.h>
@@ -16,6 +17,7 @@
 namespace mlc {
 namespace llm {
 
+using tvm::ffi::Module;
 using tvm::ffi::Shape;
 using tvm::ffi::String;
 using tvm::runtime::DataType;
@@ -94,8 +96,7 @@ struct ModelMetadata {
 
   static ModelMetadata FromJSON(const picojson::object& json_str,
                                 const picojson::object& model_config);
-  static ModelMetadata FromModule(tvm::runtime::Module module,
-                                  const picojson::object& model_config);
+  static ModelMetadata FromModule(Module module, const picojson::object& model_config);
 };
 
 }  // namespace llm

--- a/cpp/multi_gpu/multi_gpu_loader.cc
+++ b/cpp/multi_gpu/multi_gpu_loader.cc
@@ -62,7 +62,9 @@ class PreprocessorPool {
     for (const ModelMetadata::Param& param : model_metadata.params) {
       for (const ModelMetadata::Param::Preproc& preproc : param.preprocs) {
         const std::string& func_name = preproc.func_name;
-        if (Function f = vm_module.defined() ? vm_module->GetFunction(func_name, true) : nullptr;
+        if (Function f = vm_module.defined()
+                             ? vm_module->GetFunction(func_name, true).value_or(Function(nullptr))
+                             : nullptr;
             f != nullptr) {
           preproc_funcs[func_name] = f;
         } else if (const auto f = Function::GetGlobal(func_name); f.has_value()) {

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -9,6 +9,7 @@
 
 #include <picojson.h>
 #include <tvm/ffi/container/map.h>
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/runtime/disco/session.h>
@@ -76,7 +77,7 @@ struct FunctionTable {
   Session sess{nullptr};
   DRef disco_mod{nullptr};
   Map<String, ObjectRef> cached_buffers{nullptr};
-  tvm::runtime::Module local_vm{nullptr};
+  tvm::ffi::Module local_vm{nullptr};
   picojson::object model_config;
 
   TypedFunction<Function(const std::string&)> mod_get_func;

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -380,7 +380,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
 };
 
 /*! \brief The implementation of ThreadedEngine. */
-class ThreadedEngineModule : public ThreadedEngineImpl, public ModuleNode {
+class ThreadedEngineModule : public ThreadedEngineImpl, public ffi::ModuleObj {
  public:
   TVM_MODULE_VTABLE_BEGIN("mlc.serve.async_threaded_engine");
   TVM_MODULE_VTABLE_ENTRY("init_threaded_engine", &ThreadedEngineImpl::InitThreadedEngine);


### PR DESCRIPTION
This PR fixes the uses of runtime Module (now `ffi::Module`) API in MLC, to align with the latest refactor in TVM mainline.