### PR TITLE
[Testing] Add unit tests for Gemma3 model

### DIFF
--- a/tests/python/model/test_gemma3.py
+++ b/tests/python/model/test_gemma3.py
@@ -57,10 +57,12 @@ def test_gemma3_config_validation():
     assert hasattr(config, "num_attention_heads") and config.num_attention_heads > 0
     assert hasattr(config, "vocab_size") and config.vocab_size > 0
 
-    print(f"Gemma3 Config: hidden_size={config.hidden_size}, "
-          f"layers={config.num_hidden_layers}, "
-          f"heads={config.num_attention_heads}, "
-          f"vocab={config.vocab_size}")
+    print(
+        f"Gemma3 Config: hidden_size={config.hidden_size}, "
+        f"layers={config.num_hidden_layers}, "
+        f"heads={config.num_attention_heads}, "
+        f"vocab={config.vocab_size}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit tests for the Gemma3 model architecture, which was added in #3172, #3178, #3224 but lacked test coverage.

## Changes

- Add `tests/python/model/test_gemma3.py` with test cases:
  - `test_gemma3_model_registered`: Verify model is in registry
  - `test_gemma3_creation`: Test model creation and TVM export (gemma3_2b, gemma3_9b)
  - `test_gemma3_config_validation`: Validate configuration parameters
- Follows pattern from `test_llama.py`

## Testing

To run tests locally:
```bash
pytest tests/python/model/test_gemma3.py -v
```

## Part of

Adding test coverage for recently added models (Gemma3, Qwen3, Phi-4, Llama4).