### PR TITLE
[Testing] Add logit test for Qwen3 embedding model

### DIFF
--- a/python/mlc_llm/interface/package.py
+++ b/python/mlc_llm/interface/package.py
@@ -159,7 +159,7 @@ def build_model_library(  # pylint: disable=too-many-branches,too-many-locals,to
     return model_lib_path_for_prepare_libs
 
 
-def validate_model_lib(  # pylint: disable=too-many-locals
+def validate_model_lib(  # pylint: disable=too-many-locals,too-many-statements
     app_config_path: Path,
     package_config_path: Path,
     model_lib_path_for_prepare_libs: dict,
@@ -329,7 +329,7 @@ def build_macabi_binding(mlc_llm_source_dir: Path, output: Path) -> None:
     logger.info("Build macabi binding (deployment target %s)", deployment_target)
     cmd = [
         "bash",
-        mlc_llm_source_dir / "ios" / "prepare_libs.sh",
+        str(mlc_llm_source_dir / "ios" / "prepare_libs.sh"),
         "--catalyst",
         "--deployment-target",
         deployment_target,

--- a/python/mlc_llm/model/llama4/llama4_model.py
+++ b/python/mlc_llm/model/llama4/llama4_model.py
@@ -268,7 +268,6 @@ class Llama4TextAttention(nn.Module):  # pylint: disable=too-many-instance-attri
         layer_id: int,
         cache_position,
     ):
-
         d, h_q = self.head_dim, self.num_q_heads
         b, s, _ = hidden_states.shape
         # QKV Projection
@@ -398,7 +397,6 @@ class Llama4TextMoe(nn.Module):
         self.shared_expert = Llama4TextMLP(config)
 
     def forward(self, hidden_states):
-
         hidden_states = hidden_states.reshape(-1, self.hidden_dim)
         router_scores, _ = self.router(hidden_states)
 
@@ -494,7 +492,6 @@ class Llama4TextDecoderLayer(nn.Module):
         layer_id: int,
         cache_position,
     ):
-
         out = self.self_attn(
             self.input_layernorm(hidden_states),
             paged_kv_cache,

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -397,9 +397,7 @@ _MACABI_ARCH = os.environ.get("MLC_MACABI_ARCH", "").strip() or "arm64"
 if _MACABI_ARCH not in ["arm64", "x86_64"]:
     _MACABI_ARCH = "arm64"
 _MACABI_MTRIPLE = (
-    "x86_64-apple-ios18.0-macabi"
-    if _MACABI_ARCH == "x86_64"
-    else "arm64-apple-ios18.0-macabi"
+    "x86_64-apple-ios18.0-macabi" if _MACABI_ARCH == "x86_64" else "arm64-apple-ios18.0-macabi"
 )
 
 PRESET = {

--- a/tests/python/model/test_qwen3_embedding.py
+++ b/tests/python/model/test_qwen3_embedding.py
@@ -5,10 +5,9 @@ import os
 import numpy as np
 import pytest
 import torch
+import tvm
 from safetensors import safe_open
 from transformers import AutoModel, AutoTokenizer
-
-import tvm
 from tvm import relax
 from tvm.contrib import tvmjs
 from tvm.runtime import ShapeTuple
@@ -21,8 +20,7 @@ MLC_QWEN3_EMB_DEVICE = os.environ.get("MLC_QWEN3_EMB_DEVICE", "cuda")
 
 _skip = not all([MLC_QWEN3_EMB_HF_DIR, MLC_QWEN3_EMB_MODEL_DIR, MLC_QWEN3_EMB_MODEL_LIB])
 _skip_reason = (
-    "Set MLC_QWEN3_EMB_HF_DIR, MLC_QWEN3_EMB_MODEL_DIR, "
-    "MLC_QWEN3_EMB_MODEL_LIB to run this test"
+    "Set MLC_QWEN3_EMB_HF_DIR, MLC_QWEN3_EMB_MODEL_DIR, " "MLC_QWEN3_EMB_MODEL_LIB to run this test"
 )
 
 TEST_TEXTS = [
@@ -145,4 +143,3 @@ def test_mlc_hf_logit_match():
 
 if __name__ == "__main__":
     test_mlc_hf_logit_match()
-    


### PR DESCRIPTION
## Summary

This PR adds tests for the Qwen3 Embedding model architecture. The test code is modified from @xthomaswang's verification script in #3411.  

## Changes

- Adds `tests/python/model/test_qwen3_embedding.py`
  - Compares HF and MLC logits across 9 multilingual test inputs
  - Checks cosine similarity, max absolute difference, and top-10 token overlap
  - Skipped automatically when environment variables are not set

## Testing

```bash
export MLC_QWEN3_EMB_HF_DIR=/path/to/hf/model
export MLC_QWEN3_EMB_MODEL_DIR=/path/to/mlc/model
export MLC_QWEN3_EMB_MODEL_LIB=/path/to/model.so
export MLC_QWEN3_EMB_DEVICE=cuda  # optional, defaults to cuda
pytest tests/python/model/test_qwen3_embedding.py -v
```