### PR TITLE
[Config] Add `active_vocab_size` default value

### DIFF
--- a/python/mlc_llm/protocol/mlc_chat_config.py
+++ b/python/mlc_llm/protocol/mlc_chat_config.py
@@ -33,7 +33,6 @@ class MLCChatConfig(BaseModel):
     # use alias to avoid protected namespace conflict with pydantic
     field_model_config: Dict[str, Any] = Field(alias="model_config")
     vocab_size: int
-    active_vocab_size: int
     context_window_size: int
     sliding_window_size: int
     prefill_chunk_size: int
@@ -41,6 +40,7 @@ class MLCChatConfig(BaseModel):
     tensor_parallel_shards: int
     pipeline_parallel_stages: int = 1
     # Configuration of text generation
+    active_vocab_size: int = None
     temperature: Optional[float] = None
     presence_penalty: Optional[float] = None
     frequency_penalty: Optional[float] = None


### PR DESCRIPTION
This commit assigns a default value to `active_vocab_size`, so that when reading an old `mlc-chat-config.json` that does not contain the `active_vocab_size` field,

```python
with open(mlc_config_path, mode="rt", encoding="utf-8") as file:
    mlc_chat_config = MLCChatConfig.model_validate_json(file.read())
```

will not cause an error of "active_vocab_size not found".