### PR TITLE
fix(serve): add greedy sub-batching for decoder embedding when batch exceeds prefill_chunk_size

### DIFF
--- a/python/mlc_llm/serve/embedding_engine.py
+++ b/python/mlc_llm/serve/embedding_engine.py
@@ -336,19 +336,16 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         for tokens in token_lists:
             if not tokens:
                 continue
-            if len(tokens) > prefill_chunk:
-                if current_batch:
-                    sub_batches.append(("batch", current_batch, current_tokens))
-                    current_batch = []
-                    current_tokens = 0
-                sub_batches.append(("sequential", [tokens], len(tokens)))
-            elif current_tokens + len(tokens) > prefill_chunk and current_batch:
+            token_len = len(tokens)
+            is_oversized = token_len > prefill_chunk
+            if current_batch and (is_oversized or current_tokens + token_len > prefill_chunk):
                 sub_batches.append(("batch", current_batch, current_tokens))
-                current_batch = [tokens]
-                current_tokens = len(tokens)
+                current_batch, current_tokens = [], 0
+            if is_oversized:
+                sub_batches.append(("sequential", [tokens], token_len))
             else:
                 current_batch.append(tokens)
-                current_tokens += len(tokens)
+                current_tokens += token_len
         if current_batch:
             sub_batches.append(("batch", current_batch, current_tokens))
 


### PR DESCRIPTION
### Problem:
When total tokens in a batch exceed `prefill_chunk_size (2048 in my case)`, `_embed_decoder()` falls back to sequential processing for **ALL** texts, causing a throughput cliff (53 → 4 texts/s at batch_size=64)

### Fix:
Greedy sub-batching — pack texts into sub-batches that fit within prefill_chunk, preserving input order. Oversize single texts fall back to sequential chunked prefill.

### Results:
Attach the two graphs

## Test in Macbook M1 pro 16gb 
<img width="1482" height="880" alt="latency_comparison" src="https://github.com/user-attachments/assets/00f4dad4-f938-4c5e-b285-0f9eb4caf114" />
<img width="1482" height="880" alt="throughput_comparison" src="https://github.com/user-attachments/assets/612fbab2-6552-4b73-8c5a-f60245d7981e" />
