### PR TITLE
[Refactor] Replace ICHECK macros with TVM_FFI_ICHECK equivalents

### DIFF
--- a/cpp/json_ffi/conv_template.cc
+++ b/cpp/json_ffi/conv_template.cc
@@ -240,7 +240,7 @@ Result<std::vector<Data>> CreatePrompt(const Conversation& conv,
   auto f_populate_system_message = [&](const std::vector<ChatCompletionMessage>& msg_vec) {
     for (ChatCompletionMessage msg : msg_vec) {
       if (msg.role == "system") {
-        ICHECK(msg.content.IsText()) << "System message must be text";
+        TVM_FFI_ICHECK(msg.content.IsText()) << "System message must be text";
         custom_system_inputs += msg.content.Text();
         has_custom_system = true;
       }
@@ -343,7 +343,7 @@ Result<std::vector<Data>> CreatePrompt(const Conversation& conv,
           }
         }
       } else {
-        ICHECK(msg.content.IsText());
+        TVM_FFI_ICHECK(msg.content.IsText());
         pending_text += conv.GetRoleText(msg.role, msg.content.Text(), fn_call_string);
       }
       pending_text += seperator;

--- a/cpp/json_ffi/json_ffi_engine.cc
+++ b/cpp/json_ffi/json_ffi_engine.cc
@@ -176,7 +176,7 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ffi::ModuleObj {
     this->request_stream_callback_ = request_stream_callback.value();
 
     auto frequest_stream_callback_wrapper = [this](ffi::PackedArgs args, ffi::Any* ret) {
-      ICHECK_EQ(args.size(), 1);
+      TVM_FFI_ICHECK_EQ(args.size(), 1);
       Array<RequestStreamOutput> delta_outputs = args[0].cast<Array<RequestStreamOutput>>();
       std::string responses = this->GetResponseFromStreamOutput(delta_outputs);
       this->request_stream_callback_(responses);
@@ -242,10 +242,10 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ffi::ModuleObj {
         request_map_.erase(request_state_it);
         continue;
       }
-      ICHECK_NE(delta_output->group_finish_reason.size(), 0);
-      ICHECK_EQ(delta_output->group_delta_token_ids.size(),
-                delta_output->group_finish_reason.size());
-      ICHECK_EQ(delta_output->group_delta_token_ids.size(), rstate.streamer.size());
+      TVM_FFI_ICHECK_NE(delta_output->group_finish_reason.size(), 0);
+      TVM_FFI_ICHECK_EQ(delta_output->group_delta_token_ids.size(),
+                        delta_output->group_finish_reason.size());
+      TVM_FFI_ICHECK_EQ(delta_output->group_delta_token_ids.size(), rstate.streamer.size());
 
       ChatCompletionStreamResponse response;
       response.id = request_id;

--- a/cpp/multi_gpu/multi_gpu_loader.cc
+++ b/cpp/multi_gpu/multi_gpu_loader.cc
@@ -81,7 +81,7 @@ class PreprocessorPool {
       const std::string& func_name = preproc.func_name;
       Tensor param_in = param;
       param = Tensor::Empty(preproc.out_shape, preproc.out_dtype, param->device);
-      ICHECK(preproc_funcs.count(func_name));
+      TVM_FFI_ICHECK(preproc_funcs.count(func_name));
       DLTensor dl_param_in = *param_in.operator->();
       DLTensor dl_param = *param.operator->();
       preproc_funcs.at(func_name)(&dl_param_in, &dl_param);
@@ -115,7 +115,7 @@ Tensor BroadcastOrShardAndScatter(Tensor param, const ModelMetadata::Param& para
   Device device = param->device;
   Shape shape = param_info.preprocs.back().out_shape;
   DataType dtype = param_info.preprocs.back().out_dtype;
-  ICHECK(shape.size() >= 1 && shape[0] == num_shards)
+  TVM_FFI_ICHECK(shape.size() >= 1 && shape[0] == num_shards)
       << "ValueError: The first dimension of the output shape must be equal to the "
       << "number of shards, but got: " << shape << " and num_shards = " << num_shards;
   param = preprocs.Apply(param, param_info);

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -564,7 +564,7 @@ inline std::string BytesToMegabytesString(double bytes) {
  */
 Result<ModelConfigLimits> GetModelConfigLimits(const std::vector<picojson::object>& model_configs,
                                                const std::vector<ModelMetadata>& model_metadata) {
-  ICHECK_EQ(model_configs.size(), model_metadata.size());
+  TVM_FFI_ICHECK_EQ(model_configs.size(), model_metadata.size());
   int64_t model_compile_time_max_single_sequence_length = std::numeric_limits<int64_t>::max();
   int64_t model_runtime_max_single_sequence_length = std::numeric_limits<int64_t>::max();
   int64_t model_compile_time_max_prefill_chunk_size = std::numeric_limits<int64_t>::max();
@@ -624,12 +624,12 @@ Result<ModelConfigLimits> GetModelConfigLimits(const std::vector<picojson::objec
           std::min(model_max_sliding_window_size, runtime_sliding_window_size);
     }
   }
-  ICHECK_NE(model_compile_time_max_prefill_chunk_size, std::numeric_limits<int64_t>::max());
-  ICHECK_NE(model_runtime_max_prefill_chunk_size, std::numeric_limits<int64_t>::max());
-  ICHECK_NE(model_max_batch_size, std::numeric_limits<int64_t>::max());
-  ICHECK_GT(model_compile_time_max_prefill_chunk_size, 0);
-  ICHECK_GT(model_runtime_max_prefill_chunk_size, 0);
-  ICHECK_GT(model_max_batch_size, 0);
+  TVM_FFI_ICHECK_NE(model_compile_time_max_prefill_chunk_size, std::numeric_limits<int64_t>::max());
+  TVM_FFI_ICHECK_NE(model_runtime_max_prefill_chunk_size, std::numeric_limits<int64_t>::max());
+  TVM_FFI_ICHECK_NE(model_max_batch_size, std::numeric_limits<int64_t>::max());
+  TVM_FFI_ICHECK_GT(model_compile_time_max_prefill_chunk_size, 0);
+  TVM_FFI_ICHECK_GT(model_runtime_max_prefill_chunk_size, 0);
+  TVM_FFI_ICHECK_GT(model_max_batch_size, 0);
   return Result<ModelConfigLimits>::Ok(
       {model_compile_time_max_single_sequence_length, model_runtime_max_single_sequence_length,
        model_compile_time_max_prefill_chunk_size, model_runtime_max_prefill_chunk_size,
@@ -683,7 +683,7 @@ Result<MemUsageEstimationResult> EstimateMemoryUsageOnMode(
   double kv_aux_workspace_bytes = 0;
   double model_workspace_bytes = 0;
   double logit_processor_workspace_bytes = 0;
-  ICHECK_EQ(model_configs.size(), model_metadata.size());
+  TVM_FFI_ICHECK_EQ(model_configs.size(), model_metadata.size());
   int num_models = model_configs.size();
   for (int i = 0; i < num_models; ++i) {
     // - Read the vocab size and compile-time prefill chunk size (which affects memory allocation).
@@ -835,7 +835,7 @@ Result<InferrableEngineConfig> InferrableEngineConfig::InferForKVCache(
     for (const ModelMetadata::Param& param : metadata.params) {
       int64_t param_size = param.dtype.bytes();
       for (int64_t v : param.shape) {
-        ICHECK_GE(v, 0);
+        TVM_FFI_ICHECK_GE(v, 0);
         param_size *= v;
       }
       params_bytes += param_size;
@@ -969,7 +969,7 @@ Result<InferrableEngineConfig> InferrableEngineConfig::InferForRNNState(
     for (const ModelMetadata::Param& param : metadata.params) {
       int64_t param_size = param.dtype.bytes();
       for (int64_t v : param.shape) {
-        ICHECK_GE(v, 0);
+        TVM_FFI_ICHECK_GE(v, 0);
         param_size *= v;
       }
       params_bytes += param_size;
@@ -982,7 +982,7 @@ Result<InferrableEngineConfig> InferrableEngineConfig::InferForRNNState(
   double rnn_state_base_bytes = 0;  // The memory usage for rnn state when history = 1.
   double model_workspace_bytes = 0;
   double logit_processor_workspace_bytes = 0;
-  ICHECK_EQ(model_configs.size(), model_metadata.size());
+  TVM_FFI_ICHECK_EQ(model_configs.size(), model_metadata.size());
   int num_models = model_configs.size();
   for (int i = 0; i < num_models; ++i) {
     // - Read the vocab size and compile-time prefill chunk size (which affects memory allocation).
@@ -1057,7 +1057,7 @@ Result<InferrableEngineConfig> InferrableEngineConfig::InferForRNNState(
 /****************** Config utils ******************/
 
 Result<bool> ModelsUseKVCache(const std::vector<picojson::object>& model_configs) {
-  ICHECK_GE(model_configs.size(), 1);
+  TVM_FFI_ICHECK_GE(model_configs.size(), 1);
   std::string model_type = json::Lookup<std::string>(model_configs[0], "model_type");
   bool use_kv_cache = model_type.find("rwkv") == std::string::npos;
   for (int i = 1; i < static_cast<int>(model_configs.size()); ++i) {

--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -31,10 +31,10 @@ std::pair<Array<Data>, Array<Data>> SplitData(const Array<Data>& original_data, 
   std::vector<Data> lhs(original_data.begin(), original_data.end());
   std::vector<Data> rhs;
   while (total_length > split_pos) {
-    ICHECK(!lhs.empty());
+    TVM_FFI_ICHECK(!lhs.empty());
     Data last_data = lhs.back();
     int last_data_length = last_data->GetLength();
-    ICHECK_GE(total_length - last_data_length, 0);
+    TVM_FFI_ICHECK_GE(total_length - last_data_length, 0);
     if (total_length - last_data_length >= split_pos) {
       // Pop the entire last data.
       rhs.push_back(lhs.back());
@@ -182,7 +182,7 @@ inline void TokenToLogProbJSON(const Tokenizer& tokenizer, const TokenProbPair& 
 int32_t SampleResult::GetTokenId() const { return this->sampled_token_id.first; }
 
 std::string SampleResult::GetLogProbJSON(const Tokenizer& tokenizer, bool logprob) const {
-  ICHECK(top_prob_tokens.empty() || logprob);
+  TVM_FFI_ICHECK(top_prob_tokens.empty() || logprob);
   if (!logprob) {
     // Logprob is not needed.
     return "";

--- a/cpp/serve/draft_token_workspace_manager.cc
+++ b/cpp/serve/draft_token_workspace_manager.cc
@@ -29,7 +29,7 @@ DraftTokenWorkspaceManagerObj::DraftTokenWorkspaceManagerObj(int max_num_tokens,
 }
 
 void DraftTokenWorkspaceManagerObj::AllocSlots(int num_slots, std::vector<int>* result) {
-  ICHECK_LE(num_slots, free_slots_.size());
+  TVM_FFI_ICHECK_LE(num_slots, free_slots_.size());
   result->assign(free_slots_.rbegin(), free_slots_.rbegin() + num_slots);
   free_slots_.resize(free_slots_.size() - num_slots);
   for (int slot : (*result)) {
@@ -40,13 +40,13 @@ void DraftTokenWorkspaceManagerObj::AllocSlots(int num_slots, std::vector<int>* 
 void DraftTokenWorkspaceManagerObj::AllocSlots(int num_slots,
                                                const std::vector<int>& initial_ref_count,
                                                std::vector<int>* result) {
-  ICHECK_LE(num_slots, free_slots_.size());
-  ICHECK_EQ(num_slots, initial_ref_count.size());
+  TVM_FFI_ICHECK_LE(num_slots, free_slots_.size());
+  TVM_FFI_ICHECK_EQ(num_slots, initial_ref_count.size());
   result->assign(free_slots_.rbegin(), free_slots_.rbegin() + num_slots);
   free_slots_.resize(free_slots_.size() - num_slots);
   for (int i = 0; i < num_slots; ++i) {
     int slot = (*result)[i];
-    ICHECK(initial_ref_count[i] > 0);
+    TVM_FFI_ICHECK(initial_ref_count[i] > 0);
     ref_count_[slot] = initial_ref_count[i];
   }
 }

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -295,7 +295,7 @@ class MockEchoEngineImpl : public Engine {
     std::vector<String> finished_request_ids;
     for (auto& kv : request_map_) {
       MockRequestState& state = kv.second;
-      ICHECK_GE(state.reversed_outputs.size(), 2);
+      TVM_FFI_ICHECK_GE(state.reversed_outputs.size(), 2);
       if (state.reversed_outputs.size() == 2) {
         outputs.push_back(state.reversed_outputs.back());
         state.reversed_outputs.pop_back();
@@ -363,7 +363,7 @@ class EngineImpl : public Engine {
         models_and_model_libs_res.Unwrap();
 
     int num_model = models_and_model_libs.size();
-    ICHECK_GE(num_model, 1);
+    TVM_FFI_ICHECK_GE(num_model, 1);
     // - Initialize singleton states inside the engine.
     n->estate_->Reset();
     n->estate_->request_stream_callback_ = std::move(request_stream_callback);
@@ -572,9 +572,9 @@ class EngineImpl : public Engine {
       // - Check the invariant: "end - begin" equals the expanded metadata length.
       CHECK_EQ(disagg_config.kv_append_metadata.size(), models_.size());
       for (const IntTuple& compressed_kv_append_metadata : disagg_config.kv_append_metadata) {
-        ICHECK(!compressed_kv_append_metadata.empty());
+        TVM_FFI_ICHECK(!compressed_kv_append_metadata.empty());
         int num_segments = compressed_kv_append_metadata[0];
-        ICHECK_EQ(compressed_kv_append_metadata.size(), num_segments * 2 + 1);
+        TVM_FFI_ICHECK_EQ(compressed_kv_append_metadata.size(), num_segments * 2 + 1);
         int transmission_length = 0;
         for (int i = 0; i < num_segments; ++i) {
           transmission_length += compressed_kv_append_metadata[i * 2 + 2];
@@ -590,7 +590,7 @@ class EngineImpl : public Engine {
     } else if (kind == DisaggRequestKind::kStartGeneration) {
       auto it_rstate = estate_->request_states.find(request->id);
       CHECK(it_rstate != estate_->request_states.end());
-      ICHECK(!it_rstate->second->entries.empty());
+      TVM_FFI_ICHECK(!it_rstate->second->entries.empty());
       request = it_rstate->second->entries[0]->request;
       CHECK(request->generation_cfg->debug_config.disagg_config.kind ==
             DisaggRequestKind::kPrepareReceive);
@@ -674,7 +674,7 @@ class EngineImpl : public Engine {
 
     // Get a request copy where all text inputs are tokenized.
     request = Request::FromUntokenized(request, tokenizer_);
-    ICHECK_NE(request->prompt_tokens, -1);
+    TVM_FFI_ICHECK_NE(request->prompt_tokens, -1);
 
     if (request->prompt_tokens >= engine_config_->max_single_sequence_length &&
         estate_->request_stream_callback_ != nullptr) {
@@ -759,7 +759,7 @@ class EngineImpl : public Engine {
         return;
       }
     }
-    ICHECK(estate_->running_queue.empty())
+    TVM_FFI_ICHECK(estate_->running_queue.empty())
         << "Internal assumption violated: It is expected that an engine step takes at least one "
            "action (e.g. prefill, decode, etc.) but it does not.";
   }
@@ -776,7 +776,7 @@ class EngineImpl : public Engine {
       if (!StartsWith(model_lib, "system://")) {
         Module executable = ffi::Module::LoadFromFile(model_lib);
         Optional<Function> fload_exec = executable->GetFunction("vm_load_executable");
-        ICHECK(fload_exec.defined()) << "TVM runtime cannot find vm_load_executable";
+        TVM_FFI_ICHECK(fload_exec.defined()) << "TVM runtime cannot find vm_load_executable";
         Module local_vm = fload_exec.value()().cast<Module>();
         local_vm->GetFunction("vm_initialization")
             .value()(static_cast<int>(device.device_type), device.device_id,
@@ -794,7 +794,7 @@ class EngineImpl : public Engine {
     int max_num_stages = 1;
     std::vector<int> model_num_pipeline_stages;
     model_num_pipeline_stages.reserve(model_libs.size());
-    ICHECK_EQ(model_libs.size(), model_configs.size());
+    TVM_FFI_ICHECK_EQ(model_libs.size(), model_configs.size());
     for (int i = 0; i < static_cast<int>(model_libs.size()); ++i) {
       auto [model_num_shards, model_num_stages] =
           f_get_num_shards_num_stages(model_libs[i], model_configs[i]);
@@ -947,14 +947,14 @@ class EngineImpl : public Engine {
       return TResult::Error(inferrable_cfg_res.UnwrapErr());
     }
     inferrable_cfg = inferrable_cfg_res.Unwrap();
-    ICHECK(inferrable_cfg.max_num_sequence.has_value());
-    ICHECK(inferrable_cfg.max_total_sequence_length.has_value());
+    TVM_FFI_ICHECK(inferrable_cfg.max_num_sequence.has_value());
+    TVM_FFI_ICHECK(inferrable_cfg.max_total_sequence_length.has_value());
     use_kv_cache = ModelsUseKVCache(model_configs);
     if (use_kv_cache.Unwrap()) {
-      ICHECK(inferrable_cfg.max_single_sequence_length.has_value());
+      TVM_FFI_ICHECK(inferrable_cfg.max_single_sequence_length.has_value());
     }
-    ICHECK(inferrable_cfg.prefill_chunk_size.has_value());
-    ICHECK(inferrable_cfg.max_history_size.has_value());
+    TVM_FFI_ICHECK(inferrable_cfg.prefill_chunk_size.has_value());
+    TVM_FFI_ICHECK(inferrable_cfg.max_history_size.has_value());
     return TResult::Ok(EngineConfig::FromJSONAndInferredConfig(config, inferrable_cfg));
   }
 
@@ -1079,7 +1079,7 @@ class EngineModule : public ffi::ModuleObj {
 
  private:
   Engine* GetEngine() {
-    ICHECK(engine_ != nullptr) << "Engine is not initialized via init";
+    TVM_FFI_ICHECK(engine_ != nullptr) << "Engine is not initialized via init";
     return engine_.get();
   }
 

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -21,7 +21,7 @@ Array<EngineAction> CreateEngineActions(
   ModelMetadata model_metadata = models[0]->GetMetadata();
   if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
     // Speculative decoding is only possible for more than one model.
-    ICHECK_GT(models.size(), 1U);
+    TVM_FFI_ICHECK_GT(models.size(), 1U);
     if (engine_config->speculative_mode == SpeculativeMode::kEagle) {
       CHECK_GT(engine_config->spec_draft_length, 0)
           << "The automatic spec decoding does not support Eagle mode as of now.";
@@ -178,7 +178,7 @@ void ProcessFinishedRequestStateEntries(
   // - Remove the finished request state entries.
   for (const RequestStateEntry& rsentry : finished_rsentries) {
     // The finished entry must be a leaf.
-    ICHECK(rsentry->child_indices.empty());
+    TVM_FFI_ICHECK(rsentry->child_indices.empty());
     // Mark the status of this entry as finished.
     rsentry->status = RequestStateStatus::kFinished;
     // Remove the request state entry from all the models.
@@ -213,7 +213,7 @@ void ProcessFinishedRequestStateEntries(
       // Remove from running queue and engine state.
       auto it =
           std::find(estate->running_queue.begin(), estate->running_queue.end(), rsentry->request);
-      ICHECK(it != estate->running_queue.end());
+      TVM_FFI_ICHECK(it != estate->running_queue.end());
       estate->running_queue.erase(it);
       estate->request_states.erase(rsentry->request->id);
 
@@ -329,7 +329,7 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
     EngineState estate, const Array<Model>& models,
     Optional<DraftTokenWorkspaceManager> draft_token_workspace_manager,
     Optional<EventTraceRecorder> trace_recorder) {
-  ICHECK(!estate->running_queue.empty());
+  TVM_FFI_ICHECK(!estate->running_queue.empty());
   Request request = estate->running_queue.back();
 
   // Find the last alive request state entry, which is what we want to preempt.
@@ -341,7 +341,7 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
       break;
     }
   }
-  ICHECK_NE(preempt_rstate_idx, -1);
+  TVM_FFI_ICHECK_NE(preempt_rstate_idx, -1);
   RequestStateEntry rsentry = rstate->entries[preempt_rstate_idx];
   if (estate->disaggregation) {
     AbortRequestImpl(estate, models, request->id, "preempt");

--- a/cpp/serve/engine_actions/auto_spec_decode.cc
+++ b/cpp/serve/engine_actions/auto_spec_decode.cc
@@ -35,7 +35,7 @@ class AutoSpecDecodeActionObj : public EngineActionObj {
 
     // Calculate the draft length to use for the next round decode.
     estate->spec_draft_length = CalculateDraftLength(estate, num_running_rsentries);
-    ICHECK_GE(estate->spec_draft_length, 0);
+    TVM_FFI_ICHECK_GE(estate->spec_draft_length, 0);
     Array<Request> processed_requests;
     // Use speculative decoding when the computed draft length is positive.
     // Otherwise use normal mode batch decode.

--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -69,10 +69,10 @@ class BatchDecodeActionObj : public EngineActionObj {
 
     // NOTE: Right now we only support decode all the running request states at a time.
     int num_rsentries = running_rsentries.size();
-    ICHECK_GT(num_rsentries, 0)
+    TVM_FFI_ICHECK_GT(num_rsentries, 0)
         << "There should be at least one request state entry that can run decode. "
            "Possible failure reason: none of the prefill phase of the running requests is finished";
-    ICHECK_LE(num_rsentries, engine_config_->max_num_sequence)
+    TVM_FFI_ICHECK_LE(num_rsentries, engine_config_->max_num_sequence)
         << "The number of running requests exceeds the max number of sequence in EngineConfig. "
            "Possible failure reason: the prefill action allows new sequence in regardless of the "
            "max num sequence.";
@@ -101,9 +101,9 @@ class BatchDecodeActionObj : public EngineActionObj {
       NVTXScopedRange nvtx_scope("BatchDecode setting batch info");
       for (const RequestStateEntry& rsentry : running_rsentries) {
         auto mstate = rsentry->mstates[0];
-        ICHECK(mstate->num_tokens_for_next_decode > 0 &&
-               mstate->num_tokens_for_next_decode <=
-                   static_cast<int>(mstate->committed_tokens.size()));
+        TVM_FFI_ICHECK(mstate->num_tokens_for_next_decode > 0 &&
+                       mstate->num_tokens_for_next_decode <=
+                           static_cast<int>(mstate->committed_tokens.size()));
 
         for (auto begin = mstate->committed_tokens.end() - mstate->num_tokens_for_next_decode;
              begin != mstate->committed_tokens.end(); ++begin) {
@@ -136,14 +136,14 @@ class BatchDecodeActionObj : public EngineActionObj {
     Tensor logits;
     if (is_every_request_single_token) {
       logits = models_[0]->BatchDecode(embeddings, request_internal_ids);
-      ICHECK_EQ(logits->ndim, 3);
-      ICHECK_EQ(logits->shape[0], num_rsentries);
-      ICHECK_EQ(logits->shape[1], 1);
+      TVM_FFI_ICHECK_EQ(logits->ndim, 3);
+      TVM_FFI_ICHECK_EQ(logits->shape[0], num_rsentries);
+      TVM_FFI_ICHECK_EQ(logits->shape[1], 1);
     } else {
       logits = models_[0]->BatchPrefill(embeddings, request_internal_ids, lengths);
-      ICHECK_EQ(logits->ndim, 3);
-      ICHECK_EQ(logits->shape[0], 1);
-      ICHECK_EQ(logits->shape[1], num_rsentries);
+      TVM_FFI_ICHECK_EQ(logits->ndim, 3);
+      TVM_FFI_ICHECK_EQ(logits->shape[0], 1);
+      TVM_FFI_ICHECK_EQ(logits->shape[1], num_rsentries);
     }
     RECORD_EVENT(trace_recorder_, request_ids, "finish decode");
 
@@ -167,7 +167,7 @@ class BatchDecodeActionObj : public EngineActionObj {
         probs_on_device, sample_indices, request_ids, generation_cfg);
     std::vector<SampleResult> sample_results = sampler_->BatchSampleTokensWithProbAfterTopP(
         renormalized_probs, sample_indices, request_ids, generation_cfg, rngs);
-    ICHECK_EQ(sample_results.size(), num_rsentries);
+    TVM_FFI_ICHECK_EQ(sample_results.size(), num_rsentries);
 
     // - Update the committed tokens of states.
     for (int i = 0; i < num_rsentries; ++i) {

--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -48,7 +48,7 @@ class BatchVerifyActionObj : public EngineActionObj {
     }
 
     const auto& [rsentries, verify_lengths, total_verify_length] = GetDraftsToVerify(estate);
-    ICHECK_EQ(rsentries.size(), verify_lengths.size());
+    TVM_FFI_ICHECK_EQ(rsentries.size(), verify_lengths.size());
     if (rsentries.empty()) {
       return {};
     }
@@ -84,9 +84,9 @@ class BatchVerifyActionObj : public EngineActionObj {
       RequestModelState verify_mstate = rsentries[i]->mstates[verify_model_id_];
       RequestModelState draft_mstate = rsentries[i]->mstates[draft_model_id_];
       request_internal_ids.push_back(verify_mstate->internal_id);
-      ICHECK(!verify_lengths.empty());
-      ICHECK_EQ(verify_lengths[i], draft_mstate->draft_output_tokens.size() + 1);
-      ICHECK_EQ(verify_lengths[i], draft_mstate->draft_token_slots.size() + 1);
+      TVM_FFI_ICHECK(!verify_lengths.empty());
+      TVM_FFI_ICHECK_EQ(verify_lengths[i], draft_mstate->draft_output_tokens.size() + 1);
+      TVM_FFI_ICHECK_EQ(verify_lengths[i], draft_mstate->draft_token_slots.size() + 1);
       // the last committed token + all the draft tokens.
       draft_token_slots_.push_back(0);  // placeholder for the last committed token
       all_tokens_to_verify.push_back(draft_mstate->committed_tokens.back().GetTokenId());
@@ -121,9 +121,9 @@ class BatchVerifyActionObj : public EngineActionObj {
     Tensor logits = models_[verify_model_id_]->BatchVerify(embeddings, request_internal_ids,
                                                            verify_lengths, token_tree_parent_ptr);
     RECORD_EVENT(trace_recorder_, request_ids, "finish verify");
-    ICHECK_EQ(logits->ndim, 3);
-    ICHECK_EQ(logits->shape[0], 1);
-    ICHECK_EQ(logits->shape[1], total_verify_length);
+    TVM_FFI_ICHECK_EQ(logits->ndim, 3);
+    TVM_FFI_ICHECK_EQ(logits->shape[0], 1);
+    TVM_FFI_ICHECK_EQ(logits->shape[1], total_verify_length);
 
     // - Update logits.
     std::vector<int> cum_verify_lengths = {0};
@@ -153,7 +153,7 @@ class BatchVerifyActionObj : public EngineActionObj {
         sampler_->BatchVerifyDraftTokensWithProbAfterTopP(
             renormalized_probs, request_ids, cum_verify_lengths, generation_cfg, rngs,
             draft_output_tokens, token_tree_parent_ptr, draft_probs_on_device);
-    ICHECK_EQ(sample_results_arr.size(), num_rsentries);
+    TVM_FFI_ICHECK_EQ(sample_results_arr.size(), num_rsentries);
 
     // We collect the requests whose drafts are fully accepted.
     // When a request's draft is fully accepted, there is an extra token proposed
@@ -236,7 +236,7 @@ class BatchVerifyActionObj : public EngineActionObj {
             rsentries[rsentry_id]->mstates[verify_model_id_]->committed_tokens.size();
         // When a request's draft is fully accepted, an additional new token is sampled.
         // So the token needed to fill in the draft model is the committed_token[-2].
-        ICHECK_GE(num_committed_tokens, 2);
+        TVM_FFI_ICHECK_GE(num_committed_tokens, 2);
         input_tokens.push_back(rsentries[rsentry_id]
                                    ->mstates[verify_model_id_]
                                    ->committed_tokens[num_committed_tokens - 2]

--- a/cpp/serve/engine_actions/disagg_prepare_recv.cc
+++ b/cpp/serve/engine_actions/disagg_prepare_recv.cc
@@ -83,12 +83,12 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
         if (prefill_length == -1) {
           prefill_length = input_length;
         } else {
-          ICHECK_EQ(prefill_length, input_length);
+          TVM_FFI_ICHECK_EQ(prefill_length, input_length);
         }
         mstate->num_prefilled_tokens += input_length;
 
-        ICHECK(mstate->draft_output_tokens.empty());
-        ICHECK(mstate->draft_token_slots.empty());
+        TVM_FFI_ICHECK(mstate->draft_output_tokens.empty());
+        TVM_FFI_ICHECK(mstate->draft_token_slots.empty());
         if (status_before_prefill[0] == RequestStateStatus::kPending &&
             !estate->prefix_cache->HasSequence(mstate->internal_id)) {
           // Add the sequence to the model, or fork the sequence from its parent.
@@ -134,7 +134,7 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
       // - Remove the request from the waiting queue.
       auto it_request =
           std::find(estate->waiting_queue.begin(), estate->waiting_queue.end(), request);
-      ICHECK(it_request != estate->waiting_queue.end());
+      TVM_FFI_ICHECK(it_request != estate->waiting_queue.end());
       estate->waiting_queue.erase(it_request);
 
       {
@@ -149,9 +149,9 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
           for (int64_t value : compressed_kv_append_metadata) {
             kv_append_metadata_arr.push_back(picojson::value(value));
           }
-          ICHECK(!compressed_kv_append_metadata.empty());
+          TVM_FFI_ICHECK(!compressed_kv_append_metadata.empty());
           int num_segments = compressed_kv_append_metadata[0];
-          ICHECK_EQ(compressed_kv_append_metadata.size(), num_segments * 2 + 1);
+          TVM_FFI_ICHECK_EQ(compressed_kv_append_metadata.size(), num_segments * 2 + 1);
           int transmission_length = 0;
           for (int i = 0; i < num_segments; ++i) {
             transmission_length += compressed_kv_append_metadata[i * 2 + 2];
@@ -267,7 +267,7 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
         num_required_pages_under_sliding_window =
             max_single_request_page_requirement - num_pages_in_use;
         num_require_pages = std::min(num_require_pages, num_required_pages_under_sliding_window);
-        ICHECK_GE(num_require_pages, 0);
+        TVM_FFI_ICHECK_GE(num_require_pages, 0);
       }
 
       // Check if the entire request state entry can fit for prefill.
@@ -302,16 +302,16 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
     }
 
     // Prefill inputs of all models should be the same.
-    ICHECK(!prefill_input_for_all_models.empty());
+    TVM_FFI_ICHECK(!prefill_input_for_all_models.empty());
     PrefillInput prefill_input = prefill_input_for_all_models[0];
     {
       NVTXScopedRange nvtx_scope("reduction");
       for (int i = 1; i < static_cast<int>(prefill_input_for_all_models.size()); ++i) {
-        ICHECK(prefill_input_for_all_models[i].rsentry.same_as(prefill_input.rsentry));
-        ICHECK_EQ(prefill_input_for_all_models[i].max_prefill_length,
-                  prefill_input.max_prefill_length);
-        ICHECK_EQ(prefill_input_for_all_models[i].num_child_to_activate,
-                  prefill_input.num_child_to_activate);
+        TVM_FFI_ICHECK(prefill_input_for_all_models[i].rsentry.same_as(prefill_input.rsentry));
+        TVM_FFI_ICHECK_EQ(prefill_input_for_all_models[i].max_prefill_length,
+                          prefill_input.max_prefill_length);
+        TVM_FFI_ICHECK_EQ(prefill_input_for_all_models[i].num_child_to_activate,
+                          prefill_input.num_child_to_activate);
       }
     }
 

--- a/cpp/serve/engine_actions/disagg_remote_send.cc
+++ b/cpp/serve/engine_actions/disagg_remote_send.cc
@@ -85,12 +85,12 @@ class DisaggRemoteSendActionObj : public BatchPrefillBaseActionObj {
         if (prefill_lengths[i] == -1) {
           prefill_lengths[i] = input_length;
         } else {
-          ICHECK_EQ(prefill_lengths[i], input_length);
+          TVM_FFI_ICHECK_EQ(prefill_lengths[i], input_length);
         }
         mstate->num_prefilled_tokens += input_length;
 
-        ICHECK(mstate->draft_output_tokens.empty());
-        ICHECK(mstate->draft_token_slots.empty());
+        TVM_FFI_ICHECK(mstate->draft_output_tokens.empty());
+        TVM_FFI_ICHECK(mstate->draft_token_slots.empty());
         if (status_before_prefill[i] == RequestStateStatus::kPending &&
             !estate->prefix_cache->HasSequence(mstate->internal_id)) {
           // Add the sequence to the model.
@@ -147,9 +147,9 @@ class DisaggRemoteSendActionObj : public BatchPrefillBaseActionObj {
       Tensor logits =
           models_[model_id]->BatchPrefill(embeddings, request_internal_ids, prefill_lengths);
       RECORD_EVENT(trace_recorder_, request_ids, "finish prefill");
-      ICHECK_EQ(logits->ndim, 3);
-      ICHECK_EQ(logits->shape[0], 1);
-      ICHECK_EQ(logits->shape[1], num_rsentries);
+      TVM_FFI_ICHECK_EQ(logits->ndim, 3);
+      TVM_FFI_ICHECK_EQ(logits->shape[0], 1);
+      TVM_FFI_ICHECK_EQ(logits->shape[1], num_rsentries);
     }
 
     // - Commit the prefix cache changes from previous round of action.
@@ -254,7 +254,7 @@ class DisaggRemoteSendActionObj : public BatchPrefillBaseActionObj {
           num_required_pages_under_sliding_window =
               max_single_request_page_requirement - num_pages_in_use;
           num_require_pages = std::min(num_require_pages, num_required_pages_under_sliding_window);
-          ICHECK_GE(num_require_pages, 0);
+          TVM_FFI_ICHECK_GE(num_require_pages, 0);
         }
 
         total_input_length += input_length;
@@ -293,7 +293,7 @@ class DisaggRemoteSendActionObj : public BatchPrefillBaseActionObj {
         total_required_pages -= num_require_pages;
 
         // - Attempt 2. Check if the request state entry can partially fit by input chunking.
-        ICHECK_LE(total_input_length, engine_config_->prefill_chunk_size);
+        TVM_FFI_ICHECK_LE(total_input_length, engine_config_->prefill_chunk_size);
         if (engine_config_->prefill_chunk_size - total_input_length >= input_length ||
             engine_config_->prefill_chunk_size == total_input_length) {
           // 1. If the input length can fit the remaining prefill chunk size,
@@ -310,7 +310,7 @@ class DisaggRemoteSendActionObj : public BatchPrefillBaseActionObj {
         if (sliding_window_enabled) {
           // Sliding window for model i is enabled.
           num_require_pages = std::min(num_require_pages, num_required_pages_under_sliding_window);
-          ICHECK_GE(num_require_pages, 0);
+          TVM_FFI_ICHECK_GE(num_require_pages, 0);
         }
 
         {
@@ -331,7 +331,7 @@ class DisaggRemoteSendActionObj : public BatchPrefillBaseActionObj {
     }
 
     // Reduce over the prefill inputs of all models.
-    ICHECK(!prefill_inputs_for_all_models.empty());
+    TVM_FFI_ICHECK(!prefill_inputs_for_all_models.empty());
     int num_prefill_inputs = prefill_inputs_for_all_models[0].size();
     for (int i = 1; i < static_cast<int>(prefill_inputs_for_all_models.size()); ++i) {
       num_prefill_inputs =
@@ -350,15 +350,16 @@ class DisaggRemoteSendActionObj : public BatchPrefillBaseActionObj {
       for (int i = 1; i < static_cast<int>(prefill_inputs_for_all_models.size()); ++i) {
         // Prefill input lengths except the last one are supposed to be the same for all models.
         for (int j = 0; j < num_prefill_inputs - 1; ++j) {
-          ICHECK(prefill_inputs_for_all_models[i][j].rsentry.same_as(prefill_inputs[j].rsentry));
-          ICHECK_EQ(prefill_inputs_for_all_models[i][j].max_prefill_length,
-                    prefill_inputs[j].max_prefill_length);
+          TVM_FFI_ICHECK(
+              prefill_inputs_for_all_models[i][j].rsentry.same_as(prefill_inputs[j].rsentry));
+          TVM_FFI_ICHECK_EQ(prefill_inputs_for_all_models[i][j].max_prefill_length,
+                            prefill_inputs[j].max_prefill_length);
           prefill_inputs[j].num_child_to_activate =
               std::min(prefill_inputs[j].num_child_to_activate,
                        prefill_inputs_for_all_models[i][j].num_child_to_activate);
         }
         // The input length of the last input is the minimum among all models.
-        ICHECK(prefill_inputs_for_all_models[i][num_prefill_inputs - 1].rsentry.same_as(
+        TVM_FFI_ICHECK(prefill_inputs_for_all_models[i][num_prefill_inputs - 1].rsentry.same_as(
             prefill_inputs[num_prefill_inputs - 1].rsentry));
         prefill_inputs[num_prefill_inputs - 1].max_prefill_length =
             std::min(prefill_inputs[num_prefill_inputs - 1].max_prefill_length,

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -80,8 +80,8 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
       for (int i = 0; i < num_rsentries; ++i) {
         const RequestStateEntry& rsentry = prefill_inputs[i].rsentry;
         RequestModelState mstate = rsentry->mstates[model_id];
-        ICHECK(mstate->draft_output_tokens.empty());
-        ICHECK(mstate->draft_token_slots.empty());
+        TVM_FFI_ICHECK(mstate->draft_output_tokens.empty());
+        TVM_FFI_ICHECK(mstate->draft_token_slots.empty());
         if (status_before_prefill[i] == RequestStateStatus::kPending) {
           if (!estate->prefix_cache->HasSequence(mstate->internal_id)) {
             // Add the sequence to the model, or fork the sequence from its parent.
@@ -104,7 +104,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
           // Shift the input tokens by 1 for eagle models.
           if (model_id == 0) {
             for (int j = 1; j < static_cast<int>(models_.size()); ++j) {
-              ICHECK(rsentry->mstates[j]->inputs.size());
+              TVM_FFI_ICHECK(rsentry->mstates[j]->inputs.size());
               TokenData token_data = Downcast<TokenData>(rsentry->mstates[j]->inputs[0]);
               rsentry->mstates[j]->inputs.Set(
                   0, TokenData(
@@ -123,7 +123,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
         if (prefill_lengths[i] == -1) {
           prefill_lengths[i] = input_length;
         } else {
-          ICHECK_EQ(prefill_lengths[i], input_length);
+          TVM_FFI_ICHECK_EQ(prefill_lengths[i], input_length);
         }
         mstate->num_prefilled_tokens += input_length;
 
@@ -250,8 +250,8 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
             rsentry_activated.push_back(true);
             --remaining_num_child_to_activate;
             if (model_id == 0) {
-              ICHECK(rstates_of_entries[i]->entries[child_idx]->status ==
-                     RequestStateStatus::kPending);
+              TVM_FFI_ICHECK(rstates_of_entries[i]->entries[child_idx]->status ==
+                             RequestStateStatus::kPending);
               rstates_of_entries[i]->entries[child_idx]->status = RequestStateStatus::kAlive;
             }
             int64_t child_internal_id =
@@ -276,7 +276,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
       }
 
       // - Prepare input for logit processor.
-      ICHECK(logits_for_sample.defined());
+      TVM_FFI_ICHECK(logits_for_sample.defined());
       Array<GenerationConfig> generation_cfg;
       Array<RequestModelState> mstates_for_logitproc;
       std::vector<int> sample_indices(num_rsentries);
@@ -318,7 +318,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
                                                 estate, child_sample_indices);
         }
       } else if (engine_config_->speculative_mode == SpeculativeMode::kMedusa) {
-        ICHECK_NE(estate->spec_draft_length, 0);
+        TVM_FFI_ICHECK_NE(estate->spec_draft_length, 0);
         for (int draft_id = 0; draft_id < estate->spec_draft_length; ++draft_id) {
           const auto& [renormalized_probs, sample_results] = ApplyLogitProcessorAndSample(
               logit_processor_, sampler_, multi_step_logits[draft_id], generation_cfg, request_ids,

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -75,12 +75,12 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
         if (prefill_lengths[i] == -1) {
           prefill_lengths[i] = input_length;
         } else {
-          ICHECK_EQ(prefill_lengths[i], input_length);
+          TVM_FFI_ICHECK_EQ(prefill_lengths[i], input_length);
         }
         mstate->num_prefilled_tokens += input_length;
 
-        ICHECK(mstate->draft_output_tokens.empty());
-        ICHECK(mstate->draft_token_slots.empty());
+        TVM_FFI_ICHECK(mstate->draft_output_tokens.empty());
+        TVM_FFI_ICHECK(mstate->draft_token_slots.empty());
         if (status_before_prefill[i] == RequestStateStatus::kPending &&
             !estate->prefix_cache->HasSequence(mstate->internal_id)) {
           // Add the sequence to the model, or fork the sequence from its parent.
@@ -137,9 +137,9 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
       Tensor logits =
           models_[model_id]->BatchPrefill(embeddings, request_internal_ids, prefill_lengths);
       RECORD_EVENT(trace_recorder_, request_ids, "finish prefill");
-      ICHECK_EQ(logits->ndim, 3);
-      ICHECK_EQ(logits->shape[0], 1);
-      ICHECK_EQ(logits->shape[1], num_rsentries);
+      TVM_FFI_ICHECK_EQ(logits->ndim, 3);
+      TVM_FFI_ICHECK_EQ(logits->shape[0], 1);
+      TVM_FFI_ICHECK_EQ(logits->shape[1], num_rsentries);
 
       if (model_id == 0) {
         // We only need to sample for model 0 in prefill.
@@ -148,7 +148,7 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
     }
 
     // - Update logits.
-    ICHECK(logits_for_sample.defined());
+    TVM_FFI_ICHECK(logits_for_sample.defined());
     Array<GenerationConfig> generation_cfg;
     Array<RequestModelState> mstates_for_logitproc;
     generation_cfg.reserve(num_rsentries);
@@ -207,7 +207,8 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
         generation_cfg.push_back(rsentry->request->generation_cfg);
         rngs.push_back(&rstates_of_entries[i]->entries[child_idx]->rng);
 
-        ICHECK(rstates_of_entries[i]->entries[child_idx]->status == RequestStateStatus::kPending);
+        TVM_FFI_ICHECK(rstates_of_entries[i]->entries[child_idx]->status ==
+                       RequestStateStatus::kPending);
         // We only fork the first `num_child_to_activate` children.
         // The children not being forked will be forked via later prefills.
         // Usually `num_child_to_activate` is the same as the number of children.
@@ -244,7 +245,7 @@ class NewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
         probs_on_device, sample_indices, request_ids, generation_cfg);
     std::vector<SampleResult> sample_results = sampler_->BatchSampleTokensWithProbAfterTopP(
         renormalized_probs, sample_indices, request_ids, generation_cfg, rngs);
-    ICHECK_EQ(sample_results.size(), rsentries_for_sample.size());
+    TVM_FFI_ICHECK_EQ(sample_results.size(), rsentries_for_sample.size());
 
     // - Update the committed tokens of states.
     // - If a request is first-time prefilled, set the prefill finish time.

--- a/cpp/serve/engine_state.cc
+++ b/cpp/serve/engine_state.cc
@@ -26,7 +26,7 @@ void EngineStateObj::Reset() {
 }
 
 RequestState EngineStateObj::GetRequestState(Request request) {
-  ICHECK(request->rstate != nullptr) << "The state of the request has not been defined.";
+  TVM_FFI_ICHECK(request->rstate != nullptr) << "The state of the request has not been defined.";
   return GetRef<RequestState>(static_cast<RequestStateNode*>(request->rstate));
 }
 

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -72,7 +72,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
 
   int num_workers = num_shards * num_stages;
   if (num_workers > 1) {
-    ICHECK(session.defined());
+    TVM_FFI_ICHECK(session.defined());
     this->sess = session.value();
     this->use_disco = true;
     this->disco_mod = sess->CallPacked(sess->GetGlobalFunc("runtime.disco.load_vm_module"),
@@ -100,7 +100,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
         this->disco_mod.value()->DebugGetFromRemote(0).cast<Module>(), std::move(model_config));
     this->_InitFunctions();
   } else {
-    ICHECK(!session.defined());
+    TVM_FFI_ICHECK(!session.defined());
     Optional<Module> executable = std::nullopt;
     Optional<Function> fload_exec;
     if (StartsWith(reload_lib_path, "system://")) {
@@ -109,7 +109,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
       std::replace(system_lib_prefix.begin(), system_lib_prefix.end(), /*old=*/'-', /*new=*/'_');
       executable = f_load_system_lib(system_lib_prefix + "_").cast<Module>();
       fload_exec = executable.value()->GetFunction("vm_load_executable");
-      ICHECK(fload_exec.defined())
+      TVM_FFI_ICHECK(fload_exec.defined())
           << "Cannot find system lib with " << system_lib_prefix
           << ", please make sure you set model_lib field consistently with the compilation ";
     } else {
@@ -124,7 +124,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
         CHECK(f_set.defined()) << "Cannot find opencl.SetPreCompiledPrograms";
         f_set.value()(tvm::ffi::String(bytes));
       }
-      ICHECK(fload_exec.defined()) << "TVM runtime cannot find vm_load_executable";
+      TVM_FFI_ICHECK(fload_exec.defined()) << "TVM runtime cannot find vm_load_executable";
     }
     this->use_disco = false;
     this->local_vm = fload_exec.value()().cast<Module>();
@@ -144,8 +144,8 @@ void FunctionTable::Init(String reload_lib_path, Device device, picojson::object
         ModelMetadata::FromModule(this->local_vm.value(), std::move(model_config));
     this->_InitFunctions();
   }
-  ICHECK_EQ(this->model_metadata_.tensor_parallel_shards, num_shards);
-  ICHECK_EQ(this->model_metadata_.pipeline_parallel_stages, num_stages);
+  TVM_FFI_ICHECK_EQ(this->model_metadata_.tensor_parallel_shards, num_shards);
+  TVM_FFI_ICHECK_EQ(this->model_metadata_.pipeline_parallel_stages, num_stages);
   // Invoke the CUDA graph allocation init function if it is defined.
   if (cuda_graph_alloc_init_func_.defined()) {
     this->cuda_graph_alloc_init_func_();

--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -113,7 +113,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
 
     CHECK((draft_mstates == nullptr) == (draft_token_indices == nullptr));
     if (cum_num_token != nullptr) {
-      ICHECK(draft_mstates != nullptr);
+      TVM_FFI_ICHECK(draft_mstates != nullptr);
       CHECK_EQ(cum_num_token->size(), num_sequence + 1);
       CHECK_EQ(cum_num_token->back(), num_total_token);
     } else {
@@ -196,10 +196,10 @@ class LogitProcessorImpl : public LogitProcessorObj {
     Tensor probs = softmax_func_(logits.CreateView({num_total_token, 1, vocab_size_}, dtype_f32_),
                                  temperature_device)
                        .cast<Tensor>();
-    ICHECK_EQ(probs->ndim, 3);
-    ICHECK_EQ(probs->shape[0], num_total_token);
-    ICHECK_EQ(probs->shape[1], 1);
-    ICHECK_EQ(probs->shape[2], vocab_size_);
+    TVM_FFI_ICHECK_EQ(probs->ndim, 3);
+    TVM_FFI_ICHECK_EQ(probs->shape[0], num_total_token);
+    TVM_FFI_ICHECK_EQ(probs->shape[1], 1);
+    TVM_FFI_ICHECK_EQ(probs->shape[2], vocab_size_);
     if (trace_recorder_.defined()) {
       DeviceAPI::Get(device_)->StreamSync(device_, /*stream=*/nullptr);
     }
@@ -294,8 +294,8 @@ class LogitProcessorImpl : public LogitProcessorObj {
             cum_num_token == nullptr ? 1 : (cum_num_token->at(i + 1) - cum_num_token->at(i));
         int token_offset = cum_num_token == nullptr ? i : cum_num_token->at(i);
         CHECK(num_token_to_process == 1 || mstates[i]->draft_output_tokens.empty());
-        ICHECK(draft_token_indices == nullptr ||
-               draft_token_indices->at(i).size() == num_token_to_process);
+        TVM_FFI_ICHECK(draft_token_indices == nullptr ||
+                       draft_token_indices->at(i).size() == num_token_to_process);
         for (int j = 0; j < num_token_to_process; ++j) {
           p_seq_ids[num_token_for_penalty] = token_offset + j;
 
@@ -380,8 +380,8 @@ class LogitProcessorImpl : public LogitProcessorObj {
 
     // - Set arrays.
     int batch_size = logits->shape[0];
-    ICHECK((cum_num_token == nullptr && batch_size == mstates.size()) ||
-           (cum_num_token != nullptr && batch_size == cum_num_token->back()));
+    TVM_FFI_ICHECK((cum_num_token == nullptr && batch_size == mstates.size()) ||
+                   (cum_num_token != nullptr && batch_size == cum_num_token->back()));
 
     std::memset(p_seq_ids, 0, batch_size * sizeof(int32_t));
 
@@ -390,7 +390,8 @@ class LogitProcessorImpl : public LogitProcessorObj {
       int token_number =
           cum_num_token == nullptr ? 1 : (cum_num_token->at(i + 1) - cum_num_token->at(i));
       bool require_mask = mstates[i]->RequireNextTokenBitmask();
-      ICHECK(draft_token_indices == nullptr || draft_token_indices->at(i).size() == token_number);
+      TVM_FFI_ICHECK(draft_token_indices == nullptr ||
+                     draft_token_indices->at(i).size() == token_number);
       for (int j = 0; j < token_number; ++j) {
         if (require_mask) {
           std::vector<SampleResult> draft_token_seq;

--- a/cpp/serve/metrics.cc
+++ b/cpp/serve/metrics.cc
@@ -34,7 +34,7 @@ picojson::object SpecDecodeMetrics::AsJSON() const {
   metrics["draft_count"] = f_vector_to_array(draft_count);
   metrics["accept_count"] = f_vector_to_array(accept_count);
 
-  ICHECK_EQ(draft_count.size(), accept_count.size());
+  TVM_FFI_ICHECK_EQ(draft_count.size(), accept_count.size());
   // NOTE: label follows prometheus with full context
   // so it can be flattened and used in metrics reoorting end point
   picojson::object accept_prob_metrics;

--- a/cpp/serve/metrics.h
+++ b/cpp/serve/metrics.h
@@ -69,7 +69,7 @@ struct SpecDecodeMetrics {
    * \param accept_length The number of accepted tokens in the speculative decoding.
    */
   void Update(int draft_length, int accept_length) {
-    ICHECK_GE(accept_length, 1);
+    TVM_FFI_ICHECK_GE(accept_length, 1);
     if (accept_count.size() < draft_length) {
       this->accept_count.resize(draft_length, 0);
       this->draft_count.resize(draft_length, 0);

--- a/cpp/serve/request.cc
+++ b/cpp/serve/request.cc
@@ -61,7 +61,7 @@ Request Request::FromUntokenized(const Request& request, const Tokenizer& tokeni
 
   // If there is no untokenized input, we don't need to create a new request.
   if (!has_untokenized_input) {
-    ICHECK_NE(request->prompt_tokens, -1);
+    TVM_FFI_ICHECK_NE(request->prompt_tokens, -1);
     return request;
   } else {
     return Request(request->id, std::move(inputs), request->generation_cfg);

--- a/cpp/serve/request_state.cc
+++ b/cpp/serve/request_state.cc
@@ -46,7 +46,7 @@ int RequestModelStateNode::GetInputLength() const {
 bool RequestModelStateNode::RequireNextTokenBitmask() { return grammar_matcher.has_value(); }
 
 void RequestModelStateNode::GetNextTokenBitmask(DLTensor* bitmask) {
-  ICHECK(grammar_matcher.has_value());
+  TVM_FFI_ICHECK(grammar_matcher.has_value());
 
   grammar_matcher->GetNextTokenBitmask(bitmask);
 }
@@ -60,13 +60,13 @@ void RequestModelStateNode::CommitToken(SampleResult sampled_token) {
   // Update the grammar matcher state if it exists.
   if (grammar_matcher) {
     bool accepted = grammar_matcher->AcceptToken(sampled_token.GetTokenId());
-    ICHECK(accepted) << "Token id " << sampled_token.GetTokenId()
-                     << " is not accepted by the grammar state matcher.";
+    TVM_FFI_ICHECK(accepted) << "Token id " << sampled_token.GetTokenId()
+                             << " is not accepted by the grammar state matcher.";
   }
 }
 
 void RequestModelStateNode::RollbackTokens(int count) {
-  ICHECK(count <= static_cast<int>(committed_tokens.size()));
+  TVM_FFI_ICHECK(count <= static_cast<int>(committed_tokens.size()));
   for (int i = 0; i < count; ++i) {
     auto it = appeared_token_ids.find(committed_tokens.back().GetTokenId());
     CHECK(it != appeared_token_ids.end());
@@ -119,7 +119,7 @@ RequestStreamOutput RequestActionPostProcWorkspace::GetStreamOutput() {
     }
   }
 
-  ICHECK(!stream_outputs.empty());
+  TVM_FFI_ICHECK(!stream_outputs.empty());
   int num_response = stream_outputs[0]->group_delta_token_ids.size();
   std::vector<std::vector<int64_t>> group_delta_token_ids;
   std::vector<std::vector<String>> group_delta_logprob_json_strs;
@@ -186,7 +186,7 @@ void RequestStateEntryNode::GetDeltaRequestReturn(const Tokenizer& tokenizer,
 
   const std::vector<SampleResult>& committed_tokens = this->mstates[0]->committed_tokens;
   int num_committed_tokens = committed_tokens.size();
-  ICHECK_LE(this->next_callback_token_pos, num_committed_tokens);
+  TVM_FFI_ICHECK_LE(this->next_callback_token_pos, num_committed_tokens);
 
   // Case 1. There is no new token ids.
   if (this->next_callback_token_pos == num_committed_tokens && extra_prefix_string.empty()) {
@@ -194,7 +194,7 @@ void RequestStateEntryNode::GetDeltaRequestReturn(const Tokenizer& tokenizer,
   }
 
   // Case 2. Any of the stop strings is matched.
-  ICHECK(!stop_str_handler->StopTriggered());
+  TVM_FFI_ICHECK(!stop_str_handler->StopTriggered());
   while (next_callback_token_pos < num_committed_tokens) {
     stop_str_handler->Put(committed_tokens[next_callback_token_pos].GetTokenId(),
                           &(*delta_stream_output)->group_delta_token_ids[idx]);
@@ -264,7 +264,7 @@ void RequestStateEntryNode::GetDeltaRequestReturn(const Tokenizer& tokenizer,
 
 RequestState::RequestState(std::vector<RequestStateEntry> entries, int num_response,
                            std::chrono::high_resolution_clock::time_point add_time_point) {
-  ICHECK(!entries.empty());
+  TVM_FFI_ICHECK(!entries.empty());
   ObjectPtr<RequestStateNode> n = tvm::ffi::make_object<RequestStateNode>();
   n->entries = std::move(entries);
   n->metrics.prompt_tokens = n->entries[0]->request->prompt_tokens;

--- a/cpp/support/encoding.cc
+++ b/cpp/support/encoding.cc
@@ -12,7 +12,7 @@ namespace mlc {
 namespace llm {
 
 std::string PrintAsUTF8(TCodepoint codepoint) {
-  ICHECK(codepoint <= 0x10FFFF) << "Invalid codepoint: " << codepoint;
+  TVM_FFI_ICHECK(codepoint <= 0x10FFFF) << "Invalid codepoint: " << codepoint;
   std::string utf8;
   if (codepoint <= 0x7F) {
     // 1-byte sequence

--- a/cpp/support/load_bytes_from_file.h
+++ b/cpp/support/load_bytes_from_file.h
@@ -16,7 +16,7 @@ namespace llm {
 
 inline std::string LoadBytesFromFile(const std::string& path) {
   std::ifstream fs(path, std::ios::in | std::ios::binary);
-  ICHECK(!fs.fail()) << "Cannot open " << path;
+  TVM_FFI_ICHECK(!fs.fail()) << "Cannot open " << path;
   std::string data;
   fs.seekg(0, std::ios::end);
   size_t size = static_cast<size_t>(fs.tellg());

--- a/cpp/support/result.h
+++ b/cpp/support/result.h
@@ -45,8 +45,8 @@ class Result {
    * \note This function returns the ok value by moving, so a Result can be unwrapped only once.
    */
   T Unwrap() {
-    ICHECK(ok_value_.has_value()) << "Cannot unwrap result on an error value.";
-    ICHECK(!unwrapped_) << "Cannot unwrap a Result instance twice.";
+    TVM_FFI_ICHECK(ok_value_.has_value()) << "Cannot unwrap result on an error value.";
+    TVM_FFI_ICHECK(!unwrapped_) << "Cannot unwrap a Result instance twice.";
     unwrapped_ = true;
     return std::move(ok_value_.value());
   }
@@ -56,8 +56,8 @@ class Result {
    * \note This function returns the error value by moving, so a Result can be unwrapped only once.
    */
   E UnwrapErr() {
-    ICHECK(err_value_.has_value()) << "Cannot unwrap result on an okay value.";
-    ICHECK(!unwrapped_) << "Cannot unwrap a Result instance twice.";
+    TVM_FFI_ICHECK(err_value_.has_value()) << "Cannot unwrap result on an okay value.";
+    TVM_FFI_ICHECK(!unwrapped_) << "Cannot unwrap a Result instance twice.";
     unwrapped_ = true;
     return std::move(err_value_.value());
   }

--- a/cpp/support/vlm_utils.cc
+++ b/cpp/support/vlm_utils.cc
@@ -11,7 +11,7 @@ namespace llm {
 
 void CalculateResizeShape(tvm::runtime::Tensor image_data, std::string model_type,
                           int* p_target_height, int* p_target_width) {
-  ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
+  TVM_FFI_ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
   int height = image_data->shape[1];
   int width = image_data->shape[2];
 
@@ -30,14 +30,15 @@ void CalculateResizeShape(tvm::runtime::Tensor image_data, std::string model_typ
 
 void CalculatePadShape(tvm::runtime::Tensor image_data, std::string model_type, int* p_pad_height,
                        int* p_pad_width) {
-  ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
+  TVM_FFI_ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
   if ("phi3_v" == model_type) {
     int resized_height = 0, resized_width = 0;
     CalculateResizeShape(image_data, model_type, &resized_height, &resized_width);
     int tar = (int)(ceil(resized_height / 336.0) * 336);
     int top_padding = (int)((tar - resized_height) / 2);
     int bottom_padding = tar - resized_height - top_padding;
-    ICHECK_EQ(tar, resized_height + top_padding + bottom_padding) << "Padding size not equal!";
+    TVM_FFI_ICHECK_EQ(tar, resized_height + top_padding + bottom_padding)
+        << "Padding size not equal!";
     *p_pad_height = tar;
     *p_pad_width = resized_width;
   }
@@ -45,7 +46,7 @@ void CalculatePadShape(tvm::runtime::Tensor image_data, std::string model_type, 
 
 void CalculateCropShape(tvm::runtime::Tensor image_data, std::string model_type, int* p_crop_height,
                         int* p_crop_width) {
-  ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
+  TVM_FFI_ICHECK_EQ(image_data->shape[3], 3) << "Image format must be NHWC";
   if ("phi3_v" == model_type) {
     int pad_h = 0, pad_w = 0;
     CalculatePadShape(image_data, model_type, &pad_h, &pad_w);

--- a/cpp/tokenizers/streamer.cc
+++ b/cpp/tokenizers/streamer.cc
@@ -198,7 +198,7 @@ void StopStrHandlerObj::Put(int32_t token_id, std::vector<int64_t>* return_token
 
   CHECK(!stop_triggered_) << "Cannot put new token when already stopped.";
 
-  ICHECK_LT(token_id, static_cast<int>(token_table_.size()));
+  TVM_FFI_ICHECK_LT(token_id, static_cast<int>(token_table_.size()));
   const std::string& token = token_table_[token_id];
   pending_token_ids_.push_back(token_id);
   pending_token_lengths_.push_back(token.length());
@@ -231,7 +231,7 @@ void StopStrHandlerObj::Put(int32_t token_id, std::vector<int64_t>* return_token
 
       // Case 2. The stop string is not matched.
       // - Get the cutoff length that can be safely return.
-      ICHECK_GE(pending_string_len_ + 1, cur_match_length);
+      TVM_FFI_ICHECK_GE(pending_string_len_ + 1, cur_match_length);
       cutoff_length = std::min(cutoff_length, pending_string_len_ + 1 - cur_match_length);
       // - Get the updated pending string length.
       max_match_length = std::max(max_match_length, cur_match_length);
@@ -241,8 +241,8 @@ void StopStrHandlerObj::Put(int32_t token_id, std::vector<int64_t>* return_token
     if (stop_triggered_) {
       cutoff_length = stop_starting_pos;
     }
-    ICHECK_NE(cutoff_length, std::numeric_limits<int>::max());
-    ICHECK_GE(cutoff_length, 0);
+    TVM_FFI_ICHECK_NE(cutoff_length, std::numeric_limits<int>::max());
+    TVM_FFI_ICHECK_GE(cutoff_length, 0);
     int cum_length = 0;
     while (!pending_token_ids_.empty() &&
            cum_length + pending_token_lengths_.front() <= cutoff_length) {
@@ -255,7 +255,7 @@ void StopStrHandlerObj::Put(int32_t token_id, std::vector<int64_t>* return_token
       return;
     }
 
-    ICHECK_LE(cum_length, cutoff_length);
+    TVM_FFI_ICHECK_LE(cum_length, cutoff_length);
     // `cum_length` is the prefix length what we actually cut off.
     pending_string_len_ = (cutoff_length - cum_length) + max_match_length;
   }


### PR DESCRIPTION
This commit updates all instances of ICHECK_* macros to their TVM_FFI_ICHECK_* equivalents to maintain compatibility with TVM's FFI interface changes.

Changes:
- ICHECK_EQ -> TVM_FFI_ICHECK_EQ
- ICHECK_NE -> TVM_FFI_ICHECK_NE
- ICHECK_LT -> TVM_FFI_ICHECK_LT
- ICHECK_LE -> TVM_FFI_ICHECK_LE
- ICHECK_GT -> TVM_FFI_ICHECK_GT
- ICHECK_GE -> TVM_FFI_ICHECK_GE
- ICHECK -> TVM_FFI_ICHECK

Affected files: 35 C++ source and header files in cpp/ directory