### PR TITLE
[Feature] Add Qwen3.5 conversation templates

### DIFF
--- a/python/mlc_llm/conversation_template/__init__.py
+++ b/python/mlc_llm/conversation_template/__init__.py
@@ -27,6 +27,7 @@ from . import (
     orion,
     phi,
     qwen2,
+    qwen3_5,
     redpajama,
     rwkv,
     stablelm,

--- a/python/mlc_llm/conversation_template/qwen3_5.py
+++ b/python/mlc_llm/conversation_template/qwen3_5.py
@@ -1,0 +1,45 @@
+"""Qwen3.5 conversation templates.
+
+qwen3_5: Thinking enabled — assistant prefix opens a <think> block for the model
+         to reason in before responding.
+qwen3_5_nothink: Thinking disabled — assistant prefix includes a closed empty
+                 <think> block so the model skips straight to responding.
+"""
+
+from mlc_llm.protocol.conversation_protocol import Conversation, MessagePlaceholders
+
+from .registry import ConvTemplateRegistry
+
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="qwen3_5",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
+        system_message="You are a helpful assistant.",
+        roles={
+            "user": "<|im_start|>user",
+            "assistant": "<|im_start|>assistant\n<think>",
+        },
+        seps=["<|im_end|>\n"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["<|endoftext|>", "<|im_end|>"],
+        stop_token_ids=[248046, 248044],
+    )
+)
+
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="qwen3_5_nothink",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
+        system_message="You are a helpful assistant.",
+        roles={
+            "user": "<|im_start|>user",
+            "assistant": "<|im_start|>assistant\n<think>\n\n</think>\n",
+        },
+        seps=["<|im_end|>\n"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["<|endoftext|>", "<|im_end|>"],
+        stop_token_ids=[248046, 248044],
+    )
+)

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -354,4 +354,6 @@ CONV_TEMPLATES = {
     "olmo2",
     "nemotron",
     "llm-jp",
+    "qwen3_5",
+    "qwen3_5_nothink",
 }


### PR DESCRIPTION
## Summary
- Add dedicated conversation templates for Qwen3.5 models (`qwen3_5` and `qwen3_5_nothink`) instead of using the generic ChatML format
- `qwen3_5` enables thinking mode (assistant opens a `<think>` block)
- `qwen3_5_nothink` disables thinking (empty `<think>` block prefix)

## Test plan
- [ ] Verify templates are registered and selectable via gen_config
- [ ] Test chat with a Qwen3.5 model using both template variants