### PR TITLE
[CI] Update CI Unittest CUDA Version

### DIFF
--- a/ci/task/test_unittest.sh
+++ b/ci/task/test_unittest.sh
@@ -8,7 +8,7 @@ if [[ -n ${MLC_CI_SETUP_DEPS:-} ]]; then
     # Install dependency
     pip install --force-reinstall wheels/*.whl
     pip install --quiet pytest
-    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu123
+    pip install --pre -U --no-index -f https://mlc.ai/wheels mlc-ai-nightly-cu128
     export LD_LIBRARY_PATH=/usr/local/cuda/compat/:$LD_LIBRARY_PATH
 fi
 


### PR DESCRIPTION
This PR updates the CUDA package version we use to test CI unittest, from 12.3 to 12.8, as the CUDA 12.3 package is no longer delivered.