### PR TITLE
[Llama] Support attention_bias and mlp_bias config flags

### DIFF
--- a/python/mlc_llm/loader/standard_loader.py
+++ b/python/mlc_llm/loader/standard_loader.py
@@ -32,6 +32,8 @@ def make_standard_hf_loader(
     gate_up_names: Sequence[str] = ("gate_proj", "up_proj"),
     gate_up_concat_axis: int = 0,
     gate_up_target_name: str = "gate_up_proj",
+    add_gate_up_bias: bool = False,
+    gate_up_bias_optional: bool = False,
     include_qkv: bool = True,
     include_gate_up: bool = True,
     add_unused: Optional[Iterable[str]] = None,  # noqa: UP045
@@ -132,6 +134,24 @@ def make_standard_hf_loader(
                                 dtype=mlc_param.dtype,
                             ),
                         )
+
+                    if add_gate_up_bias and gate_up_names:
+                        mlc_bias_name = f"{mlp}.{gate_up_target_name}.bias"
+                        if (not gate_up_bias_optional) or mlc_bias_name in named_parameters:
+                            mlc_param = named_parameters[mlc_bias_name]
+                            mapping.add_mapping(
+                                mlc_bias_name,
+                                [
+                                    name_transform_fn(f"{mlp}.{name}.bias")
+                                    for name in gate_up_names
+                                ],
+                                functools.partial(
+                                    lambda gate, up, dtype: np.concatenate(
+                                        [gate, up], axis=gate_up_concat_axis
+                                    ).astype(dtype),
+                                    dtype=mlc_param.dtype,
+                                ),
+                            )
 
                 for unused_name in unused_names:
                     mapping.add_unused(name_transform_fn(f"{attn}.{unused_name}"))

--- a/python/mlc_llm/model/llama/llama_loader.py
+++ b/python/mlc_llm/model/llama/llama_loader.py
@@ -18,6 +18,10 @@ awq_quant = make_awq_quant(LlamaForCausalLM)
 
 huggingface = make_standard_hf_loader(
     model_cls=LlamaForCausalLM,
+    add_qkv_bias=True,
+    qkv_bias_optional=True,
+    add_gate_up_bias=True,
+    gate_up_bias_optional=True,
     add_unused=["rotary_emb.inv_freq"],
 )
 

--- a/python/mlc_llm/model/llama/llama_model.py
+++ b/python/mlc_llm/model/llama/llama_model.py
@@ -37,6 +37,8 @@ class LlamaConfig(ConfigBase):
     prefill_chunk_size: int = 0
     num_key_value_heads: int = 0
     head_dim: int = 0
+    attention_bias: bool = False
+    mlp_bias: bool = False
     tensor_parallel_shards: int = 1
     pipeline_parallel_stages: int = 1
     max_batch_size: int = 1
@@ -115,9 +117,11 @@ class LlamaFFN(nn.Module):
         self.gate_up_proj = nn.Linear(
             in_features=config.hidden_size,
             out_features=2 * self.intermediate_size,
-            bias=False,
+            bias=config.mlp_bias,
         )
-        self.down_proj = nn.Linear(self.intermediate_size, config.hidden_size, bias=False)
+        self.down_proj = nn.Linear(
+            self.intermediate_size, config.hidden_size, bias=config.mlp_bias
+        )
 
     def forward(self, x: Tensor):
         concat_x1_x2 = self.gate_up_proj(x)
@@ -150,9 +154,11 @@ class LlamaAttention(nn.Module):
         self.qkv_proj = nn.Linear(
             in_features=config.hidden_size,
             out_features=(self.num_q_heads + 2 * self.num_kv_heads) * self.head_dim,
-            bias=False,
+            bias=config.attention_bias,
         )
-        self.o_proj = nn.Linear(self.num_q_heads * self.head_dim, config.hidden_size, bias=False)
+        self.o_proj = nn.Linear(
+            self.num_q_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+        )
 
     def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
         d, h_q, h_kv = self.head_dim, self.num_q_heads, self.num_kv_heads
@@ -182,6 +188,13 @@ class LlamaDecoderLayer(nn.Module):
             def _set(layer, hint):
                 layer.weight.attrs["shard_strategy"] = hint
 
