### PR TITLE
[C++] Fix StopStrHandler initialization

### DIFF
--- a/cpp/tokenizers/streamer.h
+++ b/cpp/tokenizers/streamer.h
@@ -122,7 +122,7 @@ class StopStrHandlerObj : public Object {
   /*! \brief The token string length of each pending token id. */
   std::vector<int> pending_token_lengths_;
   /*! \brief A boolean flag indicating if stop has been triggered. */
-  bool stop_triggered_;
+  bool stop_triggered_ = false;
 
   /************ Per-stop-string states. ************/
 


### PR DESCRIPTION
This PR fixes a field that wasn't initialized previously in StopStrHandler. It did not cause any error before so was not noticed, until the latest TVM FFI bump that reveals this problem.