### PR TITLE
Fix: Use correct tvm.s_tir.Schedule API in compiler passes

### DIFF
--- a/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
+++ b/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
@@ -228,7 +228,7 @@ def _get_lse_and_softmax_func(  # pylint: disable=too-many-locals,too-many-state
                         T.float32(0),
                     )
 
-    sch = tvm.tir.Schedule(IRModule({"softmax_with_chunked_sum": softmax_with_chunked_sum}))
+    sch = tvm.s_tir.Schedule(IRModule({"softmax_with_chunked_sum": softmax_with_chunked_sum}))
 
     def apply_gpu_schedule(target, sch):
         max_threads = get_max_num_threads_per_block(target)

--- a/python/mlc_llm/compiler_pass/fuse_dequantize_take.py
+++ b/python/mlc_llm/compiler_pass/fuse_dequantize_take.py
@@ -43,7 +43,7 @@ class FuseDequantizeTake:  # pylint: disable=too-few-public-methods
             ):
                 sch_mod = tvm.IRModule({"main": func})
                 sch_mod = tir.transform.ForceNarrowIndexToInt32()(sch_mod)
-                sch = tir.Schedule(sch_mod)
+                sch = tvm.s_tir.Schedule(sch_mod)
                 sch.compute_inline("dequantize")
                 mod[g_var] = sch.mod["main"]
         return mod


