### PR TITLE
feat: add Llama 3.2 chat template with Cutting Knowledge Date

### DIFF
--- a/python/mlc_llm/conversation_template/llama.py
+++ b/python/mlc_llm/conversation_template/llama.py
@@ -29,6 +29,38 @@ ConvTemplateRegistry.register_conv_template(
     )
 )
 
+# Llama3.2 -- same as Llama3.1 but includes "Cutting Knowledge Date" and "Today Date" in system
+# template to match the official HuggingFace chat template.
+# See https://github.com/mlc-ai/mlc-llm/issues/3002
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="llama-3_2",
+        system_template=(
+            "<|start_header_id|>system<|end_header_id|>\n\n"
+            "Cutting Knowledge Date: December 2023\n"
+            f"Today Date: {MessagePlaceholders.TODAY_DATE.value}\n\n"
+            f"{MessagePlaceholders.SYSTEM.value}<|eot_id|>"
+        ),
+        system_message="You are a helpful, respectful and honest assistant.",
+        roles={
+            "user": "<|start_header_id|>user",
+            "assistant": "<|start_header_id|>assistant",
+            "tool": "<|start_header_id|>ipython",
+        },
+        seps=["<|eot_id|>"],
+        role_content_sep="<|end_header_id|>\n\n",
+        role_empty_sep="<|end_header_id|>\n\n",
+        stop_str=[],
+        stop_token_ids=[
+            128001,
+            128008,
+            128009,
+        ],  # "<|end_of_text|>", "<|eom_id|>", "<|eot_id|>"
+        system_prefix_token_ids=[128000],  # "<|begin_of_text|>"
+        add_role_after_system_message=True,
+    )
+)
+
 # Llama3.1 -- same as Llama3 except stop token ids and stop str
 ConvTemplateRegistry.register_conv_template(
     Conversation(

--- a/python/mlc_llm/protocol/conversation_protocol.py
+++ b/python/mlc_llm/protocol/conversation_protocol.py
@@ -1,5 +1,6 @@
 """The standard conversation protocol in MLC LLM"""
 
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
@@ -15,6 +16,7 @@ class MessagePlaceholders(Enum):
     ASSISTANT = "{assistant_message}"
     TOOL = "{tool_message}"
     FUNCTION = "{function_string}"
+    TODAY_DATE = "{today_date}"
 
 
 T = TypeVar("T", bound="BaseModel")
@@ -126,6 +128,11 @@ class Conversation(BaseModel):
         # - Get the system message.
         system_msg = self.system_template.replace(
             MessagePlaceholders.SYSTEM.value, self.system_message
+        )
+        # Replace the today_date placeholder with the current date.
+        system_msg = system_msg.replace(
+            MessagePlaceholders.TODAY_DATE.value,
+            datetime.now().strftime("%d %b %Y"),
         )
 
         # - Get the message strings.

--- a/tests/python/conversation_template/test_llama_template.py
+++ b/tests/python/conversation_template/test_llama_template.py
@@ -41,3 +41,50 @@ def test_llama3_prompt():
 
 if __name__ == "__main__":
     test_llama3_prompt()
+
+
+def test_llama3_2_prompt():
+    """Test that Llama 3.2 template includes Cutting Knowledge Date and dynamic Today Date.
+
+    See https://github.com/mlc-ai/mlc-llm/issues/3002
+    """
+    from datetime import datetime
+
+    conversation = ConvTemplateRegistry.get_conv_template("llama-3_2")
+    assert conversation is not None, "llama-3_2 template should be registered"
+
+    system_msg = "You are a helpful assistant."
+    user_msg = "What is the capital of France?"
+
+    conversation.system_message = system_msg
+    conversation.messages.append(("user", user_msg))
+    conversation.messages.append(("assistant", None))
+    res = conversation.as_prompt()
+
+    today = datetime.now().strftime("%d %b %Y")
+    expected = (
+        "<|start_header_id|>system<|end_header_id|>\n\n"
+        "Cutting Knowledge Date: December 2023\n"
+        f"Today Date: {today}\n\n"
+        "You are a helpful assistant.<|eot_id|>"
+        "<|start_header_id|>user<|end_header_id|>\n\n"
+        "What is the capital of France?<|eot_id|>"
+        "<|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+
+    assert res[0] == expected
+
+
+def test_llama3_2_has_tool_role():
+    """Test that Llama 3.2 template supports tool/ipython role like 3.1."""
+    conversation = ConvTemplateRegistry.get_conv_template("llama-3_2")
+    assert "tool" in conversation.roles
+    assert conversation.roles["tool"] == "<|start_header_id|>ipython"
+
+
+def test_llama3_2_stop_tokens():
+    """Test that Llama 3.2 has the correct stop token IDs."""
+    conversation = ConvTemplateRegistry.get_conv_template("llama-3_2")
+    assert 128001 in conversation.stop_token_ids  # <|end_of_text|>
+    assert 128008 in conversation.stop_token_ids  # <|eom_id|>
+    assert 128009 in conversation.stop_token_ids  # <|eot_id|>


### PR DESCRIPTION
Add a new llama-3_2 conversation template that includes the 'Cutting Knowledge Date' and 'Today Date' preamble lines in the system template, matching the official HuggingFace chat template.

Also adds unit tests for the new template verifying:
- Date preamble in system template
- Tool/ipython role support
- Correct stop token IDs
- Also fixed the date to be templated
- unrelated jenkins UT 404 failure 


Fixes #3002