### PR TITLE
Hybrid model upgrade

### DIFF
--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -323,6 +323,7 @@ class ModelImpl : public ModelObj {
     ObjectRef ret;
     if (kind == KVStateKind::kHybrid) {
       if (seq_ids.size() == 1 && !padded) {
+        std::cout << "hybrid single batch prefill" << std::endl;
         ret =
             single_batch_prefill_func(embeddings_dref_or_nd, kv_cache_, rnn_state_, params_)
                 .cast<ObjectRef>();
@@ -350,6 +351,9 @@ class ModelImpl : public ModelObj {
       logits = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Tensor>();
     } else {
       logits = Downcast<Array<Tensor>>(ret)[0];
+    }
+    if (auto dbg_print_tensor = tvm::ffi::Function::GetGlobal("dbg_print_tensor")) {
+      (*dbg_print_tensor)(logits, "logits");
     }
     if (trace_enabled_) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -322,10 +322,15 @@ class ModelImpl : public ModelObj {
     // args: embeddings, logit_pos, kv_cache, [rnn_state,] params
     ObjectRef ret;
     if (kind == KVStateKind::kHybrid) {
-      // Hybrid always uses batch_prefill (single_batch prefill has tensor-based GDN args).
-      ret =
-          prefill_func(embeddings_dref_or_nd, logit_pos_dref_or_nd, kv_cache_, rnn_state_, params_)
-              .cast<ObjectRef>();
+      if (seq_ids.size() == 1 && !padded) {
+        ret =
+            single_batch_prefill_func(embeddings_dref_or_nd, kv_cache_, rnn_state_, params_)
+                .cast<ObjectRef>();
+      } else {
+        ret = prefill_func(embeddings_dref_or_nd, logit_pos_dref_or_nd, kv_cache_, rnn_state_,
+                           params_)
+                  .cast<ObjectRef>();
+      }
     } else if (seq_ids.size() == 1 && !padded) {
       ret = single_batch_prefill_func(embeddings_dref_or_nd, kv_cache_, params_).cast<ObjectRef>();
     } else {
@@ -487,9 +492,13 @@ class ModelImpl : public ModelObj {
     // args: embeddings, kv_cache, [rnn_state,] params
     ObjectRef ret;
     if (kind == KVStateKind::kHybrid) {
-      // Hybrid always uses batch_decode (single_batch decode has tensor-based GDN args).
-      ret =
-          ft_.decode_func_(embeddings_dref_or_nd, kv_cache_, rnn_state_, params_).cast<ObjectRef>();
+      if (seq_ids.size() == 1) {
+        ret = ft_.single_batch_decode_func_(embeddings_dref_or_nd, kv_cache_, rnn_state_, params_)
+                  .cast<ObjectRef>();
+      } else {
+        ret = ft_.decode_func_(embeddings_dref_or_nd, kv_cache_, rnn_state_, params_)
+                  .cast<ObjectRef>();
+      }
     } else if (seq_ids.size() == 1) {
       ret = ft_.single_batch_decode_func_(embeddings_dref_or_nd, kv_cache_, params_)
                 .cast<ObjectRef>();

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -323,7 +323,7 @@ class ModelImpl : public ModelObj {
     ObjectRef ret;
     if (kind == KVStateKind::kHybrid) {
       if (seq_ids.size() == 1 && !padded) {
-        std::cout << "hybrid single batch prefill" << std::endl;
+        //std::cout << "hybrid single batch prefill" << std::endl;
         ret =
             single_batch_prefill_func(embeddings_dref_or_nd, kv_cache_, rnn_state_, params_)
                 .cast<ObjectRef>();
@@ -352,9 +352,9 @@ class ModelImpl : public ModelObj {
     } else {
       logits = Downcast<Array<Tensor>>(ret)[0];
     }
-    if (auto dbg_print_tensor = tvm::ffi::Function::GetGlobal("dbg_print_tensor")) {
-      (*dbg_print_tensor)(logits, "logits");
-    }
+    //if (auto dbg_print_tensor = tvm::ffi::Function::GetGlobal("dbg_print_tensor")) {
+    //  (*dbg_print_tensor)(logits, "logits");
+    //}
     if (trace_enabled_) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
     }

--- a/python/mlc_llm/interface/chat.py
+++ b/python/mlc_llm/interface/chat.py
@@ -290,6 +290,13 @@ def chat(
 ):
     """Chat cli entry"""
     # By default we use JSONFFIEngine
+    import tvm_ffi
+    @tvm_ffi.register_global_func("dbg_print_tensor")
+    def print_tensor(tensor, msg):
+        print(msg)
+        tensor = tensor.numpy()
+        print(tensor)
+
     engine = JSONFFIEngine(
         model,
         device,
@@ -303,6 +310,7 @@ def chat(
             tensor_parallel_shards=overrides.tensor_parallel_shards,
             pipeline_parallel_stages=overrides.pipeline_parallel_stages,
             opt=overrides.opt,
+            prefix_cache_mode='disable'
         ),
     )
     try:

--- a/python/mlc_llm/model/qwen35/qwen35_model.py
+++ b/python/mlc_llm/model/qwen35/qwen35_model.py
@@ -26,7 +26,6 @@ from mlc_llm.support.style import bold
 
 logger = logging.getLogger(__name__)
 
-
 @dataclasses.dataclass
 class Qwen35Config(ConfigBase):  # pylint: disable=too-many-instance-attributes
     """Configuration of the Qwen3.5 model."""
@@ -623,12 +622,10 @@ def create_gated_delta_net_chunked_func(
             with T.sblock("root"):
                 for b in T.thread_binding(batch_size, thread="blockIdx.x"):
                     for h in T.thread_binding(T.int64(num_value_heads), thread="blockIdx.y"):
-                        for kd in T.thread_binding(T.int64(key_head_dim), thread="blockIdx.z"):
-                            for vd in T.thread_binding(T.int64(value_head_dim), thread="threadIdx.x"):
+                        for kd in T.serial(T.int64(key_head_dim)):
+                            for vd in T.serial(T.int64(value_head_dim)):
                                 recurrent_state_out_buf[b, h, kd, vd] = initial_state_buf[b, h, kd, vd]
 
-                for b in T.thread_binding(batch_size, thread="blockIdx.x"):
-                    for h in T.thread_binding(T.int64(num_value_heads), thread="blockIdx.y"):
                         for chunk_idx in T.serial(num_chunks):
                             for c1 in T.serial(T.int64(chunk_size)):
                                 g_i = g_cumsum_buf[b, h, chunk_idx, c1]
@@ -894,7 +891,7 @@ class Qwen35GatedDeltaNet(nn.Module):
         k = self._l2_normalize(k)
 
         # Gate computation
-        gate, beta = self._compute_gate_beta(alpha, beta_raw)
+        gate_log, gate_exp, beta = self._compute_gate_beta(alpha, beta_raw)
         # beta is already (b, s, n_vh) — no GVA expansion needed.
 
         # Get recurrent state from RNNState (state_id=0)
@@ -909,7 +906,22 @@ class Qwen35GatedDeltaNet(nn.Module):
                 value_head_dim=V,
                 dtype=self.dtype,
                 chunk_size=self.gdn_chunk_size,
-            )(q, k, v, gate, beta, state_in_layer)
+            )(q, k, v, gate_log, beta, state_in_layer)
+            #out_recurrent, state_out_layer = op.tensor_ir_op(
+            #    create_gated_delta_net_recurrent_func(
+            #        num_key_heads=n_kh,
+            #        num_value_heads=n_vh,
+            #        key_head_dim=K,
+            #        value_head_dim=V,
+            #        dtype=self.dtype,
+            #    ),
+            #    "gated_delta_net_recurrent",
+            #    [q, k, v, gate, beta, state_in_layer],
+            #    [
+            #        Tensor.placeholder([b, s, n_vh, V], "float32"),
+            #        Tensor.placeholder([b, n_vh, K, V], "float32"),
+            #    ],
+            #)
         else:
             out_recurrent, state_out_layer = op.tensor_ir_op(
                 create_gated_delta_net_recurrent_func(
@@ -920,7 +932,7 @@ class Qwen35GatedDeltaNet(nn.Module):
                     dtype=self.dtype,
                 ),
                 "gated_delta_net_recurrent",
-                [q, k, v, gate, beta, state_in_layer],
+                [q, k, v, gate_exp, beta, state_in_layer],
                 [
                     Tensor.placeholder([b, s, n_vh, V], "float32"),
                     Tensor.placeholder([b, n_vh, K, V], "float32"),
@@ -1001,12 +1013,15 @@ class Qwen35GatedDeltaNet(nn.Module):
     def _compute_gate_beta(self, alpha: Tensor, beta_raw: Tensor):
         """Compute decay gate and update rate.
 
-        gate = exp(-exp(A_log) * softplus(alpha + dt_bias))  (per value_head)
+        gate_log = -exp(A_log) * softplus(alpha + dt_bias)  (per value_head)
+        gate_exp = exp(gate_log)  (per value_head)
         beta = sigmoid(beta_raw)  (per value_head)
+
+        chunked prefill path expects gate_log, while recurrent path expects gate_exp.
         """
 
         # alpha: (b, s, n_vh), dt_bias: (n_vh,), A_log: (n_vh,)
-        def _te_gate(alpha: te.Tensor, A_log: te.Tensor, dt_bias: te.Tensor):
+        def _te_gate_log(alpha: te.Tensor, A_log: te.Tensor, dt_bias: te.Tensor):
             b, s, h = alpha.shape
 
             def _softplus(x):
@@ -1015,22 +1030,21 @@ class Qwen35GatedDeltaNet(nn.Module):
 
             return te.compute(
                 (b, s, h),
-                lambda bi, si, hi: tirx.exp(
-                    -tirx.exp(A_log[hi].astype("float32"))
-                    * _softplus((alpha[bi, si, hi] + dt_bias[hi]).astype("float32"))
-                ),
-                name="gate",
+                lambda bi, si, hi: -tirx.exp(A_log[hi].astype("float32"))
+                * _softplus((alpha[bi, si, hi] + dt_bias[hi]).astype("float32")),
+                name="gate_log",
             )
 
-        gate = op.tensor_expr_op(
-            _te_gate,
-            "gate",
+        gate_log = op.tensor_expr_op(
+            _te_gate_log,
+            "gate_log",
             [alpha, self.A_log, self.dt_bias],
             attrs={"op_pattern": 8},
         )
+        gate_exp = op.exp(gate_log)
 
         beta = op.sigmoid(beta_raw).astype("float32")
-        return gate, beta
+        return gate_log, gate_exp, beta
 
     def to(self, dtype: Optional[str] = None):
         super().to(dtype=dtype)
@@ -1195,6 +1209,7 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
             logits = self.lm_head(hidden_states)
         if logits.dtype != "float32":
             logits = logits.astype("float32")
+        
         return logits, paged_kv_cache, rnn_state
 
     def decode(

--- a/python/mlc_llm/model/qwen35/qwen35_model.py
+++ b/python/mlc_llm/model/qwen35/qwen35_model.py
@@ -466,57 +466,66 @@ def create_gated_delta_net_chunked_func(
         return op.tensor_expr_op(_te, name, [x], attrs={"op_pattern": 8})
 
     def _create_associative_scan_primfunc():
+        _chunk_size = chunk_size
         @T.prim_func
         def associative_scan(attn_mm: T.handle, g_cumsum: T.handle, attn_out: T.handle):
             T.func_attr({"tirx.is_scheduled": True, "tirx.noalias": True})
             batch_size = T.int64()
             num_heads = T.int64()
             num_chunks = T.int64()
-
             attn_mm_buf = T.match_buffer(
                 attn_mm,
-                (batch_size, num_heads, num_chunks, T.int64(chunk_size), T.int64(chunk_size)),
-                dtype="float32",
+                (batch_size, num_heads, num_chunks, T.int64(_chunk_size), T.int64(_chunk_size)),
+                "float32",
             )
             g_cumsum_buf = T.match_buffer(
                 g_cumsum,
-                (batch_size, num_heads, num_chunks, T.int64(chunk_size)),
-                dtype="float32",
+                (batch_size, num_heads, num_chunks, T.int64(_chunk_size)),
+                "float32",
             )
             attn_out_buf = T.match_buffer(
                 attn_out,
-                (batch_size, num_heads, num_chunks, T.int64(chunk_size), T.int64(chunk_size)),
-                dtype="float32",
+                (batch_size, num_heads, num_chunks, T.int64(_chunk_size), T.int64(_chunk_size)),
+                "float32",
             )
+            scan_buf = T.alloc_buffer((T.int64(_chunk_size), T.int64(_chunk_size)), "float32", scope="shared")
 
             with T.sblock("root"):
                 for b in T.thread_binding(batch_size, thread="blockIdx.x"):
                     for h in T.thread_binding(num_heads, thread="blockIdx.y"):
                         for c in T.thread_binding(num_chunks, thread="blockIdx.z"):
-                            for i in T.serial(chunk_size):
-                                for j in T.serial(i, chunk_size):
-                                    attn_out_buf[b, h, c, i, j] = T.float32(0.0)
+                            for tx in T.thread_binding(_chunk_size, thread="threadIdx.x"):
+                                # init phase: start from all zeros (diag must stay 0 during recurrence)
+                                for i in T.serial(_chunk_size):
+                                    scan_buf[i, tx] = T.float32(0.0)
 
-                            for i in T.serial(1, chunk_size):
-                                g_i = g_cumsum_buf[b, h, c, i]
-                                for j in T.serial(0, i):
-                                    decayed_lower_attn_ij = (
-                                        -attn_mm_buf[b, h, c, i, j]
-                                        * T.exp(g_i - g_cumsum_buf[b, h, c, j])
+                                T.tvm_storage_sync("shared")
+
+                                # recurrence
+                                for i in T.serial(1, _chunk_size):
+                                    g_i = g_cumsum_buf[b, h, c, i]
+                                    scan_buf[i, tx] = T.if_then_else(
+                                        tx < i,
+                                        -attn_mm_buf[b, h, c, i, tx]
+                                        * T.exp(g_i - g_cumsum_buf[b, h, c, tx]),
+                                        scan_buf[i, tx],
                                     )
-                                    attn_out_buf[b, h, c, i, j] = decayed_lower_attn_ij
-                                    for k_idx in T.serial(0, i):
-                                        decayed_lower_attn_ik = (
-                                            -attn_mm_buf[b, h, c, i, k_idx]
-                                            * T.exp(g_i - g_cumsum_buf[b, h, c, k_idx])
-                                        )
-                                        attn_out_buf[b, h, c, i, j] += (
-                                            decayed_lower_attn_ik * attn_out_buf[b, h, c, k_idx, j]
-                                        )
+                                    for k in T.serial(i):
+                                        if tx < i:
+                                            decayed = (
+                                                -attn_mm_buf[b, h, c, i, k]
+                                                * T.exp(g_i - g_cumsum_buf[b, h, c, k])
+                                            )
+                                            scan_buf[i, tx]  = scan_buf[i, tx] + decayed * scan_buf[k, tx]
+                                    T.tvm_storage_sync("shared")
 
-                            for i in T.serial(chunk_size):
-                                attn_out_buf[b, h, c, i, i] = T.float32(1.0)
-
+                                # writeback
+                                for i in T.serial(_chunk_size):
+                                    attn_out_buf[b, h, c, i, tx] = T.if_then_else(
+                                        tx < i,
+                                        scan_buf[i, tx],
+                                        T.if_then_else(tx == i, T.float32(1.0), T.float32(0.0)),
+                                    )
         return associative_scan
 
     def _create_inter_chunk_recurrent_primfunc():

--- a/python/mlc_llm/model/qwen35/qwen35_model.py
+++ b/python/mlc_llm/model/qwen35/qwen35_model.py
@@ -722,7 +722,7 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         state: RNNState,
         logit_positions: Optional[Tensor] = None,
     ):
-        """Shared forward for batch methods using RNNState."""
+        """Shared forward for the RNNState path."""
         op_ext.configure()
         hidden_states, state = self.model.forward(input_embed, paged_kv_cache, state)
         if logit_positions is not None:
@@ -734,6 +734,32 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         if logits.dtype != "float32":
             logits = logits.astype("float32")
         return logits, paged_kv_cache, state
+
+    def prefill(
+        self,
+        input_embed: Tensor,
+        paged_kv_cache: PagedKVCache,
+        rnn_state: RNNState,
+    ):
+        op_ext.configure()
+
+        hidden_states, rnn_state = self.model.forward(input_embed, paged_kv_cache, rnn_state)
+        hidden_states = index_last_token(hidden_states)
+        if self.tie_word_embeddings:
+            logits = self.model.embed_tokens.lm_head_forward(hidden_states)
+        else:
+            logits = self.lm_head(hidden_states)
+        if logits.dtype != "float32":
+            logits = logits.astype("float32")
+        return logits, paged_kv_cache, rnn_state
+
+    def decode(
+        self,
+        input_embed: Tensor,
+        paged_kv_cache: PagedKVCache,
+        rnn_state: RNNState,
+    ):
+        return self._forward(input_embed, paged_kv_cache, rnn_state)
 
     def batch_prefill(
         self,
@@ -824,6 +850,24 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         mod_spec = {
             "embed": {
                 "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "prefill": {
+                "input_embed": nn.spec.Tensor([1, "seq_len", self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "rnn_state": nn.spec.Object(object_type=RNNState),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "decode": {
+                "input_embed": nn.spec.Tensor([1, 1, self.hidden_size], self.dtype),
+                "paged_kv_cache": nn.spec.Object(object_type=PagedKVCache),
+                "rnn_state": nn.spec.Object(object_type=RNNState),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_llm/model/qwen35/qwen35_model.py
+++ b/python/mlc_llm/model/qwen35/qwen35_model.py
@@ -421,7 +421,9 @@ class Qwen35GatedDeltaNet(nn.Module):
         # Output gating norm — per-head RMSNorm (shared weight across heads)
         self.norm = nn.RMSNorm(self.value_head_dim, -1, config.rms_norm_eps, bias=False)
 
-    def forward(self, hidden_states: Tensor, state: RNNState) -> Tuple[Tensor, RNNState]:
+    def forward(
+        self, hidden_states: Tensor, state: RNNState, is_prefill: bool
+    ) -> Tuple[Tensor, RNNState]:
         """Forward using RNNState (for MLCEngine batch methods)."""
         b, s, _ = hidden_states.shape
         K = self.key_head_dim
@@ -632,12 +634,13 @@ class Qwen35DecoderLayer(nn.Module):
         hidden_states: Tensor,
         paged_kv_cache: PagedKVCache,
         state: RNNState,
+        is_prefill: bool,
     ):
         out = self.input_layernorm(hidden_states)
         if self.layer_type == "full_attention":
             out = self.self_attn(out, paged_kv_cache, self.category_id)
         else:
-            out, state = self.linear_attn.forward(out, state)
+            out, state = self.linear_attn(out, state, is_prefill)
         hidden_states = self._apply_residual(out, residual=hidden_states)
         out = self.post_attention_layernorm(hidden_states)
         out = self.mlp(out)
@@ -672,10 +675,11 @@ class Qwen35Model(nn.Module):
         inputs: Tensor,
         paged_kv_cache: PagedKVCache,
         state: RNNState,
+        is_prefill: bool,
     ):
         hidden_states = inputs
         for layer_id, layer in enumerate(self.layers):
-            hidden_states, state = layer.forward(hidden_states, paged_kv_cache, state)
+            hidden_states, state = layer.forward(hidden_states, paged_kv_cache, state, is_prefill)
         hidden_states = self.norm(hidden_states)
         return hidden_states, state
 
@@ -720,11 +724,12 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         input_embed: Tensor,
         paged_kv_cache: PagedKVCache,
         state: RNNState,
+        is_prefill: bool,
         logit_positions: Optional[Tensor] = None,
     ):
         """Shared forward for the RNNState path."""
         op_ext.configure()
-        hidden_states, state = self.model.forward(input_embed, paged_kv_cache, state)
+        hidden_states, state = self.model.forward(input_embed, paged_kv_cache, state, is_prefill)
         if logit_positions is not None:
             hidden_states = op.take(hidden_states, logit_positions, axis=1)
         if self.tie_word_embeddings:
@@ -743,7 +748,9 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
     ):
         op_ext.configure()
 
-        hidden_states, rnn_state = self.model.forward(input_embed, paged_kv_cache, rnn_state)
+        hidden_states, rnn_state = self.model.forward(
+            input_embed, paged_kv_cache, rnn_state, True
+        )
         hidden_states = index_last_token(hidden_states)
         if self.tie_word_embeddings:
             logits = self.model.embed_tokens.lm_head_forward(hidden_states)
@@ -759,7 +766,7 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         paged_kv_cache: PagedKVCache,
         rnn_state: RNNState,
     ):
-        return self._forward(input_embed, paged_kv_cache, rnn_state)
+        return self._forward(input_embed, paged_kv_cache, rnn_state, False)
 
     def batch_prefill(
         self,
@@ -768,7 +775,7 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         paged_kv_cache: PagedKVCache,
         rnn_state: RNNState,
     ):
-        return self._forward(input_embeds, paged_kv_cache, rnn_state, logit_positions)
+        return self._forward(input_embeds, paged_kv_cache, rnn_state, True, logit_positions)
 
     def batch_decode(
         self,
@@ -776,7 +783,7 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         paged_kv_cache: PagedKVCache,
         rnn_state: RNNState,
     ):
-        return self._forward(input_embeds, paged_kv_cache, rnn_state)
+        return self._forward(input_embeds, paged_kv_cache, rnn_state, False)
 
     def batch_verify(
         self,
@@ -784,7 +791,7 @@ class Qwen35LMHeadModel(nn.Module):  # pylint: disable=too-many-instance-attribu
         paged_kv_cache: PagedKVCache,
         rnn_state: RNNState,
     ):
-        return self._forward(input_embeds, paged_kv_cache, rnn_state)
+        return self._forward(input_embeds, paged_kv_cache, rnn_state, False)
 
     def create_rnn_state(
         self,

--- a/python/mlc_llm/model/qwen35/qwen35_model.py
+++ b/python/mlc_llm/model/qwen35/qwen35_model.py
@@ -217,11 +217,11 @@ class Qwen35Attention(nn.Module):
 
 
 # ============================================================================
-# GatedDeltaNet TIR kernel
+# GatedDeltaNet kernels
 # ============================================================================
 
 
-def create_gated_delta_net_func(
+def create_gated_delta_net_recurrent_func(
     num_key_heads: int,
     num_value_heads: int,
     key_head_dim: int,
@@ -374,6 +374,430 @@ def create_gated_delta_net_func(
     return gdn_func
 
 
+def create_gated_delta_net_chunked_func(
+    num_key_heads: int,
+    num_value_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    dtype: str,
+    chunk_size: int,
+):
+    """Creates a Relax/TIR hybrid function for prefill chunked GatedDeltaNet."""
+
+    if num_value_heads % num_key_heads != 0:
+        raise ValueError(
+            "num_value_heads must be divisible by num_key_heads "
+            f"(got {num_value_heads} and {num_key_heads})"
+        )
+
+    heads_per_group = num_value_heads // num_key_heads
+
+    def _expand_key_heads_to_value_heads(x: Tensor, name: str) -> Tensor:
+        if heads_per_group == 1:
+            return x
+
+        def _te(inp: te.Tensor):
+            batch_size, seq_len, _, head_dim = inp.shape
+            return te.compute(
+                (batch_size, seq_len, num_value_heads, head_dim),
+                lambda bi, si, hi, di: inp[bi, si, hi // heads_per_group, di],
+                name=name,
+            )
+
+        return op.tensor_expr_op(_te, name, [x], attrs={"op_pattern": 8})
+
+    def _transpose_pad_bshd_to_bhsd(
+        x: Tensor,
+        padded_len,
+        name: str,
+        scale: Optional[float] = None,
+    ) -> Tensor:
+        def _te(inp: te.Tensor):
+            batch_size, seq_len, num_heads, head_dim = inp.shape
+            zero = tirx.const(0.0, inp.dtype)
+            if scale is None:
+                return te.compute(
+                    (batch_size, num_heads, padded_len, head_dim),
+                    lambda bi, hi, si, di: tirx.if_then_else(
+                        si < seq_len,
+                        inp[bi, si, hi, di],
+                        zero,
+                    ),
+                    name=name,
+                )
+
+            scale_const = tirx.const(scale, inp.dtype)
+            return te.compute(
+                (batch_size, num_heads, padded_len, head_dim),
+                lambda bi, hi, si, di: tirx.if_then_else(
+                    si < seq_len,
+                    inp[bi, si, hi, di] * scale_const,
+                    zero,
+                ),
+                name=name,
+            )
+
+        return op.tensor_expr_op(_te, name, [x], attrs={"op_pattern": 8})
+
+    def _transpose_pad_bsh_to_bhs(x: Tensor, padded_len, name: str) -> Tensor:
+        def _te(inp: te.Tensor):
+            batch_size, seq_len, num_heads = inp.shape
+            zero = tirx.const(0.0, inp.dtype)
+            return te.compute(
+                (batch_size, num_heads, padded_len),
+                lambda bi, hi, si: tirx.if_then_else(
+                    si < seq_len,
+                    inp[bi, si, hi],
+                    zero,
+                ),
+                name=name,
+            )
+
+        return op.tensor_expr_op(_te, name, [x], attrs={"op_pattern": 8})
+
+    def _crop_padded_output(x: Tensor, seq_len, name: str = "crop_padded_output") -> Tensor:
+        def _te(inp: te.Tensor):
+            batch_size, _, num_heads, value_dim = inp.shape
+            return te.compute(
+                (batch_size, seq_len, num_heads, value_dim),
+                lambda bi, si, hi, vi: inp[bi, si, hi, vi],
+                name=name,
+            )
+
+        return op.tensor_expr_op(_te, name, [x], attrs={"op_pattern": 8})
+
+    def _create_associative_scan_primfunc():
+        @T.prim_func
+        def associative_scan(attn_mm: T.handle, g_cumsum: T.handle, attn_out: T.handle):
+            T.func_attr({"tirx.is_scheduled": True, "tirx.noalias": True})
+            batch_size = T.int64()
+            num_heads = T.int64()
+            num_chunks = T.int64()
+
+            attn_mm_buf = T.match_buffer(
+                attn_mm,
+                (batch_size, num_heads, num_chunks, T.int64(chunk_size), T.int64(chunk_size)),
+                dtype="float32",
+            )
+            g_cumsum_buf = T.match_buffer(
+                g_cumsum,
+                (batch_size, num_heads, num_chunks, T.int64(chunk_size)),
+                dtype="float32",
+            )
+            attn_out_buf = T.match_buffer(
+                attn_out,
+                (batch_size, num_heads, num_chunks, T.int64(chunk_size), T.int64(chunk_size)),
+                dtype="float32",
+            )
+
+            with T.sblock("root"):
+                for b in T.thread_binding(batch_size, thread="blockIdx.x"):
+                    for h in T.thread_binding(num_heads, thread="blockIdx.y"):
+                        for c in T.thread_binding(num_chunks, thread="blockIdx.z"):
+                            for i in T.serial(chunk_size):
+                                for j in T.serial(i, chunk_size):
+                                    attn_out_buf[b, h, c, i, j] = T.float32(0.0)
+
+                            for i in T.serial(1, chunk_size):
+                                g_i = g_cumsum_buf[b, h, c, i]
+                                for j in T.serial(0, i):
+                                    decayed_lower_attn_ij = (
+                                        -attn_mm_buf[b, h, c, i, j]
+                                        * T.exp(g_i - g_cumsum_buf[b, h, c, j])
+                                    )
+                                    attn_out_buf[b, h, c, i, j] = decayed_lower_attn_ij
+                                    for k_idx in T.serial(0, i):
+                                        decayed_lower_attn_ik = (
+                                            -attn_mm_buf[b, h, c, i, k_idx]
+                                            * T.exp(g_i - g_cumsum_buf[b, h, c, k_idx])
+                                        )
+                                        attn_out_buf[b, h, c, i, j] += (
+                                            decayed_lower_attn_ik * attn_out_buf[b, h, c, k_idx, j]
+                                        )
+
+                            for i in T.serial(chunk_size):
+                                attn_out_buf[b, h, c, i, i] = T.float32(1.0)
+
+        return associative_scan
+
+    def _create_inter_chunk_recurrent_primfunc():
+        @T.prim_func
+        def inter_chunk_recurrent(
+            query: T.handle,
+            key: T.handle,
+            value_intra: T.handle,
+            k_cumdecay: T.handle,
+            g_cumsum: T.handle,
+            initial_state: T.handle,
+            core_attn_out: T.handle,
+            recurrent_state_out: T.handle,
+        ):
+            T.func_attr({"tirx.is_scheduled": True, "tirx.noalias": True})
+            batch_size = T.int64()
+            num_chunks = T.int64()
+
+            query_buf = T.match_buffer(
+                query,
+                (batch_size, T.int64(num_value_heads), num_chunks, T.int64(chunk_size), T.int64(key_head_dim)),
+                dtype="float32",
+            )
+            key_buf = T.match_buffer(
+                key,
+                (batch_size, T.int64(num_value_heads), num_chunks, T.int64(chunk_size), T.int64(key_head_dim)),
+                dtype="float32",
+            )
+            value_intra_buf = T.match_buffer(
+                value_intra,
+                (
+                    batch_size,
+                    T.int64(num_value_heads),
+                    num_chunks,
+                    T.int64(chunk_size),
+                    T.int64(value_head_dim),
+                ),
+                dtype="float32",
+            )
+            k_cumdecay_buf = T.match_buffer(
+                k_cumdecay,
+                (batch_size, T.int64(num_value_heads), num_chunks, T.int64(chunk_size), T.int64(key_head_dim)),
+                dtype="float32",
+            )
+            g_cumsum_buf = T.match_buffer(
+                g_cumsum,
+                (batch_size, T.int64(num_value_heads), num_chunks, T.int64(chunk_size)),
+                dtype="float32",
+            )
+            initial_state_buf = T.match_buffer(
+                initial_state,
+                (batch_size, T.int64(num_value_heads), T.int64(key_head_dim), T.int64(value_head_dim)),
+                dtype="float32",
+            )
+            core_attn_out_buf = T.match_buffer(
+                core_attn_out,
+                (
+                    batch_size,
+                    T.int64(num_value_heads),
+                    num_chunks,
+                    T.int64(chunk_size),
+                    T.int64(value_head_dim),
+                ),
+                dtype="float32",
+            )
+            recurrent_state_out_buf = T.match_buffer(
+                recurrent_state_out,
+                (batch_size, T.int64(num_value_heads), T.int64(key_head_dim), T.int64(value_head_dim)),
+                dtype="float32",
+            )
+
+            attn_buf = T.alloc_buffer(
+                (
+                    batch_size,
+                    T.int64(num_value_heads),
+                    num_chunks,
+                    T.int64(chunk_size),
+                    T.int64(chunk_size),
+                ),
+                dtype="float32",
+            )
+            v_new_buf = T.alloc_buffer(
+                (
+                    batch_size,
+                    T.int64(num_value_heads),
+                    num_chunks,
+                    T.int64(chunk_size),
+                    T.int64(value_head_dim),
+                ),
+                dtype="float32",
+            )
+            attn_inter_buf = T.alloc_buffer(
+                (
+                    batch_size,
+                    T.int64(num_value_heads),
+                    num_chunks,
+                    T.int64(chunk_size),
+                    T.int64(value_head_dim),
+                ),
+                dtype="float32",
+            )
+
+            with T.sblock("root"):
+                for b in T.thread_binding(batch_size, thread="blockIdx.x"):
+                    for h in T.thread_binding(T.int64(num_value_heads), thread="blockIdx.y"):
+                        for kd in T.thread_binding(T.int64(key_head_dim), thread="blockIdx.z"):
+                            for vd in T.thread_binding(T.int64(value_head_dim), thread="threadIdx.x"):
+                                recurrent_state_out_buf[b, h, kd, vd] = initial_state_buf[b, h, kd, vd]
+
+                for b in T.thread_binding(batch_size, thread="blockIdx.x"):
+                    for h in T.thread_binding(T.int64(num_value_heads), thread="blockIdx.y"):
+                        for chunk_idx in T.serial(num_chunks):
+                            for c1 in T.serial(T.int64(chunk_size)):
+                                g_i = g_cumsum_buf[b, h, chunk_idx, c1]
+                                for c2 in T.serial(T.int64(chunk_size)):
+                                    attn_buf[b, h, chunk_idx, c1, c2] = T.float32(0.0)
+                                    for kd in T.serial(T.int64(key_head_dim)):
+                                        attn_buf[b, h, chunk_idx, c1, c2] += (
+                                            query_buf[b, h, chunk_idx, c1, kd]
+                                            * key_buf[b, h, chunk_idx, c2, kd]
+                                        )
+                                    attn_buf[b, h, chunk_idx, c1, c2] = T.if_then_else(
+                                        c2 > c1,
+                                        T.float32(0.0),
+                                        attn_buf[b, h, chunk_idx, c1, c2]
+                                        * T.exp(g_i - g_cumsum_buf[b, h, chunk_idx, c2]),
+                                    )
+
+                            for c in T.serial(T.int64(chunk_size)):
+                                g_curr = g_cumsum_buf[b, h, chunk_idx, c]
+                                exp_curr = T.exp(g_curr)
+                                for vd in T.serial(T.int64(value_head_dim)):
+                                    v_new_buf[b, h, chunk_idx, c, vd] = value_intra_buf[
+                                        b, h, chunk_idx, c, vd
+                                    ]
+                                    for kd in T.serial(T.int64(key_head_dim)):
+                                        v_new_buf[b, h, chunk_idx, c, vd] -= (
+                                            k_cumdecay_buf[b, h, chunk_idx, c, kd]
+                                            * recurrent_state_out_buf[b, h, kd, vd]
+                                        )
+
+                                for vd in T.serial(T.int64(value_head_dim)):
+                                    attn_inter_buf[b, h, chunk_idx, c, vd] = T.float32(0.0)
+                                    for kd in T.serial(T.int64(key_head_dim)):
+                                        attn_inter_buf[b, h, chunk_idx, c, vd] += (
+                                            query_buf[b, h, chunk_idx, c, kd]
+                                            * exp_curr
+                                            * recurrent_state_out_buf[b, h, kd, vd]
+                                        )
+
+                                for vd in T.serial(T.int64(value_head_dim)):
+                                    core_attn_out_buf[b, h, chunk_idx, c, vd] = attn_inter_buf[
+                                        b, h, chunk_idx, c, vd
+                                    ]
+                                    for r in T.serial(T.int64(chunk_size)):
+                                        core_attn_out_buf[b, h, chunk_idx, c, vd] += (
+                                            attn_buf[b, h, chunk_idx, c, r]
+                                            * v_new_buf[b, h, chunk_idx, r, vd]
+                                        )
+
+                            for kd in T.serial(T.int64(key_head_dim)):
+                                for vd in T.serial(T.int64(value_head_dim)):
+                                    g_last = g_cumsum_buf[b, h, chunk_idx, T.int64(chunk_size - 1)]
+                                    exp_last = T.exp(g_last)
+                                    recurrent_state_out_buf[b, h, kd, vd] = (
+                                        recurrent_state_out_buf[b, h, kd, vd] * exp_last
+                                    )
+                                    for c in T.serial(T.int64(chunk_size)):
+                                        recurrent_state_out_buf[b, h, kd, vd] += (
+                                            key_buf[b, h, chunk_idx, c, kd]
+                                            * v_new_buf[b, h, chunk_idx, c, vd]
+                                            * T.exp(g_last - g_cumsum_buf[b, h, chunk_idx, c])
+                                        )
+
+        return inter_chunk_recurrent
+
+    def gdn_chunked_func(
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        gate: Tensor,
+        beta: Tensor,
+        state_in: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        q = _expand_key_heads_to_value_heads(q, "expand_query_to_value_heads")
+        k = _expand_key_heads_to_value_heads(k, "expand_key_to_value_heads")
+
+        q = op.astype(q, "float32")
+        k = op.astype(k, "float32")
+        v = op.astype(v, "float32")
+        gate = op.astype(gate, "float32")
+        beta = op.astype(beta, "float32")
+        state_in = op.astype(state_in, "float32")
+
+        batch_size, seq_len, _, _ = q.shape
+        num_chunks = tirx.ceildiv(seq_len, chunk_size)
+        padded_len = num_chunks * chunk_size
+        scale = 1.0 / math.sqrt(key_head_dim)
+
+        query_t = _transpose_pad_bshd_to_bhsd(q, padded_len, "transpose_pad_query", scale=scale)
+        key_t = _transpose_pad_bshd_to_bhsd(k, padded_len, "transpose_pad_key")
+        value_t = _transpose_pad_bshd_to_bhsd(v, padded_len, "transpose_pad_value")
+        g_t = _transpose_pad_bsh_to_bhs(gate, padded_len, "transpose_pad_g")
+        beta_t = _transpose_pad_bsh_to_bhs(beta, padded_len, "transpose_pad_beta")
+
+        v_beta = value_t * op.unsqueeze(beta_t, -1)
+        k_beta = key_t * op.unsqueeze(beta_t, -1)
+
+        query_chunked = op.reshape(
+            query_t,
+            (batch_size, num_value_heads, num_chunks, chunk_size, key_head_dim),
+        )
+        key_chunked = op.reshape(
+            key_t,
+            (batch_size, num_value_heads, num_chunks, chunk_size, key_head_dim),
+        )
+        k_beta_chunked = op.reshape(
+            k_beta,
+            (batch_size, num_value_heads, num_chunks, chunk_size, key_head_dim),
+        )
+        v_beta_chunked = op.reshape(
+            v_beta,
+            (batch_size, num_value_heads, num_chunks, chunk_size, value_head_dim),
+        )
+        g_chunked = op.reshape(g_t, (batch_size, num_value_heads, num_chunks, chunk_size))
+
+        g_cumsum = op.cumsum(g_chunked, axis=-1)
+        exp_g_cumsum = op.exp(g_cumsum)
+
+        key_chunked_t = op.permute_dims(key_chunked, [0, 1, 2, 4, 3])
+        attn_mm = op.matmul(k_beta_chunked, key_chunked_t, out_dtype="float32")
+
+        attn_identity = op.tensor_ir_op(
+            _create_associative_scan_primfunc(),
+            "gdn_associative_scan",
+            [attn_mm, g_cumsum],
+            Tensor.placeholder(
+                (batch_size, num_value_heads, num_chunks, chunk_size, chunk_size),
+                "float32",
+            ),
+        )
+
+        value_intra = op.matmul(attn_identity, v_beta_chunked, out_dtype="float32")
+        k_cumdecay_input = k_beta_chunked * op.unsqueeze(exp_g_cumsum, -1)
+        k_cumdecay = op.matmul(attn_identity, k_cumdecay_input, out_dtype="float32")
+
+        core_attn_out_chunked, recurrent_state_out = op.tensor_ir_op(
+            _create_inter_chunk_recurrent_primfunc(),
+            "gdn_inter_chunk_recurrent",
+            [
+                query_chunked,
+                key_chunked,
+                value_intra,
+                k_cumdecay,
+                g_cumsum,
+                state_in,
+            ],
+            [
+                Tensor.placeholder(
+                    (batch_size, num_value_heads, num_chunks, chunk_size, value_head_dim),
+                    "float32",
+                ),
+                Tensor.placeholder(
+                    (batch_size, num_value_heads, key_head_dim, value_head_dim),
+                    "float32",
+                ),
+            ],
+        )
+
+        core_attn_out_padded = op.reshape(
+            core_attn_out_chunked,
+            (batch_size, num_value_heads, padded_len, value_head_dim),
+        )
+        core_attn_out_padded = op.permute_dims(core_attn_out_padded, [0, 2, 1, 3])
+        core_attn_out = _crop_padded_output(core_attn_out_padded, seq_len)
+        return core_attn_out, recurrent_state_out
+
+    return gdn_chunked_func
+
+
 # ============================================================================
 # GatedDeltaNet Linear Attention Layer
 # ============================================================================
@@ -389,6 +813,9 @@ class Qwen35GatedDeltaNet(nn.Module):
         self.value_head_dim = config.linear_value_head_dim  # 128
         self.num_key_heads = config.linear_num_key_heads  # 16
         self.num_value_heads = config.linear_num_value_heads  # 16 or 32
+        # Kernel chunk size is algorithmic and should stay small (e.g. 64).
+        # Do not use engine prefill_chunk_size (e.g. 2048), which controls request splitting.
+        self.gdn_chunk_size = 64
         self.hidden_size = config.hidden_size
         self.dtype = config.dtype
 
@@ -473,22 +900,32 @@ class Qwen35GatedDeltaNet(nn.Module):
         # Get recurrent state from RNNState (state_id=0)
         state_in_layer = state.get(layer_idx, 0, (b, n_vh, K, V), "float32")
 
-        # Recurrent computation via TIR kernel
-        out_recurrent, state_out_layer = op.tensor_ir_op(
-            create_gated_delta_net_func(
+        # Dispatch recurrent path for decode and chunked path for prefill.
+        if is_prefill:
+            out_recurrent, state_out_layer = create_gated_delta_net_chunked_func(
                 num_key_heads=n_kh,
                 num_value_heads=n_vh,
                 key_head_dim=K,
                 value_head_dim=V,
                 dtype=self.dtype,
-            ),
-            "gated_delta_net",
-            [q, k, v, gate, beta, state_in_layer],
-            [
-                Tensor.placeholder([b, s, n_vh, V], "float32"),
-                Tensor.placeholder([b, n_vh, K, V], "float32"),
-            ],
-        )
+                chunk_size=self.gdn_chunk_size,
+            )(q, k, v, gate, beta, state_in_layer)
+        else:
+            out_recurrent, state_out_layer = op.tensor_ir_op(
+                create_gated_delta_net_recurrent_func(
+                    num_key_heads=n_kh,
+                    num_value_heads=n_vh,
+                    key_head_dim=K,
+                    value_head_dim=V,
+                    dtype=self.dtype,
+                ),
+                "gated_delta_net_recurrent",
+                [q, k, v, gate, beta, state_in_layer],
+                [
+                    Tensor.placeholder([b, s, n_vh, V], "float32"),
+                    Tensor.placeholder([b, n_vh, K, V], "float32"),
+                ],
+            )
 
         # Cast recurrent output back to model dtype
         out_recurrent = op.astype(out_recurrent, self.dtype)


### PR DESCRIPTION
Right now, we leverage the recurrent decode kernel for both prefill and decode in the qwen3.5 model. Huggingface / other implementations leverage a specialized prefill kernel that should be higher performance. This PR ports that logic via a custom implementation of chunked gated deltanet. 

I also adjusted the engine / model to support batch size 1 methods, these were previously disabled for hybrid models universally. 