### PR TITLE
fix: apply post_layernorm in CLIPVisionTransformer forward

### DIFF
--- a/python/mlc_llm/model/vision/clip_vision.py
+++ b/python/mlc_llm/model/vision/clip_vision.py
@@ -215,7 +215,11 @@ class CLIPVisionTransformer(Module):
         hidden_states = self.embeddings(pixel_values)
         hidden_states = self.pre_layrnorm(hidden_states)
         encoder_outputs = self.encoder(inputs_embeds=hidden_states)
-        return encoder_outputs
+        # Apply post_layernorm to the final encoder hidden state, matching
+        # the HuggingFace CLIPVisionTransformer which returns post-normed
+        # last_hidden_state. Intermediate states remain unnormalized.
+        last_hidden_state = self.post_layernorm(encoder_outputs[-1])
+        return encoder_outputs[:-1] + (last_hidden_state,)
 
 
 class CLIPVisionModel(Module):


### PR DESCRIPTION
The post_layernorm was defined in CLIPVisionTransformer.__init__ but never applied in the forward method. This fix applies it to the final encoder hidden state, replacing it in the returned tuple. This matches the HuggingFace CLIPVisionTransformer behavior where last_hidden_state is post-normalized.

The [-2] indexing in CLIPVisionModel (used by LLaVA and Phi3V to get penultimate layer features) continues to work correctly since only the last element of the tuple is replaced.

Fixes #3205