### PR TITLE
[C++] Fix EventTraceRecorder initialization

### DIFF
--- a/cpp/serve/event_trace_recorder.h
+++ b/cpp/serve/event_trace_recorder.h
@@ -56,8 +56,7 @@ class EventTraceRecorder : public ObjectRef {
   /*! \brief Create an event trace recorder. */
   static EventTraceRecorder Create();
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(EventTraceRecorder, ObjectRef,
-                                                    EventTraceRecorderObj);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(EventTraceRecorder, ObjectRef, EventTraceRecorderObj);
 };
 
 /****************** Helper macro ******************/


### PR DESCRIPTION
This PR fixes the initialization of EventTraceRecorder after the enhancement of ObjectRef null safety.

Prior to this PR, EventTraceRecorder is designed as a not-nullable class, while it doesn't have a corresponding constructor and is initialized by `make_object` in an external function. This is considered invalid with the ObjectRef null safety enhancement. Therefore, we relax the requirement and allow it to be nullable.