+            def _set_bias(layer, hint):
+                # Column-parallel layers shard their bias along the same dim as the weight's
+                # output dim. Row-parallel layers (o_proj, down_proj) replicate the bias
+                # across shards — it is added once to the post-allreduce sum, so no
+                # shard_strategy is required for them.
+                layer.bias.attrs["shard_strategy"] = hint
+
             hd = config.head_dim
             q = self.self_attn.num_q_heads * hd
             k = self.self_attn.num_kv_heads * hd
@@ -197,6 +210,16 @@ class LlamaDecoderLayer(nn.Module):
                 tp.ShardSingleDim("_shard_mlp_up", segs=[i, i], dim=0),
             )
             _set(self.mlp.down_proj, tp.ShardSingleDim("_shard_mlp_down", dim=1))
+            if config.attention_bias:
+                _set_bias(
+                    self.self_attn.qkv_proj,
+                    tp.ShardSingleDim("_shard_qkv_bias", segs=[q, k, v], dim=0),
+                )
+            if config.mlp_bias:
+                _set_bias(
+                    self.mlp.gate_up_proj,
+                    tp.ShardSingleDim("_shard_mlp_up_bias", segs=[i, i], dim=0),
+                )
 
         self.tensor_parallel_shards = config.tensor_parallel_shards
         _set_tp()

--- a/python/mlc_llm/model/llama/llama_model.py
+++ b/python/mlc_llm/model/llama/llama_model.py
@@ -189,10 +189,11 @@ class LlamaDecoderLayer(nn.Module):
                 layer.weight.attrs["shard_strategy"] = hint
 
             def _set_bias(layer, hint):
-                # Column-parallel layers shard their bias along the same dim as the weight's
-                # output dim. Row-parallel layers (o_proj, down_proj) replicate the bias
-                # across shards — it is added once to the post-allreduce sum, so no
-                # shard_strategy is required for them.
+                # Column-parallel layers (qkv_proj, gate_up_proj) shard their bias along the
+                # same dim as the weight's output dim. Row-parallel layers (o_proj, down_proj)
+                # keep a full (unsharded) bias and instead divide it by the shard count at
+                # forward time via tp.shard_bias, so the subsequent allreduce(sum) restores
+                # the original value — they don't get a shard_strategy here.
                 layer.bias.attrs["shard_strategy"] = hint
 
             hd = config.head_dim
@@ -225,9 +226,14 @@ class LlamaDecoderLayer(nn.Module):
         _set_tp()
 
     def forward(self, hidden_states: Tensor, paged_kv_cache: PagedKVCache, layer_id: int):
-        out = self.self_attn(self.input_layernorm(hidden_states), paged_kv_cache, layer_id)
+        # o_proj and down_proj are row-parallel: their bias must be divided by the shard
+        # count so the following ccl_allreduce(sum) in _apply_residual restores it (no-op
+        # when there is no bias or on a single device).
+        with tp.shard_bias(self.self_attn.o_proj, self.tensor_parallel_shards):
+            out = self.self_attn(self.input_layernorm(hidden_states), paged_kv_cache, layer_id)
         hidden_states = self._apply_residual(out, residual=hidden_states)
-        out = self.mlp(self.post_attention_layernorm(hidden_states))
+        with tp.shard_bias(self.mlp.down_proj, self.tensor_parallel_shards):
+            out = self.mlp(self.post_attention_layernorm(hidden_states))
         hidden_states = self._apply_residual(out, residual=hidden_states)
         return hidden_states
 

--- a/python/mlc_llm/support/tensor_parallel.py
+++ b/python/mlc_llm/support/tensor_parallel.py
@@ -102,6 +102,10 @@ def shard_bias(linear: nn.Linear, tensor_parallel_shards: int):
     """
     A context manager to shard the bias of a linear into `tensor_parallel_shards` shards.
 
+    Divides the bias by the shard count so that the subsequent ``ccl_allreduce(sum)``
+    over the row-parallel output restores it to its original value. No-op when the
+    linear has no bias or when running on a single device.
+
 
     Parameters
     ----------
@@ -112,7 +116,7 @@ def shard_bias(linear: nn.Linear, tensor_parallel_shards: int):
         The number of shards.
     """
     original_bias = linear.bias
-    if tensor_parallel_shards > 1:
+    if tensor_parallel_shards > 1 and linear.bias is not None:
         linear.bias = linear.bias / tensor_parallel_shards
     yield
     linear.bias = original_bias


