### PR TITLE
[C++] Fix non-nullable object initialization

### DIFF
--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -75,9 +75,9 @@ struct FunctionTable {
   bool use_disco = false;
   Device local_gpu_device;
   Session sess{nullptr};
-  DRef disco_mod{nullptr};
-  Map<String, ObjectRef> cached_buffers{nullptr};
-  tvm::ffi::Module local_vm{nullptr};
+  Optional<DRef> disco_mod = std::nullopt;
+  Optional<Map<String, ObjectRef>> cached_buffers = std::nullopt;
+  Optional<tvm::ffi::Module> local_vm = std::nullopt;
   picojson::object model_config;
 
   TypedFunction<Function(const std::string&)> mod_get_func;


### PR DESCRIPTION
Following #3332, this PR fixes a few places where `nullptr` is used to initialize non-nullable objects.

These bugs won't lead to compilation errors. They, however, lead to runtime errors that may look confusing.