### PR TITLE
[MLCChat] Fix build prefix issue

### DIFF
--- a/python/mlc_llm/interface/package.py
+++ b/python/mlc_llm/interface/package.py
@@ -197,7 +197,7 @@ def validate_model_lib(  # pylint: disable=too-many-locals
         """Get the model lib prefixes in the given static lib path."""
         global_symbol_map = cc.get_global_symbol_section_map(lib_path)
         libs = []
-        suffix = "___tvm_ffi_library_bin"
+        suffix = "___tvm_ffi__library_bin"
         for name, _ in global_symbol_map.items():
             if name.endswith(suffix):
                 model_lib = name[: -len(suffix)]
@@ -231,7 +231,7 @@ def validate_model_lib(  # pylint: disable=too-many-locals
                 f"model_lib_path_for_prepare_libs={model_lib_path_for_prepare_libs}"
             )
 
-        model_prefix_pattern = model_lib.replace("-", "_") + "___tvm_ffi_library_bin"
+        model_prefix_pattern = model_lib.replace("-", "_") + "___tvm_ffi__library_bin"
         if (
             model_prefix_pattern not in global_symbol_map
             and "_" + model_prefix_pattern not in global_symbol_map


### PR DESCRIPTION
Resolve issue when building models in MLCChat: current available model_libs in dist/lib/libmodel_android.a: []