### PR TITLE
[C++] Fix DLTensor `auto` type detection

### DIFF
--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -405,7 +405,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
             }
           }
           // Find a slice of bitmask_host_: bitmask_host_[num_token_for_mask, :]
-          auto bitmask_dltensor = *bitmask_host_.operator->();
+          DLTensor bitmask_dltensor = *bitmask_host_.operator->();
           int64_t bitmask_shape[] = {bitmask_size_};
           bitmask_dltensor.data = p_bitmask + (token_start_offset + j) * bitmask_size_;
           bitmask_dltensor.shape = bitmask_shape;


### PR DESCRIPTION
This commit fixes an auto type detection failure on DLTensor. Previously it used `auto dltensor = *tensor.operator->()`, which causes compilation failure. Providing explicit type resolves the issue.