### PR TITLE
refactor: remove dmlc-core references and update headers for TVM API changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,11 +78,7 @@ list(APPEND MLC_LLM_SRCS ${XGRAMMAR_SRCS})
 add_library(mlc_llm_objs OBJECT ${MLC_LLM_SRCS})
 
 set(MLC_LLM_INCLUDES
-    ${TVM_SOURCE_DIR}/include ${TVM_SOURCE_DIR}/3rdparty/dlpack/include
-    ${TVM_SOURCE_DIR}/3rdparty/dmlc-core/include)
-
-set(MLC_LLM_COMPILE_DEFS ${MLC_LLM_COMPILE_DEFS}
-                         DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
+    ${TVM_SOURCE_DIR}/include ${TVM_SOURCE_DIR}/3rdparty/dlpack/include)
 set(MLC_LLM_COMPILE_DEFS ${MLC_LLM_COMPILE_DEFS} __STDC_FORMAT_MACROS=1)
 set(MLC_LLM_COMPILE_DEFS ${MLC_LLM_COMPILE_DEFS} XGRAMMAR_ENABLE_LOG_DEBUG=0)
 

--- a/android/mlc4j/CMakeLists.txt
+++ b/android/mlc4j/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(
          ${JNI_HEADER}
          ${ANDROID_DIR}/src/cpp
          ${TVM_SOURCE_DIR}/3rdparty/tvm-ffi/3rdparty/dlpack/include
-         ${TVM_SOURCE_DIR}/3rdparty/dmlc-core/include
          ${TVM_SOURCE_DIR}/3rdparty/OpenCL-Headers
          ${TVM_SOURCE_DIR}/include
          ${TVM_SOURCE_DIR}/src

--- a/android/mlc4j/src/cpp/tvm_runtime.h
+++ b/android/mlc4j/src/cpp/tvm_runtime.h
@@ -1,10 +1,8 @@
-#define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
 #define TVM_USE_LIBBACKTRACE 0
 
 #include <android/log.h>
 #include <dlfcn.h>
-#include <dmlc/logging.h>
-#include <dmlc/thread_local.h>
+#include <tvm/runtime/logging.h>
 
 #include <ffi/backtrace.cc>
 #include <ffi/container.cc>
@@ -12,6 +10,8 @@
 #include <ffi/error.cc>
 #include <ffi/extra/env_c_api.cc>
 #include <ffi/extra/env_context.cc>
+#include <ffi/extra/json_parser.cc>
+#include <ffi/extra/json_writer.cc>
 #include <ffi/extra/library_module.cc>
 #include <ffi/extra/library_module_dynamic_lib.cc>
 #include <ffi/extra/library_module_system_lib.cc>

--- a/ios/MLCSwift/Package.swift
+++ b/ios/MLCSwift/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
             cxxSettings: [
                 .headerSearchPath("../../tvm_home/include"),
                 .headerSearchPath("../../tvm_home/3rdparty/tvm-ffi/include"),
-                .headerSearchPath("../../tvm_home/3rdparty/tvm-ffi/3rdparty/dlpack/include"),
-                .headerSearchPath("../../tvm_home/3rdparty/dmlc-core/include")
+                .headerSearchPath("../../tvm_home/3rdparty/tvm-ffi/3rdparty/dlpack/include")
             ]
         ),
         .target(

--- a/ios/MLCSwift/Sources/ObjC/LLMEngine.mm
+++ b/ios/MLCSwift/Sources/ObjC/LLMEngine.mm
@@ -9,7 +9,6 @@
 #include "LLMEngine.h"
 
 #define TVM_USE_LIBBACKTRACE 0
-#define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>
 
 #include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/function.h>
@@ -61,15 +60,15 @@ using tvm::ffi::TypedFunction;
     exit_background_loop_func_ =
         json_ffi_engine_.value()->GetFunction("exit_background_loop").value_or(Function(nullptr));
 
-    ICHECK(init_background_engine_func_ != nullptr);
-    ICHECK(reload_func_ != nullptr);
-    ICHECK(unload_func_ != nullptr);
-    ICHECK(reset_func_ != nullptr);
-    ICHECK(chat_completion_func_ != nullptr);
-    ICHECK(abort_func_ != nullptr);
-    ICHECK(run_background_loop_func_ != nullptr);
-    ICHECK(run_background_stream_back_loop_func_ != nullptr);
-    ICHECK(exit_background_loop_func_ != nullptr);
+    TVM_FFI_ICHECK(init_background_engine_func_ != nullptr);
+    TVM_FFI_ICHECK(reload_func_ != nullptr);
+    TVM_FFI_ICHECK(unload_func_ != nullptr);
+    TVM_FFI_ICHECK(reset_func_ != nullptr);
+    TVM_FFI_ICHECK(chat_completion_func_ != nullptr);
+    TVM_FFI_ICHECK(abort_func_ != nullptr);
+    TVM_FFI_ICHECK(run_background_loop_func_ != nullptr);
+    TVM_FFI_ICHECK(run_background_stream_back_loop_func_ != nullptr);
+    TVM_FFI_ICHECK(exit_background_loop_func_ != nullptr);
   }
   return self;
 }

--- a/web/Makefile
+++ b/web/Makefile
@@ -19,8 +19,8 @@ TVM_ROOT=$(TVM_SOURCE_DIR)
 MLC_LLM_ROOT=$(shell cd ..; pwd)
 
 INCLUDE_FLAGS = -I$(TVM_ROOT) -I$(TVM_ROOT)/include\
-	-I$(TVM_ROOT)/3rdparty/dlpack/include -I$(TVM_ROOT)/3rdparty/dmlc-core/include\
-	-I$(TVM_ROOT)/3rdparty/compiler-rt -I$(TVM_ROOT)/3rdparty/picojson\
+	-I$(TVM_ROOT)/3rdparty/dlpack/include\
+	-I$(TVM_ROOT)/3rdparty/compiler-rt\
 	-I$(MLC_LLM_ROOT)/3rdparty/tokenizers-cpp\
 	-I$(MLC_LLM_ROOT)/3rdparty/tokenizers-cpp/include -I$(MLC_LLM_ROOT)/cpp
 

--- a/web/emcc/mlc_wasm_runtime.cc
+++ b/web/emcc/mlc_wasm_runtime.cc
@@ -31,5 +31,3 @@
 #define COMPILE_MLC_WASM_RUNTIME 1
 #define __STDC_FORMAT_MACROS 1
 #define PICOJSON_USE_INT64
-
-#define DMLC_USE_LOGGING_LIBRARY <tvm/runtime/logging.h>


### PR DESCRIPTION
- Replace ICHECK with TVM_FFI_ICHECK in ios LLMEngine.mm
- Remove dmlc/logging.h and dmlc/thread_local.h includes from Android tvm_runtime.h, replacing with tvm/runtime/logging.h
- Remove DMLC_USE_LOGGING_LIBRARY defines across Android, iOS, and web
- Remove dmlc-core/include from header search paths in CMakeLists.txt, Package.swift, and web/Makefile
- Remove stale picojson include path from web/Makefile

dmlc-core has been removed from the TVM submodule; logging is now handled via TVM_LOG_CUSTOMIZE and tvm/runtime/logging.h directly.