### PR TITLE
Preserve Unicode text in generated mlc-chat-config.json

### DIFF
--- a/python/mlc_llm/interface/gen_config.py
+++ b/python/mlc_llm/interface/gen_config.py
@@ -287,7 +287,7 @@ def gen_config(
 
     # Step 5. Dump the configuration file to output directory
     with (output / "mlc-chat-config.json").open("w", encoding="utf-8") as out_file:
-        json.dump(mlc_chat_config.model_dump(by_alias=True), out_file, indent=2)
+        json.dump(mlc_chat_config.model_dump(by_alias=True), out_file, indent=2, ensure_ascii=False)
         logger.info("Dumping configuration file to: %s", bold(out_file.name))
 
 


### PR DESCRIPTION
Preserve non-ASCII characters when `gen_config` writes `mlc-chat-config.json`.

This keeps templates like `llm-jp` readable in generated configs by writing UTF-8 directly instead of escaping Japanese text as `\u...`. Parsed JSON values remain unchanged.

## Without this change

```json
  "conv_template": {
    "name": "llm-jp",
    "system_template": "{system_message}",
    "system_message": "\u4ee5\u4e0b\u306f\u3001\u30bf\u30b9\u30af\u3092\u8aac\u660e\u3059\u308b\u6307\u793a\u3067\u3059\u3002\u8981\u6c42\u3092\u9069\u5207\u306b\u6e80\u305f\u3059\u5fdc\u7b54\u3092\u66f8\u304d\u306a\u3055\u3044\u3002",
    "system_prefix_token_ids": [
      1
    ],
    "add_role_after_system_message": true,
    "roles": {
      "user": "\n\n### \u6307\u793a:",
      "assistant": "\n\n### \u5fdc\u7b54:"
    },
```

## With this change

```json
  "conv_template": {
    "name": "llm-jp",
    "system_template": "{system_message}",
    "system_message": "以下は、タスクを説明する指示です。要求を適切に満たす応答を書きなさい。",
    "system_prefix_token_ids": [
      1
    ],
    "add_role_after_system_message": true,
    "roles": {
      "user": "\n\n### 指示:",
      "assistant": "\n\n### 応答:"
    },
```