### PR TITLE
[Model] Fix weight conversion for Qwen3-Embedding while preserving Qwen3 compatibility

### DIFF
--- a/python/mlc_llm/model/model.py
+++ b/python/mlc_llm/model/model.py
@@ -359,6 +359,21 @@ MODELS: Dict[str, Model] = {
             "block-scale-quant": qwen3_quantization.block_scale_quant,
         },
     ),
+    "qwen3-embedding": Model(
+        name="qwen3-embedding",
+        model=qwen3_model.Qwen3LMHeadModel,
+        config=qwen3_model.Qwen3Config,
+        source={
+            "huggingface-torch": qwen3_loader.huggingface_embedding,
+            "huggingface-safetensor": qwen3_loader.huggingface_embedding,
+        },
+        quantize={
+            "no-quant": qwen3_quantization.no_quant,
+            "group-quant": qwen3_quantization.group_quant,
+            "ft-quant": qwen3_quantization.ft_quant,
+            "block-scale-quant": qwen3_quantization.block_scale_quant,
+        },
+    ),
     "qwen3_moe": Model(
         name="qwen3_moe",
         model=qwen3_moe_model.Qwen3MoeForCausalLM,


### PR DESCRIPTION
Fixes #3404

## Problem

Qwen3-Embedding models use different parameter naming convention (without `model.` prefix), causing weight conversion to fail with error:

Example:
- Standard Qwen3: `model.embed_tokens.weight`
- Qwen3-Embedding: `embed_tokens.weight` (no prefix)

## Solution

Add support for both naming conventions by:
1. Adding `hf_prefix` parameter to `qwen3_loader.huggingface()` with default `"model."`
2. Adding `huggingface_embedding()` wrapper that calls `huggingface()` with `hf_prefix=""`
3. Registering new model type `qwen3-embedding` in `model.py`

## Changes

- `python/mlc_llm/model/qwen3/qwen3_loader.py`: Add prefix handling logic
- `python/mlc_llm/model/model.py`: Register `qwen3-embedding` model type

## Testing

Successfully tested the full compilation pipeline with both `Qwen/Qwen3-Embedding-0.6B` and `Qwen/Qwen3-0.6B`,
including `gen_config`, `convert_weight`, and `compile` steps on macOS (Metal).