### PR TITLE
[Python] Update system platform requirement for flashinfer

### DIFF
--- a/ci/task/pylint.sh
+++ b/ci/task/pylint.sh
@@ -9,10 +9,10 @@ export PYTHONPATH="./python":${PYTHONPATH:-""}
 if [[ -n ${MLC_CI_SETUP_DEPS:-} ]]; then
     echo "MLC_CI_SETUP_DEPS=1 start setup deps"
     # TVM Unity is a dependency to this testing
-    pip install --quiet --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cpu
+    pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
     pip install apache-tvm-ffi
     pip install requests triton
-    pip install --quiet --pre -U cuda-python
+    pip install --pre -U cuda-python
 fi
 
 pylint --jobs $NUM_THREADS ./python/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "apache-tvm-ffi",
     "datasets",
     "fastapi",
-    "flashinfer-python==0.2.14",
+    "flashinfer-python==0.2.14; sys_platform == 'linux'",
     "ml_dtypes>=0.5.1",
     "openai",
     "pandas",


### PR DESCRIPTION
This PR updates the dependency system requirement for flashinfer-python so it won't be treated as a dependency on Mac.