### PR DESCRIPTION
## Motivation

HuggingFace Transformers added `attention_bias` and `mlp_bias` flags to `LlamaConfig` in [PR #30031](https://github.com/huggingface/transformers/pull/30031) (May 2024) to support llama-variant models that include bias terms in attention and MLP linear layers. Examples in the wild:

- **IBM Calico models** — used `mlp_bias=True` for stability and performance
- **SpeakLeash Bielik v3** ([speakleash/Bielik-4.5B-v3.0-Instruct](https://huggingface.co/speakleash/Bielik-4.5B-v3.0-Instruct), Apache 2.0) — uses both `attention_bias=True` and `mlp_bias=True` as a deliberate architectural choice for the Polish-language fine-tune
- Future llama variants will likely follow this pattern

MLC LLM's current `llama_model.py` hardcodes `bias=False` on the QKV, output, gate-up, and down projections, so converting bias-laden llama variants fails at weight load. The common workaround (using `--model-type qwen2`, which natively carries a fused QKV bias) silently drops 4 of 7 bias vectors per layer (`o_proj.bias`, `gate_proj.bias`, `up_proj.bias`, `down_proj.bias`) — for Bielik 4.5B v3 (60 layers) that is **240 of 420 HF bias vectors lost**.

This PR adds optional bias support to MLC's Llama implementation, defaulting to `False` for full backward compatibility with existing Llama 2/3/3.1/3.2 conversions.

## Changes

**`python/mlc_llm/model/llama/llama_model.py`**

- `LlamaConfig` dataclass — added `attention_bias: bool = False` and `mlp_bias: bool = False` fields
- `LlamaAttention.__init__` — `qkv_proj` and `o_proj` now use `bias=config.attention_bias`
- `LlamaFFN.__init__` — `gate_up_proj` and `down_proj` now use `bias=config.mlp_bias`
- `LlamaDecoderLayer._set_tp` — added a `_set_bias` helper that shards column-parallel biases (qkv, gate_up) along the same dim as the corresponding weight. Row-parallel biases (o_proj, down_proj) remain replicated across shards (added once after allreduce).

**`python/mlc_llm/loader/standard_loader.py`**

- `make_standard_hf_loader` — added `add_gate_up_bias: bool = False` and `gate_up_bias_optional: bool = False` parameters. The fusion logic mirrors the existing `add_qkv_bias` path: HF `gate_proj.bias` + `up_proj.bias` are concatenated along `gate_up_concat_axis` into MLC's fused `gate_up_proj.bias`.

**`python/mlc_llm/model/llama/llama_loader.py`**

- The default Llama loader now passes `add_qkv_bias=True, qkv_bias_optional=True, add_gate_up_bias=True, gate_up_bias_optional=True`. With `*_optional=True`, the loader picks up bias parameters when the model was instantiated with `bias=True` (so the bias keys are present in `named_parameters`), and skips them otherwise — backward compatibility with bias-free Llama configs is preserved.

The `o_proj.bias` and `down_proj.bias` parameters are passed through the existing 1:1 generic mapping at the end of the loader (no fusion needed, names match HF directly).

## Testing

### Backward compatibility — bit-identical regression

Converted `unsloth/Llama-3.2-1B-Instruct` (a bias-free Llama 3.2 mirror) twice with `--quantization q4f16_1`:

1. Once on `main` HEAD (baseline)
2. Once with this branch applied (patched)

Then byte-compared every `params_shard_*.bin`:

```
22 / 22 shards bit-identical
tensor-cache.json identical
```

The `attention_bias=False, mlp_bias=False` default path is provably unchanged.

### Forward path — Bielik 4.5B v3 conversion

Converted `speakleash/Bielik-4.5B-v3.0-Instruct` (60 layers, `attention_bias=True`, `mlp_bias=True`, 32K context) with `--quantization q4f16_1 --model-type llama`:

```
4,757,260,288 parameters → 100 shards, 2.5 GB on disk, 4.505 bits/param
```

Tensor-cache analysis vs the previous qwen2-workaround conversion:

| Conversion | Bias tensors |
|---|---|
| `--model-type qwen2` (workaround) | 60 fused QKV biases (= 180 HF biases) |
| `--model-type llama` (this PR) | 60 fused QKV + 60 o_proj + 60 fused gate/up + 60 down_proj = **all 420 HF biases** |

Compile to Metal succeeds; the runtime config log confirms `attention_bias=True, mlp_bias=True` propagating from `config.json` through to TVM compilation:

```
LlamaConfig(..., attention_bias=True, mlp_bias=True, ...)
```

Functional smoke test (3 prompts in Polish, including domain-specific legal Q&A) — all produced coherent, well-structured Polish output with appropriate legal terminology.

## Empirical quality note — important caveat

We ran a head-to-head A/B against the qwen2-workaround conversion and an FP16/bfloat16 reference (HF transformers, Apple Metal MPS) on:

- 5 short discrete prompts (block-type detection, NER, structured JSON, terminology) — all three close, within q4 quantization noise
- 3 long-form prompts (rękojmia explanation, NDA draft, multistep labor-law reasoning)
- 5 multistep reasoning prompts spanning Polish labor / consumer / civil / criminal / commercial law, requiring specific article citations

**Result on multistep reasoning (n=5): the qwen2-workaround conversion tracked the FP16 reference *more* faithfully than the patched fullbias conversion** — qwen2 won 2/5 prompts on FP16-faithfulness, fullbias won 0/5, 3/5 ties. This PR brings the Llama architecture to parity with HF transformers (PR #30031), but on this particular model/quantization the extra biases did not improve — and on multistep reasoning slightly hurt — output quality.

We do not yet have a clean explanation. Plausible hypotheses:

1. The current group-quantization (q4f16_1, group_size=32, 4-bit weights, fp16 activations) may handle 1D bias vectors sub-optimally — biases have a different statistical distribution than 2D weight matrices and may benefit from a separate precision path.
2. `q4f32_1` (4-bit weights, fp32 activations) recovered some quality on a single multistep prompt but did not generalize across the n=5 set, so the bottleneck is bias precision in q4 group quant rather than activation precision.
3. Bielik's training data has independent inconsistencies (the FP16 reference itself cited a wrong KPK article in one of our tests), so it is not a clean ground truth.

So this PR is offered as an **architectural correctness contribution** (Llama parity with HF transformers), not as a measured quality improvement for Bielik q4f16_1. Downstream users converting bias-laden models should benchmark output quality against alternative conversion paths for their specific model + quantization rather than assuming full bias coverage is strictly better. Use cases most likely to benefit:

- Bias-laden llama variants other than Bielik (Calico, future variants)
- Higher-precision quantizations (`q5f16`, `q8f16`, no-quant) where bias precision noise is smaller relative to signal
- Anyone writing tests against HF transformers parity

Happy to take reviewer guidance on whether this should land as-is, or whether bias precision in group quantization deserves a follow-up patch first. (No existing MLC issue/PR found for `attention_bias`/`mlp_bias` Llama support at the time of writing — if there is a tracking issue I missed, please point me to it.)

## References

- HuggingFace Transformers PR #30031 — added `attention_bias` / `mlp_bias` to `LlamaConfig`: https://github.com/huggingface/transformers/pull/30031
- Bielik v3 technical report (arXiv:2505.02550): https://arxiv.org/abs/2505.02550
- Bielik v3 model card (Apache 2.0): https://huggingface.co/speakleash/Bielik-4.5B-v3.0-Instruct
- Background work: Pelnora project (privilege-preserving legal AI for Polish lawyers, https://pelnora.app)

## Side benefit

Enables MLC LLM browser-native deployment of:

- Bielik 4.5B v3 / 11B v3 (Polish, Apache 2.0)
- Future llama variants with bias support (Calico, etc.)

---

## Diff summary

```
 python/mlc_llm/loader/standard_loader.py   | 20 ++++++++++++++++++++
 python/mlc_llm/model/llama/llama_loader.py |  4 ++++
 python/mlc_llm/model/llama/llama_model.py  | 31 ++++++++++++++++++++++++++----
 3 files changed, 51 insertions(+), 4 deletions(-)
```

All changes default to existing behavior; the only behavioral change is when `config.attention_bias` or `config.mlp_bias` are `True` (previously a weight-loading failure, now succeeds with proper bias handling).

## Acknowledgements

- **SpeakLeash** team — for the Bielik model series that motivated this investigation
- **Pelnora** project — for funding and attributing the integration work
- Implementation co-authored with Claude Opus 4.7
