### PR TITLE
[Python] Fix BOOL error in logit processor.

### DIFF
--- a/python/mlc_llm/compiler_pass/attach_logit_processor.py
+++ b/python/mlc_llm/compiler_pass/attach_logit_processor.py
@@ -145,7 +145,7 @@ def _get_apply_penalty_inplace_cpu():
                     penalties[pos2seq_id[vp], 0] + token_cnt[vp] * penalties[pos2seq_id[vp], 1]
                 )
                 logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] = T.if_then_else(
-                    logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] < 0,
+                    logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] < T.float32(0),
                     logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] * penalties[pos2seq_id[vp], 2],
                     logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] / penalties[pos2seq_id[vp], 2],
                 )
@@ -197,7 +197,7 @@ def _get_apply_penalty_inplace(target: tvm.target.Target):
                         penalties[pos2seq_id[vp], 0] + token_cnt[vp] * penalties[pos2seq_id[vp], 1]
                     )
                     logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] = T.if_then_else(
-                        logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] < 0,
+                        logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] < T.float32(0),
                         logits[seq_ids[pos2seq_id[vp]], token_ids[vp]]
                         * penalties[pos2seq_id[vp], 2],
                         logits[seq_ids[pos2seq_id[vp]], token_ids[vp]]


### PR DESCRIPTION
Was getting this error with `mlc_llm serve` via cpu:

```
error: BOOL
 --> /home/jake/github/mlc/models/.venv/lib/python3.10/site-packages/mlc_llm/compiler_pass/attach_logit_processor.py:148:21
     |
 148 |                      logits[seq_ids[pos2seq_id[vp]], token_ids[vp]] < 0,
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Similar to this issue with TVM (https://github.com/apache/tvm/pull/18578).

My PR casts 0 into a proper tvm type via `T.float32`.