### PR TITLE
[Embedding][Serve] Phase 4: Add first-class decoder embedding path

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
 [MESSAGES CONTROL]
 disable=too-many-positional-arguments,duplicate-code
+
+[TYPECHECK]
+generated-members=sblock_alloc_buffer

--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -104,8 +104,11 @@ ModelMetadata ModelMetadata::FromJSON(const tvm::ffi::json::Object& metadata,
   }
   result.kv_state_kind = KVStateKindFromString(
       json::LookupOrDefault<std::string>(metadata, "kv_state_kind", "kv_cache"));
+  // For encoder embedding models (e.g. BERT), kv_cache metadata may be absent
+  // even though kv_state_kind defaults to "kv_cache". Treat missing kv_cache
+  // field as no-op rather than failing.
   if (result.kv_state_kind != KVStateKind::kNone &&
-      result.kv_state_kind != KVStateKind::kRNNState) {
+      result.kv_state_kind != KVStateKind::kRNNState && metadata.count("kv_cache")) {
     result.kv_cache_metadata =
         KVCacheMetadata::FromJSON(json::Lookup<tvm::ffi::json::Object>(metadata, "kv_cache"));
   } else {
@@ -113,6 +116,10 @@ ModelMetadata ModelMetadata::FromJSON(const tvm::ffi::json::Object& metadata,
                                 /*head_dim=*/0,
                                 /*num_attention_heads=*/0,
                                 /*num_key_value_heads=*/0};
+    // If kv_cache field is missing, override kv_state_kind to None for encoder models.
+    if (!metadata.count("kv_cache") && result.model_task == "embedding") {
+      result.kv_state_kind = KVStateKind::kNone;
+    }
   }
   {
     std::vector<ModelMetadata::Param>& params = result.params;

--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -261,6 +261,70 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   });
 }
 
+/****************** EmbeddingRequest ******************/
+
+EmbeddingRequest::EmbeddingRequest(String id, std::vector<EmbeddingItem> items,
+                                   PoolingStrategy pooling_strategy, bool normalize) {
+  ObjectPtr<EmbeddingRequestNode> n = tvm::ffi::make_object<EmbeddingRequestNode>();
+  n->id = std::move(id);
+  n->items = std::move(items);
+  n->pooling_strategy = pooling_strategy;
+  n->normalize = normalize;
+  data_ = std::move(n);
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  EmbeddingRequestNode::RegisterReflection();
+}
+
+/****************** EmbeddingResult ******************/
+
+EmbeddingResult::EmbeddingResult(String request_id, Tensor embeddings, int prompt_tokens) {
+  ObjectPtr<EmbeddingResultObj> n = tvm::ffi::make_object<EmbeddingResultObj>();
+  n->request_id = std::move(request_id);
+  n->embeddings = std::move(embeddings);
+  n->prompt_tokens = prompt_tokens;
+  data_ = std::move(n);
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  EmbeddingResultObj::RegisterReflection();
+
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef()
+      .def("mlc.serve.EmbeddingResultUnpack",
+           [](EmbeddingResult result) {
+             Array<Any> ret = {result->request_id, result->embeddings,
+                               static_cast<int64_t>(result->prompt_tokens)};
+             return ret;
+           })
+      .def_packed("mlc.serve.EmbeddingRequest",
+                  [](ffi::PackedArgs args, ffi::Any* rv) {
+                    // args: request_id (String), num_items (int),
+                    //   for each item: item_index (int), num_tokens (int), token_ids...
+                    //   pooling_strategy (int), normalize (bool)
+                    String request_id = args[0].cast<String>();
+                    int num_items = args[1].cast<int>();
+                    int arg_idx = 2;
+                    std::vector<EmbeddingItem> items;
+                    items.reserve(num_items);
+                    for (int i = 0; i < num_items; ++i) {
+                      EmbeddingItem item;
+                      item.item_index = args[arg_idx++].cast<int>();
+                      int num_tokens = args[arg_idx++].cast<int>();
+                      item.token_ids.reserve(num_tokens);
+                      for (int t = 0; t < num_tokens; ++t) {
+                        item.token_ids.push_back(args[arg_idx++].cast<int32_t>());
+                      }
+                      items.push_back(std::move(item));
+                    }
+                    int pooling = args[arg_idx++].cast<int>();
+                    bool normalize = args[arg_idx++].cast<bool>();
+                    *rv = EmbeddingRequest(std::move(request_id), std::move(items),
+                                           static_cast<PoolingStrategy>(pooling), normalize);
+                  });
+}
+
 }  // namespace serve
 }  // namespace llm
 }  // namespace mlc

--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -298,31 +298,29 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                                static_cast<int64_t>(result->prompt_tokens)};
              return ret;
            })
-      .def_packed("mlc.serve.EmbeddingRequest",
-                  [](ffi::PackedArgs args, ffi::Any* rv) {
-                    // args: request_id (String), num_items (int),
-                    //   for each item: item_index (int), num_tokens (int), token_ids...
-                    //   pooling_strategy (int), normalize (bool)
-                    String request_id = args[0].cast<String>();
-                    int num_items = args[1].cast<int>();
-                    int arg_idx = 2;
-                    std::vector<EmbeddingItem> items;
-                    items.reserve(num_items);
-                    for (int i = 0; i < num_items; ++i) {
-                      EmbeddingItem item;
-                      item.item_index = args[arg_idx++].cast<int>();
-                      int num_tokens = args[arg_idx++].cast<int>();
-                      item.token_ids.reserve(num_tokens);
-                      for (int t = 0; t < num_tokens; ++t) {
-                        item.token_ids.push_back(args[arg_idx++].cast<int32_t>());
-                      }
-                      items.push_back(std::move(item));
-                    }
-                    int pooling = args[arg_idx++].cast<int>();
-                    bool normalize = args[arg_idx++].cast<bool>();
-                    *rv = EmbeddingRequest(std::move(request_id), std::move(items),
-                                           static_cast<PoolingStrategy>(pooling), normalize);
-                  });
+      .def("mlc.serve.EmbeddingRequest",
+           [](String request_id, IntTuple flat_token_ids, IntTuple token_lengths, int pooling,
+              bool normalize) {
+             // flat_token_ids is the concatenation of all items' token_ids in
+             // item_index order; token_lengths[i] is the length of item i.
+             int num_items = static_cast<int>(token_lengths.size());
+             std::vector<EmbeddingItem> items;
+             items.reserve(num_items);
+             size_t offset = 0;
+             for (int i = 0; i < num_items; ++i) {
+               EmbeddingItem item;
+               item.item_index = i;
+               int num_tokens = static_cast<int>(token_lengths[i]);
+               item.token_ids.reserve(num_tokens);
+               for (int t = 0; t < num_tokens; ++t) {
+                 item.token_ids.push_back(static_cast<int32_t>(flat_token_ids[offset + t]));
+               }
+               offset += num_tokens;
+               items.push_back(std::move(item));
+             }
+             return EmbeddingRequest(std::move(request_id), std::move(items),
+                                     static_cast<PoolingStrategy>(pooling), normalize);
+           });
 }
 
 }  // namespace serve

--- a/cpp/serve/data.h
+++ b/cpp/serve/data.h
@@ -248,6 +248,113 @@ class RequestStreamOutput : public ObjectRef {
                                              RequestStreamOutputObj);
 };
 
+/****************** Embedding Types ******************/
+
+/*! \brief The pooling strategy for encoder embedding. */
+enum class PoolingStrategy : int {
+  kCLS = 0,
+  kMean = 1,
+  kLast = 2,
+};
+
+/*!
+ * \brief A single embedding item within an embedding request.
+ * Each item is a canonicalized sequence of token IDs
+ * (already includes CLS/SEP, already truncated).
+ */
+struct EmbeddingItem {
+  /*! \brief The token ids for this item (canonicalized by Python). */
+  std::vector<int32_t> token_ids;
+  /*! \brief The original index of this item in the request. */
+  int item_index;
+};
+
+/*!
+ * \brief An embedding request containing one or more items.
+ * The C++ side only sees canonicalized token-id items.
+ */
+struct EmbeddingRequestNode : public Object {
+  /*! \brief The unique identifier of the request. */
+  String id;
+  /*! \brief The items to embed. */
+  std::vector<EmbeddingItem> items;
+  /*! \brief The pooling strategy. */
+  PoolingStrategy pooling_strategy = PoolingStrategy::kCLS;
+  /*! \brief Whether to L2-normalize the output embeddings. */
+  bool normalize = true;
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<EmbeddingRequestNode>();
+  }
+
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("mlc.serve.EmbeddingRequest", EmbeddingRequestNode, Object);
+};
+
+class EmbeddingRequest : public ObjectRef {
+ public:
+  explicit EmbeddingRequest(String id, std::vector<EmbeddingItem> items,
+                            PoolingStrategy pooling_strategy, bool normalize);
+
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(EmbeddingRequest, ObjectRef, EmbeddingRequestNode);
+};
+
+/*!
+ * \brief The result of an embedding request, carrying
+ * request-level aggregated embeddings on CPU.
+ */
+class EmbeddingResultObj : public Object {
+ public:
+  /*! \brief The request id. */
+  String request_id;
+  /*!
+   * \brief The pooled embeddings as a CPU NDArray of shape [num_items, hidden_dim].
+   * Lifetime is owned by the result; Python can read it directly.
+   */
+  Tensor embeddings;
+  /*! \brief Total number of prompt tokens across all items. */
+  int prompt_tokens = 0;
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<EmbeddingResultObj>();
+  }
+
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("mlc.serve.EmbeddingResult", EmbeddingResultObj, Object);
+};
+
+class EmbeddingResult : public ObjectRef {
+ public:
+  explicit EmbeddingResult(String request_id, Tensor embeddings, int prompt_tokens);
+
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(EmbeddingResult, ObjectRef, EmbeddingResultObj);
+};
+
+/*!
+ * \brief Internal state for tracking an in-flight embedding request
+ * inside the engine. Holds per-item completion status and the
+ * result buffer that items write into.
+ */
+struct EmbeddingRequestState {
+  /*! \brief The embedding request. */
+  EmbeddingRequest request;
+  /*! \brief Number of items that have been completed so far. */
+  int completed_items = 0;
+  /*! \brief The CPU result buffer [num_items, hidden_dim], pre-allocated. */
+  Tensor result_buffer;
+  /*! \brief Total prompt tokens across all items. */
+  int prompt_tokens = 0;
+
+  explicit EmbeddingRequestState(EmbeddingRequest request, Tensor result_buffer)
+      : request(std::move(request)), result_buffer(std::move(result_buffer)) {}
+};
+
 }  // namespace serve
 }  // namespace llm
 }  // namespace mlc

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -1063,28 +1063,39 @@ class EngineImpl : public Engine {
   }
 
   /*!
-   * \brief Initialize the embedding lane: the BatchEmbeddingPrefill action
-   * and the result hidden dim. Called from Create() when task_mode_ is
-   * kEmbedding. Asserts that the primary model actually exposes encoder
-   * prefill — embedding_model_type == "decoder" is explicitly rejected
-   * here until decoder-embedding support lands. Reads engine_config_, which
-   * must already be set.
+   * \brief Initialize the embedding lane: the BatchEmbeddingPrefill /
+   * BatchDecoderEmbeddingPrefill action and the result hidden dim. Called
+   * from Create() when task_mode_ is kEmbedding. Dispatches on the primary
+   * model's ``embedding_model_type`` metadata: "encoder" models go through
+   * the right-padded bidirectional path, "decoder" models through the
+   * left-padded causal path. Reads engine_config_, which must already be
+   * set.
    */
   void InitEmbeddingLane() {
     const ModelMetadata& metadata = models_[0]->GetMetadata();
-    TVM_FFI_ICHECK_EQ(metadata.embedding_model_type, "encoder")
-        << "Engine embedding lane currently only supports "
-           "embedding_model_type=\"encoder\". Got: \""
-        << metadata.embedding_model_type << "\". decoder-embedding is not yet implemented.";
-    TVM_FFI_ICHECK(models_[0]->HasEncoderPrefill())
-        << "Model declares model_task=\"embedding\" with embedding_model_type=\"encoder\", "
-           "but the compiled model does not expose an encoder prefill function. "
-           "Check that the model was compiled with encoder prefill support enabled.";
+    const std::string& embedding_model_type = metadata.embedding_model_type;
+    if (embedding_model_type == "encoder") {
+      TVM_FFI_ICHECK(models_[0]->HasEncoderPrefill())
+          << "Model declares model_task=\"embedding\" with embedding_model_type=\"encoder\", "
+             "but the compiled model does not expose an encoder prefill function. "
+             "Check that the model was compiled with encoder prefill support enabled.";
+      embedding_lane_.action = EngineAction::BatchEmbeddingPrefill(models_[0], engine_config_);
+    } else if (embedding_model_type == "decoder") {
+      TVM_FFI_ICHECK(models_[0]->HasDecoderEmbeddingPrefill())
+          << "Model declares model_task=\"embedding\" with embedding_model_type=\"decoder\", "
+             "but the compiled model does not expose a decoder embedding prefill function. "
+             "Check that the model was compiled with decoder embedding prefill support enabled.";
+      embedding_lane_.action =
+          EngineAction::BatchDecoderEmbeddingPrefill(models_[0], engine_config_);
+    } else {
+      LOG(FATAL) << "Engine embedding lane supports embedding_model_type in "
+                    "{\"encoder\", \"decoder\"}. Got: \""
+                 << embedding_model_type << "\".";
+    }
 
-    embedding_lane_.action = EngineAction::BatchEmbeddingPrefill(models_[0], engine_config_);
     embedding_lane_.hidden_dim = models_[0]->GetHiddenSize();
     TVM_FFI_ICHECK_GT(embedding_lane_.hidden_dim, 0)
-        << "Encoder embedding model must have a known hidden_size after initialization.";
+        << "Embedding model must have a known hidden_size after initialization.";
   }
 
   /*! \brief Set the maximum threading backend concurrency. */

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -315,6 +315,10 @@ class MockEchoEngineImpl : public Engine {
     }
   }
 
+  /************** Embedding (no-op in mock) **************/
+  void AddEmbeddingRequest(EmbeddingRequest request) final {}
+  void SetEmbeddingRequestCallback(FEmbeddingRequestCallback callback) final {}
+
   /************** Debug/Profile **************/
 
   /*! \brief Internal engine metrics. */
@@ -452,51 +456,75 @@ class EngineImpl : public Engine {
                "enabled and not implemented with hybrid prefill yet.";
       }
     }
-    // - Load model weights, create KV cache and workspace.
+    // Detect encoder-embedding-only mode: primary model is an encoder embedding model.
+    // In this mode, skip all chat-only initialization (KV cache, logit processor, sampler,
+    // grammar, chat engine actions) since the encoder embedding lane is fully independent.
+    bool is_encoder_embedding_only = n->models_[0]->HasEncoderPrefill();
+
+    // - Load model weights and set capacity limits.
     n->model_workspaces_.clear();
     for (const Model& model : n->models_) {
       model->LoadParams();
       model->SetMaxNumSequence(engine_config->max_num_sequence);
       model->SetPrefillChunkSize(engine_config->prefill_chunk_size);
-      model->CreateKVCache(engine_config->kv_cache_page_size, engine_config->max_num_sequence,
-                           engine_config->max_total_sequence_length,
-                           engine_config->prefill_chunk_size, engine_config->max_history_size,
-                           engine_config->prefix_cache_max_num_recycling_seqs);
+      if (!is_encoder_embedding_only) {
+        // Chat models need KV cache; encoder embedding models do not.
+        model->CreateKVCache(engine_config->kv_cache_page_size, engine_config->max_num_sequence,
+                             engine_config->max_total_sequence_length,
+                             engine_config->prefill_chunk_size, engine_config->max_history_size,
+                             engine_config->prefix_cache_max_num_recycling_seqs);
+      }
       n->model_workspaces_.push_back(
           ModelWorkspace{model->AllocEmbeddingTensor(), model->AllocHiddenStatesTensor()});
     }
-    // - Initialize tokenizer and grammar
-    n->tokenizer_ = Tokenizer::FromPath(engine_config->model, GetTokenizerInfo(model_configs[0]));
-    n->token_table_ = n->tokenizer_->PostProcessedTokenTable();
-    n->cached_grammar_compiler_ = xgrammar::CachedGrammarCompiler(n->token_table_);
-    // - Create the logit processor and sampler, and
-    // the DraftTokenWorkspaceManager for speculative decoding.
-    int max_num_tokens = engine_config->max_num_sequence;
-    DraftTokenWorkspaceManager draft_token_workspace_manager{nullptr};
-    if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
-      // multiply max num_tokens by two so we can do ping-pong swaping during draft/verify process
-      draft_token_workspace_manager =
-          n->models_[0]->CreateDraftTokenWorkspaceManager(max_num_tokens * 2);
-      draft_token_workspace_manager->AllocWorkspace(
-          &n->model_workspaces_[0],
-          /*require_hidden_states=*/engine_config->speculative_mode == SpeculativeMode::kEagle);
+
+    if (is_encoder_embedding_only) {
+      // --- Encoder-embedding-only path ---
+      // Only create the embedding action. No tokenizer/grammar/logit/sampler/chat actions.
+      n->embedding_action_ = EngineAction::BatchEmbeddingPrefill(n->models_[0], engine_config);
+      n->embedding_hidden_dim_ = n->models_[0]->GetHiddenSize();
+      TVM_FFI_ICHECK_GT(n->embedding_hidden_dim_, 0)
+          << "Encoder embedding model must have a known hidden_size after initialization.";
+      // actions_ stays empty — Step() handles embedding_action_ separately.
+      n->engine_config_ = engine_config;
+    } else {
+      // --- Chat / decoder path (unchanged) ---
+      // Initialize tokenizer and grammar
+      n->tokenizer_ = Tokenizer::FromPath(engine_config->model, GetTokenizerInfo(model_configs[0]));
+      n->token_table_ = n->tokenizer_->PostProcessedTokenTable();
+      n->cached_grammar_compiler_ = xgrammar::CachedGrammarCompiler(n->token_table_);
+      // Create the logit processor and sampler, and
+      // the DraftTokenWorkspaceManager for speculative decoding.
+      int max_num_tokens = engine_config->max_num_sequence;
+      DraftTokenWorkspaceManager draft_token_workspace_manager{nullptr};
+      if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
+        draft_token_workspace_manager =
+            n->models_[0]->CreateDraftTokenWorkspaceManager(max_num_tokens * 2);
+        draft_token_workspace_manager->AllocWorkspace(
+            &n->model_workspaces_[0],
+            /*require_hidden_states=*/engine_config->speculative_mode == SpeculativeMode::kEagle);
+      }
+      LogitProcessor logit_processor =
+          n->models_[0]->CreateLogitProcessor(max_num_tokens, trace_recorder);
+      Sampler sampler = n->models_[0]->CreateSampler(
+          max_num_tokens, static_cast<int>(n->models_.size()), trace_recorder);
+      // Initialize engine actions that represent state transitions.
+      if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
+        n->estate_->spec_draft_length = engine_config->spec_draft_length;
+      }
+      n->actions_ =
+          CreateEngineActions(n->models_, engine_config, model_configs, n->model_workspaces_,
+                              logit_processor, sampler, draft_token_workspace_manager, n->tokenizer_,
+                              n->trace_recorder_, n->estate_->request_stream_callback_, device);
+      n->draft_token_workspace_manager_ = draft_token_workspace_manager;
+      // Also create embedding action for hybrid models that support both chat and embedding.
+      if (n->models_[0]->HasEncoderPrefill()) {
+        n->embedding_action_ = EngineAction::BatchEmbeddingPrefill(n->models_[0], engine_config);
+        n->embedding_hidden_dim_ = n->models_[0]->GetHiddenSize();
+      }
+      n->engine_config_ = engine_config;
+      n->SetThreadMaxConcurrency();
     }
-    LogitProcessor logit_processor =
-        n->models_[0]->CreateLogitProcessor(max_num_tokens, trace_recorder);
-    Sampler sampler = n->models_[0]->CreateSampler(
-        max_num_tokens, static_cast<int>(n->models_.size()), trace_recorder);
-    // - Initialize engine actions that represent state transitions.
-    if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
-      n->estate_->spec_draft_length = engine_config->spec_draft_length;
-    }
-    n->actions_ =
-        CreateEngineActions(n->models_, engine_config, model_configs, n->model_workspaces_,
-                            logit_processor, sampler, draft_token_workspace_manager, n->tokenizer_,
-                            n->trace_recorder_, n->estate_->request_stream_callback_, device);
-    n->draft_token_workspace_manager_ = draft_token_workspace_manager;
-    // - Automatically set the threading backend max concurrency.
-    n->engine_config_ = engine_config;
-    n->SetThreadMaxConcurrency();
     // - Get the default generation config from the first model.
     GenerationConfig default_generation_cfg =
         GenerationConfig::GetDefaultFromModelConfig(model_configs[0]);
@@ -511,7 +539,10 @@ class EngineImpl : public Engine {
     }
   }
 
-  bool Empty() final { return estate_->running_queue.empty() && estate_->waiting_queue.empty(); }
+  bool Empty() final {
+    return estate_->running_queue.empty() && estate_->waiting_queue.empty() &&
+           estate_->embedding_waiting_queue.empty();
+  }
 
   String JSONMetrics() final { return tvm::ffi::json::Stringify(estate_->metrics.AsJSON(), 2); }
 
@@ -742,11 +773,43 @@ class EngineImpl : public Engine {
     }
   }
 
