### PR TITLE
[BUG FIXED] fix missing 1/sqrt(d) scaling in attention fallback path

### DIFF
--- a/python/mlc_llm/op/attention.py
+++ b/python/mlc_llm/op/attention.py
@@ -79,7 +79,12 @@ def attention(  # pylint: disable=invalid-name,too-many-locals,too-many-statemen
         target = tvm.target.Target("cuda")
         attn_output, _ = op.tensor_ir_op(
             _attention_sequence_prefill(  # pylint: disable=no-value-for-parameter
-                h_kv=h_kv, h_q=h_q, d=d, dtype=q.dtype, target=target
+                h_kv=h_kv,
+                h_q=h_q,
+                d=d,
+                dtype=q.dtype,
+                target=target,
+                sm_scale=attn_score_scaling_factor / (d**0.5),
             ),
             "sequence_prefill",
             [q, k, v],


### PR DESCRIPTION
The _fallback() path in op_ext.attention called
_attention_sequence_prefill with sm_scale=1.0 (default), but the correct scaling factor is 1/sqrt(head_dim).

This caused attention scores to be head_dim times too large, making softmax overly peaked and degrading embedding quality for any model using this fallback (BERT, CLIP Vision, or any model running on Metal/CPU/non-fp16 configurations).

Decoder models (Llama, Qwen, etc.) were not affected because they pass sm_scale=self.head_dim**-0.5 through the KV cache path, bypassing op_ext.attention entirely.

Measured impact on BGE-base-en-v1.5 (BERT encoder, Metal):
  Before: TVM vs HuggingFace cosine = 0.862 (avg)
  After:  TVM vs HuggingFace cosine = 0.999989 (avg)