### PR DESCRIPTION
## Before Fix
```
[2026-02-06 15:09:04] INFO auto_device.py:82: Found device: metal:0
[2026-02-06 15:09:04] INFO jit.py:43: MLC_JIT_POLICY = REDO. Can be one of: ON, OFF, REDO, READONLY
[2026-02-06 15:09:04] INFO jit.py:118: Compiling using commands below:
[2026-02-06 15:09:04] INFO jit.py:119: /opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/bin/python3.12 -m mlc_llm compile . --opt 'flashinfer=1;cublas_gemm=1;faster_transformer=0;cudagraph=1;cutlass=1;ipc_allreduce_strategy=NONE' --overrides '' --device metal:0 --output /var/folders/yl/w8psc6dx3dngffnmccbnrgdc0000gn/T/tmpfsio1kpj/lib.dylib
[2026-02-06 15:09:05] INFO auto_config.py:70: Found model configuration: mlc-chat-config.json
[2026-02-06 15:09:05] INFO auto_target.py:91: Detecting target device: metal:0
[2026-02-06 15:09:05] INFO auto_target.py:93: Found target: {'kind': 'metal', 'tag': '', 'keys': ['metal', 'gpu'], 'max_num_threads': 256, 'max_function_args': 31, 'thread_warp_size': 32, 'max_threads_per_block': 1024, 'max_shared_memory_per_block': 32768}
[2026-02-06 15:09:05] INFO auto_target.py:110: Found host LLVM triple: arm64-apple-darwin24.5.0
[2026-02-06 15:09:05] INFO auto_target.py:111: Found host LLVM CPU: apple-m1
[2026-02-06 15:09:05] INFO auto_config.py:154: Found model type: ministral3. Use `--model-type` to override.
[2026-02-06 15:09:05] INFO compile.py:233: Active vocab size from input config: 131072
Compiling with arguments:
  --config          Ministral3Config(hidden_size=3072, intermediate_size=9216, num_attention_heads=32, num_hidden_layers=26, rms_norm_eps=1e-05, vocab_size=131072, attention_sink_size=0, context_window_size=262144, dtype='bfloat16', head_dim=128, hidden_act='silu', max_batch_size=128, num_key_value_heads=8, position_embedding_base=1000000.0, prefill_chunk_size=1024, rope_parameters={'beta_fast': 32.0, 'beta_slow': 1.0, 'factor': 16.0, 'llama_4_scaling_beta': 0.1, 'mscale': 1.0, 'mscale_all_dim': 1.0, 'original_max_position_embeddings': 16384, 'rope_type': 'yarn', 'type': 'yarn'}, sliding_window_size=-1, tensor_parallel_shards=1, tie_word_embeddings=True, weight_block_size=None, kwargs={'active_vocab_size': 131072}, modules_to_not_convert=[])
  --quantization    GroupQuantize(name='q4f16_1', kind='group-quant', group_size=32, quantize_dtype='int4', storage_dtype='uint32', model_dtype='float16', linear_weight_layout='NK', quantize_embedding=True, quantize_final_fc=True, num_elem_per_storage=8, num_storage_per_group=4, max_int_value=7, tensor_parallel_shards=0)
  --model-type      ministral3
  --target          {'kind': 'metal', 'tag': '', 'keys': ['metal', 'gpu'], 'host': {'kind': 'llvm', 'tag': '', 'keys': ['arm_cpu', 'cpu'], 'mcpu': 'apple-m1', 'mtriple': 'arm64-apple-darwin24.5.0'}, 'max_num_threads': 256, 'max_function_args': 31, 'thread_warp_size': 32, 'max_threads_per_block': 1024, 'max_shared_memory_per_block': 32768}
  --opt             flashinfer=0;cublas_gemm=0;faster_transformer=0;cudagraph=0;cutlass=0;ipc_allreduce_strategy=NONE
  --system-lib-prefix ""
  --output          /var/folders/yl/w8psc6dx3dngffnmccbnrgdc0000gn/T/tmpfsio1kpj/lib.dylib
  --overrides       context_window_size=None;sliding_window_size=None;prefill_chunk_size=None;attention_sink_size=None;max_batch_size=None;tensor_parallel_shards=None;pipeline_parallel_stages=None;disaggregation=None
[2026-02-06 15:09:05] INFO compile.py:131: TOP LEVEL MODEL CONFIG BEFORE OVERRIDES: Ministral3Config(hidden_size=3072, intermediate_size=9216, num_attention_heads=32, num_hidden_layers=26, rms_norm_eps=1e-05, vocab_size=131072, attention_sink_size=0, context_window_size=262144, dtype='bfloat16', head_dim=128, hidden_act='silu', max_batch_size=128, num_key_value_heads=8, position_embedding_base=1000000.0, prefill_chunk_size=1024, rope_parameters={'beta_fast': 32.0, 'beta_slow': 1.0, 'factor': 16.0, 'llama_4_scaling_beta': 0.1, 'mscale': 1.0, 'mscale_all_dim': 1.0, 'original_max_position_embeddings': 16384, 'rope_type': 'yarn', 'type': 'yarn'}, sliding_window_size=-1, tensor_parallel_shards=1, tie_word_embeddings=True, weight_block_size=None, kwargs={'active_vocab_size': 131072}, modules_to_not_convert=[])
[2026-02-06 15:09:05] INFO compile.py:142: Creating model from: Ministral3Config(hidden_size=3072, intermediate_size=9216, num_attention_heads=32, num_hidden_layers=26, rms_norm_eps=1e-05, vocab_size=131072, attention_sink_size=0, context_window_size=262144, dtype='bfloat16', head_dim=128, hidden_act='silu', max_batch_size=128, num_key_value_heads=8, position_embedding_base=1000000.0, prefill_chunk_size=1024, rope_parameters={'beta_fast': 32.0, 'beta_slow': 1.0, 'factor': 16.0, 'llama_4_scaling_beta': 0.1, 'mscale': 1.0, 'mscale_all_dim': 1.0, 'original_max_position_embeddings': 16384, 'rope_type': 'yarn', 'type': 'yarn'}, sliding_window_size=-1, tensor_parallel_shards=1, tie_word_embeddings=True, weight_block_size=None, kwargs={}, modules_to_not_convert=[])
[2026-02-06 15:09:05] INFO compile.py:160: Exporting the model to TVM compiler
[2026-02-06 15:09:05] INFO compile.py:166: Running optimizations using TVM
[2026-02-06 15:09:05] INFO compile.py:192: Registering metadata: {'model_type': 'ministral3', 'quantization': 'q4f16_1', 'context_window_size': 262144, 'sliding_window_size': -1, 'attention_sink_size': 0, 'prefill_chunk_size': 1024, 'tensor_parallel_shards': 1, 'pipeline_parallel_stages': 1, 'disaggregation': False, 'kv_state_kind': 'kv_cache', 'max_batch_size': 128, 'active_vocab_size': 131072}
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/__main__.py", line 69, in <module>
    main()
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/__main__.py", line 34, in main
    cli.main(sys.argv[2:])
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/cli/compile.py", line 129, in main
    compile(
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/interface/compile.py", line 254, in compile
    _compile(args, model_config)
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/interface/compile.py", line 195, in _compile
    args.build_func(
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/support/auto_target.py", line 301, in build
    relax.build(
  File "/opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/lib/python3.12/site-packages/tvm/relax/vm_build.py", line 257, in build
    mod = relax_pipeline(mod)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/lib/python3.12/site-packages/tvm/ir/transform.py", line 167, in __call__
    return _ffi_transform_api.RunPass(self, mod)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python/tvm_ffi/cython/function.pxi", line 923, in tvm_ffi.core.Function.__call__
  File "<unknown>", line 0, in tvm::transform::Pass::operator()(tvm::IRModule) const
  File "<unknown>", line 0, in tvm::transform::Pass::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  File "<unknown>", line 0, in tvm::transform::ModulePassNode::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  File "<unknown>", line 0, in std::__1::__function::__func<tvm::transform::__TVMFFIStaticInitFunc4()::$_0::operator()(tvm::ffi::TypedFunction<tvm::IRModule (tvm::ffi::RValueRef<tvm::IRModule, void>, tvm::transform::PassContext)>, tvm::transform::PassInfo) const::'lambda'(tvm::IRModule, tvm::transform::PassContext), std::__1::allocator<tvm::transform::__TVMFFIStaticInitFunc4()::$_0::operator()(tvm::ffi::TypedFunction<tvm::IRModule (tvm::ffi::RValueRef<tvm::IRModule, void>, tvm::transform::PassContext)>, tvm::transform::PassInfo) const::'lambda'(tvm::IRModule, tvm::transform::PassContext)>, tvm::IRModule (tvm::IRModule, tvm::transform::PassContext)>::operator()(tvm::IRModule&&, tvm::transform::PassContext&&)
  File "python/tvm_ffi/cython/function.pxi", line 1077, in tvm_ffi.core.tvm_ffi_callback
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/compiler_pass/pipeline.py", line 206, in _pipeline
    mod = seq(mod)

  File "/opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/lib/python3.12/site-packages/tvm/ir/transform.py", line 167, in __call__
    return _ffi_transform_api.RunPass(self, mod)

  File "python/tvm_ffi/cython/function.pxi", line 923, in tvm_ffi.core.Function.__call__
  File "<unknown>", line 0, in tvm::transform::Pass::operator()(tvm::IRModule) const
  File "<unknown>", line 0, in tvm::transform::Pass::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  File "<unknown>", line 0, in tvm::transform::SequentialNode::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  File "<unknown>", line 0, in tvm::transform::Pass::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  File "<unknown>", line 0, in tvm::transform::ModulePassNode::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  File "<unknown>", line 0, in std::__1::__function::__func<tvm::transform::__TVMFFIStaticInitFunc4()::$_0::operator()(tvm::ffi::TypedFunction<tvm::IRModule (tvm::ffi::RValueRef<tvm::IRModule, void>, tvm::transform::PassContext)>, tvm::transform::PassInfo) const::'lambda'(tvm::IRModule, tvm::transform::PassContext), std::__1::allocator<tvm::transform::__TVMFFIStaticInitFunc4()::$_0::operator()(tvm::ffi::TypedFunction<tvm::IRModule (tvm::ffi::RValueRef<tvm::IRModule, void>, tvm::transform::PassContext)>, tvm::transform::PassInfo) const::'lambda'(tvm::IRModule, tvm::transform::PassContext)>, tvm::IRModule (tvm::IRModule, tvm::transform::PassContext)>::operator()(tvm::IRModule&&, tvm::transform::PassContext&&)
  File "python/tvm_ffi/cython/function.pxi", line 1077, in tvm_ffi.core.tvm_ffi_callback
  File "/opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/lib/python3.12/site-packages/tvm/ir/transform.py", line 234, in _pass_func
    return inst.transform_module(mod, ctx)

  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py", line 26, in transform_module
    return _Rewriter(mod, self.target, self.metadata).transform()

  File "/opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/lib/python3.12/site-packages/tvm/runtime/support.py", line 185, in method
    return result(*args, **kwargs)

  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py", line 58, in transform
    f_chunk_lse, f_softmax_with_lse = _get_lse_and_softmax_func(

  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py", line 231, in _get_lse_and_softmax_func
    sch = tir.Schedule(IRModule({"softmax_with_chunked_sum": softmax_with_chunked_sum}))

AttributeError: module 'tvm.tir' has no attribute 'Schedule'
[15:09:07] /Users/bryan/GolandProjects/mlc-cli/tvm/src/relax/ir/block_builder.cc:64: Warning: BlockBuilder destroyed with remaining blocks!
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/bin/mlc_llm", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/__main__.py", line 46, in main
    cli.main(sys.argv[2:])
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/cli/chat.py", line 36, in main
    chat(
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/interface/chat.py", line 288, in chat
    JSONFFIEngine(
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/json_ffi/engine.py", line 232, in __init__
    model_args = _process_model_args(models, device, engine_config)[0]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/serve/engine_base.py", line 171, in _process_model_args
    model_args: List[Tuple[str, str]] = [_convert_model_info(model) for model in models]
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/serve/engine_base.py", line 164, in _convert_model_info
    model_lib = jit.jit(
                ^^^^^^^^
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/interface/jit.py", line 164, in jit
    _run_jit(
  File "/Users/bryan/GolandProjects/mlc-cli/mlc-llm/python/mlc_llm/interface/jit.py", line 124, in _run_jit
    raise RuntimeError("Cannot find compilation output, compilation failed")
RuntimeError: Cannot find compilation output, compilation failed
panic: exit status 1

goroutine 1 [running]:
main.(*Platform).run(0x14000025c90)
        /Users/bryan/GolandProjects/mlc-cli/platform.go:140 +0x370
main.main()
        /Users/bryan/GolandProjects/mlc-cli/main.go:50 +0x360
exit status 2
```
## After Fix
```
[2026-02-06 15:11:37] INFO auto_device.py:82: Found device: metal:0
[2026-02-06 15:11:37] INFO jit.py:43: MLC_JIT_POLICY = REDO. Can be one of: ON, OFF, REDO, READONLY
[2026-02-06 15:11:37] INFO jit.py:118: Compiling using commands below:
[2026-02-06 15:11:37] INFO jit.py:119: /opt/homebrew/Caskroom/miniconda/base/envs/mlc-cli-venv/bin/python3.12 -m mlc_llm compile . --opt 'flashinfer=1;cublas_gemm=1;faster_transformer=0;cudagraph=1;cutlass=1;ipc_allreduce_strategy=NONE' --overrides '' --device metal:0 --output /var/folders/yl/w8psc6dx3dngffnmccbnrgdc0000gn/T/tmpgfoj8nsx/lib.dylib
[2026-02-06 15:11:38] INFO auto_config.py:70: Found model configuration: mlc-chat-config.json
[2026-02-06 15:11:38] INFO auto_target.py:91: Detecting target device: metal:0
[2026-02-06 15:11:38] INFO auto_target.py:93: Found target: {'kind': 'metal', 'tag': '', 'keys': ['metal', 'gpu'], 'max_num_threads': 256, 'max_function_args': 31, 'thread_warp_size': 32, 'max_threads_per_block': 1024, 'max_shared_memory_per_block': 32768}
[2026-02-06 15:11:38] INFO auto_target.py:110: Found host LLVM triple: arm64-apple-darwin24.5.0
[2026-02-06 15:11:38] INFO auto_target.py:111: Found host LLVM CPU: apple-m1
[2026-02-06 15:11:38] INFO auto_config.py:154: Found model type: ministral3. Use `--model-type` to override.
[2026-02-06 15:11:38] INFO compile.py:233: Active vocab size from input config: 131072
Compiling with arguments:
  --config          Ministral3Config(hidden_size=3072, intermediate_size=9216, num_attention_heads=32, num_hidden_layers=26, rms_norm_eps=1e-05, vocab_size=131072, attention_sink_size=0, context_window_size=262144, dtype='bfloat16', head_dim=128, hidden_act='silu', max_batch_size=128, num_key_value_heads=8, position_embedding_base=1000000.0, prefill_chunk_size=1024, rope_parameters={'beta_fast': 32.0, 'beta_slow': 1.0, 'factor': 16.0, 'llama_4_scaling_beta': 0.1, 'mscale': 1.0, 'mscale_all_dim': 1.0, 'original_max_position_embeddings': 16384, 'rope_type': 'yarn', 'type': 'yarn'}, sliding_window_size=-1, tensor_parallel_shards=1, tie_word_embeddings=True, weight_block_size=None, kwargs={'active_vocab_size': 131072}, modules_to_not_convert=[])
  --quantization    GroupQuantize(name='q4f16_1', kind='group-quant', group_size=32, quantize_dtype='int4', storage_dtype='uint32', model_dtype='float16', linear_weight_layout='NK', quantize_embedding=True, quantize_final_fc=True, num_elem_per_storage=8, num_storage_per_group=4, max_int_value=7, tensor_parallel_shards=0)
  --model-type      ministral3
  --target          {'kind': 'metal', 'tag': '', 'keys': ['metal', 'gpu'], 'host': {'kind': 'llvm', 'tag': '', 'keys': ['arm_cpu', 'cpu'], 'mcpu': 'apple-m1', 'mtriple': 'arm64-apple-darwin24.5.0'}, 'max_num_threads': 256, 'max_function_args': 31, 'thread_warp_size': 32, 'max_threads_per_block': 1024, 'max_shared_memory_per_block': 32768}
  --opt             flashinfer=0;cublas_gemm=0;faster_transformer=0;cudagraph=0;cutlass=0;ipc_allreduce_strategy=NONE
  --system-lib-prefix ""
  --output          /var/folders/yl/w8psc6dx3dngffnmccbnrgdc0000gn/T/tmpgfoj8nsx/lib.dylib
  --overrides       context_window_size=None;sliding_window_size=None;prefill_chunk_size=None;attention_sink_size=None;max_batch_size=None;tensor_parallel_shards=None;pipeline_parallel_stages=None;disaggregation=None
[2026-02-06 15:11:38] INFO compile.py:131: TOP LEVEL MODEL CONFIG BEFORE OVERRIDES: Ministral3Config(hidden_size=3072, intermediate_size=9216, num_attention_heads=32, num_hidden_layers=26, rms_norm_eps=1e-05, vocab_size=131072, attention_sink_size=0, context_window_size=262144, dtype='bfloat16', head_dim=128, hidden_act='silu', max_batch_size=128, num_key_value_heads=8, position_embedding_base=1000000.0, prefill_chunk_size=1024, rope_parameters={'beta_fast': 32.0, 'beta_slow': 1.0, 'factor': 16.0, 'llama_4_scaling_beta': 0.1, 'mscale': 1.0, 'mscale_all_dim': 1.0, 'original_max_position_embeddings': 16384, 'rope_type': 'yarn', 'type': 'yarn'}, sliding_window_size=-1, tensor_parallel_shards=1, tie_word_embeddings=True, weight_block_size=None, kwargs={'active_vocab_size': 131072}, modules_to_not_convert=[])
[2026-02-06 15:11:38] INFO compile.py:142: Creating model from: Ministral3Config(hidden_size=3072, intermediate_size=9216, num_attention_heads=32, num_hidden_layers=26, rms_norm_eps=1e-05, vocab_size=131072, attention_sink_size=0, context_window_size=262144, dtype='bfloat16', head_dim=128, hidden_act='silu', max_batch_size=128, num_key_value_heads=8, position_embedding_base=1000000.0, prefill_chunk_size=1024, rope_parameters={'beta_fast': 32.0, 'beta_slow': 1.0, 'factor': 16.0, 'llama_4_scaling_beta': 0.1, 'mscale': 1.0, 'mscale_all_dim': 1.0, 'original_max_position_embeddings': 16384, 'rope_type': 'yarn', 'type': 'yarn'}, sliding_window_size=-1, tensor_parallel_shards=1, tie_word_embeddings=True, weight_block_size=None, kwargs={}, modules_to_not_convert=[])
[2026-02-06 15:11:38] INFO compile.py:160: Exporting the model to TVM compiler
[2026-02-06 15:11:39] INFO compile.py:166: Running optimizations using TVM
[2026-02-06 15:11:39] INFO compile.py:192: Registering metadata: {'model_type': 'ministral3', 'quantization': 'q4f16_1', 'context_window_size': 262144, 'sliding_window_size': -1, 'attention_sink_size': 0, 'prefill_chunk_size': 1024, 'tensor_parallel_shards': 1, 'pipeline_parallel_stages': 1, 'disaggregation': False, 'kv_state_kind': 'kv_cache', 'max_batch_size': 128, 'active_vocab_size': 131072}
[2026-02-06 15:11:39] INFO pipeline.py:57: Running TVM Relax graph-level optimizations
[2026-02-06 15:11:40] INFO pipeline.py:57: Lowering to TVM TIR kernels
[15:11:41] /Users/bryan/GolandProjects/mlc-cli/tvm/include/tvm/topi/transform.h:1233: Warning: Fast mode segfaults when there are out-of-bounds indices. Make sure input indices are in bound
[15:11:41] /Users/bryan/GolandProjects/mlc-cli/tvm/include/tvm/topi/transform.h:1233: Warning: Fast mode segfaults when there are out-of-bounds indices. Make sure input indices are in bound
[2026-02-06 15:11:41] INFO pipeline.py:57: Running TVM TIR-level optimizations
[2026-02-06 15:11:42] INFO pipeline.py:57: Running TVM Dlight low-level optimizations
[2026-02-06 15:11:48] INFO pipeline.py:57: Lowering to VM bytecode
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `alloc_embedding_tensor`: 6.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `argsort_probs`: 0.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `batch_decode`: 76.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `batch_prefill`: 160.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `batch_verify`: 608.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `create_tir_paged_kv_cache`: 0.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `decode`: 0.59 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `embed`: 6.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `multinomial_from_uniform`: 0.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `prefill`: 96.51 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `renormalize_by_top_p`: 0.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `sample_with_top_p`: 0.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `sampler_take_probs`: 0.01 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `sampler_verify_draft_tokens`: 0.00 MB
[2026-02-06 15:11:48] INFO estimate_memory_usage.py:58: [Memory usage] Function `softmax_with_temperature`: 0.00 MB
[2026-02-06 15:11:48] INFO pipeline.py:57: Compiling external modules
[2026-02-06 15:11:48] INFO pipeline.py:57: Compilation complete! Exporting to disk
[2026-02-06 15:11:52] INFO model_metadata.py:94: Total memory usage without KV cache: 2447.69 MB (Parameters: 1839.69 MB. Temporary buffer: 608.00 MB)
[2026-02-06 15:11:52] INFO model_metadata.py:128: KV cache size: 0.10 MB per token in the context window
[2026-02-06 15:11:52] INFO model_metadata.py:133: Total memory usage with a 4K KV cache: 2863.69 MB
[2026-02-06 15:11:52] INFO model_metadata.py:139: To reduce memory usage, tweak `prefill_chunk_size`, `context_window_size` and `sliding_window_size`
[2026-02-06 15:11:52] INFO compile.py:214: Generated: /var/folders/yl/w8psc6dx3dngffnmccbnrgdc0000gn/T/tmpgfoj8nsx/lib.dylib
[2026-02-06 15:11:53] INFO jit.py:126: Using compiled model lib: /Users/bryan/.cache/mlc_llm/model_lib/823b68b6e8e01b11e83ed9c5e82870d5.dylib
[15:11:53] /Users/bryan/GolandProjects/mlc-cli/mlc-llm/cpp/serve/config.cc:798: Under mode "local", max batch size will be set to 4, max KV cache token capacity will be set to 8192, prefill chunk size will be set to 1024. 
[15:11:53] /Users/bryan/GolandProjects/mlc-cli/mlc-llm/cpp/serve/config.cc:798: Under mode "interactive", max batch size will be set to 1, max KV cache token capacity will be set to 14770, prefill chunk size will be set to 1024. 
[15:11:53] /Users/bryan/GolandProjects/mlc-cli/mlc-llm/cpp/serve/config.cc:798: Under mode "server", max batch size will be set to 128, max KV cache token capacity will be set to 12240, prefill chunk size will be set to 1024. 
[15:11:53] /Users/bryan/GolandProjects/mlc-cli/mlc-llm/cpp/serve/config.cc:879: The actual engine mode is "interactive". So max batch size is 1, max KV cache token capacity is 14770, prefill chunk size is 1024.
[15:11:53] /Users/bryan/GolandProjects/mlc-cli/mlc-llm/cpp/serve/config.cc:884: Estimated total single GPU memory usage: 4642.067 MB (Parameters: 1839.686 MB. KVCache: 1568.354 MB. Temporary buffer: 1234.027 MB). The actual usage might be slightly larger than the estimated number.
You can use the following special commands:
  /help               print the special commands
  /exit               quit the cli
  /stats              print out stats of last request (token/sec)
  /metrics            print out full engine metrics
  /reset              restart a fresh chat
  /set [overrides]    override settings in the generation config. For example,
                      `/set temperature=0.5;top_p=0.8;seed=23;max_tokens=100;stop=str1,str2`
                      Note: Separate stop words in the `stop` option with commas (,).
  Multi-line input: Use escape+enter to start a new line.

```
## Changes:
Changed tir.Schedule to tvm.s_tir.Schedule in:
- attach_softmax_with_temperature.py
- fuse_dequantize_take.py

Fixes AttributeError during model compilation where tir.Schedule does not exist.