### PR TITLE
[Fix] Strip reasoning in history for Qwen3 chat

### DIFF
--- a/cpp/json_ffi/conv_template.cc
+++ b/cpp/json_ffi/conv_template.cc
@@ -351,10 +351,51 @@ Result<std::vector<Data>> CreatePrompt(const Conversation& conv,
     return std::nullopt;
   };
 
-  if (auto err = f_process_messages(conv.messages)) {
+  // Optionally strip `<think>...</think>` blocks from historical assistant
+  // messages (those before the last user message), mirroring Qwen3's HF chat
+  // template. See mlc-ai/mlc-llm#3482.
+  const std::vector<ChatCompletionMessage>* conv_messages_ptr = &conv.messages;
+  const std::vector<ChatCompletionMessage>* request_messages_ptr = &request.messages;
+  std::vector<ChatCompletionMessage> stripped_conv_messages;
+  std::vector<ChatCompletionMessage> stripped_request_messages;
+  if (conv.strip_reasoning_in_history) {
+    const size_t conv_size = conv.messages.size();
+    int64_t last_user_idx = -1;
+    for (size_t i = 0; i < conv_size; ++i) {
+      if (conv.messages[i].role == "user") last_user_idx = static_cast<int64_t>(i);
+    }
+    for (size_t i = 0; i < request.messages.size(); ++i) {
+      if (request.messages[i].role == "user") last_user_idx = static_cast<int64_t>(conv_size + i);
+    }
+    const std::string kCloseTag = "</think>";
+    auto strip_range = [&](const std::vector<ChatCompletionMessage>& in, size_t offset,
+                           std::vector<ChatCompletionMessage>& out) {
+      out.reserve(in.size());
+      for (size_t i = 0; i < in.size(); ++i) {
+        ChatCompletionMessage msg = in[i];
+        const int64_t global_idx = static_cast<int64_t>(offset + i);
+        if (msg.role == "assistant" && global_idx < last_user_idx && msg.content.IsText()) {
+          const std::string& text = msg.content.Text();
+          const size_t close_pos = text.rfind(kCloseTag);
+          if (close_pos != std::string::npos) {
+            size_t start = close_pos + kCloseTag.size();
+            while (start < text.size() && text[start] == '\n') ++start;
+            msg.content = ChatCompletionMessageContent(text.substr(start));
+          }
+        }
+        out.push_back(std::move(msg));
+      }
+    };
+    strip_range(conv.messages, 0, stripped_conv_messages);
+    strip_range(request.messages, conv_size, stripped_request_messages);
+    conv_messages_ptr = &stripped_conv_messages;
+    request_messages_ptr = &stripped_request_messages;
+  }
+
+  if (auto err = f_process_messages(*conv_messages_ptr)) {
     return err.value();
   }
-  if (auto err = f_process_messages(request.messages)) {
+  if (auto err = f_process_messages(*request_messages_ptr)) {
     return err.value();
   }
   // append last assistant begin message
@@ -553,6 +594,14 @@ Result<Conversation> Conversation::FromJSON(const tvm::ffi::json::Object& json_o
     }
     conv.stop_token_ids.push_back(static_cast<int>(stop.cast<int64_t>()));
   }
+
+  Result<std::optional<bool>> strip_reasoning_res =
+      json::LookupOptionalWithResultReturn<bool>(json_obj, "strip_reasoning_in_history");
+  if (strip_reasoning_res.IsErr()) {
+    return TResult::Error(strip_reasoning_res.UnwrapErr());
+  }
+  conv.strip_reasoning_in_history = strip_reasoning_res.Unwrap().value_or(false);
+
   return TResult::Ok(conv);
 }
 