+  /***************** Embedding Request Management *****************/
+
+  void AddEmbeddingRequest(EmbeddingRequest request) final {
+    NVTXScopedRange nvtx_scope("Add embedding request " + std::string(request->id));
+
+    int num_items = static_cast<int>(request->items.size());
+    TVM_FFI_ICHECK_GT(num_items, 0) << "Embedding request must have at least one item.";
+
+    // Deterministic allocation: hidden_dim must be available now.
+    TVM_FFI_ICHECK_GT(embedding_hidden_dim_, 0)
+        << "Cannot add embedding request: model hidden_dim is not initialized. "
+        << "Is the model an encoder embedding model?";
+
+    Tensor result_buffer = Tensor::Empty({num_items, embedding_hidden_dim_}, DataType::Float(32),
+                                         Device{DLDeviceType::kDLCPU, 0});
+
+    estate_->embedding_waiting_queue.push_back(request);
+    estate_->embedding_request_states.emplace(
+        request->id, EmbeddingRequestState(request, result_buffer));
+  }
+
+  void SetEmbeddingRequestCallback(FEmbeddingRequestCallback callback) final {
+    estate_->embedding_request_callback_ = std::move(callback);
+  }
+
   /*********************** Engine Action ***********************/
 
   void Step() final {
     TVM_FFI_ICHECK(estate_->request_stream_callback_ != nullptr)
         << "The request stream callback is not set. Engine cannot execute.";
+
+    // Run the embedding action if we have an encoder model and pending embedding requests.
+    if (embedding_action_.defined() && !estate_->embedding_waiting_queue.empty()) {
+      embedding_action_->Step(estate_);
+    }
+
+    // Then, run chat actions as before.
     for (EngineAction action : actions_) {
       Array<Request> processed_requests;
       {
@@ -1009,6 +1072,10 @@ class EngineImpl : public Engine {
   Optional<DraftTokenWorkspaceManager> draft_token_workspace_manager_;
   // Event trace recorder.
   Optional<EventTraceRecorder> trace_recorder_;
+  // Embedding lane: the action for encoder embedding.
+  EngineAction embedding_action_{nullptr};
+  // The hidden dimension for encoder embedding results.
+  int embedding_hidden_dim_ = -1;
 };
 
 Result<EngineCreationOutput> Engine::Create(const std::string& engine_config_json_str,

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -82,6 +82,22 @@ inline std::pair<std::optional<std::string>, int> GetEnvSocketHostPort() {
   return {host, std::atoi(port_str)};
 }
 
+// Top-level task the engine instance is serving. Derived once from the
+// primary model's metadata at Create() time and cached to avoid re-reading
+// ModelMetadata on every Step(). An engine instance is strictly single-task:
+// hybrid chat+embedding on the same engine is intentionally not supported.
+enum class EngineTaskMode {
+  kChat,
+  kEmbedding,
+};
+
+inline EngineTaskMode InferEngineTaskMode(const ModelMetadata& metadata) {
+  if (metadata.model_task == "embedding") {
+    return EngineTaskMode::kEmbedding;
+  }
+  return EngineTaskMode::kChat;
+}
+
 // string back error node
 void StreamBackErrorImpl(Request request, FRequestStreamCallback request_stream_callback,
                          String finish_reason) {
@@ -456,74 +472,31 @@ class EngineImpl : public Engine {
                "enabled and not implemented with hybrid prefill yet.";
       }
     }
-    // Detect encoder-embedding-only mode: primary model is an encoder embedding model.
-    // In this mode, skip all chat-only initialization (KV cache, logit processor, sampler,
-    // grammar, chat engine actions) since the encoder embedding lane is fully independent.
-    bool is_encoder_embedding_only = n->models_[0]->HasEncoderPrefill();
-
-    // - Load model weights and set capacity limits.
+    // - Task-agnostic per-model setup. KV cache creation and all
+    //   lane-specific state live inside InitChatLane / InitEmbeddingLane.
     n->model_workspaces_.clear();
     for (const Model& model : n->models_) {
       model->LoadParams();
       model->SetMaxNumSequence(engine_config->max_num_sequence);
       model->SetPrefillChunkSize(engine_config->prefill_chunk_size);
-      if (!is_encoder_embedding_only) {
-        // Chat models need KV cache; encoder embedding models do not.
-        model->CreateKVCache(engine_config->kv_cache_page_size, engine_config->max_num_sequence,
-                             engine_config->max_total_sequence_length,
-                             engine_config->prefill_chunk_size, engine_config->max_history_size,
-                             engine_config->prefix_cache_max_num_recycling_seqs);
-      }
       n->model_workspaces_.push_back(
           ModelWorkspace{model->AllocEmbeddingTensor(), model->AllocHiddenStatesTensor()});
     }
 
-    if (is_encoder_embedding_only) {
-      // --- Encoder-embedding-only path ---
-      // Only create the embedding action. No tokenizer/grammar/logit/sampler/chat actions.
-      n->embedding_action_ = EngineAction::BatchEmbeddingPrefill(n->models_[0], engine_config);
-      n->embedding_hidden_dim_ = n->models_[0]->GetHiddenSize();
-      TVM_FFI_ICHECK_GT(n->embedding_hidden_dim_, 0)
-          << "Encoder embedding model must have a known hidden_size after initialization.";
-      // actions_ stays empty — Step() handles embedding_action_ separately.
-      n->engine_config_ = engine_config;
-    } else {
-      // --- Chat / decoder path (unchanged) ---
-      // Initialize tokenizer and grammar
-      n->tokenizer_ = Tokenizer::FromPath(engine_config->model, GetTokenizerInfo(model_configs[0]));
-      n->token_table_ = n->tokenizer_->PostProcessedTokenTable();
-      n->cached_grammar_compiler_ = xgrammar::CachedGrammarCompiler(n->token_table_);
-      // Create the logit processor and sampler, and
-      // the DraftTokenWorkspaceManager for speculative decoding.
-      int max_num_tokens = engine_config->max_num_sequence;
-      DraftTokenWorkspaceManager draft_token_workspace_manager{nullptr};
-      if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
-        draft_token_workspace_manager =
-            n->models_[0]->CreateDraftTokenWorkspaceManager(max_num_tokens * 2);
-        draft_token_workspace_manager->AllocWorkspace(
-            &n->model_workspaces_[0],
-            /*require_hidden_states=*/engine_config->speculative_mode == SpeculativeMode::kEagle);
-      }
-      LogitProcessor logit_processor =
-          n->models_[0]->CreateLogitProcessor(max_num_tokens, trace_recorder);
-      Sampler sampler = n->models_[0]->CreateSampler(
-          max_num_tokens, static_cast<int>(n->models_.size()), trace_recorder);
-      // Initialize engine actions that represent state transitions.
-      if (engine_config->speculative_mode != SpeculativeMode::kDisable) {
-        n->estate_->spec_draft_length = engine_config->spec_draft_length;
-      }
-      n->actions_ =
-          CreateEngineActions(n->models_, engine_config, model_configs, n->model_workspaces_,
-                              logit_processor, sampler, draft_token_workspace_manager, n->tokenizer_,
-                              n->trace_recorder_, n->estate_->request_stream_callback_, device);
-      n->draft_token_workspace_manager_ = draft_token_workspace_manager;
-      // Also create embedding action for hybrid models that support both chat and embedding.
-      if (n->models_[0]->HasEncoderPrefill()) {
-        n->embedding_action_ = EngineAction::BatchEmbeddingPrefill(n->models_[0], engine_config);
-        n->embedding_hidden_dim_ = n->models_[0]->GetHiddenSize();
-      }
-      n->engine_config_ = engine_config;
-      n->SetThreadMaxConcurrency();
+    // - Cache the resolved config so lane helpers and SetThreadMaxConcurrency
+    //   can read it via engine_config_.
+    n->engine_config_ = engine_config;
+
+    // - Dispatch lane initialization based on the primary model's task.
+    //   Strict single-task: no lane-crossing, no hybrid.
+    n->task_mode_ = InferEngineTaskMode(n->models_[0]->GetMetadata());
+    switch (n->task_mode_) {
+      case EngineTaskMode::kChat:
+        n->InitChatLane(model_configs, trace_recorder, device);
+        break;
+      case EngineTaskMode::kEmbedding:
+        n->InitEmbeddingLane();
+        break;
     }
     // - Get the default generation config from the first model.
     GenerationConfig default_generation_cfg =
@@ -540,8 +513,14 @@ class EngineImpl : public Engine {
   }
 
   bool Empty() final {
-    return estate_->running_queue.empty() && estate_->waiting_queue.empty() &&
-           estate_->embedding_waiting_queue.empty();
+    switch (task_mode_) {
+      case EngineTaskMode::kEmbedding:
+        return estate_->embedding_waiting_queue.empty();
+      case EngineTaskMode::kChat:
+        return estate_->running_queue.empty() && estate_->waiting_queue.empty();
+    }
+    // Unreachable: task_mode_ is exhaustively handled above.
+    return true;
   }
 
   String JSONMetrics() final { return tvm::ffi::json::Stringify(estate_->metrics.AsJSON(), 2); }
@@ -695,6 +674,9 @@ class EngineImpl : public Engine {
   }
 
   void AddRequest(Request request) final {
+    TVM_FFI_ICHECK(task_mode_ == EngineTaskMode::kChat)
+        << "AddRequest called on a non-chat engine. This engine was initialized with "
+           "model_task != \"chat\"; use AddEmbeddingRequest instead.";
     NVTXScopedRange nvtx_scope("Add request " + request->id);
     // special requests do not involve generation
     if (request->generation_cfg->debug_config.special_request != SpecialRequestKind::kNone) {
@@ -776,18 +758,22 @@ class EngineImpl : public Engine {
   /***************** Embedding Request Management *****************/
 
   void AddEmbeddingRequest(EmbeddingRequest request) final {
+    TVM_FFI_ICHECK(task_mode_ == EngineTaskMode::kEmbedding)
+        << "AddEmbeddingRequest called on a non-embedding engine. This engine was "
+           "initialized with model_task != \"embedding\"; use AddRequest instead.";
     NVTXScopedRange nvtx_scope("Add embedding request " + std::string(request->id));
 
     int num_items = static_cast<int>(request->items.size());
     TVM_FFI_ICHECK_GT(num_items, 0) << "Embedding request must have at least one item.";
 
-    // Deterministic allocation: hidden_dim must be available now.
-    TVM_FFI_ICHECK_GT(embedding_hidden_dim_, 0)
-        << "Cannot add embedding request: model hidden_dim is not initialized. "
-        << "Is the model an encoder embedding model?";
+    // hidden_dim was validated during InitEmbeddingLane; re-asserting here
+    // as a cheap invariant check before the allocation.
+    TVM_FFI_ICHECK_GT(embedding_lane_.hidden_dim, 0)
+        << "Embedding lane hidden_dim is not initialized.";
 
-    Tensor result_buffer = Tensor::Empty({num_items, embedding_hidden_dim_}, DataType::Float(32),
-                                         Device{DLDeviceType::kDLCPU, 0});
+    Tensor result_buffer =
+        Tensor::Empty({num_items, embedding_lane_.hidden_dim}, DataType::Float(32),
+                      Device{DLDeviceType::kDLCPU, 0});
 
     estate_->embedding_waiting_queue.push_back(request);
     estate_->embedding_request_states.emplace(
@@ -804,29 +790,37 @@ class EngineImpl : public Engine {
     TVM_FFI_ICHECK(estate_->request_stream_callback_ != nullptr)
         << "The request stream callback is not set. Engine cannot execute.";
 
-    // Run the embedding action if we have an encoder model and pending embedding requests.
-    if (embedding_action_.defined() && !estate_->embedding_waiting_queue.empty()) {
-      embedding_action_->Step(estate_);
-    }
-
-    // Then, run chat actions as before.
-    for (EngineAction action : actions_) {
-      Array<Request> processed_requests;
-      {
-        NVTXScopedRange nvtx_scope("Action step");
-        processed_requests = action->Step(estate_);
+    switch (task_mode_) {
+      case EngineTaskMode::kEmbedding: {
+        // Embedding lane: single action, no chat pipeline. Skip when the
+        // waiting queue is empty so idle Step() calls are cheap.
+        if (!estate_->embedding_waiting_queue.empty()) {
+          NVTXScopedRange nvtx_scope("Embedding action step");
+          embedding_lane_.action->Step(estate_);
+        }
+        return;
       }
-      if (!processed_requests.empty()) {
-        ActionStepPostProcess(processed_requests, estate_, models_, tokenizer_,
-                              estate_->request_stream_callback_,
-                              engine_config_->max_single_sequence_length,
-                              draft_token_workspace_manager_, trace_recorder_);
+      case EngineTaskMode::kChat: {
+        for (EngineAction action : actions_) {
+          Array<Request> processed_requests;
+          {
+            NVTXScopedRange nvtx_scope("Action step");
+            processed_requests = action->Step(estate_);
+          }
+          if (!processed_requests.empty()) {
+            ActionStepPostProcess(processed_requests, estate_, models_, tokenizer_,
+                                  estate_->request_stream_callback_,
+                                  engine_config_->max_single_sequence_length,
+                                  draft_token_workspace_manager_, trace_recorder_);
+            return;
+          }
+        }
+        TVM_FFI_ICHECK(estate_->running_queue.empty())
+            << "Internal assumption violated: It is expected that an engine step takes at least "
+               "one action (e.g. prefill, decode, etc.) but it does not.";
         return;
       }
     }
-    TVM_FFI_ICHECK(estate_->running_queue.empty())
-        << "Internal assumption violated: It is expected that an engine step takes at least one "
-           "action (e.g. prefill, decode, etc.) but it does not.";
   }
 
   /************** Utility Functions **************/
@@ -1024,6 +1018,75 @@ class EngineImpl : public Engine {
     return TResult::Ok(EngineConfig::FromJSONAndInferredConfig(config, inferrable_cfg));
   }
 
+  /*!
+   * \brief Initialize the chat lane: per-model KV cache, tokenizer, grammar,
+   * logit processor, sampler, draft workspace (for spec decoding), and the
+   * chat engine action pipeline. Called from Create() when task_mode_ is
+   * kChat. Reads engine_config_, which must already be set.
+   */
+  void InitChatLane(const std::vector<tvm::ffi::json::Object>& model_configs,
+                    Optional<EventTraceRecorder> trace_recorder, Device device) {
+    // Chat models need a KV cache on every shard.
+    for (const Model& model : models_) {
+      model->CreateKVCache(engine_config_->kv_cache_page_size, engine_config_->max_num_sequence,
+                           engine_config_->max_total_sequence_length,
+                           engine_config_->prefill_chunk_size, engine_config_->max_history_size,
+                           engine_config_->prefix_cache_max_num_recycling_seqs);
+    }
+    // Tokenizer and grammar compiler.
+    tokenizer_ = Tokenizer::FromPath(engine_config_->model, GetTokenizerInfo(model_configs[0]));
+    token_table_ = tokenizer_->PostProcessedTokenTable();
+    cached_grammar_compiler_ = xgrammar::CachedGrammarCompiler(token_table_);
+    // Logit processor, sampler, and draft-token workspace for spec decoding.
+    int max_num_tokens = engine_config_->max_num_sequence;
+    DraftTokenWorkspaceManager draft_token_workspace_manager{nullptr};
+    if (engine_config_->speculative_mode != SpeculativeMode::kDisable) {
+      // Multiply max_num_tokens by two so draft/verify can ping-pong.
+      draft_token_workspace_manager =
+          models_[0]->CreateDraftTokenWorkspaceManager(max_num_tokens * 2);
+      draft_token_workspace_manager->AllocWorkspace(
+          &model_workspaces_[0],
+          /*require_hidden_states=*/engine_config_->speculative_mode == SpeculativeMode::kEagle);
+      estate_->spec_draft_length = engine_config_->spec_draft_length;
+    }
+    LogitProcessor logit_processor =
+        models_[0]->CreateLogitProcessor(max_num_tokens, trace_recorder);
+    Sampler sampler =
+        models_[0]->CreateSampler(max_num_tokens, static_cast<int>(models_.size()), trace_recorder);
+    // Chat engine action pipeline.
+    actions_ = CreateEngineActions(models_, engine_config_, model_configs, model_workspaces_,
+                                   logit_processor, sampler, draft_token_workspace_manager,
+                                   tokenizer_, trace_recorder_, estate_->request_stream_callback_,
+                                   device);
+    draft_token_workspace_manager_ = draft_token_workspace_manager;
+    SetThreadMaxConcurrency();
+  }
+
+  /*!
+   * \brief Initialize the embedding lane: the BatchEmbeddingPrefill action
+   * and the result hidden dim. Called from Create() when task_mode_ is
+   * kEmbedding. Asserts that the primary model actually exposes encoder
+   * prefill — embedding_model_type == "decoder" is explicitly rejected
+   * here until decoder-embedding support lands. Reads engine_config_, which
+   * must already be set.
+   */
+  void InitEmbeddingLane() {
+    const ModelMetadata& metadata = models_[0]->GetMetadata();
+    TVM_FFI_ICHECK_EQ(metadata.embedding_model_type, "encoder")
+        << "Engine embedding lane currently only supports "
+           "embedding_model_type=\"encoder\". Got: \""
+        << metadata.embedding_model_type << "\". decoder-embedding is not yet implemented.";
+    TVM_FFI_ICHECK(models_[0]->HasEncoderPrefill())
+        << "Model declares model_task=\"embedding\" with embedding_model_type=\"encoder\", "
+           "but the compiled model does not expose an encoder prefill function. "
+           "Check that the model was compiled with encoder prefill support enabled.";
+
+    embedding_lane_.action = EngineAction::BatchEmbeddingPrefill(models_[0], engine_config_);
+    embedding_lane_.hidden_dim = models_[0]->GetHiddenSize();
+    TVM_FFI_ICHECK_GT(embedding_lane_.hidden_dim, 0)
+        << "Encoder embedding model must have a known hidden_size after initialization.";
+  }
+
   /*! \brief Set the maximum threading backend concurrency. */
   void SetThreadMaxConcurrency() {
     int host_cpu_usage = 1;
@@ -1072,10 +1135,20 @@ class EngineImpl : public Engine {
   Optional<DraftTokenWorkspaceManager> draft_token_workspace_manager_;
   // Event trace recorder.
   Optional<EventTraceRecorder> trace_recorder_;
-  // Embedding lane: the action for encoder embedding.
-  EngineAction embedding_action_{nullptr};
-  // The hidden dimension for encoder embedding results.
-  int embedding_hidden_dim_ = -1;
+
+  // Top-level task this engine instance serves. Set once in Create() from
+  // the primary model's metadata; all Step / Empty / AddRequest dispatch
+  // off of it. Default kChat matches historical behavior when metadata is
+  // absent or model_task is unset.
+  EngineTaskMode task_mode_ = EngineTaskMode::kChat;
+
+  // All embedding-lane state lives here so chat-only engines carry a single
+  // empty struct rather than several flat nullable fields.
+  struct EmbeddingLaneState {
+    EngineAction action{nullptr};
+    int hidden_dim = -1;
+  };
+  EmbeddingLaneState embedding_lane_;
 };
 
 Result<EngineCreationOutput> Engine::Create(const std::string& engine_config_json_str,

--- a/cpp/serve/engine.h
+++ b/cpp/serve/engine.h
@@ -87,6 +87,12 @@ class Engine {
   /*! \brief Add a new request to the engine. */
   virtual void AddRequest(Request request) = 0;
 
+  /*! \brief Add a new embedding request to the engine. */
+  virtual void AddEmbeddingRequest(EmbeddingRequest request) = 0;
+
+  /*! \brief Set the embedding result callback. */
+  virtual void SetEmbeddingRequestCallback(FEmbeddingRequestCallback callback) = 0;
+
   /*! \brief Abort the input request (specified by id string) from engine. */
   virtual void AbortRequest(const String& request_id) = 0;
 

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -262,6 +262,17 @@ class EngineAction : public ObjectRef {
    */
   static EngineAction BatchEmbeddingPrefill(Model model, EngineConfig engine_config);
 
+  /*!
+   * \brief Create the action that runs decoder-only embedding prefill for
+   * requests in the embedding waiting queue. Input batches are left-padded;
+   * the kernel applies causal + padding mask internally. No KV cache, no
+   * speculative decoding, no grammar.
+   * \param model The decoder-only embedding model.
+   * \param engine_config The engine config for batching constraints.
+   * \return The created action object.
+   */
+  static EngineAction BatchDecoderEmbeddingPrefill(Model model, EngineConfig engine_config);
+
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(EngineAction, ObjectRef, EngineActionObj);
 };
 

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -252,6 +252,16 @@ class EngineAction : public ObjectRef {
                                        FRequestStreamCallback request_stream_callback,
                                        Device device);
 
+  /*!
+   * \brief Create the action that runs encoder embedding prefill for
+   * requests in the embedding waiting queue.
+   * No KV cache, no speculative decoding, no grammar.
+   * \param model The encoder model.
+   * \param engine_config The engine config for batching constraints.
+   * \return The created action object.
+   */
+  static EngineAction BatchEmbeddingPrefill(Model model, EngineConfig engine_config);
+
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(EngineAction, ObjectRef, EngineActionObj);
 };
 

--- a/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
@@ -63,10 +63,6 @@ class BatchDecoderEmbeddingPrefillActionObj : public EngineActionObj {
       : model_(std::move(model)), engine_config_(std::move(engine_config)) {}
 
   Array<Request> Step(EngineState estate) final {
-    // This action does not interact with the chat request path.
-    // It returns an empty array since chat post-processing doesn't apply.
-    // The embedding results are delivered through the embedding callback.
-
     if (estate->embedding_waiting_queue.empty()) {
       return {};
     }

--- a/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
@@ -102,9 +102,12 @@ class BatchDecoderEmbeddingPrefillActionObj : public EngineActionObj {
         int new_max_len = std::max(candidate_max_len, item_len);
         int new_batch_size = static_cast<int>(batch_items.size()) + 1;
 
-        // Admit condition.
+        // Admit condition. Always admit at least one item, even if it exceeds
+        // the soft token budget, to prevent a single oversized item from
+        // deadlocking the embedding lane.
         if (new_batch_size > max_batch) goto done_collecting;
-        if (static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens)
+        if (!batch_items.empty() &&
+            static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens)
           goto done_collecting;
 
         batch_items.push_back({&state, i});

--- a/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
@@ -1,14 +1,24 @@
 /*!
  *  Copyright (c) 2023-2025 by Contributors
- * \file serve/engine_actions/batch_embedding_prefill.cc
- * \brief The batch embedding prefill action for encoder models.
+ * \file serve/engine_actions/batch_decoder_embedding_prefill.cc
+ * \brief The batch embedding prefill action for decoder-only models.
  *
- * This action implements the encoder embedding lane:
- * - FIFO scan of the embedding waiting queue (not unordered_map)
- * - Batch-local dynamic padding
- * - Encoder prefill (no KV cache, no TokenEmbed)
- * - Device-side pooling (CLS / Mean / Last)
+ * This action implements the decoder embedding lane:
+ * - FIFO scan of the embedding waiting queue
+ * - Batch-local dynamic left-padding
+ * - Decoder embedding prefill (no KV cache, no TokenEmbed)
+ * - Device-side last-token pool at buffer row [max_len - 1]
  * - Request-level aggregation and callback
+ *
+ * Structurally parallel to BatchEmbeddingPrefillAction (encoder lane). The
+ * only semantic differences are:
+ *  - Inputs are left-padded rather than right-padded. Real tokens occupy
+ *    ``[max_len - seq_len, max_len)``; padding sits on the left.
+ *  - Pooling is always kLast. Under left padding the last real token sits
+ *    at buffer row ``max_len - 1`` for every item in the batch, so we pass
+ *    ``lengths[i] == max_len`` to PoolEmbeddingHiddenStates and let it pick
+ *    that final row uniformly.
+ *  - Calls Model::DecoderEmbeddingPrefill instead of Model::EncoderPrefill.
  */
 #include <tvm/ffi/function.h>
 #include <tvm/runtime/device_api.h>
@@ -32,21 +42,24 @@ namespace serve {
 using namespace tvm::runtime;
 
 /*!
- * \brief The action that processes embedding requests from the embedding waiting queue.
+ * \brief The action that processes embedding requests from the embedding waiting queue
+ * for decoder-only embedding models (e.g. Qwen3-Embedding).
  *
  * Design:
- * - Scheduling granularity is per-item (not per-request).
- * - Batching: FIFO scan of embedding_waiting_queue (the source of truth for order).
- * - Admit condition: batch_size <= max_num_sequence AND batch_size * max_len <= prefill_chunk_size.
- * - Encoder execution: directly calls prefill(input_ids, attention_mask, params).
- *   input_ids: [batch, max_len], attention_mask: [batch, max_len] — both int32, 2D.
- * - No KV cache, no TokenEmbed, no speculative/prefix-cache/grammar/disagg.
- * - Pooling on device, only pooled [batch, hidden] copied to host as float32.
- * - Callback sends request-level aggregated EmbeddingResult.
+ *  - Scheduling granularity is per-item, matching the encoder lane.
+ *  - Batching: FIFO scan of embedding_waiting_queue (the source of truth for order).
+ *  - Admit condition: batch_size <= max_num_sequence AND
+ *                     batch_size * max_len <= prefill_chunk_size.
+ *  - Decoder execution: calls Model::DecoderEmbeddingPrefill, which wraps the compiled
+ *    ``prefill_embedding(input_ids, attention_mask, params)`` function. No KV cache,
+ *    no TokenEmbed, no speculative / prefix-cache / grammar / disagg.
+ *  - Pooling runs inside Model::PoolEmbeddingHiddenStates (kLast strategy); only the
+ *    pooled ``[batch, hidden]`` buffer is materialized on host as float32.
+ *  - Callback sends request-level aggregated EmbeddingResult, identical to encoder.
  */
-class BatchEmbeddingPrefillActionObj : public EngineActionObj {
+class BatchDecoderEmbeddingPrefillActionObj : public EngineActionObj {
  public:
-  explicit BatchEmbeddingPrefillActionObj(Model model, EngineConfig engine_config)
+  explicit BatchDecoderEmbeddingPrefillActionObj(Model model, EngineConfig engine_config)
       : model_(std::move(model)), engine_config_(std::move(engine_config)) {}
 
   Array<Request> Step(EngineState estate) final {
@@ -58,7 +71,7 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
       return {};
     }
 
-    NVTXScopedRange nvtx_scope("BatchEmbeddingPrefill");
+    NVTXScopedRange nvtx_scope("BatchDecoderEmbeddingPrefill");
 
     int max_batch = engine_config_->max_num_sequence;
     int64_t max_total_tokens = engine_config_->prefill_chunk_size;
@@ -111,8 +124,17 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
     int batch_size = static_cast<int>(batch_items.size());
     int max_len = candidate_max_len;
 
-    // Build padded input_ids and attention_mask on host.
-    // BERT contract: input_ids [batch_size, max_len] int32, attention_mask [batch_size, max_len] int32.
+    // Decoder-embedding lane is kLast-only by design: left-padding makes the
+    // last real token land at buffer row max_len - 1 for every item, so no
+    // per-sample gather is needed. Any other strategy would have to resolve
+    // to a per-item index and defeats the purpose of left-padding here.
+    PoolingStrategy head_strategy = batch_items[0].state->request->pooling_strategy;
+    TVM_FFI_ICHECK_EQ(static_cast<int>(head_strategy), static_cast<int>(PoolingStrategy::kLast))
+        << "Decoder embedding lane requires pooling_strategy=last; got "
+        << static_cast<int>(head_strategy);
+
+    // Build LEFT-padded input_ids and attention_mask on host.
+    // Real tokens occupy [max_len - seq_len, max_len); padding sits on the left.
     Tensor input_ids_host =
         Tensor::Empty({batch_size, max_len}, DataType::Int(32), Device{DLDeviceType::kDLCPU, 0});
     Tensor attention_mask_host =
@@ -127,30 +149,29 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
       const auto& item = batch_items[b].state->request->items[batch_items[b].item_idx];
       int seq_len = static_cast<int>(item.token_ids.size());
       real_lengths[b] = seq_len;
+      int pad = max_len - seq_len;
 
-      // Fill token IDs (right-padded with 0).
-      for (int s = 0; s < seq_len; ++s) {
-        ids_ptr[b * max_len + s] = item.token_ids[s];
-      }
-      for (int s = seq_len; s < max_len; ++s) {
+      // Left-pad: zeros for [0, pad), tokens for [pad, max_len).
+      for (int s = 0; s < pad; ++s) {
         ids_ptr[b * max_len + s] = 0;
-      }
-
-      // Fill attention mask (1 for real tokens, 0 for padding).
-      for (int s = 0; s < seq_len; ++s) {
-        mask_ptr[b * max_len + s] = 1;
-      }
-      for (int s = seq_len; s < max_len; ++s) {
         mask_ptr[b * max_len + s] = 0;
+      }
+      for (int s = 0; s < seq_len; ++s) {
+        ids_ptr[b * max_len + pad + s] = item.token_ids[s];
+        mask_ptr[b * max_len + pad + s] = 1;
       }
     }
 
-    // Run encoder prefill, then pool directly into a CPU float32 buffer.
-    int pooling_strategy = static_cast<int>(batch_items[0].state->request->pooling_strategy);
+    // Run decoder embedding prefill, then pool directly into a CPU float32 buffer.
+    // Under left padding the last real token is at buffer row max_len - 1 for
+    // every item, so we pass lengths=[max_len]*batch and let kLast pick that
+    // final row uniformly — no per-sample gather needed.
     ObjectRef hidden_states =
-        model_->EncoderPrefill(input_ids_host, attention_mask_host, batch_size, max_len);
+        model_->DecoderEmbeddingPrefill(input_ids_host, attention_mask_host, batch_size, max_len);
+    std::vector<int> pool_lengths(batch_size, max_len);
     Tensor pooled_cpu = model_->PoolEmbeddingHiddenStates(
-        hidden_states, real_lengths, batch_size, max_len, pooling_strategy);
+        hidden_states, pool_lengths, batch_size, max_len,
+        static_cast<int>(PoolingStrategy::kLast));
     int hidden_dim = static_cast<int>(pooled_cpu->shape[1]);
 
     // L2 normalize on the CPU float32 buffer if requested.
@@ -225,28 +246,28 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<BatchEmbeddingPrefillActionObj>();
+    refl::ObjectDef<BatchDecoderEmbeddingPrefillActionObj>();
   }
 
   static constexpr const bool _type_has_method_sequal_reduce = false;
   static constexpr const bool _type_has_method_shash_reduce = false;
   static constexpr const bool _type_mutable = true;
-  TVM_FFI_DECLARE_OBJECT_INFO("mlc.serve.BatchEmbeddingPrefillAction",
-                              BatchEmbeddingPrefillActionObj, EngineActionObj);
+  TVM_FFI_DECLARE_OBJECT_INFO("mlc.serve.BatchDecoderEmbeddingPrefillAction",
+                              BatchDecoderEmbeddingPrefillActionObj, EngineActionObj);
 
  private:
-  /*! \brief The encoder model. */
+  /*! \brief The decoder-only embedding model. */
   Model model_;
   /*! \brief Engine config for batching constraints. */
   EngineConfig engine_config_;
 };
 
-TVM_FFI_STATIC_INIT_BLOCK() { BatchEmbeddingPrefillActionObj::RegisterReflection(); }
+TVM_FFI_STATIC_INIT_BLOCK() { BatchDecoderEmbeddingPrefillActionObj::RegisterReflection(); }
 
-EngineAction EngineAction::BatchEmbeddingPrefill(Model model, EngineConfig engine_config) {
+EngineAction EngineAction::BatchDecoderEmbeddingPrefill(Model model, EngineConfig engine_config) {
   return EngineAction(
-      tvm::ffi::make_object<BatchEmbeddingPrefillActionObj>(std::move(model),
-                                                            std::move(engine_config)));
+      tvm::ffi::make_object<BatchDecoderEmbeddingPrefillActionObj>(std::move(model),
+                                                                   std::move(engine_config)));
 }
 
 }  // namespace serve

--- a/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_decoder_embedding_prefill.cc
@@ -41,6 +41,72 @@ namespace serve {
 
 using namespace tvm::runtime;
 
+namespace {
+
+struct ScheduledItem {
+  EmbeddingRequestState* state;
+  int item_idx;  // index into state->request->items
+};
+
+struct CollectedBatch {
+  std::vector<ScheduledItem> items;
+  int max_len = 0;
+};
+
+/*!
+ * \brief Scan the embedding waiting queue in FIFO order and collect items to
+ * form the next decoder-embedding batch. Mirrors CollectBatchItems in the
+ * encoder lane: stops on batch-size / token-budget / pooling mismatch, and
+ * always admits at least one item so an oversized request cannot deadlock
+ * the lane.
+ */
+CollectedBatch CollectBatchItems(EngineState estate, int max_batch,
+                                 int64_t max_total_tokens) {
+  std::vector<ScheduledItem> batch_items;
+  int candidate_max_len = 0;
+
+  for (const EmbeddingRequest& req : estate->embedding_waiting_queue) {
+    auto it = estate->embedding_request_states.find(req->id);
+    if (it == estate->embedding_request_states.end()) continue;
+    EmbeddingRequestState& state = it->second;
+
+    // Batch must be homogeneous in pooling_strategy/normalize; stop (not skip) on
+    // mismatch to preserve FIFO order.
+    if (!batch_items.empty()) {
+      const auto& head_req = batch_items[0].state->request;
+      if (state.request->pooling_strategy != head_req->pooling_strategy ||
+          state.request->normalize != head_req->normalize) {
+        return {std::move(batch_items), candidate_max_len};
+      }
+    }
+
+    int num_items = static_cast<int>(state.request->items.size());
+    for (int i = state.completed_items; i < num_items; ++i) {
+      int item_len = static_cast<int>(state.request->items[i].token_ids.size());
+      int new_max_len = std::max(candidate_max_len, item_len);
+      int new_batch_size = static_cast<int>(batch_items.size()) + 1;
+
+      // Admit condition. Always admit at least one item, even if it exceeds
+      // the soft token budget, to prevent a single oversized item from
+      // deadlocking the embedding lane.
+      if (new_batch_size > max_batch) {
+        return {std::move(batch_items), candidate_max_len};
+      }
+      if (!batch_items.empty() &&
+          static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens) {
+        return {std::move(batch_items), candidate_max_len};
+      }
+
+      batch_items.push_back({&state, i});
+      candidate_max_len = new_max_len;
+    }
+  }
+
+  return {std::move(batch_items), candidate_max_len};
+}
+
+}  // namespace
+
 /*!
  * \brief The action that processes embedding requests from the embedding waiting queue
  * for decoder-only embedding models (e.g. Qwen3-Embedding).
@@ -74,54 +140,14 @@ class BatchDecoderEmbeddingPrefillActionObj : public EngineActionObj {
 
     // Collect items from the waiting queue using FIFO order.
     // CRITICAL: iterate embedding_waiting_queue (ordered), NOT the unordered_map.
-    struct ScheduledItem {
-      EmbeddingRequestState* state;
-      int item_idx;  // index into state->request->items
-    };
-    std::vector<ScheduledItem> batch_items;
-    int candidate_max_len = 0;
-
-    for (const EmbeddingRequest& req : estate->embedding_waiting_queue) {
-      auto it = estate->embedding_request_states.find(req->id);
-      if (it == estate->embedding_request_states.end()) continue;
-      EmbeddingRequestState& state = it->second;
-
-      // Batch must be homogeneous in pooling_strategy/normalize; stop (not skip) on
-      // mismatch to preserve FIFO order.
-      if (!batch_items.empty()) {
-        const auto& head_req = batch_items[0].state->request;
-        if (state.request->pooling_strategy != head_req->pooling_strategy ||
-            state.request->normalize != head_req->normalize) {
-          goto done_collecting;
-        }
-      }
-
-      int num_items = static_cast<int>(state.request->items.size());
-      for (int i = state.completed_items; i < num_items; ++i) {
-        int item_len = static_cast<int>(state.request->items[i].token_ids.size());
-        int new_max_len = std::max(candidate_max_len, item_len);
-        int new_batch_size = static_cast<int>(batch_items.size()) + 1;
-
-        // Admit condition. Always admit at least one item, even if it exceeds
-        // the soft token budget, to prevent a single oversized item from
-        // deadlocking the embedding lane.
-        if (new_batch_size > max_batch) goto done_collecting;
-        if (!batch_items.empty() &&
-            static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens)
-          goto done_collecting;
-
-        batch_items.push_back({&state, i});
-        candidate_max_len = new_max_len;
-      }
-    }
-  done_collecting:
-
-    if (batch_items.empty()) {
+    CollectedBatch batch = CollectBatchItems(estate, max_batch, max_total_tokens);
+    if (batch.items.empty()) {
       return {};
     }
+    auto& batch_items = batch.items;
 
     int batch_size = static_cast<int>(batch_items.size());
-    int max_len = candidate_max_len;
+    int max_len = batch.max_len;
 
     // Decoder-embedding lane is kLast-only by design: left-padding makes the
     // last real token land at buffer row max_len - 1 for every item, so no

--- a/cpp/serve/engine_actions/batch_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_embedding_prefill.cc
@@ -77,6 +77,16 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
       if (it == estate->embedding_request_states.end()) continue;
       EmbeddingRequestState& state = it->second;
 
+      // Batch must be homogeneous in pooling_strategy/normalize; stop (not skip) on
+      // mismatch to preserve FIFO order.
+      if (!batch_items.empty()) {
+        const auto& head_req = batch_items[0].state->request;
+        if (state.request->pooling_strategy != head_req->pooling_strategy ||
+            state.request->normalize != head_req->normalize) {
+          goto done_collecting;
+        }
+      }
+
       int num_items = static_cast<int>(state.request->items.size());
       for (int i = state.completed_items; i < num_items; ++i) {
         int item_len = static_cast<int>(state.request->items[i].token_ids.size());
@@ -181,33 +191,28 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
       state->completed_items++;
     }
 
-    // Collect completed requests and fire callbacks.
-    // Iterate waiting_queue to maintain FIFO order for completion too.
+    // Completed requests form a prefix of the waiting queue under current scheduling;
+    // break on the first pending request to keep that invariant explicit.
     Array<EmbeddingResult> completed_results;
-    std::vector<String> completed_request_ids;
+    size_t completed_prefix_len = 0;
 
     for (const EmbeddingRequest& req : estate->embedding_waiting_queue) {
       auto it = estate->embedding_request_states.find(req->id);
-      if (it == estate->embedding_request_states.end()) continue;
+      if (it == estate->embedding_request_states.end()) break;
       EmbeddingRequestState& state = it->second;
       int total_items = static_cast<int>(state.request->items.size());
-      if (state.completed_items >= total_items) {
-        completed_results.push_back(
-            EmbeddingResult(state.request->id, state.result_buffer, state.prompt_tokens));
-        completed_request_ids.push_back(req->id);
-      }
+      if (state.completed_items < total_items) break;
+      completed_results.push_back(
+          EmbeddingResult(state.request->id, state.result_buffer, state.prompt_tokens));
+      ++completed_prefix_len;
     }
 
-    // Remove completed requests from the queue and state map.
-    for (const String& req_id : completed_request_ids) {
-      estate->embedding_request_states.erase(req_id);
-      auto it = std::find_if(estate->embedding_waiting_queue.begin(),
-                              estate->embedding_waiting_queue.end(),
-                              [&req_id](const EmbeddingRequest& r) { return r->id == req_id; });
-      if (it != estate->embedding_waiting_queue.end()) {
-        estate->embedding_waiting_queue.erase(it);
-      }
+    for (size_t i = 0; i < completed_prefix_len; ++i) {
+      estate->embedding_request_states.erase(estate->embedding_waiting_queue[i]->id);
     }
+    estate->embedding_waiting_queue.erase(
+        estate->embedding_waiting_queue.begin(),
+        estate->embedding_waiting_queue.begin() + completed_prefix_len);
 
     // Fire the embedding callback if we have results.
     if (!completed_results.empty() && estate->embedding_request_callback_ != nullptr) {

--- a/cpp/serve/engine_actions/batch_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_embedding_prefill.cc
@@ -31,6 +31,75 @@ namespace serve {
 
 using namespace tvm::runtime;
 
+namespace {
+
+struct ScheduledItem {
+  EmbeddingRequestState* state;
+  int item_idx;  // index into state->request->items
+};
+
+struct CollectedBatch {
+  std::vector<ScheduledItem> items;
+  int max_len = 0;
+};
+
+/*!
+ * \brief Scan the embedding waiting queue in FIFO order and collect items to
+ * form the next batch. Stops (returns) on the first constraint violation:
+ *  - batch size exceeds max_num_sequence
+ *  - padded token budget exceeds prefill_chunk_size (only once batch has >= 1)
+ *  - pooling/normalize mismatch with the head of the current batch
+ *
+ * Always admits at least one item, so a single oversized request cannot
+ * deadlock the embedding lane.
+ */
+CollectedBatch CollectBatchItems(EngineState estate, int max_batch,
+                                 int64_t max_total_tokens) {
+  std::vector<ScheduledItem> batch_items;
+  int candidate_max_len = 0;
+
+  for (const EmbeddingRequest& req : estate->embedding_waiting_queue) {
+    auto it = estate->embedding_request_states.find(req->id);
+    if (it == estate->embedding_request_states.end()) continue;
+    EmbeddingRequestState& state = it->second;
+
+    // Batch must be homogeneous in pooling_strategy/normalize; stop (not skip) on
+    // mismatch to preserve FIFO order.
+    if (!batch_items.empty()) {
+      const auto& head_req = batch_items[0].state->request;
+      if (state.request->pooling_strategy != head_req->pooling_strategy ||
+          state.request->normalize != head_req->normalize) {
+        return {std::move(batch_items), candidate_max_len};
+      }
+    }
+
+    int num_items = static_cast<int>(state.request->items.size());
+    for (int i = state.completed_items; i < num_items; ++i) {
+      int item_len = static_cast<int>(state.request->items[i].token_ids.size());
+      int new_max_len = std::max(candidate_max_len, item_len);
+      int new_batch_size = static_cast<int>(batch_items.size()) + 1;
+
+      // Admit condition. Always admit at least one item, even if it exceeds
+      // the soft token budget, to prevent a single oversized item from
+      // deadlocking the embedding lane.
+      if (new_batch_size > max_batch) {
+        return {std::move(batch_items), candidate_max_len};
+      }
+      if (!batch_items.empty() &&
+          static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens) {
+        return {std::move(batch_items), candidate_max_len};
+      }
+
+      batch_items.push_back({&state, i});
+      candidate_max_len = new_max_len;
+    }
+  }
+
+  return {std::move(batch_items), candidate_max_len};
+}
+
+}  // namespace
+
 /*!
  * \brief The action that processes embedding requests from the embedding waiting queue.
  *
@@ -65,54 +134,14 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
 
     // Collect items from the waiting queue using FIFO order.
     // CRITICAL: iterate embedding_waiting_queue (ordered), NOT the unordered_map.
-    struct ScheduledItem {
-      EmbeddingRequestState* state;
-      int item_idx;  // index into state->request->items
-    };
-    std::vector<ScheduledItem> batch_items;
-    int candidate_max_len = 0;
-
-    for (const EmbeddingRequest& req : estate->embedding_waiting_queue) {
-      auto it = estate->embedding_request_states.find(req->id);
-      if (it == estate->embedding_request_states.end()) continue;
-      EmbeddingRequestState& state = it->second;
-
-      // Batch must be homogeneous in pooling_strategy/normalize; stop (not skip) on
-      // mismatch to preserve FIFO order.
-      if (!batch_items.empty()) {
-        const auto& head_req = batch_items[0].state->request;
-        if (state.request->pooling_strategy != head_req->pooling_strategy ||
-            state.request->normalize != head_req->normalize) {
-          goto done_collecting;
-        }
-      }
-
-      int num_items = static_cast<int>(state.request->items.size());
-      for (int i = state.completed_items; i < num_items; ++i) {
-        int item_len = static_cast<int>(state.request->items[i].token_ids.size());
-        int new_max_len = std::max(candidate_max_len, item_len);
-        int new_batch_size = static_cast<int>(batch_items.size()) + 1;
-
-        // Admit condition. Always admit at least one item, even if it exceeds
-        // the soft token budget, to prevent a single oversized item from
-        // deadlocking the embedding lane.
-        if (new_batch_size > max_batch) goto done_collecting;
-        if (!batch_items.empty() &&
-            static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens)
-          goto done_collecting;
-
-        batch_items.push_back({&state, i});
-        candidate_max_len = new_max_len;
-      }
-    }
-  done_collecting:
-
-    if (batch_items.empty()) {
+    CollectedBatch batch = CollectBatchItems(estate, max_batch, max_total_tokens);
+    if (batch.items.empty()) {
       return {};
     }
+    auto& batch_items = batch.items;
 
     int batch_size = static_cast<int>(batch_items.size());
-    int max_len = candidate_max_len;
+    int max_len = batch.max_len;
 
     // Build padded input_ids and attention_mask on host.
     // BERT contract: input_ids [batch_size, max_len] int32, attention_mask [batch_size, max_len] int32.

--- a/cpp/serve/engine_actions/batch_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_embedding_prefill.cc
@@ -93,9 +93,12 @@ class BatchEmbeddingPrefillActionObj : public EngineActionObj {
         int new_max_len = std::max(candidate_max_len, item_len);
         int new_batch_size = static_cast<int>(batch_items.size()) + 1;
 
-        // Admit condition.
+        // Admit condition. Always admit at least one item, even if it exceeds
+        // the soft token budget, to prevent a single oversized item from
+        // deadlocking the embedding lane.
         if (new_batch_size > max_batch) goto done_collecting;
-        if (static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens)
+        if (!batch_items.empty() &&
+            static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens)
           goto done_collecting;
 
         batch_items.push_back({&state, i});

--- a/cpp/serve/engine_actions/batch_embedding_prefill.cc
+++ b/cpp/serve/engine_actions/batch_embedding_prefill.cc
@@ -1,0 +1,249 @@
+/*!
+ *  Copyright (c) 2023-2025 by Contributors
+ * \file serve/engine_actions/batch_embedding_prefill.cc
+ * \brief The batch embedding prefill action for encoder models.
+ *
+ * This action implements the encoder embedding lane:
+ * - FIFO scan of the embedding waiting queue (not unordered_map)
+ * - Batch-local dynamic padding
+ * - Encoder prefill (no KV cache, no TokenEmbed)
+ * - Device-side pooling (CLS / Mean / Last)
+ * - Request-level aggregation and callback
+ */
+#include <tvm/ffi/function.h>
+#include <tvm/runtime/device_api.h>
+#include <tvm/runtime/nvtx.h>
+#include <tvm/runtime/tensor.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#include "../data.h"
+#include "../engine.h"
+#include "../engine_state.h"
+#include "../model.h"
+#include "action.h"
+
+namespace mlc {
+namespace llm {
+namespace serve {
+
+using namespace tvm::runtime;
+
+/*!
+ * \brief The action that processes embedding requests from the embedding waiting queue.
+ *
+ * Design:
+ * - Scheduling granularity is per-item (not per-request).
+ * - Batching: FIFO scan of embedding_waiting_queue (the source of truth for order).
+ * - Admit condition: batch_size <= max_num_sequence AND batch_size * max_len <= prefill_chunk_size.
+ * - Encoder execution: directly calls prefill(input_ids, attention_mask, params).
+ *   input_ids: [batch, max_len], attention_mask: [batch, max_len] — both int32, 2D.
+ * - No KV cache, no TokenEmbed, no speculative/prefix-cache/grammar/disagg.
+ * - Pooling on device, only pooled [batch, hidden] copied to host as float32.
+ * - Callback sends request-level aggregated EmbeddingResult.
+ */
+class BatchEmbeddingPrefillActionObj : public EngineActionObj {
+ public:
+  explicit BatchEmbeddingPrefillActionObj(Model model, EngineConfig engine_config)
+      : model_(std::move(model)), engine_config_(std::move(engine_config)) {}
+
+  Array<Request> Step(EngineState estate) final {
+    // This action does not interact with the chat request path.
+    // It returns an empty array since chat post-processing doesn't apply.
+    // The embedding results are delivered through the embedding callback.
+
+    if (estate->embedding_waiting_queue.empty()) {
+      return {};
+    }
+
+    NVTXScopedRange nvtx_scope("BatchEmbeddingPrefill");
+
+    int max_batch = engine_config_->max_num_sequence;
+    int64_t max_total_tokens = engine_config_->prefill_chunk_size;
+
+    // Collect items from the waiting queue using FIFO order.
+    // CRITICAL: iterate embedding_waiting_queue (ordered), NOT the unordered_map.
+    struct ScheduledItem {
+      EmbeddingRequestState* state;
+      int item_idx;  // index into state->request->items
+    };
+    std::vector<ScheduledItem> batch_items;
+    int candidate_max_len = 0;
+
+    for (const EmbeddingRequest& req : estate->embedding_waiting_queue) {
+      auto it = estate->embedding_request_states.find(req->id);
+      if (it == estate->embedding_request_states.end()) continue;
+      EmbeddingRequestState& state = it->second;
+
+      int num_items = static_cast<int>(state.request->items.size());
+      for (int i = state.completed_items; i < num_items; ++i) {
+        int item_len = static_cast<int>(state.request->items[i].token_ids.size());
+        int new_max_len = std::max(candidate_max_len, item_len);
+        int new_batch_size = static_cast<int>(batch_items.size()) + 1;
+
+        // Admit condition.
+        if (new_batch_size > max_batch) goto done_collecting;
+        if (static_cast<int64_t>(new_batch_size) * new_max_len > max_total_tokens)
+          goto done_collecting;
+
+        batch_items.push_back({&state, i});
+        candidate_max_len = new_max_len;
+      }
+    }
+  done_collecting:
+
+    if (batch_items.empty()) {
+      return {};
+    }
+
+    int batch_size = static_cast<int>(batch_items.size());
+    int max_len = candidate_max_len;
+
+    // Build padded input_ids and attention_mask on host.
+    // BERT contract: input_ids [batch_size, max_len] int32, attention_mask [batch_size, max_len] int32.
+    Tensor input_ids_host =
+        Tensor::Empty({batch_size, max_len}, DataType::Int(32), Device{DLDeviceType::kDLCPU, 0});
+    Tensor attention_mask_host =
+        Tensor::Empty({batch_size, max_len}, DataType::Int(32), Device{DLDeviceType::kDLCPU, 0});
+
+    int32_t* ids_ptr = static_cast<int32_t*>(input_ids_host->data);
+    int32_t* mask_ptr = static_cast<int32_t*>(attention_mask_host->data);
+
+    std::vector<int> real_lengths(batch_size);
+
+    for (int b = 0; b < batch_size; ++b) {
+      const auto& item = batch_items[b].state->request->items[batch_items[b].item_idx];
+      int seq_len = static_cast<int>(item.token_ids.size());
+      real_lengths[b] = seq_len;
+
+      // Fill token IDs (right-padded with 0).
+      for (int s = 0; s < seq_len; ++s) {
+        ids_ptr[b * max_len + s] = item.token_ids[s];
+      }
+      for (int s = seq_len; s < max_len; ++s) {
+        ids_ptr[b * max_len + s] = 0;
+      }
+
+      // Fill attention mask (1 for real tokens, 0 for padding).
+      for (int s = 0; s < seq_len; ++s) {
+        mask_ptr[b * max_len + s] = 1;
+      }
+      for (int s = seq_len; s < max_len; ++s) {
+        mask_ptr[b * max_len + s] = 0;
+      }
+    }
+
+    // Run encoder prefill, then pool directly into a CPU float32 buffer.
+    int pooling_strategy = static_cast<int>(batch_items[0].state->request->pooling_strategy);
+    ObjectRef hidden_states =
+        model_->EncoderPrefill(input_ids_host, attention_mask_host, batch_size, max_len);
+    Tensor pooled_cpu = model_->PoolEncoderHiddenStates(
+        hidden_states, real_lengths, batch_size, max_len, pooling_strategy);
+    int hidden_dim = static_cast<int>(pooled_cpu->shape[1]);
+
+    // L2 normalize on the CPU float32 buffer if requested.
+    bool normalize = batch_items[0].state->request->normalize;
+    if (normalize) {
+      float* data = static_cast<float*>(pooled_cpu->data);
+      for (int b = 0; b < batch_size; ++b) {
+        float norm = 0.0f;
+        for (int h = 0; h < hidden_dim; ++h) {
+          float v = data[b * hidden_dim + h];
+          norm += v * v;
+        }
+        norm = std::sqrt(norm);
+        if (norm > 1e-12f) {
+          for (int h = 0; h < hidden_dim; ++h) {
+            data[b * hidden_dim + h] /= norm;
+          }
+        }
+      }
+    }
+
+    // Write pooled results back into per-request result buffers and track completion.
+    int float_bytes = sizeof(float);
+
+    for (int b = 0; b < batch_size; ++b) {
+      auto* state = batch_items[b].state;
+      int item_idx = batch_items[b].item_idx;
+      int original_item_index = state->request->items[item_idx].item_index;
+
+      // Copy this item's embedding into the request's result buffer at the correct row.
+      float* src = static_cast<float*>(pooled_cpu->data) + b * hidden_dim;
+      float* dst = static_cast<float*>(state->result_buffer->data) +
+                   original_item_index * hidden_dim;
+      std::memcpy(dst, src, hidden_dim * float_bytes);
+
+      // Update prompt tokens.
+      state->prompt_tokens += real_lengths[b];
+      state->completed_items++;
+    }
+
+    // Collect completed requests and fire callbacks.
+    // Iterate waiting_queue to maintain FIFO order for completion too.
+    Array<EmbeddingResult> completed_results;
+    std::vector<String> completed_request_ids;
+
+    for (const EmbeddingRequest& req : estate->embedding_waiting_queue) {
+      auto it = estate->embedding_request_states.find(req->id);
+      if (it == estate->embedding_request_states.end()) continue;
+      EmbeddingRequestState& state = it->second;
+      int total_items = static_cast<int>(state.request->items.size());
+      if (state.completed_items >= total_items) {
+        completed_results.push_back(
+            EmbeddingResult(state.request->id, state.result_buffer, state.prompt_tokens));
+        completed_request_ids.push_back(req->id);
+      }
+    }
+
+    // Remove completed requests from the queue and state map.
+    for (const String& req_id : completed_request_ids) {
+      estate->embedding_request_states.erase(req_id);
+      auto it = std::find_if(estate->embedding_waiting_queue.begin(),
+                              estate->embedding_waiting_queue.end(),
+                              [&req_id](const EmbeddingRequest& r) { return r->id == req_id; });
+      if (it != estate->embedding_waiting_queue.end()) {
+        estate->embedding_waiting_queue.erase(it);
+      }
+    }
+
+    // Fire the embedding callback if we have results.
+    if (!completed_results.empty() && estate->embedding_request_callback_ != nullptr) {
+      estate->embedding_request_callback_(completed_results);
+    }
+
+    // Return empty — embedding lane doesn't feed into chat post-processing.
+    return {};
+  }
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<BatchEmbeddingPrefillActionObj>();
+  }
+
+  static constexpr const bool _type_has_method_sequal_reduce = false;
+  static constexpr const bool _type_has_method_shash_reduce = false;
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("mlc.serve.BatchEmbeddingPrefillAction",
+                              BatchEmbeddingPrefillActionObj, EngineActionObj);
+
+ private:
+  /*! \brief The encoder model. */
+  Model model_;
+  /*! \brief Engine config for batching constraints. */
+  EngineConfig engine_config_;
+};
+
+TVM_FFI_STATIC_INIT_BLOCK() { BatchEmbeddingPrefillActionObj::RegisterReflection(); }
+
+EngineAction EngineAction::BatchEmbeddingPrefill(Model model, EngineConfig engine_config) {
+  return EngineAction(
+      tvm::ffi::make_object<BatchEmbeddingPrefillActionObj>(std::move(model),
+                                                            std::move(engine_config)));
+}
+
+}  // namespace serve
+}  // namespace llm
+}  // namespace mlc

--- a/cpp/serve/engine_state.cc
+++ b/cpp/serve/engine_state.cc
@@ -23,6 +23,9 @@ void EngineStateObj::Reset() {
   }
   running_rsentries_changed = true;
   postproc_workspace = ActionPostProcessWorkspace();
+  // Reset embedding lane state.
+  embedding_waiting_queue.clear();
+  embedding_request_states.clear();
 }
 
 RequestState EngineStateObj::GetRequestState(Request request) {

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -20,6 +20,7 @@ namespace serve {
 using namespace tvm::runtime;
 
 typedef TypedFunction<void(Array<RequestStreamOutput>)> FRequestStreamCallback;
+typedef TypedFunction<void(Array<EmbeddingResult>)> FEmbeddingRequestCallback;
 
 /*! \brief The manager of internal id for requests in engine. */
 struct EngineInternalIDManager {
@@ -89,6 +90,14 @@ class EngineStateObj : public Object {
    * We make it a workspace to avoid repetitive memory allocation/free in the action post process.
    */
   ActionPostProcessWorkspace postproc_workspace;
+
+  /****************** Embedding Lane ******************/
+  /*! \brief The embedding requests waiting to be processed. */
+  std::vector<EmbeddingRequest> embedding_waiting_queue;
+  /*! \brief The states of all in-flight embedding requests, keyed by request id. */
+  std::unordered_map<String, EmbeddingRequestState> embedding_request_states;
+  /*! \brief The embedding result callback. */
+  FEmbeddingRequestCallback embedding_request_callback_{nullptr};
 
   /*! \brief Reset the engine state and clear the metrics. */
   void Reset();

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -7,6 +7,8 @@
 
 #include <tvm/ffi/string.h>
 
+#include <deque>
+
 #include "config.h"
 #include "metrics.h"
 #include "prefix_cache.h"
@@ -93,7 +95,7 @@ class EngineStateObj : public Object {
 
   /****************** Embedding Lane ******************/
   /*! \brief The embedding requests waiting to be processed. */
-  std::vector<EmbeddingRequest> embedding_waiting_queue;
+  std::deque<EmbeddingRequest> embedding_waiting_queue;
   /*! \brief The states of all in-flight embedding requests, keyed by request id. */
   std::unordered_map<String, EmbeddingRequestState> embedding_request_states;
   /*! \brief The embedding result callback. */

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -293,6 +293,11 @@ void FunctionTable::_InitFunctions() {
   this->scatter_probs_func_ = mod->GetFunction("scatter_probs", true).value_or(Function(nullptr));
   this->gather_hidden_states_func_ = mod_get_func("gather_hidden_states");
   this->scatter_hidden_states_func_ = mod_get_func("scatter_hidden_states");
+
+  // Encoder embedding support: try to load "prefill" as encoder-style function.
+  // For encoder models (BERT), "prefill" takes (input_ids, attention_mask, params).
+  // We store it separately from the chat prefill functions.
+  this->encoder_prefill_func_ = mod_get_func("prefill");
 }
 
 ObjectRef FunctionTable::Empty(Shape shape, DataType dtype, Device device,

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -298,6 +298,14 @@ void FunctionTable::_InitFunctions() {
   // For encoder models (BERT), "prefill" takes (input_ids, attention_mask, params).
   // We store it separately from the chat prefill functions.
   this->encoder_prefill_func_ = mod_get_func("prefill");
+
+  // Decoder-only embedding support: try to load "prefill_embedding" as the
+  // left-pad / causal-mask prefill function for decoder embedding models
+  // (e.g. Qwen3-Embedding). It takes (input_ids, attention_mask, params) and
+  // returns last-layer hidden states [batch, seq, hidden]. The name is kept
+  // distinct from the encoder-lane "prefill" so embedding libs can declare
+  // either (or neither) without collision with chat "prefill".
+  this->decoder_embedding_prefill_func_ = mod_get_func("prefill_embedding");
 }
 
 ObjectRef FunctionTable::Empty(Shape shape, DataType dtype, Device device,

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -145,6 +145,13 @@ struct FunctionTable {
   // Encoder embedding support.
   // The encoder prefill function: prefill(input_ids, attention_mask, params) -> [1, seq, hidden].
   Function encoder_prefill_func_;
+
+  // Decoder-only embedding support.
+  // The decoder embedding prefill function:
+  //   prefill_embedding(input_ids, attention_mask, params) -> [batch, seq, hidden].
+  // Expected to consume left-padded input_ids and return raw last hidden states
+  // (no lm_head, no logits). The caller handles pooling and normalization.
+  Function decoder_embedding_prefill_func_;
 };
 
 }  // namespace serve

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -141,6 +141,10 @@ struct FunctionTable {
   Function scatter_probs_func_;
   Function gather_hidden_states_func_;
   Function scatter_hidden_states_func_;
+
+  // Encoder embedding support.
+  // The encoder prefill function: prefill(input_ids, attention_mask, params) -> [1, seq, hidden].
+  Function encoder_prefill_func_;
 };
 
 }  // namespace serve

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -1326,7 +1326,8 @@ class ModelImpl : public ModelObj {
         if (exp == 0) {
           val = std::ldexp(static_cast<float>(mant), -24);
         } else if (exp == 31) {
-          val = mant ? 0.0f : 65504.0f;
+          val = (mant == 0) ? std::numeric_limits<float>::infinity()
+                            : std::numeric_limits<float>::quiet_NaN();
         } else {
           val = std::ldexp(static_cast<float>(mant + 1024), static_cast<int>(exp) - 25);
         }

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -1188,13 +1188,22 @@ class ModelImpl : public ModelObj {
     return logits;
   }
 
-  /*********************** Encoder Embedding Support ***********************/
+  /*********************** Embedding Support ***********************/
 
   bool HasEncoderPrefill() const final {
     // Gated by metadata: only embedding + encoder models.
     const ModelMetadata& meta = ft_.model_metadata_;
     return ft_.encoder_prefill_func_.defined() && meta.model_task == "embedding" &&
            meta.embedding_model_type == "encoder";
+  }
+
+  bool HasDecoderEmbeddingPrefill() const final {
+    // Gated by metadata: only embedding + decoder models with the dedicated
+    // prefill_embedding export. Chat-lane prefill is intentionally not treated
+    // as a decoder-embedding entry point.
+    const ModelMetadata& meta = ft_.model_metadata_;
+    return ft_.decoder_embedding_prefill_func_.defined() && meta.model_task == "embedding" &&
+           meta.embedding_model_type == "decoder";
   }
 
   int GetHiddenSize() const final { return hidden_size_; }
@@ -1205,6 +1214,28 @@ class ModelImpl : public ModelObj {
                                " max_len=" + std::to_string(max_len));
     TVM_FFI_ICHECK(ft_.encoder_prefill_func_.defined())
         << "Encoder prefill function is not available in this model.";
+    return RunEmbeddingPrefill(ft_.encoder_prefill_func_, input_ids_nd, attention_mask_nd);
+  }
+
+  ObjectRef DecoderEmbeddingPrefill(const Tensor& input_ids_nd, const Tensor& attention_mask_nd,
+                                    int batch_size, int max_len) final {
+    NVTXScopedRange nvtx_scope("DecoderEmbeddingPrefill batch=" + std::to_string(batch_size) +
+                               " max_len=" + std::to_string(max_len));
+    TVM_FFI_ICHECK(ft_.decoder_embedding_prefill_func_.defined())
+        << "Decoder embedding prefill function is not available in this model.";
+    return RunEmbeddingPrefill(ft_.decoder_embedding_prefill_func_, input_ids_nd,
+                               attention_mask_nd);
+  }
+
+  /*!
+   * \brief Shared implementation for encoder and decoder-only embedding prefill.
+   * Both lanes compile a function with signature
+   * ``f(input_ids, attention_mask, params) -> hidden_states`` (optionally wrapped
+   * in a 1-tuple). Buffer copy to device, return-unwrap, and trace sync are
+   * identical; the only difference is which Function pointer is invoked.
+   */
+  ObjectRef RunEmbeddingPrefill(const Function& prefill_func, const Tensor& input_ids_nd,
+                                const Tensor& attention_mask_nd) {
     // input_ids_nd: CPU [batch_size, max_len] int32
     // attention_mask_nd: CPU [batch_size, max_len] int32
     TVM_FFI_ICHECK_EQ(input_ids_nd->ndim, 2);
@@ -1227,18 +1258,18 @@ class ModelImpl : public ModelObj {
       Tensor::CopyFromTo(&src, &dst);
     }
 
-    // Call encoder prefill: prefill(input_ids, attention_mask, params)
-    // BERT returns a Tensor directly, not a tuple.
+    // Call the embedding prefill: f(input_ids, attention_mask, params).
+    // BERT returns a Tensor directly; Qwen3-Embedding (and others) may return a
+    // tuple depending on how the forward was compiled.
     ObjectRef result =
-        ft_.encoder_prefill_func_(input_ids_device, attention_mask_device, params_)
-            .cast<ObjectRef>();
+        prefill_func(input_ids_device, attention_mask_device, params_).cast<ObjectRef>();
 
     // Handle return: BERT returns Tensor directly; some models may return a tuple.
     // Both disco and non-disco paths use the same logic:
     // - In disco mode, the result is always a DRef. The disco VM wraps all returns,
     //   so tuple_getitem(0) is always needed — this matches every other disco path
     //   in this file (BatchPrefill, BatchPrefillToLastHidden, BatchDecodeToLastHidden, etc.).
-    // - In non-disco mode, BERT returns a raw Tensor. Other encoder models might
+    // - In non-disco mode, BERT returns a raw Tensor. Other embedding models might
     //   return a tuple. We check IsInstance<TensorObj> to distinguish.
     ObjectRef hidden_states{nullptr};
     if (ft_.use_disco) {
@@ -1258,10 +1289,10 @@ class ModelImpl : public ModelObj {
     return hidden_states;
   }
 
-  Tensor PoolEncoderHiddenStates(const ObjectRef& hidden_states,
-                                 const std::vector<int>& lengths, int batch_size, int max_len,
-                                 int strategy) final {
-    NVTXScopedRange nvtx_scope("PoolEncoderHiddenStates");
+  Tensor PoolEmbeddingHiddenStates(const ObjectRef& hidden_states,
+                                   const std::vector<int>& lengths, int batch_size, int max_len,
+                                   int strategy) final {
+    NVTXScopedRange nvtx_scope("PoolEmbeddingHiddenStates");
 
     Tensor hs_nd{nullptr};
     if (ft_.use_disco) {

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -10,7 +10,10 @@
 #include <tvm/runtime/memory/memory_manager.h>
 #include <tvm/runtime/nvtx.h>
 
+#include <cmath>
+#include <cstring>
 #include <fstream>
+#include <limits>
 #include <unordered_set>
 
 #include "../support/json_parser.h"
@@ -1185,6 +1188,188 @@ class ModelImpl : public ModelObj {
     return logits;
   }
 
+  /*********************** Encoder Embedding Support ***********************/
+
+  bool HasEncoderPrefill() const final {
+    // Gated by metadata: only embedding + encoder models.
+    const ModelMetadata& meta = ft_.model_metadata_;
+    return ft_.encoder_prefill_func_.defined() && meta.model_task == "embedding" &&
+           meta.embedding_model_type == "encoder";
+  }
+
+  int GetHiddenSize() const final { return hidden_size_; }
+
+  ObjectRef EncoderPrefill(const Tensor& input_ids_nd, const Tensor& attention_mask_nd,
+                           int batch_size, int max_len) final {
+    NVTXScopedRange nvtx_scope("EncoderPrefill batch=" + std::to_string(batch_size) +
+                               " max_len=" + std::to_string(max_len));
+    TVM_FFI_ICHECK(ft_.encoder_prefill_func_.defined())
+        << "Encoder prefill function is not available in this model.";
+    // input_ids_nd: CPU [batch_size, max_len] int32
+    // attention_mask_nd: CPU [batch_size, max_len] int32
+    TVM_FFI_ICHECK_EQ(input_ids_nd->ndim, 2);
+    TVM_FFI_ICHECK_EQ(attention_mask_nd->ndim, 2);
+
+    // Copy 2D tensors to device. We allocate fresh contiguous device tensors
+    // to avoid non-contiguity issues from CopyToWorker0's view-based caching
+    // (which creates non-contiguous views when actual shape != reserved shape).
+    Tensor input_ids_device = Tensor::Empty(input_ids_nd.Shape(), input_ids_nd.DataType(), device_);
+    {
+      DLTensor src = *(input_ids_nd.operator->());
+      DLTensor dst = *(input_ids_device.operator->());
+      Tensor::CopyFromTo(&src, &dst);
+    }
+    Tensor attention_mask_device =
+        Tensor::Empty(attention_mask_nd.Shape(), attention_mask_nd.DataType(), device_);
+    {
+      DLTensor src = *(attention_mask_nd.operator->());
+      DLTensor dst = *(attention_mask_device.operator->());
+      Tensor::CopyFromTo(&src, &dst);
+    }
+
+    // Call encoder prefill: prefill(input_ids, attention_mask, params)
+    // BERT returns a Tensor directly, not a tuple.
+    ObjectRef result =
+        ft_.encoder_prefill_func_(input_ids_device, attention_mask_device, params_)
+            .cast<ObjectRef>();
+
+    // Handle return: BERT returns Tensor directly; some models may return a tuple.
+    // Both disco and non-disco paths use the same logic:
+    // - In disco mode, the result is always a DRef. The disco VM wraps all returns,
+    //   so tuple_getitem(0) is always needed — this matches every other disco path
+    //   in this file (BatchPrefill, BatchPrefillToLastHidden, BatchDecodeToLastHidden, etc.).
+    // - In non-disco mode, BERT returns a raw Tensor. Other encoder models might
+    //   return a tuple. We check IsInstance<TensorObj> to distinguish.
+    ObjectRef hidden_states{nullptr};
+    if (ft_.use_disco) {
+      // Disco VM always wraps returns; tuple_getitem(0) is the established pattern.
+      hidden_states = ft_.tuple_getitem_func_(result, 0).cast<ObjectRef>();
+    } else {
+      if (result->IsInstance<tvm::ffi::TensorObj>()) {
+        hidden_states = result;
+      } else {
+        hidden_states = ft_.tuple_getitem_func_(result, 0).cast<ObjectRef>();
+      }
+    }
+
+    if (trace_enabled_) {
+      DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
+    }
+    return hidden_states;
+  }
+
+  Tensor PoolEncoderHiddenStates(const ObjectRef& hidden_states,
+                                 const std::vector<int>& lengths, int batch_size, int max_len,
+                                 int strategy) final {
+    NVTXScopedRange nvtx_scope("PoolEncoderHiddenStates");
+
+    Tensor hs_nd{nullptr};
+    if (ft_.use_disco) {
+      hs_nd = Downcast<DRef>(hidden_states)->DebugGetFromRemote(0).cast<Tensor>();
+    } else {
+      hs_nd = Downcast<Tensor>(hidden_states);
+    }
+
+    TVM_FFI_ICHECK_NE(hidden_size_, -1);
+    // Reshape to [batch, max_len, hidden] if needed.
+    Tensor hs_3d{nullptr};
+    if (hs_nd->ndim == 3 && hs_nd->shape[0] == batch_size) {
+      // Already [batch, max_len, hidden].
+      hs_3d = hs_nd;
+    } else if (hs_nd->ndim == 3 && hs_nd->shape[0] == 1) {
+      // [1, batch*max_len, hidden] -> [batch, max_len, hidden]
+      hs_3d = hs_nd.CreateView({batch_size, max_len, hidden_size_}, hs_nd->dtype);
+    } else if (hs_nd->ndim == 2) {
+      hs_3d = hs_nd.CreateView({batch_size, max_len, hidden_size_}, hs_nd->dtype);
+    } else {
+      LOG(FATAL) << "Unexpected hidden states shape for pooling: ndim=" << hs_nd->ndim
+                 << " shape[0]=" << hs_nd->shape[0];
+    }
+
+    // Copy full hidden states [batch, max_len, hidden] to CPU for pooling.
+    // For encoder models, max_len is bounded (typically <=512) so this is manageable.
+    // This avoids non-contiguous slice copy issues with device tensors.
+    Tensor hs_cpu = Tensor::Empty({batch_size, max_len, hidden_size_}, hs_3d->dtype,
+                                  Device{DLDeviceType::kDLCPU, 0});
+    {
+      DLTensor src_dl = *(hs_3d.operator->());
+      DLTensor dst_dl = *(hs_cpu.operator->());
+      Tensor::CopyFromTo(&src_dl, &dst_dl);
+    }
+    DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
+
+    // Pool on CPU into a float32 buffer.
+    Tensor pooled_cpu = Tensor::Empty({batch_size, hidden_size_}, DataType::Float(32),
+                                      Device{DLDeviceType::kDLCPU, 0});
+    DLDataType hs_dtype = hs_3d->dtype;
+    bool is_bf16 = (hs_dtype.bits == 16 && hs_dtype.code == kDLBfloat);
+    bool is_fp16 = (hs_dtype.bits == 16 && hs_dtype.code == kDLFloat);
+    bool is_fp32 = (hs_dtype.bits == 32 && hs_dtype.code == kDLFloat);
+    TVM_FFI_ICHECK(is_fp32 || is_fp16 || is_bf16)
+        << "Pooling only supports float32, float16, and bfloat16 hidden states, got code="
+        << hs_dtype.code << " bits=" << hs_dtype.bits;
+
+    // Helper lambda to read one element from hs_cpu as float32.
+    auto read_f32 = [&](int64_t offset) -> float {
+      if (is_bf16) {
+        uint16_t bits = static_cast<const uint16_t*>(hs_cpu->data)[offset];
+        uint32_t bits32 = static_cast<uint32_t>(bits) << 16;
+        float val;
+        std::memcpy(&val, &bits32, sizeof(float));
+        return val;
+      } else if (is_fp16) {
+        uint16_t bits = static_cast<const uint16_t*>(hs_cpu->data)[offset];
+        uint32_t sign = (bits >> 15) & 1;
+        uint32_t exp = (bits >> 10) & 0x1F;
+        uint32_t mant = bits & 0x3FF;
+        float val;
+        if (exp == 0) {
+          val = std::ldexp(static_cast<float>(mant), -24);
+        } else if (exp == 31) {
+          val = mant ? 0.0f : 65504.0f;
+        } else {
+          val = std::ldexp(static_cast<float>(mant + 1024), static_cast<int>(exp) - 25);
+        }
+        if (sign) val = -val;
+        return val;
+      } else {
+        return static_cast<const float*>(hs_cpu->data)[offset];
+      }
+    };
+
+    float* out_ptr = static_cast<float*>(pooled_cpu->data);
+    if (strategy == 0) {
+      // CLS: take [i, 0, :] for each i.
+      for (int i = 0; i < batch_size; ++i) {
+        for (int h = 0; h < hidden_size_; ++h) {
+          out_ptr[i * hidden_size_ + h] = read_f32((i * max_len + 0) * hidden_size_ + h);
+        }
+      }
+    } else if (strategy == 2) {
+      // Last: take [i, lengths[i]-1, :] for each i.
+      for (int i = 0; i < batch_size; ++i) {
+        int last_pos = lengths[i] - 1;
+        for (int h = 0; h < hidden_size_; ++h) {
+          out_ptr[i * hidden_size_ + h] = read_f32((i * max_len + last_pos) * hidden_size_ + h);
+        }
+      }
+    } else {
+      // Mean: average over valid positions.
+      for (int i = 0; i < batch_size; ++i) {
+        int count = lengths[i];
+        for (int h = 0; h < hidden_size_; ++h) {
+          float sum = 0.0f;
+          for (int s = 0; s < count; ++s) {
+            sum += read_f32((i * max_len + s) * hidden_size_ + h);
+          }
+          out_ptr[i * hidden_size_ + h] = sum / static_cast<float>(count);
+        }
+      }
+    }
+
+    return pooled_cpu;
+  }
+
   /************** Debug/Profile **************/
 
   void DebugCallFuncOnAllAllWorker(const String& func_name, Optional<String> func_args) final {
@@ -1203,6 +1388,13 @@ class ModelImpl : public ModelObj {
     this->attention_sink_size_ = std::max(this->attention_sink_size_, 0);
     this->vocab_size_ = json::Lookup<int64_t>(config, "vocab_size");
     this->model_type_ = json::Lookup<std::string>(config, "model_type");
+    // Read hidden_size from nested model_config if available (used by encoder embedding models
+    // that don't have alloc_embedding_tensor).
+    if (config.count("model_config")) {
+      const auto& mc = config.at("model_config").cast<tvm::ffi::json::Object>();
+      this->hidden_size_ =
+          json::LookupOrDefault<int64_t>(mc, "hidden_size", this->hidden_size_);
+    }
   }
 
   //----------------------------

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -364,7 +364,7 @@ class ModelObj : public Object {
   virtual void ScatterDraftProbs(const Tensor& input, const std::vector<int>& indices,
                                  Tensor* dst) = 0;
 
-  /*********************** Encoder Embedding Support ***********************/
+  /*********************** Embedding Support ***********************/
 
   /*!
    * \brief Check if the model is an encoder embedding model.
@@ -372,6 +372,13 @@ class ModelObj : public Object {
    * AND the encoder prefill function is available.
    */
   virtual bool HasEncoderPrefill() const = 0;
+
+  /*!
+   * \brief Check if the model is a decoder-only embedding model.
+   * Returns true only when model_task=="embedding" AND embedding_model_type=="decoder"
+   * AND the decoder embedding prefill function is available.
+   */
+  virtual bool HasDecoderEmbeddingPrefill() const = 0;
 
   /*!
    * \brief Get the hidden size of the model. Available after model init.
@@ -392,20 +399,40 @@ class ModelObj : public Object {
                                    int batch_size, int max_len) = 0;
 
   /*!
-   * \brief Pool the encoder hidden states and return a CPU float32 tensor.
+   * \brief Run decoder-only embedding prefill for a batch of left-padded sequences.
+   * Calls the model's prefill_embedding(input_ids, attention_mask, params). Real
+   * tokens occupy positions ``[max_len - valid_len, max_len)``; padding sits on
+   * the left. The kernel applies causal-with-left-padding masking internally, so
+   * no explicit KV cache is allocated for this path.
+   * \param input_ids_nd CPU tensor of shape [batch_size, max_len], int32.
+   * \param attention_mask_nd CPU tensor of shape [batch_size, max_len], int32.
+   * \param batch_size Number of sequences in the batch.
+   * \param max_len Maximum sequence length (with padding).
+   * \return The full hidden states tensor on device, shape [batch_size, max_len, hidden].
+   */
+  virtual ObjectRef DecoderEmbeddingPrefill(const Tensor& input_ids_nd,
+                                            const Tensor& attention_mask_nd, int batch_size,
+                                            int max_len) = 0;
+
+  /*!
+   * \brief Pool a batch of embedding hidden states and return a CPU float32 tensor.
    * Supports CLS (first token), Mean (masked average), and Last (last real token).
+   * Shared by both the encoder lane (right-padded) and the decoder-embedding lane
+   * (left-padded, last-token pool): for the left-padded case the caller passes
+   * ``lengths[i] = max_len`` so ``kLast`` lands on the final buffer row, which is
+   * the actual last real token.
    * Hidden states are gathered from device (and from worker 0 under Disco) and
    * pooled directly on CPU, so the caller never needs to round-trip through device.
-   * \param hidden_states The full hidden states from encoder (device or DRef).
-   * \param lengths The real (unpadded) length of each sequence.
+   * \param hidden_states The full hidden states from prefill (device or DRef).
+   * \param lengths Per-sequence index of the last row to include (1-based).
    * \param batch_size Number of sequences.
    * \param max_len The padded sequence length.
    * \param strategy The pooling strategy (0=CLS, 1=Mean, 2=Last).
    * \return Pooled embeddings on CPU, float32, shape [batch, hidden].
    */
-  virtual Tensor PoolEncoderHiddenStates(const ObjectRef& hidden_states,
-                                         const std::vector<int>& lengths, int batch_size,
-                                         int max_len, int strategy) = 0;
+  virtual Tensor PoolEmbeddingHiddenStates(const ObjectRef& hidden_states,
+                                           const std::vector<int>& lengths, int batch_size,
+                                           int max_len, int strategy) = 0;
 
   /************** Debug/Profile **************/
 

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -364,6 +364,49 @@ class ModelObj : public Object {
   virtual void ScatterDraftProbs(const Tensor& input, const std::vector<int>& indices,
                                  Tensor* dst) = 0;
 
+  /*********************** Encoder Embedding Support ***********************/
+
+  /*!
+   * \brief Check if the model is an encoder embedding model.
+   * Returns true only when model_task=="embedding" AND embedding_model_type=="encoder"
+   * AND the encoder prefill function is available.
+   */
+  virtual bool HasEncoderPrefill() const = 0;
+
+  /*!
+   * \brief Get the hidden size of the model. Available after model init.
+   * \return The hidden dimension, or -1 if not yet initialized.
+   */
+  virtual int GetHiddenSize() const = 0;
+
+  /*!
+   * \brief Run encoder prefill for a batch of padded sequences.
+   * Calls the model's prefill(input_ids, attention_mask, params).
+   * \param input_ids_nd CPU tensor of shape [batch_size, max_len], int32.
+   * \param attention_mask_nd CPU tensor of shape [batch_size, max_len], int32.
+   * \param batch_size Number of sequences in the batch.
+   * \param max_len Maximum sequence length (with padding).
+   * \return The full hidden states tensor on device, shape [batch_size, max_len, hidden].
+   */
+  virtual ObjectRef EncoderPrefill(const Tensor& input_ids_nd, const Tensor& attention_mask_nd,
+                                   int batch_size, int max_len) = 0;
+
+  /*!
+   * \brief Pool the encoder hidden states and return a CPU float32 tensor.
+   * Supports CLS (first token), Mean (masked average), and Last (last real token).
+   * Hidden states are gathered from device (and from worker 0 under Disco) and
+   * pooled directly on CPU, so the caller never needs to round-trip through device.
+   * \param hidden_states The full hidden states from encoder (device or DRef).
+   * \param lengths The real (unpadded) length of each sequence.
+   * \param batch_size Number of sequences.
+   * \param max_len The padded sequence length.
+   * \param strategy The pooling strategy (0=CLS, 1=Mean, 2=Last).
+   * \return Pooled embeddings on CPU, float32, shape [batch, hidden].
+   */
+  virtual Tensor PoolEncoderHiddenStates(const ObjectRef& hidden_states,
+                                         const std::vector<int>& lengths, int batch_size,
+                                         int max_len, int strategy) = 0;
+
   /************** Debug/Profile **************/
 
   /*! \brief Call the given global function on all workers. Only for debug purpose. */

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -34,6 +34,7 @@ enum class InstructionKind : int {
   kReloadEngine = 3,
   kResetEngine = 4,
   kDebugCallFuncOnAllAllWorker = 5,
+  kAddEmbeddingRequest = 6,
 };
 
 /*! \brief The implementation of ThreadedEngine. */
@@ -119,6 +120,41 @@ class ThreadedEngineImpl : public ThreadedEngine {
     }
   }
 
+  void AddEmbeddingRequest(EmbeddingRequest request) final {
+    bool need_notify = false;
+    {
+      std::lock_guard<std::mutex> lock(background_loop_mutex_);
+      instruction_queue_.emplace_back(InstructionKind::kAddEmbeddingRequest, request);
+      ++pending_request_operation_cnt_;
+      need_notify = engine_waiting_;
+    }
+    if (need_notify) {
+      background_loop_cv_.notify_one();
+    }
+  }
+
+  void SetEmbeddingRequestCallback(Function embedding_callback) final {
+    embedding_request_callback_ = std::move(embedding_callback);
+    // If the background engine is already loaded, install the wrapper immediately.
+    // This mirrors how chat callback is installed — we don't require reload.
+    if (background_engine_ != nullptr && embedding_request_callback_.defined()) {
+      auto fembedding_callback_wrapper = [this](Array<EmbeddingResult> results) {
+        bool need_notify = false;
+        {
+          std::lock_guard<std::mutex> lock(request_stream_callback_mutex_);
+          embedding_request_callback_inputs_.push_back(std::move(results));
+          ++pending_request_stream_callback_cnt_;
+          need_notify = stream_callback_waiting_;
+        }
+        if (need_notify) {
+          request_stream_callback_cv_.notify_one();
+        }
+      };
+      background_engine_->SetEmbeddingRequestCallback(
+          FEmbeddingRequestCallback(fembedding_callback_wrapper));
+    }
+  }
+
   void AbortRequest(const String& request_id) final {
     bool need_notify = false;
     {
@@ -172,6 +208,9 @@ class ThreadedEngineImpl : public ThreadedEngine {
           if (background_engine_ != nullptr) {
             background_engine_->Reset();
           }
+        } else if (kind == InstructionKind::kAddEmbeddingRequest) {
+          TVM_FFI_ICHECK(background_engine_ != nullptr) << "Background engine is not loaded.";
+          background_engine_->AddEmbeddingRequest(Downcast<EmbeddingRequest>(arg));
         } else if (kind == InstructionKind::kDebugCallFuncOnAllAllWorker) {
           TVM_FFI_ICHECK(background_engine_ != nullptr) << "Background engine is not loaded.";
           Array<Any> packed_args = Downcast<Array<Any>>(arg);
@@ -191,6 +230,8 @@ class ThreadedEngineImpl : public ThreadedEngine {
     // The local vectors that load the request stream callback inputs from critical regions.
     std::vector<Array<RequestStreamOutput>> local_request_stream_callback_inputs;
     std::vector<RequestStreamOutput> flattened_callback_inputs;
+    std::vector<Array<EmbeddingResult>> local_embedding_callback_inputs;
+    std::vector<EmbeddingResult> flattened_embedding_inputs;
 
     while (!exit_now_.load(std::memory_order_relaxed)) {
       {
@@ -204,8 +245,12 @@ class ThreadedEngineImpl : public ThreadedEngine {
 
         local_request_stream_callback_inputs = request_stream_callback_inputs_;
         request_stream_callback_inputs_.clear();
+        local_embedding_callback_inputs = embedding_request_callback_inputs_;
+        embedding_request_callback_inputs_.clear();
         pending_request_stream_callback_cnt_ = 0;
       }
+
+      // Process chat callbacks.
       for (const Array<RequestStreamOutput>& callback_inputs :
            local_request_stream_callback_inputs) {
         for (const RequestStreamOutput& callback_input : callback_inputs) {
@@ -216,6 +261,21 @@ class ThreadedEngineImpl : public ThreadedEngine {
         request_stream_callback_(Array<RequestStreamOutput>(flattened_callback_inputs));
       }
       flattened_callback_inputs.clear();
+      local_request_stream_callback_inputs.clear();
+
+      // Process embedding callbacks (separate from chat).
+      if (embedding_request_callback_.defined()) {
+        for (const Array<EmbeddingResult>& emb_inputs : local_embedding_callback_inputs) {
+          for (const EmbeddingResult& emb_input : emb_inputs) {
+            flattened_embedding_inputs.push_back(emb_input);
+          }
+        }
+        if (!flattened_embedding_inputs.empty()) {
+          embedding_request_callback_(Array<EmbeddingResult>(flattened_embedding_inputs));
+        }
+        flattened_embedding_inputs.clear();
+      }
+      local_embedding_callback_inputs.clear();
     }
   }
 
@@ -289,6 +349,25 @@ class ThreadedEngineImpl : public ThreadedEngine {
     background_engine_ = std::move(output.reloaded_engine);
     default_generation_config_ = output.default_generation_cfg;
     complete_engine_config_ = output.completed_engine_config;
+
+    // Install embedding callback wrapper if an embedding callback is registered.
+    if (embedding_request_callback_.defined()) {
+      auto fembedding_callback_wrapper = [this](Array<EmbeddingResult> results) {
+        bool need_notify = false;
+        {
+          std::lock_guard<std::mutex> lock(request_stream_callback_mutex_);
+          embedding_request_callback_inputs_.push_back(std::move(results));
+          ++pending_request_stream_callback_cnt_;
+          need_notify = stream_callback_waiting_;
+        }
+        if (need_notify) {
+          request_stream_callback_cv_.notify_one();
+        }
+      };
+      background_engine_->SetEmbeddingRequestCallback(
+          FEmbeddingRequestCallback(fembedding_callback_wrapper));
+    }
+
     {
       // Wake up the thread waiting for reload finish.
       std::lock_guard<std::mutex> lock(reload_unload_mutex_);
@@ -322,6 +401,8 @@ class ThreadedEngineImpl : public ThreadedEngine {
   std::unique_ptr<Engine> background_engine_;
   /*! \brief The request stream callback. */
   Function request_stream_callback_;
+  /*! \brief The embedding request callback (set by Python via SetEmbeddingRequestCallback). */
+  Function embedding_request_callback_{nullptr};
   /*! \brief Event trace recorder. */
   Optional<EventTraceRecorder> trace_recorder_;
 
@@ -359,6 +440,8 @@ class ThreadedEngineImpl : public ThreadedEngine {
    * consumed by the foreground thread.
    */
   std::vector<Array<RequestStreamOutput>> request_stream_callback_inputs_;
+  /*! \brief The embedding result outputs to pass through callback. */
+  std::vector<Array<EmbeddingResult>> embedding_request_callback_inputs_;
   /*!
    * \brief Number of pending request operations, should be the size of
    * `requests_to_add_` and `requests_to_abort_`.
@@ -386,6 +469,9 @@ class ThreadedEngineModule : public ThreadedEngineImpl, public ffi::ModuleObj {
   TVM_MODULE_VTABLE_ENTRY("init_threaded_engine", &ThreadedEngineImpl::InitThreadedEngine);
   TVM_MODULE_VTABLE_ENTRY("reload", &ThreadedEngineImpl::Reload);
   TVM_MODULE_VTABLE_ENTRY("add_request", &ThreadedEngineImpl::AddRequest);
+  TVM_MODULE_VTABLE_ENTRY("add_embedding_request", &ThreadedEngineImpl::AddEmbeddingRequest);
+  TVM_MODULE_VTABLE_ENTRY("set_embedding_request_callback",
+                          &ThreadedEngineImpl::SetEmbeddingRequestCallback);
   TVM_MODULE_VTABLE_ENTRY("create_request", &ThreadedEngineImpl::CreateRequest);
   TVM_MODULE_VTABLE_ENTRY("abort_request", &ThreadedEngineImpl::AbortRequest);
   TVM_MODULE_VTABLE_ENTRY("run_background_loop", &ThreadedEngineImpl::RunBackgroundLoop);

--- a/cpp/serve/threaded_engine.h
+++ b/cpp/serve/threaded_engine.h
@@ -68,6 +68,12 @@ class ThreadedEngine {
   /*! \brief Add a new request to the engine. */
   virtual void AddRequest(Request request) = 0;
 
+  /*! \brief Add a new embedding request to the engine. */
+  virtual void AddEmbeddingRequest(EmbeddingRequest request) = 0;
+
+  /*! \brief Set the embedding result callback for threaded engine. */
+  virtual void SetEmbeddingRequestCallback(Function embedding_callback) = 0;
+
   /*! \brief Abort the input request (specified by id string) from engine. */
   virtual void AbortRequest(const String& request_id) = 0;
 

--- a/docs/deploy/rest.rst
+++ b/docs/deploy/rest.rst
@@ -24,11 +24,31 @@ You should see serve help message if the installation was successful.
 Quick Start
 ------------
 
-This section provides a quick start guide to work with MLC-LLM REST API. To launch a server, run the following command:
+This section provides a quick start guide to work with MLC-LLM REST API.
+
+``mlc_llm serve`` automatically detects the model's ``model_task`` field in
+``mlc-chat-config.json`` and routes to the appropriate serving mode:
+
+- **Chat models** (``model_task: "chat"``, the default): serves ``/v1/completions``,
+  ``/v1/chat/completions``, ``/v1/models``, ``/metrics``, and optionally ``/debug/*``.
+- **Embedding models** (``model_task: "embedding"``): serves only ``/v1/embeddings``
+  and ``/v1/models``.  Requires ``--model-lib``.
+
+**Chat model (default):**
 
 .. code:: bash
 
    mlc_llm serve MODEL [--model-lib PATH-TO-MODEL-LIB]
+
+**Embedding model:**
+
+.. code:: bash
+
+   mlc_llm serve EMBEDDING_MODEL --model-lib PATH-TO-MODEL-LIB
+
+When serving an embedding model, the following chat-only options are **not allowed**:
+``--mode``, ``--additional-models``, ``--speculative-mode``, ``--prefix-cache-mode``,
+``--prefill-mode``, ``--overrides``, ``--enable-tracing``, ``--enable-debug``.
 
 where ``MODEL`` is the model folder after compiling with :ref:`MLC-LLM build process <compile-model-libraries>`. Information about other arguments can be found under :ref:`Launch the server <rest_launch_server>` section.
 
@@ -71,7 +91,10 @@ If you want to enable tensor parallelism to run LLMs on multiple GPUs, please sp
 Launch the Server
 -----------------
 
-To launch the MLC Server for MLC-LLM, run the following command in your terminal.
+``mlc_llm serve`` reads the primary model's ``model_task`` field from
+``mlc-chat-config.json`` and automatically selects the appropriate serving mode.
+
+**Chat model** (``model_task: "chat"``, the default):
 
 .. code:: bash
 
@@ -80,13 +103,30 @@ To launch the MLC Server for MLC-LLM, run the following command in your terminal
        [--speculative-mode SPECULATIVE-MODE] \
        [--overrides OVERRIDES] \
        [--enable-tracing] \
-       [--host HOST] \
-       [--port PORT] \
-       [--allow-credentials] \
-       [--allowed-origins ALLOWED_ORIGINS] \
-       [--allowed-methods ALLOWED_METHODS] \
-       [--allowed-headers ALLOWED_HEADERS]
+       [--host HOST] [--port PORT] [--allow-credentials] \
+       [--allow-origins ALLOW_ORIGINS] [--allow-methods ALLOW_METHODS] \
+       [--allow-headers ALLOW_HEADERS]
 
+Serves ``/v1/models``, ``/v1/completions``, ``/v1/chat/completions``,
+``/metrics``, and optionally ``/debug/*``.
+
+**Embedding model** (``model_task: "embedding"``):
+
+.. code:: bash
+
+   mlc_llm serve EMBEDDING_MODEL --model-lib PATH-TO-MODEL-LIB \
+       [--device DEVICE] [--host HOST] [--port PORT] \
+       [--allow-credentials] [--allow-origins ALLOW_ORIGINS] \
+       [--allow-methods ALLOW_METHODS] [--allow-headers ALLOW_HEADERS] \
+       [--api-key API_KEY]
+
+Serves only ``/v1/models`` and ``/v1/embeddings``.  ``--model-lib`` is
+**required**.  The following chat-only options are **not allowed**:
+``--mode``, ``--additional-models``, ``--speculative-mode``,
+``--prefix-cache-mode``, ``--prefill-mode``, ``--overrides``,
+``--enable-tracing``, ``--enable-debug``.
+
+**Parameter reference (chat models):**
 
 MODEL                  The model folder after compiling with MLC-LLM build process. The parameter
                        can either be the model name with its quantization scheme
@@ -160,9 +200,9 @@ MODEL                  The model folder after compiling with MLC-LLM build proce
 --port                 The port on which the server should be started, defaults to ``8000``.
 --allow-credentials    A flag to indicate whether the server should allow credentials. If set, the server will
                        include the ``CORS`` header in the response
---allowed-origins      Specifies the allowed origins. It expects a JSON list of strings, with the default value being ``["*"]``, allowing all origins.
---allowed-methods      Specifies the allowed methods. It expects a JSON list of strings, with the default value being ``["*"]``, allowing all methods.
---allowed-headers      Specifies the allowed headers. It expects a JSON list of strings, with the default value being ``["*"]``, allowing all headers.
+--allow-origins      Specifies the allowed origins. It expects a JSON list of strings, with the default value being ``["*"]``, allowing all origins.
+--allow-methods      Specifies the allowed methods. It expects a JSON list of strings, with the default value being ``["*"]``, allowing all methods.
+--allow-headers      Specifies the allowed headers. It expects a JSON list of strings, with the default value being ``["*"]``, allowing all headers.
 
 You can access ``http://127.0.0.1:PORT/docs`` (replace ``PORT`` with the port number you specified) to see the list of
 supported endpoints.
@@ -430,6 +470,39 @@ Function Calling with streaming is also supported. Below is an example on how to
 
    # Output: ["get_current_weather(location='Pittsburgh,PA',unit='fahrenheit')", "get_current_weather(location='Tokyo,JP',unit='fahrenheit')"]
 
+
+.. http:post:: /v1/embeddings
+
+------------------------------------------------
+
+   Get embeddings for input text(s).  Only available when serving an embedding model.
+
+**Embedding Request Object**
+
+- **input** (*Union[str, List[str]]*, required): The text or list of texts to embed.
+- **model** (*str*, required): The model to use for embedding.
+- **dimensions** (*Optional[int]*): Truncate embeddings to this many dimensions (Matryoshka).
+- **encoding_format** (*Optional[Literal["float", "base64"]]*, optional, default="float"): Output format.
+
+**Returns**
+
+An ``EmbeddingResponse`` containing a list of embedding vectors and usage info.
+
+**Example**
+
+.. code:: bash
+
+   import requests
+
+   payload = {
+       "input": ["What is machine learning?", "How to brew coffee?"],
+       "model": "embedding",
+   }
+   r = requests.post("http://127.0.0.1:8000/v1/embeddings", json=payload)
+   for item in r.json()["data"]:
+       print(f"[{item['index']}] dim={len(item['embedding'])}")
+
+------------------------------------------------
 
 .. note::
    The API is a uniform interface that supports multiple languages. You can also utilize these functionalities in languages other than Python.

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -107,13 +107,10 @@ class EngineConfigOverride:  # pylint: disable=too-many-instance-attributes
 def _detect_model_task(model: str) -> str:
     """Detect the model_task field from the main model's mlc-chat-config.json."""
     from mlc_llm.support.auto_config import (  # pylint: disable=import-outside-toplevel
-        detect_mlc_chat_config,
+        detect_model_task,
     )
 
-    config_path = detect_mlc_chat_config(model)
-    with open(config_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-    return config.get("model_task", "chat")
+    return detect_model_task(model)
 
 
 def _argv_has_option(argv, option_name: str) -> bool:

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import json
+import sys
 from io import StringIO
 from typing import Literal, Optional
 
@@ -103,6 +104,67 @@ class EngineConfigOverride:  # pylint: disable=too-many-instance-attributes
         )
 
 
+def _detect_model_task(model: str) -> str:
+    """Detect the model_task field from the main model's mlc-chat-config.json."""
+    from mlc_llm.support.auto_config import (  # pylint: disable=import-outside-toplevel
+        detect_mlc_chat_config,
+    )
+
+    config_path = detect_mlc_chat_config(model)
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+    return config.get("model_task", "chat")
+
+
+def _argv_has_option(argv, option_name: str) -> bool:
+    """Check whether *option_name* (e.g. ``--mode``) was explicitly supplied in *argv*.
+
+    This inspects the raw argv list so that even ``--mode local`` (which equals the
+    default) is detected as "explicitly passed".
+    """
+    for arg in argv:
+        if arg == option_name or arg.startswith(option_name + "="):
+            return True
+    return False
+
+
+# Options that are forbidden when the main model is an embedding model.
+_EMBEDDING_FORBIDDEN_OPTIONS = (
+    "--additional-models",
+    "--mode",
+    "--speculative-mode",
+    "--prefix-cache-mode",
+    "--prefill-mode",
+    "--overrides",
+    "--enable-tracing",
+    "--enable-debug",
+)
+
+
+def _validate_embedding_model_args(argv, parsed) -> None:
+    """Validate CLI arguments when the main model has model_task == 'embedding'.
+
+    Raises ``SystemExit`` (via ``parser.error``-style messages) on violations.
+    """
+    # --model-lib is mandatory for embedding models
+    if parsed.model_lib is None:
+        print(
+            "error: --model-lib is required when the main model is an embedding model.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Reject forbidden options that were explicitly passed
+    explicitly_passed = [opt for opt in _EMBEDDING_FORBIDDEN_OPTIONS if _argv_has_option(argv, opt)]
+    if explicitly_passed:
+        print(
+            "error: the following options are not allowed for embedding models: "
+            + ", ".join(explicitly_passed),
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
 def main(argv):
     """Parse command line arguments and call `mlc_llm.interface.serve`."""
     parser = ArgumentParser("MLC LLM Serve CLI")
@@ -138,18 +200,6 @@ def main(argv):
     )
     parser.add_argument(
         "--additional-models", type=str, nargs="*", help=HELP["additional_models_serve"]
-    )
-    parser.add_argument(
-        "--embedding-model",
-        type=str,
-        default=None,
-        help="Path to the embedding model weight directory (enables /v1/embeddings endpoint)",
-    )
-    parser.add_argument(
-        "--embedding-model-lib",
-        type=str,
-        default=None,
-        help="Path to the compiled embedding model library (.so/.dylib file)",
     )
     parser.add_argument(
         "--speculative-mode",
@@ -218,6 +268,11 @@ def main(argv):
     )
     parsed = parser.parse_args(argv)
 
+    # Detect model task and validate arguments for embedding models
+    model_task = _detect_model_task(parsed.model)
+    if model_task == "embedding":
+        _validate_embedding_model_args(argv, parsed)
+
     additional_models = []
     if parsed.additional_models is not None:
         for additional_model in parsed.additional_models:
@@ -234,8 +289,6 @@ def main(argv):
         mode=parsed.mode,
         enable_debug=parsed.enable_debug,
         additional_models=additional_models,
-        embedding_model=parsed.embedding_model,
-        embedding_model_lib=parsed.embedding_model_lib,
         tensor_parallel_shards=parsed.overrides.tensor_parallel_shards,
         pipeline_parallel_stages=parsed.overrides.pipeline_parallel_stages,
         opt=parsed.overrides.opt,

--- a/python/mlc_llm/compiler_pass/fuse_add_norm.py
+++ b/python/mlc_llm/compiler_pass/fuse_add_norm.py
@@ -210,12 +210,30 @@ class _FuseAddRMSNormRewriter(PyExprMutator):  # pylint: disable=abstract-method
         x1 = y.args[0]
         x2 = y.args[1]
         # Extra check
-        n, _, h = x1.struct_info.shape
+        n, s, h = x1.struct_info.shape
         h = int(h)
         if h % self.TX != 0:
             return call
 
-        is_prefill = n == 1
+        def _is_one(dim) -> bool:
+            return isinstance(dim, tvm.tirx.IntImm) and int(dim) == 1
+
+        # This pass only has two specialized kernels:
+        # - prefill: [1, seq, hidden]
+        # - decode:  [batch, 1, hidden]
+        #
+        # Decoder-only embedding prefill runs on [batch, seq, hidden] with both
+        # batch and seq potentially dynamic. Routing that shape into the decode
+        # kernel would bake an incorrect middle dimension of 1 and fail at
+        # runtime shape checks. When neither axis is statically 1, skip fusion
+        # and keep the original add + rms_norm.
+        if _is_one(n):
+            is_prefill = True
+        elif _is_one(s):
+            is_prefill = False
+        else:
+            return call
+
         func_gv = self.prefill_norm_gv if is_prefill else self.decode_norm_gv
         if func_gv is None:
             if is_prefill:

--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -26,9 +26,20 @@ NOT_FOUND = red("Not found")
 FAILED = red("Failed")
 
 
+# Chat-only sampling fields kept in MLCChatConfig for book-keep but meaningless
+# for embedding tasks. Skipping them on embedding artifacts avoids misleading
+# "Setting temperature: 1.0"-style log lines that suggest sampling applies.
+_CHAT_ONLY_SAMPLING_FIELDS = frozenset(
+    {"temperature", "presence_penalty", "frequency_penalty", "repetition_penalty", "top_p"}
+)
+
+
 def apply_system_defaults_for_missing_fields(mlc_chat_config: MLCChatConfig) -> None:
     """Apply system default value."""
+    model_task = mlc_chat_config.field_model_task
     for key, value in mlc_chat_config.get_system_defaults_for_missing_fields().items():
+        if model_task == "embedding" and key in _CHAT_ONLY_SAMPLING_FIELDS:
+            continue
         setattr(mlc_chat_config, key, value)
         logger.info("[System default] Setting %s: %s", bold(key), value)
 
@@ -114,6 +125,31 @@ def gen_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-b
         conversation = conv_template  # type: ignore
     else:
         conversation = conversation_reg.to_json_dict()  # type: ignore
+
+    # Embedding-task artifacts have very different runtime characteristics from chat:
+    # each request is a list-of-texts batch (not N concurrent sessions), and inputs
+    # are bounded short documents (not long generations). Inheriting chat's defaults
+    # (`max_batch_size=128`, `context_window_size=max_position_embeddings=32768`,
+    # `prefill_chunk_size=min(cws, 2048)`) produces ~20 GB temp buffer on compile and
+    # OOMs consumer GPUs at engine reload. Apply embedding-appropriate defaults when
+    # the user did not pass an explicit override. Users wanting long-document
+    # embedding must opt in via the CLI flags (see docs ladder).
+    if model.model_task == "embedding":
+        _CLI_MAX_BATCH_SIZE_DEFAULT = 128  # cli/gen_config.py `--max-batch-size` default
+        if context_window_size is None:
+            # Cap at 1024 for temp-buffer budget, but never exceed the model's HF
+            # max_position_embeddings: bge-base has 512-slot position table and
+            # pushing cws above that makes the compiled graph index past the
+            # weight tensor at runtime.
+            _hf_cfg = model.config.from_file(config)
+            _hf_max = getattr(_hf_cfg, "context_window_size", 0)
+            if _hf_max <= 0:
+                _hf_max = _hf_cfg.kwargs.get("max_position_embeddings", 1024)
+            context_window_size = min(_hf_max, 1024)
+        if prefill_chunk_size is None:
+            prefill_chunk_size = context_window_size
+        if max_batch_size == _CLI_MAX_BATCH_SIZE_DEFAULT:
+            max_batch_size = 8
 
     model_config = ModelConfigOverride(
         context_window_size=context_window_size,

--- a/python/mlc_llm/interface/help.py
+++ b/python/mlc_llm/interface/help.py
@@ -1,7 +1,8 @@
 """Help message for CLI arguments."""
 
 HELP = {
-    "config": ("""
+    "config": (
+        """
 1) Path to a HuggingFace model directory that contains a `config.json` or
 2) Path to `config.json` in HuggingFace format, or
 3) The name of a pre-defined model architecture.
@@ -15,7 +16,8 @@ the non-quantized model weights in PyTorch or SafeTensor format, tokenizer confi
 as well as an optional `generation_config.json` provides additional default configuration for
 text generation.
 Example: https://huggingface.co/codellama/CodeLlama-7b-hf/tree/main.
-""").strip(),
+"""
+    ).strip(),
     "quantization": """
 The quantization mode we use to compile. If unprovided, will infer from `model`.
 """.strip(),

--- a/python/mlc_llm/interface/help.py
+++ b/python/mlc_llm/interface/help.py
@@ -1,8 +1,7 @@
 """Help message for CLI arguments."""
 
 HELP = {
-    "config": (
-        """
+    "config": ("""
 1) Path to a HuggingFace model directory that contains a `config.json` or
 2) Path to `config.json` in HuggingFace format, or
 3) The name of a pre-defined model architecture.
@@ -16,19 +15,21 @@ the non-quantized model weights in PyTorch or SafeTensor format, tokenizer confi
 as well as an optional `generation_config.json` provides additional default configuration for
 text generation.
 Example: https://huggingface.co/codellama/CodeLlama-7b-hf/tree/main.
-"""
-    ).strip(),
+""").strip(),
     "quantization": """
 The quantization mode we use to compile. If unprovided, will infer from `model`.
 """.strip(),
     "model": """
 A path to ``mlc-chat-config.json``, or an MLC model directory that contains `mlc-chat-config.json`.
 It can also be a link to a HF repository pointing to an MLC compiled model.
+The model's ``model_task`` field (``"chat"`` or ``"embedding"``) determines the serving mode.
+When the model is an embedding model, only ``--model-lib``, ``--device``, ``--host``, ``--port``,
+CORS options, and ``--api-key`` are accepted.
 """.strip(),
     "model_lib": """
-The full path to the model library file to use (e.g. a ``.so`` file). If unspecified, we will use
-the provided ``model`` to search over possible paths. It the model lib is not found, it will be
-compiled in a JIT manner.
+The full path to the model library file to use (e.g. a ``.so`` file).
+For chat models, if unspecified we search over possible paths and JIT-compile when not found.
+For embedding models, ``--model-lib`` is required and must be provided explicitly.
 """.strip(),
     "model_type": """
 Model architecture such as "llama". If not set, it is inferred from `mlc-chat-config.json`.
@@ -176,7 +177,8 @@ to get the Chrome Trace. For example,
 """.strip(),
     "mode_serve": """
 The engine mode in MLC LLM. We provide three preset modes: "local", "interactive" and "server".
-The default mode is "local".
+The default mode is "local". This option applies only to chat models; it is not allowed for
+embedding models.
 The choice of mode decides the values of "max_num_sequence", "max_total_seq_length" and
 "prefill_chunk_size" when they are not explicitly specified.
 1. Mode "local" refers to the local server deployment which has low request concurrency.

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -1,6 +1,5 @@
 """Python entrypoint of serve."""
 
-import json
 from typing import Any, List, Literal, Optional, Tuple, Union
 
 import fastapi
@@ -18,20 +17,9 @@ from mlc_llm.serve.entrypoints import (
 )
 from mlc_llm.serve.server import ServerContext
 from mlc_llm.support import logging
-from mlc_llm.support.auto_config import detect_mlc_chat_config
+from mlc_llm.support.auto_config import detect_model_task as _detect_model_task
 
 logger = logging.getLogger(__name__)
-
-
-def _detect_model_task(model: str) -> str:
-    """Detect the model_task field from the primary model's mlc-chat-config.json.
-
-    Returns "chat" or "embedding". Defaults to "chat" if the field is absent.
-    """
-    config_path = detect_mlc_chat_config(model)
-    with open(config_path, "r", encoding="utf-8") as f:
-        cfg = json.load(f)
-    return cfg.get("model_task", "chat")
 
 
 def serve(

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -1,5 +1,6 @@
 """Python entrypoint of serve."""
 
+import json
 from typing import Any, List, Literal, Optional, Tuple, Union
 
 import fastapi
@@ -17,8 +18,20 @@ from mlc_llm.serve.entrypoints import (
 )
 from mlc_llm.serve.server import ServerContext
 from mlc_llm.support import logging
+from mlc_llm.support.auto_config import detect_mlc_chat_config
 
 logger = logging.getLogger(__name__)
+
+
+def _detect_model_task(model: str) -> str:
+    """Detect the model_task field from the primary model's mlc-chat-config.json.
+
+    Returns "chat" or "embedding". Defaults to "chat" if the field is absent.
+    """
+    config_path = detect_mlc_chat_config(model)
+    with open(config_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    return cfg.get("model_task", "chat")
 
 
 def serve(
@@ -28,8 +41,6 @@ def serve(
     mode: Literal["local", "interactive", "server"],
     enable_debug: bool,
     additional_models: List[Union[str, Tuple[str, str]]],
-    embedding_model: Optional[str],
-    embedding_model_lib: Optional[str],
     tensor_parallel_shards: Optional[int],
     pipeline_parallel_stages: Optional[int],
     opt: Optional[str],
@@ -57,6 +68,144 @@ def serve(
     api_key: Optional[str] = None,
 ):  # pylint: disable=too-many-arguments, too-many-locals
     """Serve the model with the specified configuration."""
+    # Detect primary model task to decide the serve path
+    model_task = _detect_model_task(model)
+    logger.info("Primary model task: %s", model_task)
+
+    if model_task == "embedding":
+        _serve_embedding(
+            model=model,
+            device=device,
+            model_lib=model_lib,
+            host=host,
+            port=port,
+            allow_credentials=allow_credentials,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            api_key=api_key,
+        )
+    else:
+        _serve_chat(
+            model=model,
+            device=device,
+            model_lib=model_lib,
+            mode=mode,
+            enable_debug=enable_debug,
+            additional_models=additional_models,
+            tensor_parallel_shards=tensor_parallel_shards,
+            pipeline_parallel_stages=pipeline_parallel_stages,
+            opt=opt,
+            max_num_sequence=max_num_sequence,
+            max_total_sequence_length=max_total_sequence_length,
+            max_single_sequence_length=max_single_sequence_length,
+            prefill_chunk_size=prefill_chunk_size,
+            sliding_window_size=sliding_window_size,
+            attention_sink_size=attention_sink_size,
+            max_history_size=max_history_size,
+            gpu_memory_utilization=gpu_memory_utilization,
+            speculative_mode=speculative_mode,
+            spec_draft_length=spec_draft_length,
+            spec_tree_width=spec_tree_width,
+            prefix_cache_mode=prefix_cache_mode,
+            prefix_cache_max_num_recycling_seqs=prefix_cache_max_num_recycling_seqs,
+            prefill_mode=prefill_mode,
+            enable_tracing=enable_tracing,
+            host=host,
+            port=port,
+            allow_credentials=allow_credentials,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            api_key=api_key,
+        )
+
+
+def _serve_embedding(
+    model: str,
+    device: str,
+    model_lib: Optional[str],
+    host: str,
+    port: int,
+    allow_credentials: bool,
+    allow_origins: Any,
+    allow_methods: Any,
+    allow_headers: Any,
+    api_key: Optional[str],
+):  # pylint: disable=too-many-arguments
+    """Embedding-only serve path: only AsyncEmbeddingEngine, only /v1/models and /v1/embeddings."""
+    if model_lib is None:
+        raise ValueError("--model-lib is required when serving an embedding model.")
+
+    emb_engine = AsyncEmbeddingEngine(
+        model=model,
+        model_lib=model_lib,
+        device=device,
+    )
+    logger.info("Embedding model %s loaded successfully.", model)
+
+    with ServerContext() as server_context:
+        server_context.add_embedding_engine(model, emb_engine)
+        server_context.api_key = api_key
+
+        app = fastapi.FastAPI()
+        app.add_middleware(
+            CORSMiddleware,
+            allow_credentials=allow_credentials,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+        )
+
+        app.include_router(openai_entrypoints.embedding_app)
+
+        app.exception_handler(error_protocol.BadRequestError)(
+            error_protocol.bad_request_error_handler
+        )
+
+        logger.info("Embedding server started.")
+        logger.info("  model_task  : embedding")
+        logger.info("  base URL    : http://%s:%d", host, port)
+        logger.info("  GET  /v1/models")
+        logger.info("  POST /v1/embeddings")
+
+        uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def _serve_chat(
+    model: str,
+    device: str,
+    model_lib: Optional[str],
+    mode: Literal["local", "interactive", "server"],
+    enable_debug: bool,
+    additional_models: List[Union[str, Tuple[str, str]]],
+    tensor_parallel_shards: Optional[int],
+    pipeline_parallel_stages: Optional[int],
+    opt: Optional[str],
+    max_num_sequence: Optional[int],
+    max_total_sequence_length: Optional[int],
+    max_single_sequence_length: Optional[int],
+    prefill_chunk_size: Optional[int],
+    sliding_window_size: Optional[int],
+    attention_sink_size: Optional[int],
+    max_history_size: Optional[int],
+    gpu_memory_utilization: Optional[float],
+    speculative_mode: Literal["disable", "small_draft", "eagle", "medusa"],
+    spec_draft_length: Optional[int],
+    spec_tree_width: Optional[int],
+    prefix_cache_mode: Literal["disable", "radix"],
+    prefix_cache_max_num_recycling_seqs: Optional[int],
+    prefill_mode: Literal["hybrid", "chunked"],
+    enable_tracing: bool,
+    host: str,
+    port: int,
+    allow_credentials: bool,
+    allow_origins: Any,
+    allow_methods: Any,
+    allow_headers: Any,
+    api_key: Optional[str],
+):  # pylint: disable=too-many-arguments, too-many-locals
+    """Chat serve path: existing AsyncMLCEngine behavior, unchanged."""
     # Create engine and start the background loop
     async_engine = engine.AsyncMLCEngine(
         model=model,
@@ -86,24 +235,8 @@ def serve(
         enable_tracing=enable_tracing,
     )
 
-    # Set up embedding model if specified
-    emb_engine = None
-    if embedding_model is not None:
-        if embedding_model_lib is None:
-            raise ValueError(
-                "--embedding-model-lib is required when --embedding-model is specified."
-            )
-        emb_engine = AsyncEmbeddingEngine(
-            model=embedding_model,
-            model_lib=embedding_model_lib,
-            device=device,
-        )
-        logger.info("Embedding model %s loaded successfully.", embedding_model)
-
     with ServerContext() as server_context:
         server_context.add_model(model, async_engine)
-        if emb_engine is not None:
-            server_context.add_embedding_engine(embedding_model, emb_engine)
         server_context.api_key = api_key
 
         app = fastapi.FastAPI()
@@ -115,7 +248,7 @@ def serve(
             allow_headers=allow_headers,
         )
 
-        app.include_router(openai_entrypoints.app)
+        app.include_router(openai_entrypoints.chat_app)
         app.include_router(metrics_entrypoints.app)
         app.include_router(microserving_entrypoints.app)
 
@@ -128,4 +261,14 @@ def serve(
         app.exception_handler(error_protocol.BadRequestError)(
             error_protocol.bad_request_error_handler
         )
+
+        logger.info("Chat server started.")
+        logger.info("  model_task  : chat")
+        logger.info("  base URL    : http://%s:%d", host, port)
+        logger.info("  GET  /v1/models")
+        logger.info("  POST /v1/completions")
+        logger.info("  POST /v1/chat/completions")
+        if enable_debug:
+            logger.info("  POST /debug/dump_event_trace  (debug enabled)")
+
         uvicorn.run(app, host=host, port=port, log_level="info")

--- a/python/mlc_llm/model/bert/bert_model.py
+++ b/python/mlc_llm/model/bert/bert_model.py
@@ -6,7 +6,7 @@ import dataclasses
 from functools import partial
 from typing import Any, Dict, Optional
 
-from tvm import te, tirx
+from tvm import te
 from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import Tensor, op
 
@@ -100,7 +100,7 @@ class BertSelfAttention(nn.Module):  # pylint: disable=too-many-instance-attribu
             bias=True,
         )
 
-    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
+    def forward(self, hidden_states: Tensor, valid_lens: Tensor):
         d, h = self.head_dim, self.num_heads
         b, s, _ = hidden_states.shape
 
@@ -108,8 +108,7 @@ class BertSelfAttention(nn.Module):  # pylint: disable=too-many-instance-attribu
         qkv = op.reshape(qkv, (b, s, 3 * h, d))
         q, k, v = op.split(qkv, 3, axis=2)
 
-        # Attention
-        output = op_ext.attention(q, k, v, attention_mask)
+        output = op_ext.encoder_attention(q, k, v, valid_lens)
         return output
 
 
@@ -129,8 +128,8 @@ class BertAttention(nn.Module):
         self.self = BertSelfAttention(config)
         self.output = BertSelfOutput(config)
 
-    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
-        self_output = self.self(hidden_states, attention_mask)
+    def forward(self, hidden_states: Tensor, valid_lens: Tensor):
+        self_output = self.self(hidden_states, valid_lens)
         attention_output = self.output(self_output, hidden_states)
         return attention_output
 
@@ -172,8 +171,8 @@ class BertLayer(nn.Module):
         self.intermediate = BertIntermediate(config)
         self.output = BertOutput(config)
 
-    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
-        attention_output = self.attention(hidden_states, attention_mask)
+    def forward(self, hidden_states: Tensor, valid_lens: Tensor):
+        attention_output = self.attention(hidden_states, valid_lens)
         intermediate_output = self.intermediate(attention_output)
         layer_output = self.output(intermediate_output, attention_output)
         return layer_output
@@ -183,9 +182,9 @@ class BertEncoder(nn.Module):
     def __init__(self, config: BertConfig):
         self.layer = nn.ModuleList([BertLayer(config) for _ in range(config.num_hidden_layers)])
 
-    def forward(self, hidden_states: Tensor, attention_mask: Tensor):
+    def forward(self, hidden_states: Tensor, valid_lens: Tensor):
         for layer in self.layer:
-            hidden_states = layer(hidden_states, attention_mask)
+            hidden_states = layer(hidden_states, valid_lens)
         return hidden_states
 
 
@@ -221,7 +220,7 @@ class BertModel(nn.Module):
         if dtype is not None:
             self.dtype = dtype
 
-    def forward(self, inputs: Tensor, attention_mask: Tensor):
+    def forward(self, inputs: Tensor, valid_lens: Tensor):
         # TODO: XLM-RoBERTa models use position indices starting from pad_token_id + 1  # pylint: disable=fixme
         # (e.g., [2, 3, 4, ...] when pad_token_id=1), while this implementation uses
         # [0, 1, 2, ...]. For XLM-RoBERTa models (e.g., bge-m3), the position_embeddings
@@ -239,28 +238,25 @@ class BertModel(nn.Module):
         token_type_ids = op.zeros(inputs.shape, dtype="int32")
 
         embeddings = self.embeddings(inputs, token_type_ids, input_positions)
-        encoder_output = self.encoder(embeddings, attention_mask)
+        encoder_output = self.encoder(embeddings, valid_lens)
         return encoder_output
 
     def prefill(self, inputs: Tensor, attention_mask: Tensor):
-        def _attention_mask(mask: te.Tensor, zero, batch_size, seq_len):
+        def _valid_lens(mask: te.Tensor):
+            batch_size, seq_len = mask.shape
+            k = te.reduce_axis((0, seq_len), name="k")
             return te.compute(
-                (batch_size, 1, seq_len, seq_len),
-                lambda b, _, i, j: tirx.if_then_else(
-                    tirx.any(mask[b, i] == zero, mask[b, j] == zero),
-                    tirx.min_value(self.dtype),
-                    tirx.max_value(self.dtype),
-                ),
-                name="attention_mask_prefill",
+                (batch_size,),
+                lambda b: te.sum(mask[b, k].astype("int32"), axis=k),
+                name="valid_lens",
             )
 
-        batch_size, seq_len = inputs.shape
-        attention_mask_2d = op.tensor_expr_op(
-            _attention_mask,
-            name_hint="attention_mask_prefill",
-            args=[attention_mask, tirx.IntImm("int32", 0), batch_size, seq_len],
+        valid_lens = op.tensor_expr_op(
+            _valid_lens,
+            name_hint="valid_lens",
+            args=[attention_mask],
         )
-        return self.forward(inputs, attention_mask_2d)
+        return self.forward(inputs, valid_lens)
 
     def get_default_spec(self):
         mod_spec = {

--- a/python/mlc_llm/model/qwen3/qwen3_model.py
+++ b/python/mlc_llm/model/qwen3/qwen3_model.py
@@ -6,9 +6,10 @@ import dataclasses
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
 
-from tvm import tirx
+from tvm import te, tirx
 from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import Tensor, op
+from tvm.relax.frontend.nn.llm import position_embedding
 
 from mlc_llm import op as op_ext
 from mlc_llm.model.model_utils import index_last_token
@@ -150,6 +151,77 @@ class Qwen3Attention(nn.Module):  # pylint: disable=too-many-instance-attributes
         attn_output = self.o_proj(output)
         return attn_output
 
+    def forward_embedding(self, hidden_states: Tensor, valid_lens: Tensor):
+        """Embedding-mode attention: no KV cache, left-pad + causal mask.
+
+        Parallel to :meth:`forward` but drops :class:`PagedKVCache` and applies
+        RoPE via :func:`position_embedding.llama_rope_with_position_map` before
+        invoking :func:`op_ext.decoder_embedding_attention`. All weights
+        (``c_attn``, ``q_norm``, ``k_norm``, ``o_proj``) are shared with the
+        chat forward path, so switching lanes requires no separate params.
+        """
+        d, h_q, h_kv = self.head_dim, self.num_attention_heads, self.num_key_value_heads
+        b, s, _ = hidden_states.shape
+
+        qkv = self.c_attn(hidden_states)
+        qkv = op.reshape(qkv, (b, s, h_q + h_kv + h_kv, d))
+        q, k, v = op.split(qkv, [h_q, h_q + h_kv], axis=2)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        qkv = op.concat([q, k, v], dim=2)
+
+        # llama_rope_with_position_map takes fused QKV in shape (seq_len, fused_heads, head_dim),
+        # with a per-element int32 position_map of length seq_len. Flatten batch*seq so a single
+        # RoPE call covers the whole batch; positions wrap as [0..s-1] per sample (batch-flat
+        # index mod s), which keeps Q/K relative-position differences identical to the chat
+        # path — the only thing attention / RoPE actually depend on.
+        fused_heads = h_q + 2 * h_kv
+        qkv_flat = op.reshape(qkv, (b * s, fused_heads, d))
+
+        def _position_map(_seq: te.Tensor):
+            bs = _seq.shape[0]
+            s_dim = _seq.shape[1]
+            return te.compute(
+                (bs * s_dim,),
+                lambda i: (i % s_dim).astype("int32"),
+                name="embedding_position_map",
+            )
+
+        position_map = op.tensor_expr_op(
+            _position_map,
+            name_hint="embedding_position_map",
+            args=[hidden_states],
+        )
+
+        apply_rope_flag = tirx.IntImm("int32", 1)
+        rotary_emb = position_embedding.llama_rope_with_position_map(
+            theta=self.rope_theta,
+            scale=1.0,
+            head_dim=d,
+            num_q_heads=h_q,
+            num_kv_heads=h_kv,
+            dtype=qkv.dtype,
+            rope_scaling={},
+        )
+
+        q_rot, k_rot, v_out = op.tensor_ir_op(
+            rotary_emb,
+            "llama_rope_with_position_map",
+            args=[qkv_flat, position_map, apply_rope_flag],
+            out=(
+                Tensor.placeholder((b * s, h_q, d), qkv.dtype),
+                Tensor.placeholder((b * s, h_kv, d), qkv.dtype),
+                Tensor.placeholder((b * s, h_kv, d), qkv.dtype),
+            ),
+        )
+
+        q_rot = op.reshape(q_rot, (b, s, h_q, d))
+        k_rot = op.reshape(k_rot, (b, s, h_kv, d))
+        v_out = op.reshape(v_out, (b, s, h_kv, d))
+
+        attn_output = op_ext.decoder_embedding_attention(q_rot, k_rot, v_out, valid_lens)
+        return self.o_proj(attn_output)
+
 
 ACT2FN = {
     "gelu": partial(nn.gelu, approximate=False),
@@ -237,6 +309,17 @@ class Qwen3DecoderLayer(nn.Module):
         hidden_states = self._apply_residual(out, residual=hidden_states)
         return hidden_states
 
+    def forward_embedding(self, hidden_states: Tensor, valid_lens: Tensor):
+        """Embedding-mode decoder layer: parallels :meth:`forward` but routes
+        attention through :meth:`Qwen3Attention.forward_embedding` (no KV cache)."""
+        out = self.input_layernorm(hidden_states)
+        out = self.self_attn.forward_embedding(out, valid_lens)
+        hidden_states = self._apply_residual(out, residual=hidden_states)
+        out = self.post_attention_layernorm(hidden_states)
+        out = self.mlp(out)
+        hidden_states = self._apply_residual(out, residual=hidden_states)
+        return hidden_states
+
     def _apply_residual(self, out, residual):
         if self.tensor_parallel_shards > 1:
             return op.ccl_allreduce(out, "sum") + residual
@@ -255,6 +338,16 @@ class Qwen3Model(nn.Module):
         hidden_states = inputs
         for layer_id, layer in enumerate(self.layers):
             hidden_states = layer(hidden_states, paged_kv_cache, layer_id)
+        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+    def forward_embedding(self, inputs: Tensor, valid_lens: Tensor):
+        """Embedding-mode model forward: skips :class:`PagedKVCache` entirely
+        and forwards through :meth:`Qwen3DecoderLayer.forward_embedding` at
+        each layer. Returns last hidden states (no lm_head / logits)."""
+        hidden_states = inputs
+        for layer in self.layers:
+            hidden_states = layer.forward_embedding(hidden_states, valid_lens)
         hidden_states = self.norm(hidden_states)
         return hidden_states
 
@@ -475,10 +568,52 @@ class Qwen3EmbeddingModel(Qwen3LMHeadModel):
         hidden_states = self.model(input_embeds, paged_kv_cache)
         return hidden_states, paged_kv_cache
 
+    def prefill_embedding(self, input_ids: Tensor, attention_mask: Tensor):
+        """First-class decoder embedding prefill.
+
+        Takes left-padded ``input_ids`` / ``attention_mask`` (real tokens at
+        ``[seq - valid_len, seq)``, padding on the left) and returns last-layer
+        hidden states ``[batch, seq, hidden]``. The chat-lane autoregressive
+        ``prefill`` function (logits + PagedKVCache) is intentionally not used
+        here; the whole forward runs without any KV cache so the embedding lane
+        does not contend for chat's KV budget.
+        """
+        op_ext.configure()
+
+        # Embed tokens: [batch, seq] int32 -> [batch, seq, hidden]
+        hidden_states = self.model.embed_tokens(input_ids)
+
+        # Derive per-sample valid_lens from the attention mask. Shared with the
+        # encoder lane (BertModel.prefill) — any 0/1 mask sums to the real length.
+        def _valid_lens(mask: te.Tensor):
+            batch_size, seq_len = mask.shape
+            k = te.reduce_axis((0, seq_len), name="k")
+            return te.compute(
+                (batch_size,),
+                lambda b: te.sum(mask[b, k].astype("int32"), axis=k),
+                name="valid_lens",
+            )
+
+        valid_lens = op.tensor_expr_op(
+            _valid_lens,
+            name_hint="valid_lens",
+            args=[attention_mask],
+        )
+
+        return self.model.forward_embedding(hidden_states, valid_lens)
+
     def get_default_spec(self):
         mod_spec = {
             "embed": {
                 "input_ids": nn.spec.Tensor(["seq_len"], "int32"),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            },
+            "prefill_embedding": {
+                "input_ids": nn.spec.Tensor(["batch_size", "seq_len"], "int32"),
+                "attention_mask": nn.spec.Tensor(["batch_size", "seq_len"], "int32"),
                 "$": {
                     "param_mode": "packed",
                     "effect_mode": "none",

--- a/python/mlc_llm/model/qwen3/qwen3_model.py
+++ b/python/mlc_llm/model/qwen3/qwen3_model.py
@@ -193,7 +193,7 @@ class Qwen3Attention(nn.Module):  # pylint: disable=too-many-instance-attributes
             args=[hidden_states],
         )
 
-        apply_rope_flag = tirx.IntImm("int32", 1)
+        apply_rope_flag = tirx.IntImm("int64", 1)
         rotary_emb = position_embedding.llama_rope_with_position_map(
             theta=self.rope_theta,
             scale=1.0,

--- a/python/mlc_llm/op/__init__.py
+++ b/python/mlc_llm/op/__init__.py
@@ -1,7 +1,7 @@
 """Extern module for compiler."""
 
 from . import moe_matmul, moe_misc
-from .attention import attention
+from .attention import attention, encoder_attention
 from .batch_spec_verify import batch_spec_verify
 from .extern import configure, enable, get_store
 from .ft_gemm import faster_transformer_dequantize_gemm

--- a/python/mlc_llm/op/__init__.py
+++ b/python/mlc_llm/op/__init__.py
@@ -1,7 +1,7 @@
 """Extern module for compiler."""
 
 from . import moe_matmul, moe_misc
-from .attention import attention, encoder_attention
+from .attention import attention, decoder_embedding_attention, encoder_attention
 from .batch_spec_verify import batch_spec_verify
 from .extern import configure, enable, get_store
 from .ft_gemm import faster_transformer_dequantize_gemm

--- a/python/mlc_llm/op/attention.py
+++ b/python/mlc_llm/op/attention.py
@@ -202,6 +202,44 @@ def encoder_attention(
     Uses the tiled sequence prefill kernel and applies per-batch valid lengths
     inside the kernel so encoder batches stay memory-efficient.
     """
+    return _masked_sequence_attention(q, k, v, valid_lens, mask_mode="padded")
+
+
+def decoder_embedding_attention(
+    q: nn.Tensor,
+    k: nn.Tensor,
+    v: nn.Tensor,
+    valid_lens: nn.Tensor,
+) -> nn.Tensor:
+    """Decoder-embedding self-attention with left-padding lengths and causal mask.
+
+    Counterpart of :func:`encoder_attention` for decoder-only embedding models
+    (e.g. Qwen3-Embedding). Real tokens occupy ``[seq_len - valid_lens[b], seq_len)``
+    and the causal mask additionally keeps ``col <= row`` within the valid range,
+    so the last real token always sits at buffer position ``seq_len - 1`` and
+    last-token pooling is a cheap stride slice.
+
+    Rotary embeddings, if required by the model, must be applied to ``q``/``k``
+    by the caller before invoking this op; the masked prefill kernel treats its
+    inputs as raw Q/K/V.
+    """
+    return _masked_sequence_attention(q, k, v, valid_lens, mask_mode="causal_padded_left")
+
+
+def _masked_sequence_attention(
+    q: nn.Tensor,
+    k: nn.Tensor,
+    v: nn.Tensor,
+    valid_lens: nn.Tensor,
+    *,
+    mask_mode: str,
+) -> nn.Tensor:
+    """Shared backend for right-pad and left-pad-causal masked prefill.
+
+    Both encoder and decoder-embedding lanes lower to the same tiled kernel in
+    TVM (``_attention_sequence_prefill_with_mask``), selecting the padding /
+    causality regime through ``mask_mode``.
+    """
     b, s, h, d = q.shape
     t, h_kv, _ = k.shape[-3:]
 
@@ -211,15 +249,19 @@ def encoder_attention(
 
     if valid_lens.ndim != 1:
         raise ValueError(
-            f"encoder_attention expects a 1D valid_lens tensor, but got ndim={valid_lens.ndim}"
+            f"masked sequence attention expects a 1D valid_lens tensor, "
+            f"but got ndim={valid_lens.ndim}"
         )
     if k.ndim == 3:
         k = op.reshape(k, [b, t, h_kv, d])
     if v.ndim == 3:
         v = op.reshape(v, [b, t, h_kv, d])
-    if h_kv != h:
-        k = k.repeat(h // h_kv, axis=2)
-        v = v.repeat(h // h_kv, axis=2)
+
+    # NOTE: the masked prefill TIR kernel is GQA-native (takes h_q and h_kv
+    # separately and handles group_size internally), so K/V must keep their
+    # native ``h_kv`` count here. Do NOT pre-repeat K/V to ``h_q`` — that
+    # caused a shape mismatch vs the TIR signature for Qwen3-Embedding
+    # (h_q=16, h_kv=8).
 
     target = _get_attention_target()
     attn_output, _ = op.tensor_ir_op(
@@ -230,6 +272,7 @@ def encoder_attention(
             dtype=q.dtype,
             target=target,
             sm_scale=1.0 / (d**0.5),
+            mask_mode=mask_mode,
         ),
         "sequence_prefill_masked",
         [q, k, v, valid_lens],

--- a/python/mlc_llm/op/attention.py
+++ b/python/mlc_llm/op/attention.py
@@ -15,6 +15,13 @@ WARN_FLASHINFER_GROUP_SIZE = False
 WARN_FLASHINFER_HEAD_DIM = False
 
 
+def _get_attention_target() -> tvm.target.Target:
+    current = tvm.target.Target.current(allow_none=True)
+    if current is not None:
+        return current
+    return tvm.target.Target("cuda")
+
+
 def attention(  # pylint: disable=invalid-name,too-many-locals,too-many-statements,too-many-arguments, unused-argument
     q: nn.Tensor,
     k: nn.Tensor,
@@ -182,3 +189,53 @@ def attention(  # pylint: disable=invalid-name,too-many-locals,too-many-statemen
 
     # Fallback Implementation
     return _fallback()
+
+
+def encoder_attention(
+    q: nn.Tensor,
+    k: nn.Tensor,
+    v: nn.Tensor,
+    valid_lens: nn.Tensor,
+) -> nn.Tensor:
+    """Encoder self-attention with right-padding lengths.
+
+    Uses the tiled sequence prefill kernel and applies per-batch valid lengths
+    inside the kernel so encoder batches stay memory-efficient.
+    """
+    b, s, h, d = q.shape
+    t, h_kv, _ = k.shape[-3:]
+
+    from tvm.relax.frontend.nn.llm.kv_cache import (  # pylint: disable=import-outside-toplevel
+        _attention_sequence_prefill_with_mask,
+    )
+
+    if valid_lens.ndim != 1:
+        raise ValueError(
+            f"encoder_attention expects a 1D valid_lens tensor, but got ndim={valid_lens.ndim}"
+        )
+    if k.ndim == 3:
+        k = op.reshape(k, [b, t, h_kv, d])
+    if v.ndim == 3:
+        v = op.reshape(v, [b, t, h_kv, d])
+    if h_kv != h:
+        k = k.repeat(h // h_kv, axis=2)
+        v = v.repeat(h // h_kv, axis=2)
+
+    target = _get_attention_target()
+    attn_output, _ = op.tensor_ir_op(
+        _attention_sequence_prefill_with_mask(  # pylint: disable=no-value-for-parameter
+            h_kv=h_kv,
+            h_q=h,
+            d=d,
+            dtype=q.dtype,
+            target=target,
+            sm_scale=1.0 / (d**0.5),
+        ),
+        "sequence_prefill_masked",
+        [q, k, v, valid_lens],
+        [
+            Tensor.placeholder([b, s, h, d], q.dtype),
+            Tensor.placeholder([b, s, h], q.dtype),
+        ],
+    )
+    return op.reshape(attn_output, shape=(b, s, h * d))

--- a/python/mlc_llm/serve/embedding_engine.py
+++ b/python/mlc_llm/serve/embedding_engine.py
@@ -1,5 +1,6 @@
 """Asynchronous embedding inference engine for encoder and decoder models."""
 
+import abc
 import asyncio
 import concurrent.futures
 import json
@@ -15,13 +16,68 @@ from mlc_llm.serve import engine_utils
 from mlc_llm.support.auto_device import detect_device
 from mlc_llm.tokenizers import Tokenizer
 
+# ====================================================================
+# EmbeddingRuntime — abstract interface
+# ====================================================================
 
-class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
-    """Asynchronous embedding inference engine.
 
-    Supports both encoder models (BERT-style) and decoder-only embedding models
-    (e.g. Qwen3-Embeddings). Uses a ThreadPoolExecutor for background inference
-    so that the asyncio event loop is not blocked.
+class EmbeddingRuntime(abc.ABC):
+    """Abstract base class for embedding runtime implementations.
+
+    Minimal responsibilities:
+    - Initialize tokenizer, module, params, metadata
+    - Provide embed(inputs) -> (embeddings, total_tokens)
+    - Expose read-only state: tokenizer, model_type, pooling_strategy, normalize, metadata
+    """
+
+    @property
+    @abc.abstractmethod
+    def tokenizer(self) -> Tokenizer:
+        """The tokenizer instance."""
+
+    @property
+    @abc.abstractmethod
+    def model_type(self) -> str:
+        """Model type: 'encoder' or 'decoder'."""
+
+    @property
+    @abc.abstractmethod
+    def pooling_strategy(self) -> str:
+        """Pooling strategy: 'cls', 'mean', or 'last'."""
+
+    @property
+    @abc.abstractmethod
+    def normalize(self) -> bool:
+        """Whether to L2-normalize embeddings."""
+
+    @property
+    @abc.abstractmethod
+    def metadata(self) -> dict:
+        """Model metadata dictionary."""
+
+    @abc.abstractmethod
+    def embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
+        """Compute embeddings for input strings.
+
+        Returns
+        -------
+        embeddings : List[List[float]]
+            The embedding vectors.
+        total_tokens : int
+            Total number of tokens processed.
+        """
+
+
+# ====================================================================
+# TVMNativeEmbeddingRuntime — TVM-native implementation
+# ====================================================================
+
+
+class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-instance-attributes
+    """TVM-native embedding runtime for encoder and decoder models.
+
+    Handles TVM module loading, tokenization, and embedding inference
+    for both encoder (BERT-style) and decoder-only (Qwen3-Embeddings) models.
 
     Parameters
     ----------
@@ -35,9 +91,7 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         Device string, e.g. "auto", "cuda:0", "metal".
 
     pooling_strategy : Optional[str]
-        Pooling strategy: "cls" (first token), "mean" (masked average),
-        or "last" (last token). If None, auto-detected based on model type:
-        encoder -> "cls", decoder -> "last".
+        Pooling strategy override: "cls", "mean", or "last".
     """
 
     def __init__(  # pylint: disable=too-many-branches
@@ -49,48 +103,89 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         pooling_strategy: Optional[str] = None,
     ) -> None:
         # Reuse existing utility: device detection
-        self.device = detect_device(device) if isinstance(device, str) else device
+        self._device = detect_device(device) if isinstance(device, str) else device
         # Reuse existing utility: tokenizer
-        self.tokenizer = Tokenizer(model)
+        self._tokenizer = Tokenizer(model)
 
         # Load TVM module, metadata, and params via engine_utils helpers
         ex = tvm.runtime.load_module(model_lib)
-        vm = relax.VirtualMachine(ex, device=self.device)
+        vm = relax.VirtualMachine(ex, device=self._device)
         self._mod = vm.module
-        self._metadata = json.loads(self._mod["_metadata"]())
-        self._params = engine_utils.load_embedding_params(model, self.device, self._metadata)
+        self._raw_metadata = json.loads(self._mod["_metadata"]())
+        self._params = engine_utils.load_embedding_params(model, self._device, self._raw_metadata)
 
-        # Detect model type and set pooling strategy
-        self.embedding_metadata = engine_utils.get_embedding_metadata(self._metadata)
-        if self.embedding_metadata:
-            self.model_type = self.embedding_metadata["model_type"]
-            self.pooling_strategy = self.embedding_metadata["pooling_strategy"]
-            self.normalize = self.embedding_metadata["normalize"]
-        else:
-            self.model_type = engine_utils.detect_embedding_model_type(self._mod)
-            self.pooling_strategy = "cls" if self.model_type == "encoder" else "last"
-            self.normalize = True
+        # Read embedding metadata — required since phase-1 metadata path
+        self._embedding_metadata = engine_utils.get_embedding_metadata(self._raw_metadata)
+        _REQUIRED_FIELDS = ("model_type", "pooling_strategy", "normalize")
+        if self._embedding_metadata is None or not all(
+            k in self._embedding_metadata for k in _REQUIRED_FIELDS
+        ):
+            missing = (
+                "all"
+                if self._embedding_metadata is None
+                else ", ".join(k for k in _REQUIRED_FIELDS if k not in self._embedding_metadata)
+            )
+            raise ValueError(
+                f"Embedding metadata is missing or incomplete in the model library metadata "
+                f"(missing: {missing}). "
+                "Embedding serving requires models compiled with embedding_metadata "
+                "(phase-1 metadata path). Please regenerate/recompile the model artifacts "
+                "with the current MLC LLM toolchain."
+            )
+        self._model_type = self._embedding_metadata["model_type"]
+        self._pooling_strategy = self._embedding_metadata["pooling_strategy"]
+        self._normalize = self._embedding_metadata["normalize"]
         # Allow caller to override pooling strategy
         if pooling_strategy:
-            self.pooling_strategy = pooling_strategy
+            self._pooling_strategy = pooling_strategy
+
+        # Special token ids (set by _init_encoder; None for decoder models)
+        self._cls_token_id: Optional[int] = None
+        self._sep_token_id: Optional[int] = None
 
         # Initialize model-type-specific functions
-        if self.model_type == "encoder":
+        if self._model_type == "encoder":
             self._init_encoder(model)
         else:
             self._init_decoder(model)
 
-        # Background thread pool (1 worker = serialized GPU inference)
-        self._executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="embedding"
-        )
-        self._terminated = False
+    # ---- Read-only properties (abstract interface) ----
+
+    @property
+    def device(self) -> Device:
+        """The target device."""
+        return self._device
+
+    @property
+    def tokenizer(self) -> Tokenizer:
+        return self._tokenizer
+
+    @property
+    def model_type(self) -> str:
+        return self._model_type
+
+    @property
+    def pooling_strategy(self) -> str:
+        return self._pooling_strategy
+
+    @property
+    def normalize(self) -> bool:
+        return self._normalize
+
+    @property
+    def metadata(self) -> dict:
+        return self._raw_metadata
+
+    @property
+    def embedding_metadata(self) -> Optional[dict]:
+        """Embedding-specific metadata, or None for legacy models."""
+        return self._embedding_metadata
+
+    # ---- Initialization helpers ----
 
     def _init_encoder(self, model: str) -> None:
         """Initialize encoder (BERT-style) model functions and special tokens."""
         self._prefill_func = self._mod["prefill"]
-        self._cls_token_id: Optional[int] = None
-        self._sep_token_id: Optional[int] = None
         tok_config_path = os.path.join(model, "tokenizer_config.json")
         if os.path.exists(tok_config_path):
             with open(tok_config_path, encoding="utf-8") as f:
@@ -104,11 +199,11 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
                     self._sep_token_id = int(tid)
             # Fallback: encode the special token strings via tokenizer
             if self._cls_token_id is None and tok_config.get("cls_token"):
-                ids = list(self.tokenizer.encode(tok_config["cls_token"]))
+                ids = list(self._tokenizer.encode(tok_config["cls_token"]))
                 if len(ids) == 1:
                     self._cls_token_id = ids[0]
             if self._sep_token_id is None and tok_config.get("sep_token"):
-                ids = list(self.tokenizer.encode(tok_config["sep_token"]))
+                ids = list(self._tokenizer.encode(tok_config["sep_token"]))
                 if len(ids) == 1:
                     self._sep_token_id = ids[0]
 
@@ -127,7 +222,7 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
                 # Check if the post-processor actually appends a special token at the end
                 # (e.g. TemplateProcessing with "$A <|endoftext|>"). We verify by encoding
                 # a test string and checking if the last token is a known special token.
-                test_tokens = list(self.tokenizer.encode("test"))
+                test_tokens = list(self._tokenizer.encode("test"))
                 if len(test_tokens) > 0:
                     vocab = tokenizer_json.get("added_tokens", [])
                     special_ids = {t["id"] for t in vocab if t.get("special", False)}
@@ -161,6 +256,8 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         self._kv_state_end_forward = tvm.get_global_func("vm.builtin.kv_state_end_forward")
         self._nd_reshape = tvm.get_global_func("vm.builtin.reshape")
 
+    # ---- Embedding methods ----
+
     def embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
         """Compute embeddings for a list of input strings (synchronous).
 
@@ -176,29 +273,9 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         total_tokens : int
             Total number of tokens processed.
         """
-        if self.model_type == "encoder":
+        if self._model_type == "encoder":
             return self._embed_encoder(inputs)
         return self._embed_decoder(inputs)
-
-    async def async_embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
-        """Compute embeddings asynchronously in a background thread.
-
-        This method does not block the asyncio event loop.
-
-        Parameters
-        ----------
-        inputs : List[str]
-            The input strings to embed.
-
-        Returns
-        -------
-        embeddings : List[List[float]]
-            The L2-normalized embedding vectors.
-        total_tokens : int
-            Total number of tokens processed.
-        """
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(self._executor, self.embed, inputs)
 
     def _embed_encoder(  # pylint: disable=too-many-locals
         self, inputs: List[str]
@@ -215,15 +292,15 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         TODO: For better long-text support, implement sliding window + mean pooling:
           1. Split text into overlapping windows of prefill_chunk_size (stride=chunk/2)
           2. Encode each window independently
-          3. Mean-pool all window embeddings → final embedding → L2 normalize
-          This preserves information from the full text at the cost of N× compute.
+          3. Mean-pool all window embeddings -> final embedding -> L2 normalize
+          This preserves information from the full text at the cost of N x compute.
         """
         embeddings: List[List[float]] = []
         total_tokens = 0
-        prefill_chunk = self._metadata.get("prefill_chunk_size", 512)
+        prefill_chunk = self._raw_metadata.get("prefill_chunk_size", 512)
 
         for text in inputs:
-            tokens = list(self.tokenizer.encode(text))
+            tokens = list(self._tokenizer.encode(text))
             # Add [CLS] and [SEP] if needed
             if self._cls_token_id is not None and (
                 len(tokens) == 0 or tokens[0] != self._cls_token_id
@@ -246,24 +323,24 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
             token_ids = np.array([tokens], dtype=np.int32)  # [1, seq_len]
             attention_mask: np.ndarray = np.ones((1, seq_len), dtype=np.int32)  # [1, seq_len]
 
-            tokens_tvm = tvm.runtime.tensor(token_ids, device=self.device)
-            mask_tvm = tvm.runtime.tensor(attention_mask, device=self.device)
+            tokens_tvm = tvm.runtime.tensor(token_ids, device=self._device)
+            mask_tvm = tvm.runtime.tensor(attention_mask, device=self._device)
 
             output = self._prefill_func(tokens_tvm, mask_tvm, self._params)
             # .numpy() copies to CPU, escaping TVM workspace buffer reuse across calls.
             output_np = output.numpy()  # [1, seq_len, hidden_size]
 
             # Pooling
-            if self.pooling_strategy == "cls":
+            if self._pooling_strategy == "cls":
                 pooled = output_np[0, 0, :]
-            elif self.pooling_strategy == "mean":
+            elif self._pooling_strategy == "mean":
                 pooled = output_np[0].mean(axis=0)
             else:  # "last"
                 pooled = output_np[0, -1, :]
 
             # L2 normalize
             pooled = pooled.astype(np.float32)
-            if self.normalize:
+            if self._normalize:
                 norm = np.linalg.norm(pooled)
                 if norm > 1e-12:
                     pooled = pooled / norm
@@ -280,18 +357,18 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         to sequential chunked prefill per input.
         """
         # Read KV cache config from metadata
-        prefill_chunk = self._metadata.get("prefill_chunk_size", 2048)
-        max_seq_len = self._metadata.get("context_window_size", 32768)
+        prefill_chunk = self._raw_metadata.get("prefill_chunk_size", 2048)
+        max_seq_len = self._raw_metadata.get("context_window_size", 32768)
         if max_seq_len == -1:
-            max_seq_len = self._metadata.get("sliding_window_size", -1)
+            max_seq_len = self._raw_metadata.get("sliding_window_size", -1)
         assert max_seq_len > 0, f"max_seq_len must be positive, got {max_seq_len}"
-        support_sliding = int(self._metadata.get("sliding_window_size", -1) != -1)
+        support_sliding = int(self._raw_metadata.get("sliding_window_size", -1) != -1)
 
         # Tokenize all inputs. Prefer tokenizer post-processor output. If absent (older models),
         # fall back to appending eos_token_id when missing.
         token_lists: List[List[int]] = []
         for text in inputs:
-            tokens = list(self.tokenizer.encode(text))
+            tokens = list(self._tokenizer.encode(text))
             if (
                 not self._decoder_tokenizer_appends_eos
                 and self._decoder_eos_token_id is not None
@@ -304,7 +381,7 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
 
         total_tokens = sum(len(t) for t in token_lists)
 
-        # Fast path: all tokens fit in one prefill chunk → batch forward
+        # Fast path: all tokens fit in one prefill chunk -> batch forward
         if total_tokens <= prefill_chunk and all(len(t) > 0 for t in token_lists):
             return self._batch_embed_decoder(
                 token_lists, total_tokens, max_seq_len, prefill_chunk, support_sliding
@@ -388,11 +465,11 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         # Begin forward with all sequences at once
         self._kv_state_begin_forward(kv_cache, ShapeTuple(seq_ids), ShapeTuple(seq_lens))
 
-        # Concatenate all tokens → embed → batch prefill
+        # Concatenate all tokens -> embed -> batch prefill
         all_tokens = []
         for tokens in token_lists:
             all_tokens.extend(tokens)
-        token_ids = tvm.runtime.tensor(np.array(all_tokens, dtype=np.int32), device=self.device)
+        token_ids = tvm.runtime.tensor(np.array(all_tokens, dtype=np.int32), device=self._device)
         all_embed = self._embed_func(token_ids, self._params)
         all_embed = self._nd_reshape(all_embed, ShapeTuple([1, total_tokens, all_embed.shape[-1]]))
 
@@ -410,7 +487,7 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
         for tokens in token_lists:
             last_pos = offset + len(tokens) - 1
             pooled = hidden_np[0, last_pos, :].astype(np.float32)
-            if self.normalize:
+            if self._normalize:
                 norm = np.linalg.norm(pooled)
                 if norm > 1e-12:
                     pooled = pooled / norm
@@ -452,7 +529,7 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
                 chunk_len = len(chunk_tokens)
 
                 token_ids = tvm.runtime.tensor(
-                    np.array(chunk_tokens, dtype=np.int32), device=self.device
+                    np.array(chunk_tokens, dtype=np.int32), device=self._device
                 )
                 chunk_embed = self._embed_func(token_ids, self._params)
                 chunk_embed = self._nd_reshape(
@@ -468,13 +545,121 @@ class AsyncEmbeddingEngine:  # pylint: disable=too-many-instance-attributes
 
             pooled = hidden_np[0, -1, :] if hidden_np.ndim == 3 else hidden_np[-1, :]
             pooled = pooled.astype(np.float32)
-            if self.normalize:
+            if self._normalize:
                 norm = np.linalg.norm(pooled)
                 if norm > 1e-12:
                     pooled = pooled / norm
             embeddings.append(pooled.tolist())
 
         return embeddings, total_tokens
+
+
+# ====================================================================
+# AsyncEmbeddingEngine — thin async wrapper around EmbeddingRuntime
+# ====================================================================
+
+
+class AsyncEmbeddingEngine:
+    """Asynchronous embedding inference engine.
+
+    Thin wrapper around an EmbeddingRuntime that adds:
+    - ThreadPoolExecutor for non-blocking async inference
+    - async_embed convenience method
+    - terminate lifecycle management
+
+    Backward-compatible attributes are mirrored from the underlying runtime
+    so that existing code accessing engine.tokenizer, engine.model_type, etc.
+    continues to work without changes.
+
+    Parameters
+    ----------
+    model : str
+        Path to the model weight directory.
+
+    model_lib : str
+        Path to the compiled model library (.so/.dylib file).
+
+    device : Union[str, Device]
+        Device string, e.g. "auto", "cuda:0", "metal".
+
+    pooling_strategy : Optional[str]
+        Pooling strategy: "cls" (first token), "mean" (masked average),
+        or "last" (last token). If None, auto-detected based on model type:
+        encoder -> "cls", decoder -> "last".
+    """
+
+    def __init__(
+        self,
+        model: str,
+        model_lib: str,
+        device: Union[str, Device] = "auto",
+        *,
+        pooling_strategy: Optional[str] = None,
+        _runtime: Optional[EmbeddingRuntime] = None,
+    ) -> None:
+        # Create or accept runtime
+        if _runtime is not None:
+            self._runtime = _runtime
+        else:
+            self._runtime = TVMNativeEmbeddingRuntime(
+                model, model_lib, device, pooling_strategy=pooling_strategy
+            )
+
+        # Mirror core attributes from the abstract interface
+        self.tokenizer = self._runtime.tokenizer
+        self.model_type = self._runtime.model_type
+        self.pooling_strategy = self._runtime.pooling_strategy
+        self.normalize = self._runtime.normalize
+        self._metadata = self._runtime.metadata
+
+        # Mirror implementation-specific attributes for backward compatibility
+        self.device = getattr(self._runtime, "device", None)
+        self.embedding_metadata = getattr(self._runtime, "embedding_metadata", None)
+        self._cls_token_id = getattr(self._runtime, "_cls_token_id", None)
+        self._sep_token_id = getattr(self._runtime, "_sep_token_id", None)
+
+        # Background thread pool (1 worker = serialized GPU inference)
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="embedding"
+        )
+        self._terminated = False
+
+    def embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
+        """Compute embeddings for a list of input strings (synchronous).
+
+        Parameters
+        ----------
+        inputs : List[str]
+            The input strings to embed.
+
+        Returns
+        -------
+        embeddings : List[List[float]]
+            The L2-normalized embedding vectors.
+        total_tokens : int
+            Total number of tokens processed.
+        """
+        return self._runtime.embed(inputs)
+
+    async def async_embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
+        """Compute embeddings asynchronously in a background thread.
+
+        This method does not block the asyncio event loop.
+
+        Parameters
+        ----------
+        inputs : List[str]
+            The input strings to embed.
+
+        Returns
+        -------
+        embeddings : List[List[float]]
+            The L2-normalized embedding vectors.
+        total_tokens : int
+            Total number of tokens processed.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, self.embed, inputs)
 
     def terminate(self) -> None:
         """Terminate the engine and clean up the thread pool."""

--- a/python/mlc_llm/serve/embedding_engine.py
+++ b/python/mlc_llm/serve/embedding_engine.py
@@ -208,6 +208,18 @@ def _canonicalize_decoder_inputs(
             tokens.append(eos_token_id)
         if len(tokens) > max_seq_len:
             tokens = tokens[:max_seq_len]
+            # Preserve the kLast pooling sentinel: decoder embedding models are
+            # trained to emit the sentence embedding at the EOS position, so
+            # truncation must not drop the trailing EOS.
+            if eos_token_id is not None:
+                tokens[-1] = eos_token_id
+        if len(tokens) == 0:
+            raise ValueError(
+                "Decoder embedding input tokenized to 0 tokens; the decoder "
+                "lane requires at least one token per input "
+                f"(tokenizer_appends_eos={tokenizer_appends_eos}, "
+                f"eos_token_id={eos_token_id})."
+            )
         result.append(tokens)
     return result
 
@@ -733,6 +745,17 @@ class ThreadedEmbeddingRuntime(EmbeddingRuntime):
         if pooling_strategy:
             self._pooling_strategy = pooling_strategy
 
+        # Decoder lane is kLast-only at the C++ layer (enforced by a fatal
+        # ICHECK in BatchDecoderEmbeddingPrefillAction). Reject at init so a
+        # misconfigured pooling_strategy can't crash the engine on first request.
+        if self._model_type == "decoder" and self._pooling_strategy != "last":
+            raise ValueError(
+                f"Decoder embedding lane requires pooling_strategy='last'; "
+                f"got {self._pooling_strategy!r}. Fix embedding_metadata."
+                f"pooling_strategy in mlc-chat-config.json or pass "
+                f"pooling_strategy='last'."
+            )
+
         # Lane-specific canonicalization state.
         # Encoder lane: CLS/SEP pre/post append, truncate to prefill_chunk_size.
         # Decoder lane: conditional EOS append, truncate to max_seq_len.
@@ -751,16 +774,19 @@ class ThreadedEmbeddingRuntime(EmbeddingRuntime):
             self._decoder_tokenizer_appends_eos, self._decoder_eos_token_id = (
                 _get_decoder_special_tokens(self._tokenizer, model)
             )
-            # Decoder lane truncates to the model's context window rather than the
-            # compiled prefill chunk (the C++ action re-checks batch*seq vs chunk).
-            self._max_seq_len = self._raw_metadata.get("context_window_size", 32768)
-            if self._max_seq_len == -1:
-                self._max_seq_len = self._raw_metadata.get("sliding_window_size", -1)
-            if self._max_seq_len <= 0:
+            # Decoder lane truncates to min(context_window_size, prefill_chunk_size).
+            # The C++ admit loop rejects batch*seq > prefill_chunk_size with no
+            # chunking fallback, so any request past that threshold deadlocks at
+            # the head of the waiting queue.
+            ctx_window = self._raw_metadata.get("context_window_size", 32768)
+            if ctx_window == -1:
+                ctx_window = self._raw_metadata.get("sliding_window_size", -1)
+            if ctx_window <= 0:
                 raise ValueError(
                     f"Decoder embedding model must have a positive context/sliding window; "
-                    f"got max_seq_len={self._max_seq_len}"
+                    f"got context_window_size={ctx_window}"
                 )
+            self._max_seq_len = min(ctx_window, self._prefill_chunk_size)
 
         # FFI functions
         self._f_embedding_request = tvm.get_global_func("mlc.serve.EmbeddingRequest")

--- a/python/mlc_llm/serve/embedding_engine.py
+++ b/python/mlc_llm/serve/embedding_engine.py
@@ -4,8 +4,12 @@ import abc
 import asyncio
 import concurrent.futures
 import json
+import logging
 import os
-from typing import List, Literal, Optional, Tuple, Union
+import threading
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import tvm
@@ -13,8 +17,105 @@ from tvm import relax
 from tvm.runtime import Device, ShapeTuple
 
 from mlc_llm.serve import engine_utils
+from mlc_llm.serve.config import EngineConfig
 from mlc_llm.support.auto_device import detect_device
 from mlc_llm.tokenizers import Tokenizer
+
+logger = logging.getLogger(__name__)
+
+# ====================================================================
+# Shared encoder canonicalization helpers
+# ====================================================================
+
+
+def _get_encoder_special_token_ids(
+    tokenizer: Tokenizer, model_path: str
+) -> Tuple[Optional[int], Optional[int]]:
+    """Read CLS and SEP token IDs for an encoder model.
+
+    Mirrors the Phase 2 TVMNativeEmbeddingRuntime._init_encoder logic exactly.
+
+    Returns
+    -------
+    cls_token_id : Optional[int]
+    sep_token_id : Optional[int]
+    """
+    cls_token_id: Optional[int] = None
+    sep_token_id: Optional[int] = None
+
+    tok_config_path = os.path.join(model_path, "tokenizer_config.json")
+    if os.path.exists(tok_config_path):
+        with open(tok_config_path, encoding="utf-8") as f:
+            tok_config = json.load(f)
+        # Try added_tokens_decoder first (newer HF format)
+        added = tok_config.get("added_tokens_decoder", {})
+        for tid, info in added.items():
+            if info.get("content") == tok_config.get("cls_token"):
+                cls_token_id = int(tid)
+            if info.get("content") == tok_config.get("sep_token"):
+                sep_token_id = int(tid)
+        # Fallback: encode the special token strings via tokenizer
+        if cls_token_id is None and tok_config.get("cls_token"):
+            ids = list(tokenizer.encode(tok_config["cls_token"]))
+            if len(ids) == 1:
+                cls_token_id = ids[0]
+        if sep_token_id is None and tok_config.get("sep_token"):
+            ids = list(tokenizer.encode(tok_config["sep_token"]))
+            if len(ids) == 1:
+                sep_token_id = ids[0]
+
+    return cls_token_id, sep_token_id
+
+
+def _canonicalize_encoder_inputs(
+    inputs: List[str],
+    tokenizer: Tokenizer,
+    cls_token_id: Optional[int],
+    sep_token_id: Optional[int],
+    prefill_chunk_size: int,
+) -> List[List[int]]:
+    """Canonicalize encoder inputs: tokenize, add CLS/SEP, truncate.
+
+    This is the single source of truth for encoder preprocessing, shared by
+    TVMNativeEmbeddingRuntime and ThreadEncoderRuntime.
+
+    Bug-for-bug compatible with Phase 2 TVMNativeEmbeddingRuntime._embed_encoder.
+
+    Parameters
+    ----------
+    inputs : List[str]
+        Raw text inputs.
+    tokenizer : Tokenizer
+        The tokenizer instance.
+    cls_token_id : Optional[int]
+        CLS token ID, or None if not applicable.
+    sep_token_id : Optional[int]
+        SEP token ID, or None if not applicable.
+    prefill_chunk_size : int
+        Maximum sequence length; inputs are truncated to this length.
+
+    Returns
+    -------
+    List[List[int]]
+        Canonicalized token ID sequences (one per input).
+    """
+    result: List[List[int]] = []
+    for text in inputs:
+        tokens = list(tokenizer.encode(text))
+        # Add [CLS] if needed
+        if cls_token_id is not None and (len(tokens) == 0 or tokens[0] != cls_token_id):
+            tokens = [cls_token_id] + tokens
+        # Add [SEP] if needed
+        if sep_token_id is not None and (len(tokens) == 0 or tokens[-1] != sep_token_id):
+            tokens = tokens + [sep_token_id]
+        # Truncate to compiled buffer limit (keep [CLS] at start, force [SEP] at end)
+        if len(tokens) > prefill_chunk_size:
+            tokens = tokens[:prefill_chunk_size]
+            if sep_token_id is not None:
+                tokens[-1] = sep_token_id
+        result.append(tokens)
+    return result
+
 
 # ====================================================================
 # EmbeddingRuntime — abstract interface
@@ -186,26 +287,9 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
     def _init_encoder(self, model: str) -> None:
         """Initialize encoder (BERT-style) model functions and special tokens."""
         self._prefill_func = self._mod["prefill"]
-        tok_config_path = os.path.join(model, "tokenizer_config.json")
-        if os.path.exists(tok_config_path):
-            with open(tok_config_path, encoding="utf-8") as f:
-                tok_config = json.load(f)
-            # Try added_tokens_decoder first (newer HF format)
-            added = tok_config.get("added_tokens_decoder", {})
-            for tid, info in added.items():
-                if info.get("content") == tok_config.get("cls_token"):
-                    self._cls_token_id = int(tid)
-                if info.get("content") == tok_config.get("sep_token"):
-                    self._sep_token_id = int(tid)
-            # Fallback: encode the special token strings via tokenizer
-            if self._cls_token_id is None and tok_config.get("cls_token"):
-                ids = list(self._tokenizer.encode(tok_config["cls_token"]))
-                if len(ids) == 1:
-                    self._cls_token_id = ids[0]
-            if self._sep_token_id is None and tok_config.get("sep_token"):
-                ids = list(self._tokenizer.encode(tok_config["sep_token"]))
-                if len(ids) == 1:
-                    self._sep_token_id = ids[0]
+        self._cls_token_id, self._sep_token_id = _get_encoder_special_token_ids(
+            self._tokenizer, model
+        )
 
     def _init_decoder(self, model: str) -> None:
         """Initialize decoder (Qwen3-Embeddings style) model functions."""
@@ -259,20 +343,7 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
     # ---- Embedding methods ----
 
     def embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
-        """Compute embeddings for a list of input strings (synchronous).
-
-        Parameters
-        ----------
-        inputs : List[str]
-            The input strings to embed.
-
-        Returns
-        -------
-        embeddings : List[List[float]]
-            The L2-normalized embedding vectors.
-        total_tokens : int
-            Total number of tokens processed.
-        """
+        """Compute embeddings for a list of input strings (synchronous)."""
         if self._model_type == "encoder":
             return self._embed_encoder(inputs)
         return self._embed_decoder(inputs)
@@ -280,43 +351,17 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
     def _embed_encoder(  # pylint: disable=too-many-locals
         self, inputs: List[str]
     ) -> Tuple[List[List[float]], int]:
-        """Encoder model embedding (BERT-style).
-
-        Processes each input individually to avoid batch padding artifacts.
-
-        Encoder uses bidirectional attention, so chunked prefill is NOT possible
-        (each token must attend to all other tokens in the full sequence).
-        Inputs exceeding prefill_chunk_size are truncated.
-
-        (Additional Strategy)
-        TODO: For better long-text support, implement sliding window + mean pooling:
-          1. Split text into overlapping windows of prefill_chunk_size (stride=chunk/2)
-          2. Encode each window independently
-          3. Mean-pool all window embeddings -> final embedding -> L2 normalize
-          This preserves information from the full text at the cost of N x compute.
-        """
+        """Encoder model embedding (BERT-style)."""
         embeddings: List[List[float]] = []
         total_tokens = 0
         prefill_chunk = self._raw_metadata.get("prefill_chunk_size", 512)
 
-        for text in inputs:
-            tokens = list(self._tokenizer.encode(text))
-            # Add [CLS] and [SEP] if needed
-            if self._cls_token_id is not None and (
-                len(tokens) == 0 or tokens[0] != self._cls_token_id
-            ):
-                tokens = [self._cls_token_id] + tokens
-            if self._sep_token_id is not None and (
-                len(tokens) == 0 or tokens[-1] != self._sep_token_id
-            ):
-                tokens = tokens + [self._sep_token_id]
+        # Use shared canonicalization helper
+        token_lists = _canonicalize_encoder_inputs(
+            inputs, self._tokenizer, self._cls_token_id, self._sep_token_id, prefill_chunk
+        )
 
-            # Truncate to compiled buffer limit (keep [CLS] at start, [SEP] at end)
-            if len(tokens) > prefill_chunk:
-                tokens = tokens[:prefill_chunk]
-                if self._sep_token_id is not None:
-                    tokens[-1] = self._sep_token_id
-
+        for tokens in token_lists:
             seq_len = len(tokens)
             total_tokens += seq_len
 
@@ -327,7 +372,6 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
             mask_tvm = tvm.runtime.tensor(attention_mask, device=self._device)
 
             output = self._prefill_func(tokens_tvm, mask_tvm, self._params)
-            # .numpy() copies to CPU, escaping TVM workspace buffer reuse across calls.
             output_np = output.numpy()  # [1, seq_len, hidden_size]
 
             # Pooling
@@ -350,13 +394,7 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
         return embeddings, total_tokens
 
     def _embed_decoder(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
-        """Decoder model embedding with batch prefill optimization.
-
-        When total tokens fit within prefill_chunk_size, all inputs are processed
-        in a single batch forward pass using shared KV cache. Otherwise, falls back
-        to sequential chunked prefill per input.
-        """
-        # Read KV cache config from metadata
+        """Decoder model embedding with batch prefill optimization."""
         prefill_chunk = self._raw_metadata.get("prefill_chunk_size", 2048)
         max_seq_len = self._raw_metadata.get("context_window_size", 32768)
         if max_seq_len == -1:
@@ -364,8 +402,6 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
         assert max_seq_len > 0, f"max_seq_len must be positive, got {max_seq_len}"
         support_sliding = int(self._raw_metadata.get("sliding_window_size", -1) != -1)
 
-        # Tokenize all inputs. Prefer tokenizer post-processor output. If absent (older models),
-        # fall back to appending eos_token_id when missing.
         token_lists: List[List[int]] = []
         for text in inputs:
             tokens = list(self._tokenizer.encode(text))
@@ -381,15 +417,11 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
 
         total_tokens = sum(len(t) for t in token_lists)
 
-        # Fast path: all tokens fit in one prefill chunk -> batch forward
         if total_tokens <= prefill_chunk and all(len(t) > 0 for t in token_lists):
             return self._batch_embed_decoder(
                 token_lists, total_tokens, max_seq_len, prefill_chunk, support_sliding
             )
 
-        # Greedy sub-batching: pack texts into sub-batches that fit within
-        # prefill_chunk, preserving input order. Oversize texts (single text
-        # exceeding prefill_chunk) fall back to sequential chunked prefill.
         sub_batches = self._build_sub_batches(token_lists, prefill_chunk)
         all_embeddings: List[List[float]] = []
         for batch_type, batch, batch_total in sub_batches:
@@ -409,11 +441,7 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
     def _build_sub_batches(
         token_lists: List[List[int]], prefill_chunk: int
     ) -> List[Tuple[Literal["batch", "sequential"], List[List[int]], int]]:
-        """Partition token lists into sub-batches that fit within prefill_chunk.
-
-        Each sub-batch is a tuple of (mode, token_lists, total_token_count).
-        Empty token lists are skipped to avoid invalid batch processing.
-        """
+        """Partition token lists into sub-batches that fit within prefill_chunk."""
         sub_batches: List[Tuple[Literal["batch", "sequential"], List[List[int]], int]] = []
         current_batch: List[List[int]] = []
         current_tokens = 0
@@ -447,7 +475,6 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
         """Batch prefill: process all inputs in a single forward pass."""
         batch_size = len(token_lists)
 
-        # Create KV cache for the entire batch
         kv_cache = self._create_kv_cache_func(
             ShapeTuple([batch_size]),
             ShapeTuple([max_seq_len]),
@@ -456,16 +483,13 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
             ShapeTuple([support_sliding]),
         )
 
-        # Register all sequences
         seq_ids = list(range(batch_size))
         seq_lens = [len(t) for t in token_lists]
         for sid in seq_ids:
             self._kv_state_add_sequence(kv_cache, sid)
 
-        # Begin forward with all sequences at once
         self._kv_state_begin_forward(kv_cache, ShapeTuple(seq_ids), ShapeTuple(seq_lens))
 
-        # Concatenate all tokens -> embed -> batch prefill
         all_tokens = []
         for tokens in token_lists:
             all_tokens.extend(tokens)
@@ -474,14 +498,11 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
         all_embed = self._nd_reshape(all_embed, ShapeTuple([1, total_tokens, all_embed.shape[-1]]))
 
         hidden_states, _ = self._batch_prefill_to_hidden_func(all_embed, kv_cache, self._params)
-        # .numpy() copies to CPU, escaping TVM workspace buffer reuse across calls.
-        # (torch.from_dlpack is zero-copy and hits aliasing bugs on 2nd+ invocation.)
         hidden_np = hidden_states.numpy()
         self._kv_state_end_forward(kv_cache)
         for sid in seq_ids:
             self._kv_state_remove_sequence(kv_cache, sid)
 
-        # Extract last token hidden state per sequence
         embeddings: List[List[float]] = []
         offset = 0
         for tokens in token_lists:
@@ -511,7 +532,6 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
             if len(tokens) == 0:
                 continue
 
-            # Create KV cache for this single sequence
             kv_cache = self._create_kv_cache_func(
                 ShapeTuple([1]),
                 ShapeTuple([max_seq_len]),
@@ -521,7 +541,6 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
             )
             self._kv_state_add_sequence(kv_cache, 0)
 
-            # Process tokens in chunks
             hidden = None
             for chunk_start in range(0, len(tokens), prefill_chunk):
                 chunk_end = min(chunk_start + prefill_chunk, len(tokens))
@@ -537,7 +556,6 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
                 )
                 self._kv_state_begin_forward(kv_cache, ShapeTuple([0]), ShapeTuple([chunk_len]))
                 hidden, kv_cache = self._prefill_to_hidden_func(chunk_embed, kv_cache, self._params)
-                # .numpy() copies to CPU, escaping TVM buffer aliasing.
                 hidden_np = hidden.numpy()
                 self._kv_state_end_forward(kv_cache)
 
@@ -555,21 +573,414 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
 
 
 # ====================================================================
-# AsyncEmbeddingEngine — thin async wrapper around EmbeddingRuntime
+# ThreadEncoderRuntime — C++ threaded encoder backend
 # ====================================================================
 
+# Pooling strategy name -> C++ int mapping
+_POOLING_STRATEGY_MAP = {"cls": 0, "mean": 1, "last": 2}
+_THREAD_WAIT_POLL_SEC = 0.1
 
-class AsyncEmbeddingEngine:
-    """Asynchronous embedding inference engine.
 
-    Thin wrapper around an EmbeddingRuntime that adds:
-    - ThreadPoolExecutor for non-blocking async inference
-    - async_embed convenience method
-    - terminate lifecycle management
+class ThreadEncoderRuntime(EmbeddingRuntime):
+    """C++ threaded encoder embedding runtime using the Phase 3a embedding lane.
 
-    Backward-compatible attributes are mirrored from the underlying runtime
-    so that existing code accessing engine.tokenizer, engine.model_type, etc.
-    continues to work without changes.
+    This runtime delegates encoder embedding to the C++ threaded engine,
+    following the same two-thread pattern as AsyncMLCEngine for chat.
+    Phase 4 will add ThreadDecoderRuntime for decoder-only embedding models.
+
+    Only supports model_type == "encoder".
+    """
+
+    def __init__(
+        self,
+        model: str,
+        model_lib: str,
+        device: Union[str, Device] = "auto",
+        *,
+        pooling_strategy: Optional[str] = None,
+    ) -> None:
+        # Set _terminated early so __del__ is safe even if __init__ fails partway.
+        self._terminated = True
+        self._module = None
+        self._ffi: Dict[str, Any] = {}
+        self._bg_loop_thread: Optional[threading.Thread] = None
+        self._bg_stream_thread: Optional[threading.Thread] = None
+        self._pending_lock = threading.Lock()
+        self._pending: Dict[str, "_PendingEntry"] = {}
+
+        self._device = detect_device(device) if isinstance(device, str) else device
+        self._tokenizer = Tokenizer(model)
+        self._model_path = model
+        self._model_lib = model_lib
+
+        # Read metadata from mlc-chat-config.json
+        config_path = os.path.join(model, "mlc-chat-config.json")
+        with open(config_path, encoding="utf-8") as f:
+            self._raw_metadata = json.load(f)
+
+        self._embedding_metadata = engine_utils.get_embedding_metadata(self._raw_metadata)
+        if self._embedding_metadata is None:
+            raise ValueError("Model does not have embedding_metadata in mlc-chat-config.json")
+
+        self._model_type = self._embedding_metadata["model_type"]
+        if self._model_type != "encoder":
+            raise ValueError(
+                f"ThreadEncoderRuntime only supports encoder models, "
+                f"got model_type={self._model_type!r}"
+            )
+
+        self._pooling_strategy = self._embedding_metadata["pooling_strategy"]
+        self._normalize = self._embedding_metadata["normalize"]
+        if pooling_strategy:
+            self._pooling_strategy = pooling_strategy
+
+        self._prefill_chunk_size = self._raw_metadata.get("prefill_chunk_size", 512)
+
+        # Encoder special tokens (shared helper)
+        self._cls_token_id, self._sep_token_id = _get_encoder_special_token_ids(
+            self._tokenizer, model
+        )
+
+        # FFI functions
+        self._f_embedding_request = tvm.get_global_func("mlc.serve.EmbeddingRequest")
+        self._f_embedding_result_unpack = tvm.get_global_func("mlc.serve.EmbeddingResultUnpack")
+
+        # Threaded engine initialization — wrapped in try so that if ANY step
+        # fails after threads are started, we clean up before re-raising.
+        try:
+            self._module = tvm.get_global_func(
+                "mlc.serve.create_threaded_engine", allow_missing=False
+            )()
+            for key in [
+                "init_threaded_engine",
+                "run_background_loop",
+                "run_background_stream_back_loop",
+                "reload",
+                "exit_background_loop",
+                "add_embedding_request",
+                "set_embedding_request_callback",
+            ]:
+                self._ffi[key] = self._module[key]
+
+            # Init threaded engine with a no-op chat callback (required by C++ init).
+            def _noop_chat_callback(delta_outputs):
+                pass
+
+            self._ffi["init_threaded_engine"](self._device, _noop_chat_callback, None)
+
+            # Register embedding callback BEFORE reload (per C++ contract).
+            self._ffi["set_embedding_request_callback"](self._embedding_callback)
+
+            # Start background threads (same pattern as chat)
+            self._bg_loop_thread = threading.Thread(
+                target=self._ffi["run_background_loop"], daemon=True
+            )
+            self._bg_stream_thread = threading.Thread(
+                target=self._ffi["run_background_stream_back_loop"], daemon=True
+            )
+            self._bg_loop_thread.start()
+            self._bg_stream_thread.start()
+
+            # Reload with embedding-safe config defaults.
+            engine_config = EngineConfig(
+                model=model,
+                model_lib=model_lib,
+                additional_models=[],
+                mode="local",
+                prefix_cache_mode="disable",
+                prefill_mode="chunked",
+            )
+            self._ffi["reload"](engine_config.asjson())
+            # Init succeeded — mark as alive.
+            self._terminated = False
+        except Exception:
+            self._cleanup_init_failure()
+            raise
+
+    def _cleanup_init_failure(self) -> None:
+        """Best-effort cleanup when __init__ fails after threads may have started."""
+        # Signal C++ to exit loops
+        exit_fn = self._ffi.get("exit_background_loop")
+        if exit_fn is not None:
+            try:
+                exit_fn()
+            except Exception:  # pylint: disable=broad-except
+                pass
+        # Join any started threads
+        for t in [self._bg_loop_thread, self._bg_stream_thread]:
+            if t is not None and t.is_alive():
+                try:
+                    t.join(timeout=5.0)
+                except Exception:  # pylint: disable=broad-except
+                    pass
+        # Clear pending map
+        with self._pending_lock:
+            self._pending.clear()
+        self._terminated = True
+
+    # ---- Read-only properties ----
+
+    @property
+    def tokenizer(self) -> Tokenizer:
+        return self._tokenizer
+
+    @property
+    def model_type(self) -> str:
+        return self._model_type
+
+    @property
+    def pooling_strategy(self) -> str:
+        return self._pooling_strategy
+
+    @property
+    def normalize(self) -> bool:
+        return self._normalize
+
+    @property
+    def metadata(self) -> dict:
+        return self._raw_metadata
+
+    @property
+    def embedding_metadata(self) -> Optional[dict]:
+        return self._embedding_metadata
+
+    # ---- Embedding callback (called from stream-back thread) ----
+
+    def _embedding_callback(self, results) -> None:
+        """Called from the C++ stream-back thread with Array<EmbeddingResult>."""
+        for result in results:
+            unpacked = self._f_embedding_result_unpack(result)
+            request_id = str(unpacked[0])
+            embeddings_nd = unpacked[1]  # CPU float32 NDArray [num_items, hidden_dim]
+            prompt_tokens = int(unpacked[2])
+
+            # Convert NDArray to numpy
+            embeddings_np = embeddings_nd.numpy()  # [num_items, hidden_dim]
+            embeddings_list = embeddings_np.tolist()
+
+            with self._pending_lock:
+                entry = self._pending.pop(request_id, None)
+
+            if entry is None:
+                # Request already cleaned up or terminated; silently ignore.
+                continue
+
+            entry.result = (embeddings_list, prompt_tokens)
+
+            # Deliver to consumer
+            if entry.event is not None:
+                # Sync path: wake up blocking waiter
+                entry.event.set()
+            if entry.future is not None and entry.loop is not None:
+                # Async path: deliver via call_soon_threadsafe
+                entry.loop.call_soon_threadsafe(
+                    _set_future_result, entry.future, (embeddings_list, prompt_tokens)
+                )
+
+    def _background_failure_message(self) -> Optional[str]:
+        """Return a descriptive error if a background thread has exited unexpectedly."""
+        if self._terminated:
+            return "Embedding engine has been terminated"
+        if self._bg_loop_thread is not None and not self._bg_loop_thread.is_alive():
+            return "Embedding engine background loop thread exited before request completion"
+        if self._bg_stream_thread is not None and not self._bg_stream_thread.is_alive():
+            return "Embedding engine callback thread exited before request completion"
+        return None
+
+    # ---- Sync embed ----
+
+    def embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
+        """Compute embeddings synchronously (blocks until result is ready)."""
+        if self._terminated:
+            raise RuntimeError("Engine has been terminated")
+
+        request_id = str(uuid.uuid4())
+
+        # Canonicalize inputs
+        token_lists = _canonicalize_encoder_inputs(
+            inputs, self._tokenizer, self._cls_token_id, self._sep_token_id,
+            self._prefill_chunk_size,
+        )
+
+        # Create pending entry with sync event
+        entry = _PendingEntry()
+        entry.event = threading.Event()
+
+        with self._pending_lock:
+            self._pending[request_id] = entry
+
+        # Build and submit — clean up pending on failure so no dangling entry remains.
+        try:
+            self._submit_embedding_request(request_id, token_lists)
+        except Exception:
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            raise
+
+        # Block until callback sets the event, but surface background-thread failures
+        # instead of waiting forever when the C++ engine crashes.
+        while not entry.event.wait(timeout=_THREAD_WAIT_POLL_SEC):
+            failure_message = self._background_failure_message()
+            if failure_message is not None:
+                with self._pending_lock:
+                    self._pending.pop(request_id, None)
+                raise RuntimeError(failure_message)
+
+        if entry.result is None:
+            raise RuntimeError("Embedding request completed without result (engine terminated?)")
+
+        return entry.result
+
+    # ---- Async embed ----
+
+    async def async_embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
+        """Compute embeddings asynchronously (non-blocking, uses asyncio Future)."""
+        if self._terminated:
+            raise RuntimeError("Engine has been terminated")
+
+        request_id = str(uuid.uuid4())
+
+        # Canonicalize inputs
+        token_lists = _canonicalize_encoder_inputs(
+            inputs, self._tokenizer, self._cls_token_id, self._sep_token_id,
+            self._prefill_chunk_size,
+        )
+
+        # Create pending entry with async future
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        entry = _PendingEntry()
+        entry.future = future
+        entry.loop = loop
+
+        with self._pending_lock:
+            self._pending[request_id] = entry
+
+        # Build and submit — clean up pending on failure so no dangling entry/future remains.
+        try:
+            self._submit_embedding_request(request_id, token_lists)
+        except Exception:
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            raise
+
+        while True:
+            try:
+                return await asyncio.wait_for(asyncio.shield(future), timeout=_THREAD_WAIT_POLL_SEC)
+            except asyncio.TimeoutError:
+                failure_message = self._background_failure_message()
+                if failure_message is None:
+                    continue
+                with self._pending_lock:
+                    self._pending.pop(request_id, None)
+                if not future.done():
+                    future.cancel()
+                raise RuntimeError(failure_message)
+
+    # ---- Internal helpers ----
+
+    def _submit_embedding_request(
+        self, request_id: str, token_lists: List[List[int]]
+    ) -> None:
+        """Build FFI EmbeddingRequest and submit to C++ engine."""
+        pooling_int = _POOLING_STRATEGY_MAP.get(self._pooling_strategy, 0)
+
+        # Build packed args for mlc.serve.EmbeddingRequest:
+        # request_id, num_items, then for each item: item_index, num_tokens, token_ids...,
+        # then pooling_strategy (int), normalize (bool)
+        args: List[Any] = [request_id, len(token_lists)]
+        for item_idx, tokens in enumerate(token_lists):
+            args.append(item_idx)
+            args.append(len(tokens))
+            args.extend(tokens)
+        args.append(pooling_int)
+        args.append(self._normalize)
+
+        emb_request = self._f_embedding_request(*args)
+        self._ffi["add_embedding_request"](emb_request)
+
+    def terminate(self) -> None:
+        """Stop the threaded engine and clean up."""
+        if self._terminated:
+            return
+        self._terminated = True
+
+        # Signal C++ to exit loops
+        exit_fn = self._ffi.get("exit_background_loop")
+        if exit_fn is not None:
+            try:
+                exit_fn()
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        # Join background threads (may be None if init failed early)
+        for t in [self._bg_loop_thread, self._bg_stream_thread]:
+            if t is not None and t.is_alive():
+                try:
+                    t.join(timeout=5.0)
+                except Exception:  # pylint: disable=broad-except
+                    pass
+
+        # Clean up pending requests
+        with self._pending_lock:
+            for req_id, entry in self._pending.items():
+                if entry.event is not None:
+                    entry.event.set()  # Wake up sync waiters
+                if entry.future is not None and not entry.future.done():
+                    try:
+                        entry.loop.call_soon_threadsafe(
+                            entry.future.set_exception,
+                            RuntimeError("Embedding engine terminated"),
+                        )
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+            self._pending.clear()
+
+    def __del__(self):
+        self.terminate()
+
+
+class _PendingEntry:
+    """Tracks a single in-flight embedding request."""
+
+    __slots__ = ("result", "event", "future", "loop")
+
+    def __init__(self):
+        self.result: Optional[Tuple[List[List[float]], int]] = None
+        self.event: Optional[threading.Event] = None  # For sync path
+        self.future: Optional[asyncio.Future] = None  # For async path
+        self.loop: Optional[asyncio.AbstractEventLoop] = None  # For async path
+
+
+def _set_future_result(future: asyncio.Future, result: Any) -> None:
+    """Thread-safe helper to set a future's result (only if not done)."""
+    if not future.done():
+        future.set_result(result)
+
+
+# ====================================================================
+# AsyncMLCEmbeddingEngine — backend selector + async wrapper
+# ====================================================================
+
+# Backend selection environment variable
+_EMBEDDING_BACKEND_ENV = "MLC_SERVE_EMBEDDING_BACKEND"
+
+
+class AsyncMLCEmbeddingEngine:
+    """Asynchronous embedding inference engine with backend selection.
+
+    This is the main entry point for embedding serving, aligned with
+    AsyncMLCEngine for chat. It selects the best backend automatically
+    and exposes sync/async embed methods.
+
+    Backend selection (via env var MLC_SERVE_EMBEDDING_BACKEND):
+    - "auto" (default): encoder models try ThreadEncoderRuntime first,
+      fallback to TVMNativeEmbeddingRuntime.
+    - "cpp": force ThreadEncoderRuntime; fail if not available.
+    - "tvm_native": force TVMNativeEmbeddingRuntime.
+
+    Decoder models always use TVMNativeEmbeddingRuntime regardless of
+    backend setting. Phase 4 will add ThreadDecoderRuntime.
 
     Parameters
     ----------
@@ -584,8 +995,7 @@ class AsyncEmbeddingEngine:
 
     pooling_strategy : Optional[str]
         Pooling strategy: "cls" (first token), "mean" (masked average),
-        or "last" (last token). If None, auto-detected based on model type:
-        encoder -> "cls", decoder -> "last".
+        or "last" (last token). If None, auto-detected based on model type.
     """
 
     def __init__(
@@ -601,9 +1011,7 @@ class AsyncEmbeddingEngine:
         if _runtime is not None:
             self._runtime = _runtime
         else:
-            self._runtime = TVMNativeEmbeddingRuntime(
-                model, model_lib, device, pooling_strategy=pooling_strategy
-            )
+            self._runtime = self._select_backend(model, model_lib, device, pooling_strategy)
 
         # Mirror core attributes from the abstract interface
         self.tokenizer = self._runtime.tokenizer
@@ -618,55 +1026,109 @@ class AsyncEmbeddingEngine:
         self._cls_token_id = getattr(self._runtime, "_cls_token_id", None)
         self._sep_token_id = getattr(self._runtime, "_sep_token_id", None)
 
-        # Background thread pool (1 worker = serialized GPU inference)
+        # Background thread pool (only used for TVM native runtime fallback)
         self._executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="embedding"
         )
         self._terminated = False
 
+    @staticmethod
+    def _select_backend(
+        model: str,
+        model_lib: str,
+        device: Union[str, Device],
+        pooling_strategy: Optional[str],
+    ) -> EmbeddingRuntime:
+        """Select the embedding runtime backend."""
+        backend = os.environ.get(_EMBEDDING_BACKEND_ENV, "auto").lower()
+
+        # Read model metadata to determine model type
+        config_path = os.path.join(model, "mlc-chat-config.json")
+        model_type = None
+        if os.path.exists(config_path):
+            with open(config_path, encoding="utf-8") as f:
+                cfg = json.load(f)
+            emb_meta = cfg.get("embedding_metadata")
+            if emb_meta:
+                model_type = emb_meta.get("model_type")
+
+        is_encoder = model_type == "encoder"
+
+        if backend == "tvm_native":
+            logger.info("Embedding backend: tvm_native (forced)")
+            return TVMNativeEmbeddingRuntime(
+                model, model_lib, device, pooling_strategy=pooling_strategy
+            )
+
+        if backend == "cpp":
+            if not is_encoder:
+                raise ValueError(
+                    f"ThreadEncoderRuntime requires encoder model, "
+                    f"got model_type={model_type!r}. "
+                    f"Set {_EMBEDDING_BACKEND_ENV}=tvm_native for decoder models."
+                )
+            logger.info("Embedding backend: ThreadEncoderRuntime (forced)")
+            return ThreadEncoderRuntime(
+                model, model_lib, device, pooling_strategy=pooling_strategy
+            )
+
+        # backend == "auto"
+        if is_encoder:
+            try:
+                runtime = ThreadEncoderRuntime(
+                    model, model_lib, device, pooling_strategy=pooling_strategy
+                )
+                logger.info("Embedding backend: ThreadEncoderRuntime (auto, encoder model)")
+                return runtime
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    "ThreadEncoderRuntime failed to initialize, "
+                    "falling back to TVMNativeEmbeddingRuntime. Error: %s",
+                    e,
+                )
+
+        logger.info(
+            "Embedding backend: tvm_native (auto, model_type=%s)",
+            model_type or "unknown",
+        )
+        return TVMNativeEmbeddingRuntime(
+            model, model_lib, device, pooling_strategy=pooling_strategy
+        )
+
     def embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
-        """Compute embeddings for a list of input strings (synchronous).
-
-        Parameters
-        ----------
-        inputs : List[str]
-            The input strings to embed.
-
-        Returns
-        -------
-        embeddings : List[List[float]]
-            The L2-normalized embedding vectors.
-        total_tokens : int
-            Total number of tokens processed.
-        """
+        """Compute embeddings synchronously."""
         return self._runtime.embed(inputs)
 
     async def async_embed(self, inputs: List[str]) -> Tuple[List[List[float]], int]:
-        """Compute embeddings asynchronously in a background thread.
+        """Compute embeddings asynchronously.
 
-        This method does not block the asyncio event loop.
-
-        Parameters
-        ----------
-        inputs : List[str]
-            The input strings to embed.
-
-        Returns
-        -------
-        embeddings : List[List[float]]
-            The L2-normalized embedding vectors.
-        total_tokens : int
-            Total number of tokens processed.
+        If the underlying runtime has a native async_embed (ThreadEncoderRuntime),
+        use it directly. Otherwise, fall back to threadpool execution.
         """
+        # Check for native async fast-path (duck typing)
+        native_async = getattr(self._runtime, "async_embed", None)
+        if native_async is not None and asyncio.iscoroutinefunction(native_async):
+            return await native_async(inputs)
+
+        # Fallback: run sync embed in threadpool
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(self._executor, self.embed, inputs)
 
     def terminate(self) -> None:
-        """Terminate the engine and clean up the thread pool."""
+        """Terminate the engine and clean up."""
         if getattr(self, "_terminated", True):
             return
         self._terminated = True
+
+        # Terminate the underlying runtime if it has a terminate method
+        if hasattr(self._runtime, "terminate"):
+            self._runtime.terminate()
+
         self._executor.shutdown(wait=False)
 
     def __del__(self):
         self.terminate()
+
+
+# Backward-compat alias for code that still imports the old name.
+AsyncEmbeddingEngine = AsyncMLCEmbeddingEngine

--- a/python/mlc_llm/serve/embedding_engine.py
+++ b/python/mlc_llm/serve/embedding_engine.py
@@ -24,7 +24,7 @@ from mlc_llm.tokenizers import Tokenizer
 logger = logging.getLogger(__name__)
 
 # ====================================================================
-# Shared encoder canonicalization helpers
+# Shared canonicalization helpers (encoder + decoder lanes)
 # ====================================================================
 
 
@@ -113,6 +113,101 @@ def _canonicalize_encoder_inputs(
             tokens = tokens[:prefill_chunk_size]
             if sep_token_id is not None:
                 tokens[-1] = sep_token_id
+        result.append(tokens)
+    return result
+
+
+def _get_decoder_special_tokens(
+    tokenizer: Tokenizer, model_path: str
+) -> Tuple[bool, Optional[int]]:
+    """Read decoder-embedding EOS handling for a Qwen3-Embedding-style model.
+
+    Mirrors the Phase 2 TVMNativeEmbeddingRuntime._init_decoder logic exactly.
+    Extracted so both the legacy TVM-native runtime and the Phase-4 threaded
+    runtime agree on when to append EOS during canonicalization.
+
+    Returns
+    -------
+    tokenizer_appends_eos : bool
+        ``True`` when the HF ``tokenizer.json`` already appends a special token
+        (e.g. via ``TemplateProcessing`` with ``$A <|endoftext|>``). If true, the
+        caller must NOT append EOS manually.
+    eos_token_id : Optional[int]
+        Model's EOS token id read from ``mlc-chat-config.json``'s
+        ``eos_token_id`` field. ``None`` if absent; caller should skip manual
+        EOS append in that case.
+    """
+    tokenizer_appends_eos = False
+    tokenizer_json_path = os.path.join(model_path, "tokenizer.json")
+    if os.path.exists(tokenizer_json_path):
+        with open(tokenizer_json_path, encoding="utf-8") as f:
+            tokenizer_json = json.load(f)
+        post_proc = tokenizer_json.get("post_processor")
+        if post_proc is not None:
+            test_tokens = list(tokenizer.encode("test"))
+            if len(test_tokens) > 0:
+                vocab = tokenizer_json.get("added_tokens", [])
+                special_ids = {t["id"] for t in vocab if t.get("special", False)}
+                if test_tokens[-1] in special_ids:
+                    tokenizer_appends_eos = True
+
+    eos_token_id: Optional[int] = None
+    config_path = os.path.join(model_path, "mlc-chat-config.json")
+    if os.path.exists(config_path):
+        with open(config_path, encoding="utf-8") as f:
+            chat_config = json.load(f)
+        eos = chat_config.get("eos_token_id")
+        if isinstance(eos, list):
+            eos_token_id = eos[0]
+        elif isinstance(eos, int):
+            eos_token_id = eos
+
+    return tokenizer_appends_eos, eos_token_id
+
+
+def _canonicalize_decoder_inputs(
+    inputs: List[str],
+    tokenizer: Tokenizer,
+    tokenizer_appends_eos: bool,
+    eos_token_id: Optional[int],
+    max_seq_len: int,
+) -> List[List[int]]:
+    """Canonicalize decoder-embedding inputs: tokenize, conditionally append EOS, truncate.
+
+    Shared source of truth for decoder preprocessing between
+    :class:`TVMNativeEmbeddingRuntime._embed_decoder` and the Phase-4 threaded
+    runtime decoder lane.
+
+    Parameters
+    ----------
+    inputs : List[str]
+        Raw text inputs.
+    tokenizer : Tokenizer
+        The tokenizer instance.
+    tokenizer_appends_eos : bool
+        If ``True``, the tokenizer already appends EOS via its post-processor,
+        so this helper skips manual append.
+    eos_token_id : Optional[int]
+        EOS token id. ``None`` disables manual append.
+    max_seq_len : int
+        Maximum sequence length; inputs are truncated to this length.
+
+    Returns
+    -------
+    List[List[int]]
+        Canonicalized token ID sequences (one per input).
+    """
+    result: List[List[int]] = []
+    for text in inputs:
+        tokens = list(tokenizer.encode(text))
+        if (
+            not tokenizer_appends_eos
+            and eos_token_id is not None
+            and (len(tokens) == 0 or tokens[-1] != eos_token_id)
+        ):
+            tokens.append(eos_token_id)
+        if len(tokens) > max_seq_len:
+            tokens = tokens[:max_seq_len]
         result.append(tokens)
     return result
 
@@ -573,7 +668,7 @@ class TVMNativeEmbeddingRuntime(EmbeddingRuntime):  # pylint: disable=too-many-i
 
 
 # ====================================================================
-# ThreadEncoderRuntime — C++ threaded encoder backend
+# ThreadedEmbeddingRuntime — C++ threaded embedding backend (encoder + decoder)
 # ====================================================================
 
 # Pooling strategy name -> C++ int mapping
@@ -581,14 +676,18 @@ _POOLING_STRATEGY_MAP = {"cls": 0, "mean": 1, "last": 2}
 _THREAD_WAIT_POLL_SEC = 0.1
 
 
-class ThreadEncoderRuntime(EmbeddingRuntime):
-    """C++ threaded encoder embedding runtime using the Phase 3a embedding lane.
+class ThreadedEmbeddingRuntime(EmbeddingRuntime):
+    """C++ threaded embedding runtime using the first-class embedding lane.
 
-    This runtime delegates encoder embedding to the C++ threaded engine,
-    following the same two-thread pattern as AsyncMLCEngine for chat.
-    Phase 4 will add ThreadDecoderRuntime for decoder-only embedding models.
+    Covers both encoder models (Phase 3, right-pad bidirectional) and
+    decoder-only models (Phase 4, left-pad causal). Lane selection is driven
+    by ``embedding_metadata.model_type`` in ``mlc-chat-config.json``; the C++
+    engine's ``InitEmbeddingLane`` picks the matching
+    ``BatchEmbeddingPrefillAction`` / ``BatchDecoderEmbeddingPrefillAction``.
 
-    Only supports model_type == "encoder".
+    The threaded runtime itself uses the same two-thread pattern as
+    ``AsyncMLCEngine`` for chat. Only the token canonicalization step differs
+    per model_type (CLS/SEP append for encoder, EOS append for decoder).
     """
 
     def __init__(
@@ -623,10 +722,10 @@ class ThreadEncoderRuntime(EmbeddingRuntime):
             raise ValueError("Model does not have embedding_metadata in mlc-chat-config.json")
 
         self._model_type = self._embedding_metadata["model_type"]
-        if self._model_type != "encoder":
+        if self._model_type not in ("encoder", "decoder"):
             raise ValueError(
-                f"ThreadEncoderRuntime only supports encoder models, "
-                f"got model_type={self._model_type!r}"
+                f"ThreadedEmbeddingRuntime supports model_type in "
+                f"{{'encoder', 'decoder'}}; got {self._model_type!r}"
             )
 
         self._pooling_strategy = self._embedding_metadata["pooling_strategy"]
@@ -634,12 +733,34 @@ class ThreadEncoderRuntime(EmbeddingRuntime):
         if pooling_strategy:
             self._pooling_strategy = pooling_strategy
 
+        # Lane-specific canonicalization state.
+        # Encoder lane: CLS/SEP pre/post append, truncate to prefill_chunk_size.
+        # Decoder lane: conditional EOS append, truncate to max_seq_len.
+        self._cls_token_id: Optional[int] = None
+        self._sep_token_id: Optional[int] = None
+        self._decoder_tokenizer_appends_eos: bool = False
+        self._decoder_eos_token_id: Optional[int] = None
         self._prefill_chunk_size = self._raw_metadata.get("prefill_chunk_size", 512)
+        self._max_seq_len = 0  # Decoder only; see below.
 
-        # Encoder special tokens (shared helper)
-        self._cls_token_id, self._sep_token_id = _get_encoder_special_token_ids(
-            self._tokenizer, model
-        )
+        if self._model_type == "encoder":
+            self._cls_token_id, self._sep_token_id = _get_encoder_special_token_ids(
+                self._tokenizer, model
+            )
+        else:
+            self._decoder_tokenizer_appends_eos, self._decoder_eos_token_id = (
+                _get_decoder_special_tokens(self._tokenizer, model)
+            )
+            # Decoder lane truncates to the model's context window rather than the
+            # compiled prefill chunk (the C++ action re-checks batch*seq vs chunk).
+            self._max_seq_len = self._raw_metadata.get("context_window_size", 32768)
+            if self._max_seq_len == -1:
+                self._max_seq_len = self._raw_metadata.get("sliding_window_size", -1)
+            if self._max_seq_len <= 0:
+                raise ValueError(
+                    f"Decoder embedding model must have a positive context/sliding window; "
+                    f"got max_seq_len={self._max_seq_len}"
+                )
 
         # FFI functions
         self._f_embedding_request = tvm.get_global_func("mlc.serve.EmbeddingRequest")
@@ -796,11 +917,8 @@ class ThreadEncoderRuntime(EmbeddingRuntime):
 
         request_id = str(uuid.uuid4())
 
-        # Canonicalize inputs
-        token_lists = _canonicalize_encoder_inputs(
-            inputs, self._tokenizer, self._cls_token_id, self._sep_token_id,
-            self._prefill_chunk_size,
-        )
+        # Canonicalize inputs per lane.
+        token_lists = self._canonicalize_inputs(inputs)
 
         # Create pending entry with sync event
         entry = _PendingEntry()
@@ -840,11 +958,8 @@ class ThreadEncoderRuntime(EmbeddingRuntime):
 
         request_id = str(uuid.uuid4())
 
-        # Canonicalize inputs
-        token_lists = _canonicalize_encoder_inputs(
-            inputs, self._tokenizer, self._cls_token_id, self._sep_token_id,
-            self._prefill_chunk_size,
-        )
+        # Canonicalize inputs per lane.
+        token_lists = self._canonicalize_inputs(inputs)
 
         # Create pending entry with async future
         loop = asyncio.get_running_loop()
@@ -878,6 +993,28 @@ class ThreadEncoderRuntime(EmbeddingRuntime):
                 raise RuntimeError(failure_message)
 
     # ---- Internal helpers ----
+
+    def _canonicalize_inputs(self, inputs: List[str]) -> List[List[int]]:
+        """Dispatch canonicalization to the right lane helper.
+
+        Encoder: CLS/SEP pre/post append + truncate to ``prefill_chunk_size``.
+        Decoder: conditional EOS append + truncate to model context window.
+        """
+        if self._model_type == "encoder":
+            return _canonicalize_encoder_inputs(
+                inputs,
+                self._tokenizer,
+                self._cls_token_id,
+                self._sep_token_id,
+                self._prefill_chunk_size,
+            )
+        return _canonicalize_decoder_inputs(
+            inputs,
+            self._tokenizer,
+            self._decoder_tokenizer_appends_eos,
+            self._decoder_eos_token_id,
+            self._max_seq_len,
+        )
 
     def _submit_embedding_request(
         self, request_id: str, token_lists: List[List[int]]
@@ -974,13 +1111,12 @@ class AsyncMLCEmbeddingEngine:
     and exposes sync/async embed methods.
 
     Backend selection (via env var MLC_SERVE_EMBEDDING_BACKEND):
-    - "auto" (default): encoder models try ThreadEncoderRuntime first,
-      fallback to TVMNativeEmbeddingRuntime.
-    - "cpp": force ThreadEncoderRuntime; fail if not available.
+    - "auto" (default): both encoder and decoder models try
+      ThreadedEmbeddingRuntime first, fall back to TVMNativeEmbeddingRuntime
+      if threaded init fails (e.g. missing prefill function in the compiled
+      lib).
+    - "cpp": force ThreadedEmbeddingRuntime; fail if not available.
     - "tvm_native": force TVMNativeEmbeddingRuntime.
-
-    Decoder models always use TVMNativeEmbeddingRuntime regardless of
-    backend setting. Phase 4 will add ThreadDecoderRuntime.
 
     Parameters
     ----------
@@ -1052,7 +1188,7 @@ class AsyncMLCEmbeddingEngine:
             if emb_meta:
                 model_type = emb_meta.get("model_type")
 
-        is_encoder = model_type == "encoder"
+        supports_threaded = model_type in ("encoder", "decoder")
 
         if backend == "tvm_native":
             logger.info("Embedding backend: tvm_native (forced)")
@@ -1061,28 +1197,34 @@ class AsyncMLCEmbeddingEngine:
             )
 
         if backend == "cpp":
-            if not is_encoder:
+            if not supports_threaded:
                 raise ValueError(
-                    f"ThreadEncoderRuntime requires encoder model, "
-                    f"got model_type={model_type!r}. "
-                    f"Set {_EMBEDDING_BACKEND_ENV}=tvm_native for decoder models."
+                    f"ThreadedEmbeddingRuntime requires model_type in "
+                    f"{{'encoder', 'decoder'}}; got model_type={model_type!r}. "
+                    f"Set {_EMBEDDING_BACKEND_ENV}=tvm_native for unsupported model types."
                 )
-            logger.info("Embedding backend: ThreadEncoderRuntime (forced)")
-            return ThreadEncoderRuntime(
+            logger.info(
+                "Embedding backend: ThreadedEmbeddingRuntime (forced, model_type=%s)",
+                model_type,
+            )
+            return ThreadedEmbeddingRuntime(
                 model, model_lib, device, pooling_strategy=pooling_strategy
             )
 
         # backend == "auto"
-        if is_encoder:
+        if supports_threaded:
             try:
-                runtime = ThreadEncoderRuntime(
+                runtime = ThreadedEmbeddingRuntime(
                     model, model_lib, device, pooling_strategy=pooling_strategy
                 )
-                logger.info("Embedding backend: ThreadEncoderRuntime (auto, encoder model)")
+                logger.info(
+                    "Embedding backend: ThreadedEmbeddingRuntime (auto, model_type=%s)",
+                    model_type,
+                )
                 return runtime
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(
-                    "ThreadEncoderRuntime failed to initialize, "
+                    "ThreadedEmbeddingRuntime failed to initialize, "
                     "falling back to TVMNativeEmbeddingRuntime. Error: %s",
                     e,
                 )
@@ -1130,5 +1272,8 @@ class AsyncMLCEmbeddingEngine:
         self.terminate()
 
 
-# Backward-compat alias for code that still imports the old name.
+# Backward-compat aliases for code that still imports the old names.
 AsyncEmbeddingEngine = AsyncMLCEmbeddingEngine
+# Phase 3 name kept for downstream tests / notebooks. ThreadedEmbeddingRuntime
+# handles both encoder and decoder lanes now.
+ThreadEncoderRuntime = ThreadedEmbeddingRuntime

--- a/python/mlc_llm/serve/embedding_engine.py
+++ b/python/mlc_llm/serve/embedding_engine.py
@@ -1048,18 +1048,22 @@ class ThreadedEmbeddingRuntime(EmbeddingRuntime):
         """Build FFI EmbeddingRequest and submit to C++ engine."""
         pooling_int = _POOLING_STRATEGY_MAP.get(self._pooling_strategy, 0)
 
-        # Build packed args for mlc.serve.EmbeddingRequest:
-        # request_id, num_items, then for each item: item_index, num_tokens, token_ids...,
-        # then pooling_strategy (int), normalize (bool)
-        args: List[Any] = [request_id, len(token_lists)]
-        for item_idx, tokens in enumerate(token_lists):
-            args.append(item_idx)
-            args.append(len(tokens))
-            args.extend(tokens)
-        args.append(pooling_int)
-        args.append(self._normalize)
+        # Pack token IDs into a single IntTuple (concatenation of all items)
+        # plus a lengths IntTuple, so the FFI call takes a fixed number of
+        # args regardless of total token count.
+        flat_token_ids: List[int] = []
+        token_lengths: List[int] = []
+        for tokens in token_lists:
+            flat_token_ids.extend(tokens)
+            token_lengths.append(len(tokens))
 
-        emb_request = self._f_embedding_request(*args)
+        emb_request = self._f_embedding_request(
+            request_id,
+            ShapeTuple(flat_token_ids),
+            ShapeTuple(token_lengths),
+            pooling_int,
+            self._normalize,
+        )
         self._ffi["add_embedding_request"](emb_request)
 
     def terminate(self) -> None:

--- a/python/mlc_llm/serve/engine_utils.py
+++ b/python/mlc_llm/serve/engine_utils.py
@@ -1,7 +1,7 @@
 """Utility functions for MLC Serve engine"""
 
 import uuid
-from typing import Any, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from mlc_llm.protocol import error_protocol, openai_api_protocol
 from mlc_llm.protocol.generation_config import GenerationConfig

--- a/python/mlc_llm/serve/engine_utils.py
+++ b/python/mlc_llm/serve/engine_utils.py
@@ -306,31 +306,3 @@ def get_embedding_metadata(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if config.get("model_task") == "embedding":
         return config.get("embedding_metadata")
     return None
-
-
-def detect_embedding_model_type(mod) -> Literal["encoder", "decoder"]:
-    """Detect embedding model type from compiled TVM module functions.
-
-    Parameters
-    ----------
-    mod : tvm.runtime.Module
-        The VM module with model functions.
-
-    Returns
-    -------
-    model_type : str
-        "encoder" for BERT-style models, "decoder" for Qwen3-Embeddings style.
-    """
-    has_embed = mod.implements_function("embed")
-    has_prefill_to_hidden = mod.implements_function("prefill_to_last_hidden_states")
-    has_prefill = mod.implements_function("prefill")
-
-    if has_embed and has_prefill_to_hidden:
-        return "decoder"
-    if has_prefill:
-        return "encoder"
-    raise ValueError(
-        "Model does not support embedding inference. "
-        "Expected 'embed' + 'prefill_to_last_hidden_states' (decoder) "
-        "or 'prefill' (encoder)."
-    )

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -36,13 +36,18 @@ def verify_api_key(request: fastapi.Request):
             raise fastapi.HTTPException(status_code=401, detail="Invalid API Key")
 
 
-app = fastapi.APIRouter(dependencies=[fastapi.Depends(verify_api_key)])
+_api_key_deps = [fastapi.Depends(verify_api_key)]
+
+models_router = fastapi.APIRouter(dependencies=_api_key_deps)
+embeddings_router = fastapi.APIRouter(dependencies=_api_key_deps)
+completions_router = fastapi.APIRouter(dependencies=_api_key_deps)
+chat_completions_router = fastapi.APIRouter(dependencies=_api_key_deps)
 
 
 ################ v1/embeddings ################
 
 
-@app.post("/v1/embeddings")
+@embeddings_router.post("/v1/embeddings")
 async def request_embedding(request: EmbeddingRequest):
     """OpenAI-compatible embedding API.
     API reference: https://platform.openai.com/docs/api-reference/embeddings/create
@@ -121,7 +126,7 @@ async def request_embedding(request: EmbeddingRequest):
 ################ v1/models ################
 
 
-@app.get("/v1/models")
+@models_router.get("/v1/models")
 async def request_models() -> ListResponse:
     """OpenAI-compatible served model query API.
     API reference: https://platform.openai.com/docs/api-reference/models
@@ -133,7 +138,7 @@ async def request_models() -> ListResponse:
 ################ v1/completions ################
 
 
-@app.post("/v1/completions")
+@completions_router.post("/v1/completions")
 async def request_completion(request: CompletionRequest, raw_request: fastapi.Request):
     """OpenAI-compatible completion API.
     API reference: https://platform.openai.com/docs/api-reference/completions/create
@@ -237,7 +242,7 @@ async def request_completion(request: CompletionRequest, raw_request: fastapi.Re
 ################ v1/chat/completions ################
 
 
-@app.post("/v1/chat/completions")
+@chat_completions_router.post("/v1/chat/completions")
 async def request_chat_completion(
     request: ChatCompletionRequest, raw_request: fastapi.Request
 ):  # pylint: disable=too-many-branches
@@ -344,3 +349,24 @@ async def request_chat_completion(
         use_function_calling=use_function_calling,
         usage=request_final_usage,
     )
+
+
+################ Combined routers ################
+
+# Chat-only router: /v1/models + /v1/completions + /v1/chat/completions
+chat_app = fastapi.APIRouter()
+chat_app.include_router(models_router)
+chat_app.include_router(completions_router)
+chat_app.include_router(chat_completions_router)
+
+# Embedding-only router: /v1/models + /v1/embeddings
+embedding_app = fastapi.APIRouter()
+embedding_app.include_router(models_router)
+embedding_app.include_router(embeddings_router)
+
+# Combined router (backward compatibility — includes all endpoints)
+app = fastapi.APIRouter()
+app.include_router(models_router)
+app.include_router(embeddings_router)
+app.include_router(completions_router)
+app.include_router(chat_completions_router)

--- a/python/mlc_llm/serve/server/popen_server.py
+++ b/python/mlc_llm/serve/server/popen_server.py
@@ -14,14 +14,7 @@ from tvm.runtime import Device
 
 from mlc_llm.serve.config import EngineConfig
 from mlc_llm.serve.engine_base import _check_engine_config
-from mlc_llm.support.auto_config import detect_mlc_chat_config
-
-
-def _is_embedding_model(model: str) -> bool:
-    """Return True when *model*'s mlc-chat-config.json has model_task == 'embedding'."""
-    config_path = detect_mlc_chat_config(model)
-    with open(config_path, "r", encoding="utf-8") as f:
-        return json.load(f).get("model_task", "chat") == "embedding"
+from mlc_llm.support.auto_config import detect_model_task
 
 
 class PopenServer:  # pylint: disable=too-many-instance-attributes
@@ -130,7 +123,7 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         cmd = self._build_base_cmd()
 
         try:
-            is_embedding = _is_embedding_model(self.model)
+            is_embedding = detect_model_task(self.model) == "embedding"
         except (ValueError, FileNotFoundError, OSError, json.JSONDecodeError) as exc:
             raise RuntimeError(
                 "The server fails to launch. "

--- a/python/mlc_llm/serve/server/popen_server.py
+++ b/python/mlc_llm/serve/server/popen_server.py
@@ -1,5 +1,6 @@
 """The MLC LLM server launched in a subprocess."""
 
+import json
 import os
 import subprocess
 import sys
@@ -13,6 +14,14 @@ from tvm.runtime import Device
 
 from mlc_llm.serve.config import EngineConfig
 from mlc_llm.serve.engine_base import _check_engine_config
+from mlc_llm.support.auto_config import detect_mlc_chat_config
+
+
+def _is_embedding_model(model: str) -> bool:
+    """Return True when *model*'s mlc-chat-config.json has model_task == 'embedding'."""
+    config_path = detect_mlc_chat_config(model)
+    with open(config_path, "r", encoding="utf-8") as f:
+        return json.load(f).get("model_task", "chat") == "embedding"
 
 
 class PopenServer:  # pylint: disable=too-many-instance-attributes
@@ -56,25 +65,20 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
         self.base_url = ""
         self.openai_v1_base_url = ""
 
-    def start(  # pylint: disable=too-many-branches,too-many-statements
-        self, extra_env=None
-    ) -> None:
-        """Launch the server in a popen subprocess.
-        Wait until the server becomes ready before return.
-        """
-        extra_env = extra_env or {}
-        cmd = [sys.executable]
-        cmd += ["-m", "mlc_llm", "serve", self.model]
+    def _build_base_cmd(self):
+        """Build the common prefix of the subprocess command."""
+        cmd = [sys.executable, "-m", "mlc_llm", "serve", self.model]
         if self.model_lib is not None:
             cmd += ["--model-lib", self.model_lib]
         cmd += ["--device", self.device]
+        return cmd
 
+    def _append_chat_args(self, cmd):
+        """Append chat-only CLI flags to *cmd*."""
         if self.enable_debug:
             cmd += ["--enable-debug"]
-
         if self.mode is not None:
             cmd += ["--mode", self.mode]
-
         if len(self.engine_config.additional_models) > 0:
             args_additional_model = []
             for additional_model in self.engine_config.additional_models:
@@ -115,6 +119,32 @@ class PopenServer:  # pylint: disable=too-many-instance-attributes
             cmd += ["--enable-tracing"]
         if self.enable_debug:
             cmd += ["--enable-debug"]
+
+    def start(  # pylint: disable=too-many-branches,too-many-statements
+        self, extra_env=None
+    ) -> None:
+        """Launch the server in a popen subprocess.
+        Wait until the server becomes ready before return.
+        """
+        extra_env = extra_env or {}
+        cmd = self._build_base_cmd()
+
+        try:
+            is_embedding = _is_embedding_model(self.model)
+        except (ValueError, FileNotFoundError, OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                "The server fails to launch. "
+                f'Please check if "{self.model}" is a valid model compiled by MLC LLM. '
+                f"(detail: {exc})"
+            ) from exc
+
+        if is_embedding:
+            # Embedding models: only base args + host/port are valid.
+            # Chat-only flags (--mode, --speculative-mode, etc.) are
+            # forbidden by the CLI and must not be appended.
+            pass
+        else:
+            self._append_chat_args(cmd)
 
         cmd += ["--host", self.host]
         cmd += ["--port", str(self.port)]

--- a/python/mlc_llm/support/auto_config.py
+++ b/python/mlc_llm/support/auto_config.py
@@ -71,6 +71,18 @@ def detect_mlc_chat_config(mlc_chat_config: str) -> Path:
     return mlc_chat_config_json_path
 
 
+def detect_model_task(model: str) -> str:
+    """Detect the ``model_task`` field from a model's ``mlc-chat-config.json``.
+
+    Returns ``"chat"`` or ``"embedding"``.  Defaults to ``"chat"`` when the
+    field is absent.
+    """
+    config_path = detect_mlc_chat_config(model)
+    with open(config_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    return cfg.get("model_task", "chat")
+
+
 def detect_config(config: str) -> Path:
     """Detect and return the path that points to config.json. If `config` is a directory,
     it looks for config.json below it.

--- a/tests/python/cli/test_serve_cli.py
+++ b/tests/python/cli/test_serve_cli.py
@@ -1,0 +1,306 @@
+"""Unit tests for mlc_llm.cli.serve – single-task serve CLI validation.
+
+No module-level import of mlc_llm — everything is loaded via the ``serve_mod``
+fixture.  When tvm is unavailable, the fixture installs minimal stubs scoped
+to this module's lifetime and removes them on teardown, so other test files
+in the same pytest session are never affected.
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub lists (only used when tvm is absent)
+# ---------------------------------------------------------------------------
+_TVM_NAMES = (
+    "tvm",
+    "tvm.relax",
+    "tvm.relax.frontend",
+    "tvm.relax.frontend.nn",
+    "tvm.runtime",
+    "tvm.runtime.disco",
+)
+_MOCK_NAMES = (
+    "mlc_llm.serve",
+    "mlc_llm.serve.engine",
+    "mlc_llm.serve.engine_base",
+    "mlc_llm.serve.engine_utils",
+    "mlc_llm.serve.embedding_engine",
+    "mlc_llm.serve.entrypoints",
+    "mlc_llm.serve.entrypoints.debug_entrypoints",
+    "mlc_llm.serve.entrypoints.metrics_entrypoints",
+    "mlc_llm.serve.entrypoints.microserving_entrypoints",
+    "mlc_llm.serve.entrypoints.openai_entrypoints",
+    "mlc_llm.serve.server",
+    "mlc_llm.serve.config",
+    "mlc_llm.protocol",
+    "mlc_llm.protocol.error_protocol",
+    "mlc_llm.libinfo",
+    "fastapi",
+    "fastapi.middleware",
+    "fastapi.middleware.cors",
+    "uvicorn",
+)
+
+_MISSING = object()
+
+
+@pytest.fixture(scope="module")
+def serve_mod():
+    """Import ``mlc_llm.cli.serve``, installing tvm stubs only when needed.
+
+    Stubs are removed on teardown so they never leak to other modules.
+    """
+    installed: dict = {}  # name → previous sys.modules value or _MISSING
+
+    try:
+        import mlc_llm.cli.serve as mod  # noqa: F811
+
+        yield mod
+        return  # no stubs, nothing to clean up
+    except ImportError:
+        pass
+
+    # --- tvm unavailable: install stubs ---
+    tvm_stub = types.ModuleType("tvm")
+    tvm_stub.register_global_func = lambda *a, **kw: (lambda fn: fn)
+
+    for name in _TVM_NAMES:
+        installed[name] = sys.modules.get(name, _MISSING)
+        sys.modules[name] = tvm_stub if name == "tvm" else MagicMock()
+    for name in _MOCK_NAMES:
+        installed[name] = sys.modules.get(name, _MISSING)
+        sys.modules[name] = MagicMock()
+    if "mlc_llm.libinfo" in sys.modules:
+        sys.modules["mlc_llm.libinfo"].__version__ = "0.0.0-test"
+
+    import mlc_llm.cli.serve as mod  # noqa: F811
+
+    yield mod
+
+    # --- teardown: remove every stub we inserted ---
+    # Also remove the module-under-test itself so a later real import
+    # is not served the stale, stub-backed module object.
+    for key in list(sys.modules):
+        if key == "mlc_llm.cli.serve" or key.startswith("mlc_llm.cli.serve."):
+            sys.modules.pop(key, None)
+    for name, prev in installed.items():
+        if prev is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = prev
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_config(tmp_path, model_task=None, **extra):
+    config = {"model_type": "test", **extra}
+    if model_task is not None:
+        config["model_task"] = model_task
+    (tmp_path / "mlc-chat-config.json").write_text(json.dumps(config))
+    return str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def embedding_model_dir(tmp_path):
+    return _write_config(tmp_path, model_task="embedding")
+
+
+@pytest.fixture()
+def chat_model_dir(tmp_path):
+    return _write_config(tmp_path, model_task="chat")
+
+
+@pytest.fixture()
+def default_model_dir(tmp_path):
+    return _write_config(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _argv_has_option
+# ---------------------------------------------------------------------------
+
+
+class TestArgvHasOption:
+    def test_exact_match(self, serve_mod):
+        assert serve_mod._argv_has_option(["--mode", "local"], "--mode") is True
+
+    def test_equals_syntax(self, serve_mod):
+        assert serve_mod._argv_has_option(["--mode=local"], "--mode") is True
+
+    def test_absent(self, serve_mod):
+        assert serve_mod._argv_has_option(["--host", "0.0.0.0"], "--mode") is False
+
+    def test_prefix_does_not_false_positive(self, serve_mod):
+        assert serve_mod._argv_has_option(["--model-lib", "foo.so"], "--model") is False
+
+
+# ---------------------------------------------------------------------------
+# _detect_model_task
+# ---------------------------------------------------------------------------
+
+
+class TestDetectModelTask:
+    @staticmethod
+    def _mock_detect(model_dir):
+        return lambda model: Path(model_dir) / "mlc-chat-config.json"
+
+    def test_embedding(self, serve_mod, embedding_model_dir):
+        with patch(
+            "mlc_llm.support.auto_config.detect_mlc_chat_config",
+            side_effect=self._mock_detect(embedding_model_dir),
+        ):
+            assert serve_mod._detect_model_task(embedding_model_dir) == "embedding"
+
+    def test_chat(self, serve_mod, chat_model_dir):
+        with patch(
+            "mlc_llm.support.auto_config.detect_mlc_chat_config",
+            side_effect=self._mock_detect(chat_model_dir),
+        ):
+            assert serve_mod._detect_model_task(chat_model_dir) == "chat"
+
+    def test_default_is_chat(self, serve_mod, default_model_dir):
+        with patch(
+            "mlc_llm.support.auto_config.detect_mlc_chat_config",
+            side_effect=self._mock_detect(default_model_dir),
+        ):
+            assert serve_mod._detect_model_task(default_model_dir) == "chat"
+
+
+# ---------------------------------------------------------------------------
+# Removed args: --embedding-model, --embedding-model-lib
+# ---------------------------------------------------------------------------
+
+
+class TestRemovedArgs:
+    def test_embedding_model_rejected(self, serve_mod, chat_model_dir):
+        with pytest.raises(SystemExit):
+            serve_mod.main([chat_model_dir, "--embedding-model", "/some/path"])
+
+    def test_embedding_model_lib_rejected(self, serve_mod, chat_model_dir):
+        with pytest.raises(SystemExit):
+            serve_mod.main([chat_model_dir, "--embedding-model-lib", "/some/lib.so"])
+
+
+# ---------------------------------------------------------------------------
+# Embedding model: --model-lib required
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingModelLibRequired:
+    def test_missing_model_lib_errors(self, serve_mod, embedding_model_dir):
+        with patch("mlc_llm.cli.serve._detect_model_task", return_value="embedding"):
+            with pytest.raises(SystemExit) as exc_info:
+                serve_mod.main([embedding_model_dir])
+            assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Embedding model: forbidden options
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingForbiddenOptions:
+    @pytest.mark.parametrize(
+        "extra_argv",
+        [
+            ["--mode", "local"],
+            ["--speculative-mode", "disable"],
+            ["--prefix-cache-mode", "radix"],
+            ["--prefill-mode", "hybrid"],
+            ["--overrides", "max_num_sequence=1"],
+            ["--enable-tracing"],
+            ["--enable-debug"],
+            ["--additional-models", "/some/model"],
+        ],
+        ids=[
+            "mode",
+            "speculative-mode",
+            "prefix-cache-mode",
+            "prefill-mode",
+            "overrides",
+            "enable-tracing",
+            "enable-debug",
+            "additional-models",
+        ],
+    )
+    def test_forbidden_option_rejected(self, serve_mod, embedding_model_dir, extra_argv):
+        argv = [embedding_model_dir, "--model-lib", "/fake/lib.so"] + extra_argv
+        with patch("mlc_llm.cli.serve._detect_model_task", return_value="embedding"):
+            with pytest.raises(SystemExit) as exc_info:
+                serve_mod.main(argv)
+            assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Chat model: normal path calls serve()
+# ---------------------------------------------------------------------------
+
+
+class TestChatModelServe:
+    @patch("mlc_llm.cli.serve.serve")
+    @patch("mlc_llm.cli.serve._detect_model_task", return_value="chat")
+    def test_chat_model_calls_serve(self, _mock_task, mock_serve, serve_mod, chat_model_dir):
+        serve_mod.main([chat_model_dir])
+        mock_serve.assert_called_once()
+        kw = mock_serve.call_args.kwargs
+        assert kw["model"] == chat_model_dir
+        # embedding_model / embedding_model_lib no longer passed (single-task serve)
+        assert "embedding_model" not in kw
+        assert "embedding_model_lib" not in kw
+
+    @patch("mlc_llm.cli.serve.serve")
+    @patch("mlc_llm.cli.serve._detect_model_task", return_value="chat")
+    def test_chat_model_with_mode(self, _mock_task, mock_serve, serve_mod, chat_model_dir):
+        serve_mod.main([chat_model_dir, "--mode", "server"])
+        kw = mock_serve.call_args.kwargs
+        assert kw["mode"] == "server"
+
+
+# ---------------------------------------------------------------------------
+# Embedding model: valid args accepted
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingValidArgs:
+    @patch("mlc_llm.cli.serve.serve")
+    @patch("mlc_llm.cli.serve._detect_model_task", return_value="embedding")
+    def test_embedding_valid_args_calls_serve(
+        self, _mock_task, mock_serve, serve_mod, embedding_model_dir
+    ):
+        serve_mod.main(
+            [
+                embedding_model_dir,
+                "--model-lib",
+                "/fake/lib.so",
+                "--device",
+                "cuda",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "9000",
+                "--api-key",
+                "secret",
+            ]
+        )
+        mock_serve.assert_called_once()
+        kw = mock_serve.call_args.kwargs
+        assert kw["model"] == embedding_model_dir
+        assert kw["model_lib"] == "/fake/lib.so"
+        assert kw["device"] == "cuda"
+        assert kw["host"] == "0.0.0.0"
+        assert kw["port"] == 9000
+        assert kw["api_key"] == "secret"

--- a/tests/python/serve/server/test_embedding_server.py
+++ b/tests/python/serve/server/test_embedding_server.py
@@ -9,7 +9,7 @@ Reuses MLC LLM test infrastructure:
   - OpenAI client usage pattern from test_server.py
   - Session-scoped server fixture pattern from conftest.py
 
-Run (launches its own embedding-only server):
+Run (launches its own embedding-only server via ``mlc_llm serve``):
   MLC_SERVE_EMBEDDING_MODEL_LIB="path/to/model.dylib" \
     pytest -m endpoint tests/python/serve/server/test_embedding_server.py -v
 
@@ -23,7 +23,6 @@ Environment variables:
 
 import json
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -31,6 +30,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import numpy as np
+import psutil
 import pytest
 import requests
 from openai import OpenAI
@@ -121,78 +121,82 @@ def expect_error(response_str: str, msg_prefix: Optional[str] = None):
 
 
 # ---------------------------------------------------------------------------
-# Server fixture — follows PopenServer/launch_server pattern from conftest.py
+# Server fixture — uses the proper ``mlc_llm serve`` CLI path
 # ---------------------------------------------------------------------------
+
+
+def _terminate_proc(proc):
+    """Terminate a subprocess and all its children (same pattern as PopenServer)."""
+    try:
+        parent = psutil.Process(proc.pid)
+        for child in parent.children(recursive=True):
+            try:
+                child.kill()
+            except psutil.NoSuchProcess:
+                pass
+    except psutil.NoSuchProcess:
+        pass
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 @pytest.fixture(scope="module")
 def launch_embedding_server():
-    """Launch an embedding-only server as a subprocess.
+    """Launch an embedding-only server via ``mlc_llm serve``.
 
-    Follows the same lifecycle pattern as the launch_server fixture
-    in serve/server/conftest.py, but uses a lightweight embedding-only
-    server since PopenServer doesn't support --embedding-model yet.
+    Uses the proper serve path so that model_task detection in
+    interface/serve.py routes to the embedding-only app automatically.
+    Follows the same lifecycle pattern as PopenServer.
     """
     _skip_if_no_model()
 
-    mlc_llm_path = str(Path(__file__).resolve().parents[4] / "python")
-    server_code = f"""
-import sys
-sys.path.insert(0, "{mlc_llm_path}")
+    cmd = [
+        sys.executable,
+        "-m",
+        "mlc_llm",
+        "serve",
+        EMBEDDING_MODEL_DIR,
+        "--model-lib",
+        EMBEDDING_MODEL_LIB,
+        "--device",
+        "auto",
+        "--host",
+        EMBEDDING_SERVER_HOST,
+        "--port",
+        str(EMBEDDING_SERVER_PORT),
+    ]
 
-import fastapi
-import uvicorn
-from mlc_llm.serve.embedding_engine import AsyncEmbeddingEngine
-from mlc_llm.serve.server import ServerContext
-from mlc_llm.serve.entrypoints import openai_entrypoints
+    process_path = str(Path(__file__).resolve().parents[4])
+    proc = subprocess.Popen(cmd, cwd=process_path)  # pylint: disable=consider-using-with
 
-app = fastapi.FastAPI()
-app.include_router(openai_entrypoints.app)
-
-engine = AsyncEmbeddingEngine(
-    model="{EMBEDDING_MODEL_DIR}",
-    model_lib="{EMBEDDING_MODEL_LIB}",
-    device="auto",
-)
-ctx = ServerContext()
-ServerContext.server_context = ctx
-ctx.add_embedding_engine("{EMBEDDING_MODEL_NAME}", engine)
-
-uvicorn.run(app, host="{EMBEDDING_SERVER_HOST}", port={EMBEDDING_SERVER_PORT}, log_level="info")
-"""
-    with subprocess.Popen(
-        [sys.executable, "-c", server_code],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    ) as proc:
-        # Wait for server readiness — same polling pattern as PopenServer.start()
-        timeout = 120
-        attempts = 0.0
-        ready = False
-        while attempts < timeout:
-            try:
-                response = requests.get(f"{EMBEDDING_BASE_URL}/models", timeout=2)
-                if response.status_code == 200:
-                    ready = True
-                    break
-            except requests.RequestException:
-                pass
-            attempts += 0.5
-            time.sleep(0.5)
-
-        if not ready:
-            stderr = proc.stderr.read().decode() if proc.stderr else ""
-            proc.kill()
-            raise RuntimeError(f"Embedding server failed to start in {timeout}s.\nStderr: {stderr}")
-
-        yield proc
-
-        # Cleanup — same pattern as PopenServer.terminate()
-        proc.send_signal(signal.SIGINT)
+    # Wait for server readiness — same polling pattern as PopenServer.start()
+    timeout = 120
+    attempts = 0.0
+    ready = False
+    while attempts < timeout:
         try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+            response = requests.get(f"{EMBEDDING_BASE_URL}/models", timeout=2)
+            if response.status_code == 200:
+                ready = True
+                break
+        except requests.RequestException:
+            pass
+        attempts += 0.5
+        time.sleep(0.5)
+
+    if not ready:
+        _terminate_proc(proc)
+        raise RuntimeError(f"Embedding server failed to start in {timeout}s.")
+
+    yield proc
+
+    _terminate_proc(proc)
 
 
 @pytest.fixture(scope="module")
@@ -344,6 +348,49 @@ def test_any_model_name_works_with_single_engine():
 
 
 # ===================================================================
+# Chat-only endpoints must NOT be registered (404)
+# ===================================================================
+
+_BASE = f"http://{EMBEDDING_SERVER_HOST}:{EMBEDDING_SERVER_PORT}"
+
+
+@pytest.mark.usefixtures("launch_embedding_server")
+def test_metrics_not_registered():
+    """/metrics must return 404 for embedding-only serve."""
+    resp = requests.get(f"{_BASE}/metrics", timeout=5)
+    assert resp.status_code == 404
+
+
+@pytest.mark.usefixtures("launch_embedding_server")
+def test_debug_dump_event_trace_not_registered():
+    """/debug/dump_event_trace must return 404 for embedding-only serve."""
+    resp = requests.post(f"{_BASE}/debug/dump_event_trace", timeout=5)
+    assert resp.status_code == 404
+
+
+@pytest.mark.usefixtures("launch_embedding_server")
+def test_completions_not_registered():
+    """/v1/completions must return 404 for embedding-only serve."""
+    resp = requests.post(
+        f"{EMBEDDING_BASE_URL}/completions",
+        json={"model": "x", "prompt": "hi"},
+        timeout=5,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.usefixtures("launch_embedding_server")
+def test_chat_completions_not_registered():
+    """/v1/chat/completions must return 404 for embedding-only serve."""
+    resp = requests.post(
+        f"{EMBEDDING_BASE_URL}/chat/completions",
+        json={"model": "x", "messages": [{"role": "user", "content": "hi"}]},
+        timeout=5,
+    )
+    assert resp.status_code == 404
+
+
+# ===================================================================
 # Standalone runner (same pattern as test_server.py __main__)
 # ===================================================================
 
@@ -368,4 +415,8 @@ if __name__ == "__main__":
     test_dimension_truncation(c)
     test_base64_encoding()
     test_any_model_name_works_with_single_engine()
+    test_metrics_not_registered()
+    test_debug_dump_event_trace_not_registered()
+    test_completions_not_registered()
+    test_chat_completions_not_registered()
     print("\nAll embedding server tests passed!")

--- a/tests/python/serve/test_embedding_engine.py
+++ b/tests/python/serve/test_embedding_engine.py
@@ -705,27 +705,9 @@ class TestBackendSelector:
         )
         assert isinstance(rt, _eng_mod.TVMNativeEmbeddingRuntime)
 
-    def test_cpp_forced_rejects_decoder(self, monkeypatch, tmp_path):
-        """MLC_SERVE_EMBEDDING_BACKEND=cpp rejects decoder models."""
+    def test_cpp_forced_routes_decoder_to_threaded(self, monkeypatch, tmp_path):
+        """MLC_SERVE_EMBEDDING_BACKEND=cpp now routes decoder models through ThreadedEmbeddingRuntime."""
         monkeypatch.setenv("MLC_SERVE_EMBEDDING_BACKEND", "cpp")
-        # Write a minimal mlc-chat-config.json with decoder model type
-        config_dir = tmp_path / "model"
-        config_dir.mkdir()
-        import json as _json
-
-        (config_dir / "mlc-chat-config.json").write_text(
-            _json.dumps({"embedding_metadata": {"model_type": "decoder"}})
-        )
-        from mlc_llm.serve.embedding_engine import AsyncMLCEmbeddingEngine
-
-        with pytest.raises(ValueError, match="requires encoder model"):
-            AsyncMLCEmbeddingEngine._select_backend(
-                str(config_dir), "fake.so", "cpu", None
-            )
-
-    def test_auto_decoder_skips_cpp(self, monkeypatch, tmp_path):
-        """auto mode for decoder models goes straight to TVMNativeEmbeddingRuntime."""
-        monkeypatch.setenv("MLC_SERVE_EMBEDDING_BACKEND", "auto")
         config_dir = tmp_path / "model"
         config_dir.mkdir()
         import json as _json
@@ -735,18 +717,53 @@ class TestBackendSelector:
         )
         import mlc_llm.serve.embedding_engine as _eng_mod
 
-        raw_meta = {
-            "model_task": "embedding",
-            "embedding_metadata": {"model_type": "decoder", "pooling_strategy": "last", "normalize": True},
-            "params": [],
-        }
-        _patch_tvm_deps(monkeypatch, raw_meta)
+        threaded_sentinel = object()
+        native_sentinel = object()
+        monkeypatch.setattr(
+            _eng_mod, "ThreadedEmbeddingRuntime", lambda *a, **kw: threaded_sentinel
+        )
+        monkeypatch.setattr(
+            _eng_mod, "TVMNativeEmbeddingRuntime", lambda *a, **kw: native_sentinel
+        )
 
-        # Should not raise — decoder goes to TVMNativeEmbeddingRuntime directly
         rt = _eng_mod.AsyncMLCEmbeddingEngine._select_backend(
             str(config_dir), "fake.so", "cpu", None
         )
-        assert isinstance(rt, _eng_mod.TVMNativeEmbeddingRuntime)
+        assert rt is threaded_sentinel
+
+    def test_auto_decoder_prefers_threaded(self, monkeypatch, tmp_path):
+        """auto mode for decoder models now prefers ThreadedEmbeddingRuntime over TVMNative."""
+        monkeypatch.setenv("MLC_SERVE_EMBEDDING_BACKEND", "auto")
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        import json as _json
+
+        (config_dir / "mlc-chat-config.json").write_text(
+            _json.dumps(
+                {
+                    "embedding_metadata": {
+                        "model_type": "decoder",
+                        "pooling_strategy": "last",
+                        "normalize": True,
+                    }
+                }
+            )
+        )
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        threaded_sentinel = object()
+        native_sentinel = object()
+        monkeypatch.setattr(
+            _eng_mod, "ThreadedEmbeddingRuntime", lambda *a, **kw: threaded_sentinel
+        )
+        monkeypatch.setattr(
+            _eng_mod, "TVMNativeEmbeddingRuntime", lambda *a, **kw: native_sentinel
+        )
+
+        rt = _eng_mod.AsyncMLCEmbeddingEngine._select_backend(
+            str(config_dir), "fake.so", "cpu", None
+        )
+        assert rt is threaded_sentinel
 
 
 # ===================================================================
@@ -758,25 +775,13 @@ class TestBackendSelector:
 class TestNegativeCases:
     """Embedding lane should reject chat-only features."""
 
-    def test_thread_encoder_runtime_rejects_decoder(self, monkeypatch, tmp_path):
-        """ThreadEncoderRuntime rejects decoder model type."""
-        config_dir = tmp_path / "model"
-        config_dir.mkdir()
-        import json as _json
+    def test_thread_encoder_runtime_is_alias_for_threaded(self):
+        """ThreadEncoderRuntime is now an alias for the unified ThreadedEmbeddingRuntime,
+        which accepts both encoder and decoder models. The old 'rejects decoder'
+        expectation no longer holds under the current architecture."""
+        from mlc_llm.serve.embedding_engine import ThreadEncoderRuntime, ThreadedEmbeddingRuntime
 
-        (config_dir / "mlc-chat-config.json").write_text(
-            _json.dumps({
-                "model_task": "embedding",
-                "embedding_metadata": {"model_type": "decoder", "pooling_strategy": "last", "normalize": True},
-            })
-        )
-        import mlc_llm.serve.embedding_engine as _eng_mod
-
-        monkeypatch.setattr(_eng_mod, "Tokenizer", lambda path: mock.MagicMock())
-        from mlc_llm.serve.embedding_engine import ThreadEncoderRuntime
-
-        with pytest.raises(ValueError, match="only supports encoder models"):
-            ThreadEncoderRuntime(str(config_dir), "fake.so", "cpu")
+        assert ThreadEncoderRuntime is ThreadedEmbeddingRuntime
 
     def test_thread_encoder_runtime_rejects_missing_metadata(self, monkeypatch, tmp_path):
         """ThreadEncoderRuntime rejects model without embedding_metadata."""
@@ -845,6 +850,241 @@ def test_parity_cpp_vs_tvm_native(embedding_engine):
         cos = cosine_similarity(cpp_emb[i], tvm_emb[i])
         assert cos > 0.99, (
             f"Parity mismatch for item {i} ({texts[i]!r}): cosine={cos:.6f}"
+        )
+
+
+# ===================================================================
+# Phase 4 — Decoder-lane cosine parity (real model required)
+# ===================================================================
+
+
+def test_decoder_threaded_vs_native_parity():
+    """[Decoder only] ThreadedEmbeddingRuntime matches TVMNativeEmbeddingRuntime to
+    cosine >= 0.999 on mixed-length inputs.
+
+    Exercises the Phase-4 C++ BatchDecoderEmbeddingPrefillAction (left-pad kLast
+    gather + batched/single paths) against the legacy Python _embed_decoder as
+    numerical ground truth. Skips only when no artifact is available; a backend
+    init failure when the artifact IS present fails the test (real regression).
+    """
+    _skip_if_no_model()
+
+    import json as _json
+
+    from mlc_llm.serve.embedding_engine import (
+        ThreadedEmbeddingRuntime,
+        TVMNativeEmbeddingRuntime,
+    )
+
+    # Gate on decoder model_type. For encoder artifacts, this parity check is
+    # not applicable (Phase 3 already has its own parity test).
+    with open(os.path.join(EMBEDDING_MODEL_DIR, "mlc-chat-config.json")) as _f:
+        _cfg = _json.load(_f)
+    if _cfg.get("embedding_metadata", {}).get("model_type") != "decoder":
+        pytest.skip("Decoder parity test is not applicable to encoder artifacts")
+
+    # Construct both runtimes explicitly. Init failures propagate (the artifact
+    # is present; failure to spin up either backend is a real regression, not
+    # a skippable condition).
+    threaded = ThreadedEmbeddingRuntime(
+        model=EMBEDDING_MODEL_DIR,
+        model_lib=EMBEDDING_MODEL_LIB,
+        device="auto",
+    )
+    native = TVMNativeEmbeddingRuntime(
+        model=EMBEDDING_MODEL_DIR,
+        model_lib=EMBEDDING_MODEL_LIB,
+        device="auto",
+    )
+
+    try:
+        # Mixed lengths: tiny single-token, medium, long, max-cap. Exercises
+        # the batched left-pad gather path AND the single-item fast path.
+        texts = [
+            "ok",
+            "The quick brown fox jumps over the lazy dog. " * 10,
+            "Machine learning systems research is a fascinating field. " * 60,
+            "Large language models require careful engineering at every layer. " * 100,
+        ]
+
+        t_emb, _ = threaded.embed(texts)
+        n_emb, _ = native.embed(texts)
+
+        assert len(t_emb) == len(n_emb) == len(texts)
+        assert len(t_emb[0]) == len(n_emb[0]), (
+            f"Hidden dim mismatch: threaded={len(t_emb[0])} native={len(n_emb[0])}"
+        )
+
+        for i, text in enumerate(texts):
+            cos = cosine_similarity(t_emb[i], n_emb[i])
+            assert cos >= 0.999, (
+                f"Decoder parity mismatch for item {i} (~{len(text)} chars): "
+                f"cosine={cos:.6f} (expected >= 0.999). The Phase-4 C++ lane "
+                f"output diverges from the legacy Python _embed_decoder path."
+            )
+    finally:
+        # Best-effort cleanup; don't mask test failures on teardown errors.
+        for rt in (threaded, native):
+            terminate = getattr(rt, "terminate", None)
+            if terminate is not None:
+                try:
+                    terminate()
+                except Exception:  # pylint: disable=broad-except
+                    pass
+
+
+# ===================================================================
+# Phase 4 — Decoder-lane canary regression gates (unit, no model needed)
+# ===================================================================
+
+
+@_skip_no_tvm
+class TestDecoderCanaries:
+    """Regression gates for the decoder-lane runtime guards."""
+
+    def test_decoder_rejects_nonlast_pooling_at_init(self, monkeypatch, tmp_path):
+        """Decoder + pooling_strategy != 'last' must raise ValueError at __init__,
+        before any FFI is touched, so misconfiguration fails fast instead of
+        crashing the engine process on first request via the C++ ICHECK."""
+        import json as _json
+
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        (config_dir / "mlc-chat-config.json").write_text(
+            _json.dumps(
+                {
+                    "model_task": "embedding",
+                    "embedding_metadata": {
+                        "model_type": "decoder",
+                        "pooling_strategy": "mean",
+                        "normalize": True,
+                    },
+                    "context_window_size": 4096,
+                    "prefill_chunk_size": 1024,
+                }
+            )
+        )
+
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        monkeypatch.setattr(_eng_mod, "detect_device", lambda d: mock.MagicMock())
+        monkeypatch.setattr(_eng_mod, "Tokenizer", lambda path: mock.MagicMock())
+
+        with pytest.raises(ValueError, match="pooling_strategy='last'"):
+            _eng_mod.ThreadedEmbeddingRuntime(str(config_dir), "fake.so", "cpu")
+
+    def test_canonicalize_decoder_preserves_eos_after_truncation(self):
+        """When truncation fires, the final token must stay eos_token_id.
+        Decoder embedding models are trained to emit the sentence embedding at the
+        EOS position; dropping the EOS breaks last-token pooling semantics."""
+        from mlc_llm.serve.embedding_engine import _canonicalize_decoder_inputs
+
+        eos_id = 151643  # representative Qwen3 EOS
+        fake_tokenizer = mock.MagicMock()
+        # Long input so truncation is guaranteed. No EOS in tokenizer output → helper
+        # appends EOS at index 500, then truncates back to 256 and must restore it.
+        fake_tokenizer.encode = mock.MagicMock(return_value=list(range(1000, 1500)))
+
+        result = _canonicalize_decoder_inputs(
+            inputs=["anything"],
+            tokenizer=fake_tokenizer,
+            tokenizer_appends_eos=False,
+            eos_token_id=eos_id,
+            max_seq_len=256,
+        )
+
+        assert len(result) == 1
+        assert len(result[0]) == 256
+        assert result[0][-1] == eos_id, (
+            f"Truncation dropped the EOS sentinel; last token was {result[0][-1]} "
+            f"instead of {eos_id}. Decoder embedding pooling expects EOS at [-1]."
+        )
+
+    def test_canonicalize_decoder_rejects_empty_after_truncate(self):
+        """Post-canonicalization 0-token inputs raise ValueError rather than
+        silently sending a degenerate request into the C++ engine."""
+        from mlc_llm.serve.embedding_engine import _canonicalize_decoder_inputs
+
+        fake_tokenizer = mock.MagicMock()
+        fake_tokenizer.encode = mock.MagicMock(return_value=[])
+
+        with pytest.raises(ValueError, match="tokenized to 0 tokens"):
+            _canonicalize_decoder_inputs(
+                inputs=[""],
+                tokenizer=fake_tokenizer,
+                tokenizer_appends_eos=False,
+                eos_token_id=None,  # no EOS to append → stays empty → raises
+                max_seq_len=128,
+            )
+
+    def test_threaded_decoder_caps_max_seq_len_at_prefill_chunk_size(
+        self, monkeypatch, tmp_path
+    ):
+        """_max_seq_len must clamp to min(context_window_size, prefill_chunk_size).
+
+        Without this cap, Python admits inputs up to context_window_size but the
+        C++ admit loop rejects anything exceeding prefill_chunk_size, deadlocking
+        the waiting queue. We construct the runtime with ctx=32768, pcs=1024 and
+        assert the computed cap is 1024.
+
+        We capture the partial runtime via a subclass before the FFI init (which
+        happens after _max_seq_len is set) raises; this isolates the test from
+        the real FFI surface.
+        """
+        import json as _json
+
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        (config_dir / "mlc-chat-config.json").write_text(
+            _json.dumps(
+                {
+                    "model_task": "embedding",
+                    "embedding_metadata": {
+                        "model_type": "decoder",
+                        "pooling_strategy": "last",
+                        "normalize": True,
+                    },
+                    "context_window_size": 32768,
+                    "prefill_chunk_size": 1024,
+                }
+            )
+        )
+
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        monkeypatch.setattr(_eng_mod, "detect_device", lambda d: mock.MagicMock())
+        monkeypatch.setattr(_eng_mod, "Tokenizer", lambda path: mock.MagicMock())
+        monkeypatch.setattr(
+            _eng_mod,
+            "_get_decoder_special_tokens",
+            lambda tok, path: (False, None),
+        )
+
+        # Trip FFI init with a distinctive exception as soon as it's reached.
+        # _max_seq_len (set on line ~789) is computed BEFORE this point.
+        _stop = RuntimeError("unit-test: stopping before real FFI")
+        monkeypatch.setattr(
+            _eng_mod.tvm,
+            "get_global_func",
+            lambda *a, **kw: (_ for _ in ()).throw(_stop),
+        )
+
+        # Subclass so we capture `self` before the FFI boundary exception propagates.
+        captured = {}
+
+        class _Capturing(_eng_mod.ThreadedEmbeddingRuntime):
+            def __init__(self, *a, **kw):  # pylint: disable=super-init-not-called
+                captured["rt"] = self
+                _eng_mod.ThreadedEmbeddingRuntime.__init__(self, *a, **kw)
+
+        with pytest.raises(RuntimeError, match="unit-test"):
+            _Capturing(str(config_dir), "fake.so", "cpu")
+
+        rt = captured.get("rt")
+        assert rt is not None, "Failed to capture partial runtime for inspection"
+        assert rt._max_seq_len == 1024, (
+            f"Expected _max_seq_len = min(32768, 1024) = 1024; got {rt._max_seq_len}. "
+            f"Without this cap, long inputs deadlock the C++ waiting queue."
         )
 
 

--- a/tests/python/serve/test_embedding_engine.py
+++ b/tests/python/serve/test_embedding_engine.py
@@ -14,7 +14,7 @@ Environment variables:
                                   (optional, defaults to dirname of model lib)
 """
 
-# pylint: disable=import-outside-toplevel,protected-access,redefined-outer-name
+# pylint: disable=import-outside-toplevel,protected-access,redefined-outer-name,possibly-used-before-assignment
 
 import asyncio
 import os
@@ -331,6 +331,237 @@ def test_unicode_text(embedding_engine):
     assert len(embeddings) == 3
     for emb in embeddings:
         assert abs(float(np.linalg.norm(emb)) - 1.0) < 1e-4
+
+
+# ===================================================================
+# Unit tests — no real model required
+# ===================================================================
+
+from unittest import mock
+
+try:
+    from mlc_llm.serve import engine_utils
+    from mlc_llm.serve.embedding_engine import AsyncEmbeddingEngine, EmbeddingRuntime
+
+    _HAS_UNIT_DEPS = isinstance(EmbeddingRuntime, type) and isinstance(AsyncEmbeddingEngine, type)
+except ImportError:
+    _HAS_UNIT_DEPS = False
+
+_skip_no_tvm = pytest.mark.skipif(not _HAS_UNIT_DEPS, reason="tvm not installed")
+
+if _HAS_UNIT_DEPS:
+
+    class _FakeRuntime(EmbeddingRuntime):
+        """Minimal fake runtime for unit testing AsyncEmbeddingEngine delegation."""
+
+        def __init__(self, model_type="decoder", pooling="last", norm=True, emb_meta=None):
+            self._tokenizer_obj = mock.MagicMock(name="fake_tokenizer")
+            self._model_type = model_type
+            self._pooling = pooling
+            self._norm = norm
+            self._raw_metadata = {
+                "prefill_chunk_size": 512,
+                "context_window_size": 4096,
+            }
+            self._emb_meta = emb_meta
+            self._cls_token_id = None
+            self._sep_token_id = None
+            self.embed_calls = []
+
+        @property
+        def device(self):
+            return None
+
+        @property
+        def tokenizer(self):
+            return self._tokenizer_obj
+
+        @property
+        def model_type(self):
+            return self._model_type
+
+        @property
+        def pooling_strategy(self):
+            return self._pooling
+
+        @property
+        def normalize(self):
+            return self._norm
+
+        @property
+        def metadata(self):
+            return self._raw_metadata
+
+        @property
+        def embedding_metadata(self):
+            return self._emb_meta
+
+        def embed(self, inputs):
+            self.embed_calls.append(inputs)
+            dim = 4
+            return [[0.5] * dim for _ in inputs], sum(len(s.split()) for s in inputs)
+
+    def _make_fake_mod(raw_metadata_dict):
+        """Build a minimal fake TVM module whose ["_metadata"]() returns JSON."""
+        import json as _json
+
+        metadata_json = _json.dumps(raw_metadata_dict)
+        fake_mod = mock.MagicMock()
+        fake_mod.__getitem__ = lambda self, key: (
+            (lambda: metadata_json) if key == "_metadata" else mock.MagicMock()
+        )
+        fake_mod.implements_function.return_value = True
+        return fake_mod
+
+    def _patch_tvm_deps(monkeypatch, raw_metadata_dict):
+        """Monkeypatch TVM/tokenizer deps so TVMNativeEmbeddingRuntime.__init__ can run."""
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        fake_mod = _make_fake_mod(raw_metadata_dict)
+        fake_vm = mock.MagicMock()
+        fake_vm.module = fake_mod
+
+        monkeypatch.setattr(_eng_mod, "detect_device", lambda d: mock.MagicMock())
+        monkeypatch.setattr(_eng_mod, "Tokenizer", lambda path: mock.MagicMock())
+        monkeypatch.setattr(_eng_mod.tvm.runtime, "load_module", lambda path: mock.MagicMock())
+        monkeypatch.setattr(_eng_mod.relax, "VirtualMachine", lambda ex, device: fake_vm)
+        monkeypatch.setattr(_eng_mod.engine_utils, "load_embedding_params", lambda *a: [])
+
+
+@_skip_no_tvm
+def test_unit_engine_delegates_embed():
+    """AsyncEmbeddingEngine.embed delegates to runtime.embed."""
+    rt = _FakeRuntime()
+    eng = AsyncEmbeddingEngine("", "", _runtime=rt)
+    result = eng.embed(["hello world", "foo"])
+    assert result == ([[0.5, 0.5, 0.5, 0.5]] * 2, 3)
+    assert rt.embed_calls == [["hello world", "foo"]]
+    eng.terminate()
+
+
+@_skip_no_tvm
+def test_unit_async_embed_matches_sync():
+    """async_embed returns same result as sync embed."""
+    rt = _FakeRuntime()
+    eng = AsyncEmbeddingEngine("", "", _runtime=rt)
+    sync_result = eng.embed(["test input"])
+    loop = asyncio.new_event_loop()
+    try:
+        async_result = loop.run_until_complete(eng.async_embed(["test input"]))
+    finally:
+        loop.close()
+    assert sync_result == async_result
+    eng.terminate()
+
+
+@_skip_no_tvm
+def test_unit_attributes_mirrored():
+    """Backward-compat attributes are mirrored from runtime."""
+    rt = _FakeRuntime(model_type="encoder", pooling="cls", norm=False)
+    rt._cls_token_id = 101  # pylint: disable=protected-access
+    rt._sep_token_id = 102  # pylint: disable=protected-access
+    eng = AsyncEmbeddingEngine("", "", _runtime=rt)
+    assert eng.model_type == "encoder"
+    assert eng.pooling_strategy == "cls"
+    assert eng.normalize is False
+    assert eng.tokenizer is rt._tokenizer_obj  # pylint: disable=protected-access
+    assert eng._metadata is rt.metadata  # pylint: disable=protected-access
+    assert eng._cls_token_id == 101  # pylint: disable=protected-access
+    assert eng._sep_token_id == 102  # pylint: disable=protected-access
+    assert eng.embedding_metadata is None
+    eng.terminate()
+
+
+@_skip_no_tvm
+def test_unit_attributes_with_embedding_metadata():
+    """embedding_metadata is mirrored when present."""
+    emb_meta = {
+        "model_type": "decoder",
+        "pooling_strategy": "last",
+        "normalize": True,
+    }
+    rt = _FakeRuntime(emb_meta=emb_meta)
+    eng = AsyncEmbeddingEngine("", "", _runtime=rt)
+    assert eng.embedding_metadata == emb_meta
+    eng.terminate()
+
+
+@_skip_no_tvm
+def test_unit_terminate_idempotent():
+    """Calling terminate multiple times does not raise."""
+    rt = _FakeRuntime()
+    eng = AsyncEmbeddingEngine("", "", _runtime=rt)
+    eng.terminate()
+    eng.terminate()
+    assert eng._terminated is True  # pylint: disable=protected-access
+
+
+@_skip_no_tvm
+def test_unit_terminate_shuts_down_executor():
+    """terminate shuts down the thread pool executor."""
+    rt = _FakeRuntime()
+    eng = AsyncEmbeddingEngine("", "", _runtime=rt)
+    executor = eng._executor  # pylint: disable=protected-access
+    eng.terminate()
+    with pytest.raises(RuntimeError):
+        executor.submit(lambda: None)
+
+
+@_skip_no_tvm
+def test_unit_get_embedding_metadata_present():
+    """get_embedding_metadata returns metadata when model_task == 'embedding'."""
+    config = {
+        "model_task": "embedding",
+        "embedding_metadata": {
+            "model_type": "decoder",
+            "pooling_strategy": "last",
+            "normalize": True,
+        },
+    }
+    result = engine_utils.get_embedding_metadata(config)
+    assert result is not None
+    assert result["model_type"] == "decoder"
+    assert result["pooling_strategy"] == "last"
+    assert result["normalize"] is True
+
+
+@_skip_no_tvm
+def test_unit_get_embedding_metadata_chat_task():
+    """get_embedding_metadata returns None for chat models."""
+    assert engine_utils.get_embedding_metadata({"model_task": "chat"}) is None
+
+
+@_skip_no_tvm
+def test_unit_get_embedding_metadata_missing_task():
+    """get_embedding_metadata returns None when model_task is absent."""
+    assert engine_utils.get_embedding_metadata({}) is None
+
+
+@_skip_no_tvm
+def test_unit_runtime_rejects_missing_metadata(monkeypatch):
+    """TVMNativeEmbeddingRuntime hard-fails when embedding_metadata is absent."""
+    from mlc_llm.serve.embedding_engine import TVMNativeEmbeddingRuntime
+
+    _patch_tvm_deps(monkeypatch, {"model_task": "chat", "params": []})
+
+    with pytest.raises(ValueError, match="Embedding metadata is missing or incomplete"):
+        TVMNativeEmbeddingRuntime("fake_model", "fake_lib.so", device="cpu")
+
+
+@_skip_no_tvm
+def test_unit_runtime_rejects_incomplete_metadata(monkeypatch):
+    """TVMNativeEmbeddingRuntime hard-fails when embedding_metadata lacks required fields."""
+    from mlc_llm.serve.embedding_engine import TVMNativeEmbeddingRuntime
+
+    raw_meta = {
+        "model_task": "embedding",
+        "embedding_metadata": {"model_type": "decoder"},  # missing pooling_strategy, normalize
+        "params": [],
+    }
+    _patch_tvm_deps(monkeypatch, raw_meta)
+
+    with pytest.raises(ValueError, match="Embedding metadata is missing or incomplete"):
+        TVMNativeEmbeddingRuntime("fake_model", "fake_lib.so", device="cpu")
 
 
 # ===================================================================

--- a/tests/python/serve/test_embedding_engine.py
+++ b/tests/python/serve/test_embedding_engine.py
@@ -80,13 +80,9 @@ def cosine_similarity(a, b):
 # ===================================================================
 
 
-def test_engine_model_type(embedding_engine):
-    """Engine reports a valid model type."""
+def test_engine_metadata(embedding_engine):
+    """Engine reports valid model type and matching pooling strategy."""
     assert embedding_engine.model_type in ("encoder", "decoder")
-
-
-def test_engine_pooling_strategy(embedding_engine):
-    """Engine selects appropriate default pooling strategy."""
     if embedding_engine.model_type == "encoder":
         assert embedding_engine.pooling_strategy == "cls"
     else:
@@ -98,17 +94,12 @@ def test_engine_pooling_strategy(embedding_engine):
 # ===================================================================
 
 
-def test_single_text_shape(embedding_engine):
-    """Single text returns exactly one embedding vector."""
+def test_single_text_smoke(embedding_engine):
+    """Single text returns one unit-norm embedding vector."""
     embeddings, tokens = embedding_engine.embed(["Hello world"])
     assert len(embeddings) == 1
     assert len(embeddings[0]) > 0
     assert tokens > 0
-
-
-def test_single_text_unit_norm(embedding_engine):
-    """Embedding output is L2-normalized."""
-    embeddings, _ = embedding_engine.embed(["Hello world"])
     norm = float(np.linalg.norm(embeddings[0]))
     assert abs(norm - 1.0) < 1e-4, f"Expected unit norm, got {norm}"
 
@@ -117,33 +108,42 @@ def test_single_text_unit_norm(embedding_engine):
 # Batch embedding
 # ===================================================================
 
-BATCH_TEXTS = [
-    "Machine learning is fascinating",
-    "I love pizza",
-    "Deep learning uses neural networks",
-]
 
+def test_batch_mixed_lengths(embedding_engine):
+    """Mixed-length batch returns correct count, consistent dim, unit norms, tokens>0."""
+    texts = [
+        "a",
+        "a b c d e f g h i j",
+        "a " * 100,
+        "Machine learning is fascinating",
+        "I love pizza",
+        "Deep learning uses neural networks",
+    ] + [f"item {i}" for i in range(10)]
+    embeddings, tokens = embedding_engine.embed(texts)
 
-def test_batch_count(embedding_engine):
-    """Batch embedding returns one vector per input."""
-    embeddings, tokens = embedding_engine.embed(BATCH_TEXTS)
-    assert len(embeddings) == len(BATCH_TEXTS)
+    # count
+    assert len(embeddings) == len(texts)
     assert tokens > 0
 
-
-def test_batch_all_normalized(embedding_engine):
-    """Every vector in a batch is L2-normalized."""
-    embeddings, _ = embedding_engine.embed(BATCH_TEXTS)
-    for i, emb in enumerate(embeddings):
-        norm = float(np.linalg.norm(emb))
-        assert abs(norm - 1.0) < 1e-4, f"Embedding [{i}] norm={norm}"
-
-
-def test_batch_consistent_dimension(embedding_engine):
-    """All embeddings in a batch have the same dimension."""
-    embeddings, _ = embedding_engine.embed(BATCH_TEXTS)
+    # consistent dimension
     dims = {len(emb) for emb in embeddings}
     assert len(dims) == 1, f"Inconsistent dimensions: {dims}"
+
+    # all unit-norm
+    for i, emb in enumerate(embeddings):
+        norm = float(np.linalg.norm(emb))
+        assert abs(norm - 1.0) < 1e-3, f"Embedding [{i}] norm={norm}"
+
+
+def test_item_order_preserved_in_batch(embedding_engine):
+    """Output order matches input order, not sorted by length."""
+    texts = ["short", "a much longer sentence for testing", "mid"]
+    emb1, _ = embedding_engine.embed(texts)
+    # Verify by re-embedding individually and matching
+    for i, t in enumerate(texts):
+        single_emb, _ = embedding_engine.embed([t])
+        cos = cosine_similarity(emb1[i], single_emb[0])
+        assert cos > 0.999, f"Item {i} order mismatch: cosine={cos}"
 
 
 # ===================================================================
@@ -166,20 +166,6 @@ def test_cosine_similarity_ranking(embedding_engine):
     assert (
         sim_related > sim_unrelated
     ), f"Related sim ({sim_related:.4f}) should > unrelated sim ({sim_unrelated:.4f})"
-
-
-# ===================================================================
-# Determinism
-# ===================================================================
-
-
-def test_deterministic_output(embedding_engine):
-    """Same input produces identical output across calls."""
-    text = ["Deterministic test"]
-    emb1, _ = embedding_engine.embed(text)
-    emb2, _ = embedding_engine.embed(text)
-    cos = cosine_similarity(emb1[0], emb2[0])
-    assert cos > 0.9999, f"Expected deterministic output, cosine={cos}"
 
 
 # ===================================================================
@@ -211,14 +197,18 @@ def test_async_embed(embedding_engine):
 def test_empty_string(embedding_engine):
     """Empty string should still produce a valid embedding for supported models."""
     embeddings, tokens = embedding_engine.embed([""])
-    if embedding_engine.model_type == "encoder":
-        assert len(embeddings) == 1
-        assert len(embeddings[0]) > 0
-        assert tokens > 0
-    else:
-        assert len(embeddings) == 1
-        assert len(embeddings[0]) > 0
-        assert tokens > 0
+    assert len(embeddings) == 1
+    assert len(embeddings[0]) > 0
+    assert tokens > 0
+
+
+def test_unicode_text(embedding_engine):
+    """Unicode input is handled correctly."""
+    texts = ["Привет мир", "你好世界", "こんにちは世界"]
+    embeddings, _ = embedding_engine.embed(texts)
+    assert len(embeddings) == 3
+    for emb in embeddings:
+        assert abs(float(np.linalg.norm(emb)) - 1.0) < 1e-4
 
 
 # ===================================================================
@@ -324,13 +314,23 @@ def test_long_vs_short_semantic_quality(embedding_engine):
     ), f"Same topic ({sim_same_topic:.4f}) should > different ({sim_different:.4f})"
 
 
-def test_unicode_text(embedding_engine):
-    """Unicode input is handled correctly."""
-    texts = ["Привет мир", "你好世界", "こんにちは世界"]
-    embeddings, _ = embedding_engine.embed(texts)
-    assert len(embeddings) == 3
-    for emb in embeddings:
-        assert abs(float(np.linalg.norm(emb)) - 1.0) < 1e-4
+# ===================================================================
+# Repeated-call determinism (real model required)
+# ===================================================================
+
+
+def test_repeated_calls_no_workspace_pollution(embedding_engine):
+    """Repeated calls with same input produce identical results.
+
+    This catches workspace buffer reuse bugs where a previous call's
+    hidden states leak into the next call's output.
+    """
+    text = ["workspace pollution test"]
+    results = [embedding_engine.embed(text) for _ in range(5)]
+    for i in range(1, 5):
+        cos = cosine_similarity(results[0][0][0], results[i][0][0])
+        assert cos > 0.9999, f"Call {i} diverged from call 0: cosine={cos}"
+        assert results[0][1] == results[i][1], "Token counts should be identical"
 
 
 # ===================================================================
@@ -508,60 +508,344 @@ def test_unit_terminate_shuts_down_executor():
 
 
 @_skip_no_tvm
-def test_unit_get_embedding_metadata_present():
-    """get_embedding_metadata returns metadata when model_task == 'embedding'."""
-    config = {
-        "model_task": "embedding",
-        "embedding_metadata": {
-            "model_type": "decoder",
-            "pooling_strategy": "last",
-            "normalize": True,
-        },
-    }
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        pytest.param(
+            {
+                "model_task": "embedding",
+                "embedding_metadata": {
+                    "model_type": "decoder",
+                    "pooling_strategy": "last",
+                    "normalize": True,
+                },
+            },
+            {"model_type": "decoder", "pooling_strategy": "last", "normalize": True},
+            id="embedding_task_returns_metadata",
+        ),
+        pytest.param(
+            {"model_task": "chat"},
+            None,
+            id="chat_task_returns_none",
+        ),
+        pytest.param(
+            {},
+            None,
+            id="missing_task_returns_none",
+        ),
+    ],
+)
+def test_unit_get_embedding_metadata(config, expected):
+    """get_embedding_metadata returns metadata only for embedding models."""
     result = engine_utils.get_embedding_metadata(config)
-    assert result is not None
-    assert result["model_type"] == "decoder"
-    assert result["pooling_strategy"] == "last"
-    assert result["normalize"] is True
+    assert result == expected
 
 
 @_skip_no_tvm
-def test_unit_get_embedding_metadata_chat_task():
-    """get_embedding_metadata returns None for chat models."""
-    assert engine_utils.get_embedding_metadata({"model_task": "chat"}) is None
-
-
-@_skip_no_tvm
-def test_unit_get_embedding_metadata_missing_task():
-    """get_embedding_metadata returns None when model_task is absent."""
-    assert engine_utils.get_embedding_metadata({}) is None
-
-
-@_skip_no_tvm
-def test_unit_runtime_rejects_missing_metadata(monkeypatch):
-    """TVMNativeEmbeddingRuntime hard-fails when embedding_metadata is absent."""
+@pytest.mark.parametrize(
+    "raw_meta, match_msg",
+    [
+        pytest.param(
+            {"model_task": "chat", "params": []},
+            "Embedding metadata is missing or incomplete",
+            id="missing_metadata",
+        ),
+        pytest.param(
+            {
+                "model_task": "embedding",
+                "embedding_metadata": {"model_type": "decoder"},  # missing pooling_strategy, normalize
+                "params": [],
+            },
+            "Embedding metadata is missing or incomplete",
+            id="incomplete_metadata",
+        ),
+    ],
+)
+def test_unit_runtime_rejects_bad_metadata(monkeypatch, raw_meta, match_msg):
+    """TVMNativeEmbeddingRuntime hard-fails on missing or incomplete embedding_metadata."""
     from mlc_llm.serve.embedding_engine import TVMNativeEmbeddingRuntime
 
-    _patch_tvm_deps(monkeypatch, {"model_task": "chat", "params": []})
-
-    with pytest.raises(ValueError, match="Embedding metadata is missing or incomplete"):
-        TVMNativeEmbeddingRuntime("fake_model", "fake_lib.so", device="cpu")
-
-
-@_skip_no_tvm
-def test_unit_runtime_rejects_incomplete_metadata(monkeypatch):
-    """TVMNativeEmbeddingRuntime hard-fails when embedding_metadata lacks required fields."""
-    from mlc_llm.serve.embedding_engine import TVMNativeEmbeddingRuntime
-
-    raw_meta = {
-        "model_task": "embedding",
-        "embedding_metadata": {"model_type": "decoder"},  # missing pooling_strategy, normalize
-        "params": [],
-    }
     _patch_tvm_deps(monkeypatch, raw_meta)
 
-    with pytest.raises(ValueError, match="Embedding metadata is missing or incomplete"):
+    with pytest.raises(ValueError, match=match_msg):
         TVMNativeEmbeddingRuntime("fake_model", "fake_lib.so", device="cpu")
+
+
+# ===================================================================
+# Phase 3 — Canonicalization parity tests (unit, no model needed)
+# ===================================================================
+
+try:
+    from mlc_llm.serve.embedding_engine import (
+        _canonicalize_encoder_inputs,
+        _get_encoder_special_token_ids,
+    )
+
+    _HAS_CANON_DEPS = True
+except ImportError:
+    _HAS_CANON_DEPS = False
+
+_skip_no_canon = pytest.mark.skipif(not _HAS_CANON_DEPS, reason="tvm not installed")
+
+
+class _MockTokenizer:
+    """Deterministic mock tokenizer: each char -> its ordinal."""
+
+    def encode(self, text):
+        return [ord(c) for c in text]
+
+
+@_skip_no_canon
+class TestCanonicalizationParity:
+    """Verify _canonicalize_encoder_inputs matches Phase 2 behavior exactly."""
+
+    def test_cls_sep_injection(self):
+        """CLS prepended, SEP appended when not already present."""
+        tok = _MockTokenizer()
+        result = _canonicalize_encoder_inputs(["abc"], tok, cls_token_id=101, sep_token_id=102, prefill_chunk_size=512)
+        assert result[0][0] == 101
+        assert result[0][-1] == 102
+        assert result[0][1:-1] == [97, 98, 99]
+
+    def test_no_duplicate_cls_sep(self):
+        """No double-injection when first/last tokens already match CLS/SEP."""
+        tok = _MockTokenizer()
+        # 'a'=97 is CLS, 'c'=99 is SEP
+        result = _canonicalize_encoder_inputs(["abc"], tok, cls_token_id=97, sep_token_id=99, prefill_chunk_size=512)
+        assert result[0] == [97, 98, 99]
+
+    @pytest.mark.parametrize(
+        "cls_id, sep_id, expected_len, check_first, check_last",
+        [
+            pytest.param(101, 102, 5, 101, 102, id="truncation_with_sep_forced"),
+            pytest.param(None, None, 5, ord("a"), ord("a"), id="truncation_without_sep"),
+        ],
+    )
+    def test_truncation(self, cls_id, sep_id, expected_len, check_first, check_last):
+        """Truncation respects CLS/SEP placement."""
+        tok = _MockTokenizer()
+        result = _canonicalize_encoder_inputs(
+            ["a" * 10], tok, cls_token_id=cls_id, sep_token_id=sep_id, prefill_chunk_size=5
+        )
+        assert len(result[0]) == expected_len
+        assert result[0][0] == check_first
+        assert result[0][-1] == check_last
+
+    def test_no_special_tokens(self):
+        """No CLS/SEP when both are None."""
+        tok = _MockTokenizer()
+        result = _canonicalize_encoder_inputs(["xy"], tok, cls_token_id=None, sep_token_id=None, prefill_chunk_size=512)
+        assert result[0] == [120, 121]
+
+    def test_empty_string(self):
+        """Empty string gets CLS+SEP if configured."""
+        tok = _MockTokenizer()
+        result = _canonicalize_encoder_inputs([""], tok, cls_token_id=101, sep_token_id=102, prefill_chunk_size=512)
+        assert result[0] == [101, 102]
+
+    def test_item_order_preserved(self):
+        """Multiple inputs preserve order."""
+        tok = _MockTokenizer()
+        result = _canonicalize_encoder_inputs(
+            ["a", "b", "c"], tok, cls_token_id=None, sep_token_id=None, prefill_chunk_size=512
+        )
+        assert len(result) == 3
+        assert result[0] == [97]
+        assert result[1] == [98]
+        assert result[2] == [99]
+
+    def test_total_tokens_consistent_with_phase2(self):
+        """Sum of canonicalized lengths matches Phase 2 total_tokens semantics."""
+        tok = _MockTokenizer()
+        inputs = ["hello", "world"]
+        result = _canonicalize_encoder_inputs(
+            inputs, tok, cls_token_id=101, sep_token_id=102, prefill_chunk_size=512
+        )
+        total = sum(len(t) for t in result)
+        # "hello" = 5 chars + CLS + SEP = 7, "world" = 5 chars + CLS + SEP = 7
+        assert total == 14
+
+
+# ===================================================================
+# Phase 3 — Backend selector tests (unit, no model needed)
+# ===================================================================
+
+
+@_skip_no_tvm
+class TestBackendSelector:
+    """Verify AsyncEmbeddingEngine / AsyncMLCEmbeddingEngine backend selection."""
+
+    def test_tvm_native_forced(self, monkeypatch, tmp_path):
+        """MLC_SERVE_EMBEDDING_BACKEND=tvm_native calls _select_backend → TVMNativeEmbeddingRuntime."""
+        monkeypatch.setenv("MLC_SERVE_EMBEDDING_BACKEND", "tvm_native")
+
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        import json as _json
+
+        (config_dir / "mlc-chat-config.json").write_text(
+            _json.dumps({"embedding_metadata": {"model_type": "encoder"}})
+        )
+
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        raw_meta = {
+            "model_task": "embedding",
+            "embedding_metadata": {
+                "model_type": "encoder",
+                "pooling_strategy": "cls",
+                "normalize": True,
+            },
+            "params": [],
+        }
+        _patch_tvm_deps(monkeypatch, raw_meta)
+
+        rt = _eng_mod.AsyncMLCEmbeddingEngine._select_backend(
+            str(config_dir), "fake.so", "cpu", None
+        )
+        assert isinstance(rt, _eng_mod.TVMNativeEmbeddingRuntime)
+
+    def test_cpp_forced_rejects_decoder(self, monkeypatch, tmp_path):
+        """MLC_SERVE_EMBEDDING_BACKEND=cpp rejects decoder models."""
+        monkeypatch.setenv("MLC_SERVE_EMBEDDING_BACKEND", "cpp")
+        # Write a minimal mlc-chat-config.json with decoder model type
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        import json as _json
+
+        (config_dir / "mlc-chat-config.json").write_text(
+            _json.dumps({"embedding_metadata": {"model_type": "decoder"}})
+        )
+        from mlc_llm.serve.embedding_engine import AsyncMLCEmbeddingEngine
+
+        with pytest.raises(ValueError, match="requires encoder model"):
+            AsyncMLCEmbeddingEngine._select_backend(
+                str(config_dir), "fake.so", "cpu", None
+            )
+
+    def test_auto_decoder_skips_cpp(self, monkeypatch, tmp_path):
+        """auto mode for decoder models goes straight to TVMNativeEmbeddingRuntime."""
+        monkeypatch.setenv("MLC_SERVE_EMBEDDING_BACKEND", "auto")
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        import json as _json
+
+        (config_dir / "mlc-chat-config.json").write_text(
+            _json.dumps({"embedding_metadata": {"model_type": "decoder"}})
+        )
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        raw_meta = {
+            "model_task": "embedding",
+            "embedding_metadata": {"model_type": "decoder", "pooling_strategy": "last", "normalize": True},
+            "params": [],
+        }
+        _patch_tvm_deps(monkeypatch, raw_meta)
+
+        # Should not raise — decoder goes to TVMNativeEmbeddingRuntime directly
+        rt = _eng_mod.AsyncMLCEmbeddingEngine._select_backend(
+            str(config_dir), "fake.so", "cpu", None
+        )
+        assert isinstance(rt, _eng_mod.TVMNativeEmbeddingRuntime)
+
+
+# ===================================================================
+# Phase 3 — Negative tests (unit, no model needed)
+# ===================================================================
+
+
+@_skip_no_tvm
+class TestNegativeCases:
+    """Embedding lane should reject chat-only features."""
+
+    def test_thread_encoder_runtime_rejects_decoder(self, monkeypatch, tmp_path):
+        """ThreadEncoderRuntime rejects decoder model type."""
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        import json as _json
+
+        (config_dir / "mlc-chat-config.json").write_text(
+            _json.dumps({
+                "model_task": "embedding",
+                "embedding_metadata": {"model_type": "decoder", "pooling_strategy": "last", "normalize": True},
+            })
+        )
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        monkeypatch.setattr(_eng_mod, "Tokenizer", lambda path: mock.MagicMock())
+        from mlc_llm.serve.embedding_engine import ThreadEncoderRuntime
+
+        with pytest.raises(ValueError, match="only supports encoder models"):
+            ThreadEncoderRuntime(str(config_dir), "fake.so", "cpu")
+
+    def test_thread_encoder_runtime_rejects_missing_metadata(self, monkeypatch, tmp_path):
+        """ThreadEncoderRuntime rejects model without embedding_metadata."""
+        config_dir = tmp_path / "model"
+        config_dir.mkdir()
+        import json as _json
+
+        (config_dir / "mlc-chat-config.json").write_text(_json.dumps({"model_task": "chat"}))
+        import mlc_llm.serve.embedding_engine as _eng_mod
+
+        monkeypatch.setattr(_eng_mod, "Tokenizer", lambda path: mock.MagicMock())
+        from mlc_llm.serve.embedding_engine import ThreadEncoderRuntime
+
+        with pytest.raises(ValueError, match="embedding_metadata"):
+            ThreadEncoderRuntime(str(config_dir), "fake.so", "cpu")
+
+
+# ===================================================================
+# Phase 3 — Parity: C++ vs Phase 2 runtime (real model required)
+# ===================================================================
+
+
+def test_parity_cpp_vs_tvm_native(embedding_engine):
+    """If using C++ backend, compare with TVMNativeEmbeddingRuntime output.
+
+    This test only runs when the engine is backed by ThreadEncoderRuntime
+    AND the model is available. It constructs a TVMNativeEmbeddingRuntime
+    as golden reference and compares outputs.
+    """
+    try:
+        from mlc_llm.serve.embedding_engine import ThreadEncoderRuntime
+    except ImportError:
+        pytest.skip("ThreadEncoderRuntime not available")
+
+    # Only run this parity test if the engine is using the C++ backend
+    if not isinstance(embedding_engine._runtime, ThreadEncoderRuntime):
+        pytest.skip("Engine is not using C++ ThreadEncoderRuntime backend")
+
+    from mlc_llm.serve.embedding_engine import TVMNativeEmbeddingRuntime
+
+    # Construct the Phase 2 runtime for parity comparison
+    tvm_rt = TVMNativeEmbeddingRuntime(
+        model=EMBEDDING_MODEL_DIR,
+        model_lib=EMBEDDING_MODEL_LIB,
+        device="auto",
+    )
+
+    texts = [
+        "Hello world",
+        "Machine learning is great",
+        "",  # empty string edge case
+    ]
+
+    cpp_emb, cpp_tokens = embedding_engine.embed(texts)
+    tvm_emb, tvm_tokens = tvm_rt.embed(texts)
+
+    # Item count must match
+    assert len(cpp_emb) == len(tvm_emb) == len(texts)
+    # Dimension must match
+    assert len(cpp_emb[0]) == len(tvm_emb[0])
+    # Token counts should be consistent
+    assert cpp_tokens == tvm_tokens, f"Token count mismatch: C++={cpp_tokens}, TVM={tvm_tokens}"
+
+    # Embeddings should be very close (cosine > 0.99)
+    for i in range(len(texts)):
+        cos = cosine_similarity(cpp_emb[i], tvm_emb[i])
+        assert cos > 0.99, (
+            f"Parity mismatch for item {i} ({texts[i]!r}): cosine={cos:.6f}"
+        )
 
 
 # ===================================================================
@@ -578,21 +862,18 @@ if __name__ == "__main__":
         device="auto",
     )
     try:
-        test_engine_model_type(engine)
-        test_engine_pooling_strategy(engine)
-        test_single_text_shape(engine)
-        test_single_text_unit_norm(engine)
-        test_batch_count(engine)
-        test_batch_all_normalized(engine)
-        test_batch_consistent_dimension(engine)
+        test_engine_metadata(engine)
+        test_single_text_smoke(engine)
+        test_batch_mixed_lengths(engine)
+        test_item_order_preserved_in_batch(engine)
         test_cosine_similarity_ranking(engine)
-        test_deterministic_output(engine)
         test_async_embed(engine)
         test_empty_string(engine)
+        test_unicode_text(engine)
         test_long_text_decoder_chunked_prefill(engine)
         test_long_text_encoder_truncation(engine)
         test_long_vs_short_semantic_quality(engine)
-        test_unicode_text(engine)
+        test_repeated_calls_no_workspace_pollution(engine)
         print("\nAll embedding engine tests passed!")
     finally:
         engine.terminate()


### PR DESCRIPTION
## Summary

Phase 4 of the embedding-serving stack tracked in #3451.

This adds first-class serving support for decoder-only embedding models such as Qwen3-Embedding:

- Adds `Qwen3EmbeddingModel.prefill_embedding(...)`.
- Adds decoder masked prefill via `mask_mode="causal_padded_left"`.
- Adds C++ `DecoderEmbeddingPrefill` and `BatchDecoderEmbeddingPrefillAction`.
- Routes decoder embedding models through `ThreadedEmbeddingRuntime`.
- Adds runtime guards for EOS truncation, empty inputs, non-`last` pooling, and `prefill_chunk_size` admission.
- Adds decoder parity and runtime canary tests.

## Dependencies

This PR is stacked and is not expected to merge until these land first:

1. apache/tvm#19430  

2. apache/tvm#19431  

3. MLC-LLM Phase 2

4. MLC-LLM Phase 3

Then this Phase 4 PR can be rebased and merged.

## Validation

- TVM masked sequence prefill tests: Metal 8/8 pass.
- Encoder parity: `bge-base-en-v1.5`, cosine >= 0.999.
- Decoder parity: `Qwen3-Embedding-0.6B`, cosine >= 0.999.
- Decoder runtime canaries added for Phase 4 regressions.

Thanks. I’ll keep the current structure for consistency with the existing `softmax_update_causal` / `softmax_update_valid_length` macros. In particular, those macros also keep the `T.sblock("update")` outside and the `row < tile_x` guard inside the Phase-2 loop body.

This PR is focused on adding the new mask semantics; if we want to optimize this pattern, I think it should be a follow-up applied consistently across all softmax update macros.

## Performance Notes

Benchmark / profiling notes are tracked in #3451.

Test setup: `Qwen3-Embedding-4B`, MLC `q0f16`, HF/Ollama/oMLX `fp16`, Metal backend on MacBook Pro M1 Pro 16GB. Server backends include HTTP overhead.

Selected decoder benchmark results:

| seq | batch | `mlc_thread` | `mlc_tvm_native` | `hf_mps_fp16` | `ollama` | `omlx` |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 4 | 2626 ms, 1.52 texts/s | 2684 ms, 1.49 texts/s | 2677 ms, 1.49 texts/s | 2168 ms, 1.85 texts/s | 2038 ms, 1.96 texts/s |
| 512 | 4 | 5953 ms, 0.67 texts/s | 6342 ms, 0.63 texts/s | 5839 ms, 0.69 texts/s | 4367 ms, 0.92 texts/s | 4102 ms, 0.98 texts/s |
| 1024 | 4 | 14608 ms, 0.27 texts/s | 15986 ms, 0.25 texts/s | 27005 ms, 0.15 texts/s | 8919 ms, 0.45 texts/s | 4112 ms, 0.97 texts/s |
| 1024 | 8 | 29176 ms, 0.27 texts/s | 32230 ms, 0.25 texts/s | 41383 ms, 0.19 texts/s | 17790 ms, 0.45 texts/s | 8169 ms, 0.98 texts/s |

Phase 4 improves the MLC runtime path over the legacy native path: at `seq=1024`, `mlc_thread` is about 8-10% faster than `mlc_tvm_native`.

The remaining long-sequence throughput gap appears related to the masked attention prefill kernel (`batch_sequence_prefill_kv_masked`), not Python/C++ embedding runtime overhead. This conclusion is currently based only on Metal / M1 Pro testing and should not be assumed to generalize to CUDA without separate benchmarking.

