### PR TITLE
[CMake][Doc] Document BUILD_DUMMY_LIBTVM and source-build for compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,15 @@ set(USE_AOT_EXECUTOR OFF)
 set(USE_PROFILER OFF)
 set(USE_GTEST OFF)
 set(USE_LIBBACKTRACE OFF)
-set(BUILD_DUMMY_LIBTVM ON)
+option(BUILD_DUMMY_LIBTVM
+       "Build a stub libtvm (runtime-only, no LLVM target codegen). \
+OFF to enable model compilation via mlc_llm compile." ON)
+if(BUILD_DUMMY_LIBTVM)
+  message(STATUS "BUILD_DUMMY_LIBTVM=ON: libtvm will be a runtime-only stub. "
+                 "Sufficient for loading prebuilt rt.dylib artifacts. "
+                 "To build a libtvm capable of `mlc_llm compile`, re-configure "
+                 "with -DBUILD_DUMMY_LIBTVM=OFF -DUSE_LLVM=<llvm-config path>.")
+endif()
 if(NOT DEFINED TVM_SOURCE_DIR)
   if(DEFINED ENV{TVM_SOURCE_DIR})
     set(TVM_SOURCE_DIR "$ENV{TVM_SOURCE_DIR}")

--- a/docs/install/mlc_llm.rst
+++ b/docs/install/mlc_llm.rst
@@ -210,6 +210,36 @@ This step is useful when you want to make modification or obtain a specific vers
     # build mlc_llm libraries
     cmake .. && make -j $(nproc) && cd ..
 
+.. note::
+    The default source build sets ``BUILD_DUMMY_LIBTVM=ON``, producing a
+    runtime-only ``libtvm`` that is sufficient for loading prebuilt
+    ``rt.dylib`` model artifacts but cannot drive ``mlc_llm compile``. To
+    build a ``libtvm`` capable of model compilation, install LLVM and
+    re-configure cmake with both flags below:
+
+    .. code-block:: bash
+        :caption: Build for model compilation (LLVM-enabled libtvm)
+
+        # macOS (Homebrew)
+        brew install llvm
+        cmake .. -DBUILD_DUMMY_LIBTVM=OFF \
+                 -DUSE_LLVM="$(brew --prefix llvm)/bin/llvm-config --link-static"
+
+        # Linux (apt)
+        sudo apt install llvm-dev
+        cmake .. -DBUILD_DUMMY_LIBTVM=OFF \
+                 -DUSE_LLVM="llvm-config --link-static"
+
+    Verify LLVM is linked into the resulting ``libtvm``:
+
+    .. code-block:: bash
+
+        # macOS: > 0 means LLVM is in; expected libtvm size ~250 MB
+        nm build/tvm/libtvm.dylib | grep -ci llvm
+
+        # Linux equivalent
+        nm build/tvm/libtvm.so | grep -ci llvm
+
 **Step 3. Install via Python.** We recommend that you install ``mlc_llm`` as a Python package, giving you
 access to ``mlc_llm.compile``, ``mlc_llm.MLCEngine``, and the CLI.
 There are two ways to do so:


### PR DESCRIPTION
Source builds default to `BUILD_DUMMY_LIBTVM=ON`, which produces a runtime-only `libtvm` that loads prebuilt `rt.dylib` artifacts but silently breaks `mlc_llm compile` later — LLVM target codegen is not linked, so calls like `tvm.codegen.llvm.GetDefaultTargetTriple` fail with an opaque "global function not registered" error after the user has finished a long build. Today the default is discoverable nowhere: not in `CMakeLists.txt` comments, not in `cmake/gen_cmake_config.py` prompts, not in `docs/install/mlc_llm.rst` (which only mentions the TVM install doc indirectly).

This change makes the default and its escape hatch visible at the two earliest natural points. `CMakeLists.txt` emits a `message(STATUS ...)` immediately after the existing `set(BUILD_DUMMY_LIBTVM ON)` so anyone running `cmake ..` sees what the default produces and how to switch (`-DBUILD_DUMMY_LIBTVM=OFF -DUSE_LLVM=<llvm-config path>`); the message uses the same form as the surrounding `message(STATUS ...)` calls (lines 23, 40, 66, 124). `docs/install/mlc_llm.rst` gains a `.. note::` under "Option 2. Build from Source / Step 2" with the matching cmake invocation for macOS (Homebrew LLVM) and Linux (apt), plus an `nm build/tvm/libtvm.{dylib,so} | grep -ci llvm` check to confirm LLVM ended up in the resulting libtvm.

No behavioural change; `BUILD_DUMMY_LIBTVM=ON` stays the default — it is the right default for the dominant runtime-only use case (prebuilt wheel users). Anyone wanting compilation support flips the two flags as documented.