--- a/cpp/json_ffi/conv_template.h
+++ b/cpp/json_ffi/conv_template.h
@@ -118,6 +118,12 @@ struct Conversation {
   std::vector<std::string> stop_str;
   std::vector<int> stop_token_ids;
 
+  // When true, strip `<think>...</think>` blocks (and any trailing whitespace)
+  // from historical assistant messages before rendering the prompt, mirroring
+  // Qwen3's official HF chat template. Only assistant messages that appear
+  // before the last user message are affected.
+  bool strip_reasoning_in_history = false;
+
   Conversation();
 
   /*!

--- a/python/mlc_llm/conversation_template/__init__.py
+++ b/python/mlc_llm/conversation_template/__init__.py
@@ -27,6 +27,7 @@ from . import (
     orion,
     phi,
     qwen2,
+    qwen3,
     qwen3_5,
     redpajama,
     rwkv,

--- a/python/mlc_llm/conversation_template/qwen3.py
+++ b/python/mlc_llm/conversation_template/qwen3.py
@@ -1,0 +1,26 @@
+"""Qwen3 conversation template.
+
+Matches Qwen2's ChatML structure but strips `<think>...</think>` blocks from
+historical assistant turns, mirroring Qwen3's official HF chat template. Small
+Qwen3 variants (e.g. 0.6B) otherwise emit `<|im_end|>` prematurely when their
+own thinking traces are echoed back in multi-turn context (see mlc-ai/mlc-llm#3482).
+"""
+
+from mlc_llm.protocol.conversation_protocol import Conversation, MessagePlaceholders
+
+from .registry import ConvTemplateRegistry
+
+ConvTemplateRegistry.register_conv_template(
+    Conversation(
+        name="qwen3",
+        system_template=f"<|im_start|>system\n{MessagePlaceholders.SYSTEM.value}<|im_end|>\n",
+        system_message="You are a helpful assistant.",
+        roles={"user": "<|im_start|>user", "assistant": "<|im_start|>assistant"},
+        seps=["<|im_end|>\n"],
+        role_content_sep="\n",
+        role_empty_sep="\n",
+        stop_str=["<|endoftext|>", "<|im_end|>"],
+        stop_token_ids=[151643, 151645],
+        strip_reasoning_in_history=True,
+    )
+)

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -354,6 +354,7 @@ CONV_TEMPLATES = {
     "olmo2",
     "nemotron",
     "llm-jp",
+    "qwen3",
     "qwen3_5",
     "qwen3_5_nothink",
 }

--- a/python/mlc_llm/protocol/conversation_protocol.py
+++ b/python/mlc_llm/protocol/conversation_protocol.py
@@ -77,6 +77,13 @@ class Conversation(BaseModel):
     stop_str: List[str] = Field(default_factory=lambda: [])
     stop_token_ids: List[int] = Field(default_factory=lambda: [])
 
+    # When True, strip `<think>...</think>` blocks (and any trailing whitespace)
+    # from historical assistant messages before rendering the prompt, mirroring
+    # Qwen3's official HF chat template. Only historical turns before the last
+    # user message are affected; reasoning on the most recent assistant turn is
+    # preserved for tool-call prefill scenarios.
+    strip_reasoning_in_history: bool = False
+
     # Function call fields
     function_string: str = ""
     # whether using function calling or not, helps check for output message format in API call
@@ -137,7 +144,13 @@ class Conversation(BaseModel):
         if system_msg != "":
             message_list.append(system_msg)
 
-        for i, (role, content) in enumerate(self.messages):  # pylint: disable=not-an-iterable
+        messages = (
+            _strip_reasoning_in_history(self.messages)
+            if self.strip_reasoning_in_history
+            else self.messages
+        )
+
+        for i, (role, content) in enumerate(messages):
             if role not in self.roles.keys():
                 raise ValueError(f'Role "{role}" is not a supported role in {self.roles.keys()}')
             separator = separators[role == "assistant"]  # check assistant role
@@ -212,6 +225,32 @@ def _get_url_from_item(item: Dict) -> str:
             "Should be a string or a dict with a url field."
         )
     return image_url
+
+
+def _strip_reasoning_in_history(
+    messages: List[Tuple[str, Optional[Union[str, List[Dict]]]]],
+) -> List[Tuple[str, Optional[Union[str, List[Dict]]]]]:
+    """Strip `<think>...</think>` blocks from assistant messages that precede
+    the last user message, matching Qwen3's HF chat-template behavior. The last
+    assistant message (if any) is preserved so tool-call prefill continuations
+    keep their reasoning context.
+    """
+    last_user_idx = -1
+    for i, (role, _) in enumerate(messages):
+        if role == "user":
+            last_user_idx = i
+
+    result: List[Tuple[str, Optional[Union[str, List[Dict]]]]] = []
+    for i, (role, content) in enumerate(messages):
+        if (
+            role == "assistant"
+            and i < last_user_idx
+            and isinstance(content, str)
+            and "</think>" in content
+        ):
+            content = content.split("</think>")[-1].lstrip("\n")
+        result.append((role, content))
+    return result
 
 
 def _combine_consecutive_messages(messages: List[Any]) -> List[Any]:


### PR DESCRIPTION
Qwen3's official HF chat template strips `<think>...</think>` blocks from historical assistant messages (all turns before the last user message) before rendering the prompt. mlc-llm's `qwen2` template — which the published Qwen3-*-MLC repos use — does not, so prior thinking traces get echoed back into context verbatim. On small Qwen3 variants (e.g. 0.6B) this pushes the model to emit `<|im_end|>` prematurely inside its next-turn `<think>` block, truncating the response before `</think>` is ever produced.

This change adds a `strip_reasoning_in_history` flag on the `Conversation` protocol (both the Python `as_prompt` in `conversation_protocol.py` and the C++ `CreatePrompt` in `json_ffi/conv_template.cc`), and registers a new `qwen3` template that sets it. For Qwen3-*-MLC repos to pick it up, their `mlc-chat-config.json` on HuggingFace needs the `conv_template` entry swapped to the new `qwen3` template; no weight changes.

Fixes #3482.