### PR TITLE
[Refactor] Adapt to mainline TVM runtime/script refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
 endif()
 
 add_library(mlc_llm_module SHARED $<TARGET_OBJECTS:mlc_llm_objs>)
-target_link_libraries(mlc_llm_module PUBLIC tvm)
+target_link_libraries(mlc_llm_module PUBLIC tvm_runtime)
 target_link_libraries(mlc_llm_module PRIVATE tokenizers_cpp)
 
 set_property(

--- a/cpp/json_ffi/json_ffi_engine.cc
+++ b/cpp/json_ffi/json_ffi_engine.cc
@@ -1,15 +1,16 @@
 #include "json_ffi_engine.h"
 
 #include <tvm/ffi/extra/json.h>
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/runtime/module.h>
 
 #include <filesystem>
 #include <fstream>
 
 #include "../serve/model.h"
 #include "../support/json_parser.h"
+#include "../support/module_vtable.h"
 #include "../support/result.h"
 
 namespace mlc {
@@ -17,6 +18,8 @@ namespace llm {
 namespace json_ffi {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::Shape;
 
 JSONFFIEngine::JSONFFIEngine() { engine_ = serve::ThreadedEngine::Create(); }
 
@@ -272,7 +275,7 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ffi::ModuleObj {
         choice.index = static_cast<int>(i);
         ChatCompletionMessage delta;
         // Size of delta_output->group_delta_token_ids Array should be 1
-        const IntTuple& delta_token_ids = delta_output->group_delta_token_ids[i];
+        const Shape& delta_token_ids = delta_output->group_delta_token_ids[i];
         std::vector<int32_t> delta_token_ids_vec(delta_token_ids.begin(), delta_token_ids.end());
         std::string content = rstate.streamer[i]->Put(delta_token_ids_vec);
         if (finish_reason.has_value()) {

--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -9,6 +9,7 @@ namespace llm {
 
 using namespace tvm::runtime;
 using tvm::ffi::Function;
+using tvm::ffi::Object;
 using tvm::ffi::Optional;
 
 ModelMetadata::Param::Preproc ModelMetadata::Param::Preproc::FromJSON(

--- a/cpp/metadata/model.h
+++ b/cpp/metadata/model.h
@@ -10,7 +10,7 @@
 #include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/string.h>
 #include <tvm/runtime/data_type.h>
-#include <tvm/runtime/module.h>
+#include <tvm/runtime/logging.h>
 
 #include <unordered_map>
 

--- a/cpp/multi_gpu/builtin.cc
+++ b/cpp/multi_gpu/builtin.cc
@@ -9,7 +9,7 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/node/cast.h>
+#include <tvm/ir/cast.h>
 #include <tvm/runtime/disco/builtin.h>
 #include <tvm/runtime/disco/disco_worker.h>
 #include <tvm/runtime/tensor.h>
@@ -22,6 +22,7 @@ namespace multi_gpu {
 using namespace tvm::runtime;
 using tvm::Downcast;
 using tvm::ffi::Array;
+using tvm::ffi::ObjectRef;
 using tvm::ffi::Optional;
 using tvm::ffi::Shape;
 

--- a/cpp/multi_gpu/multi_gpu_loader.cc
+++ b/cpp/multi_gpu/multi_gpu_loader.cc
@@ -35,7 +35,9 @@ using tvm::runtime::vm::TensorCacheMetadata;
 using namespace tvm::runtime;
 using tvm::ffi::Array;
 using tvm::ffi::Function;
+using tvm::ffi::Object;
 using tvm::ffi::Optional;
+using tvm::ffi::Shape;
 using tvm::ffi::TypedFunction;
 using DurationType = std::chrono::microseconds;
 

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -97,7 +97,7 @@ Result<DisaggConfig> DisaggConfig::FromJSON(const tvm::ffi::json::Object& config
       return TResult::Error("kv_append_metadata is not array of integer.");
     }
     tvm::ffi::json::Array kv_append_metadata_arr = parse_result.cast<tvm::ffi::json::Array>();
-    std::vector<IntTuple> kv_append_metadata;
+    std::vector<Shape> kv_append_metadata;
     int ptr = 0;
     while (ptr < static_cast<int>(kv_append_metadata_arr.size())) {
       if (!kv_append_metadata_arr[ptr].try_cast<int64_t>().has_value()) {
@@ -115,7 +115,7 @@ Result<DisaggConfig> DisaggConfig::FromJSON(const tvm::ffi::json::Object& config
         }
         compressed_kv_append_metadata.push_back(kv_append_metadata_arr[ptr + i].cast<int64_t>());
       }
-      kv_append_metadata.push_back(IntTuple(std::move(compressed_kv_append_metadata)));
+      kv_append_metadata.push_back(Shape(std::move(compressed_kv_append_metadata)));
       ptr += num_segments * 2 + 1;
     }
     res.kv_append_metadata = std::move(kv_append_metadata);
@@ -146,7 +146,7 @@ tvm::ffi::json::Object DisaggConfig::AsJSON() const {
   }
   if (!kv_append_metadata.empty()) {
     tvm::ffi::json::Array kv_append_metadata_arr;
-    for (const IntTuple& compressed_kv_append_metadata : kv_append_metadata) {
+    for (const Shape& compressed_kv_append_metadata : kv_append_metadata) {
       for (int64_t value : compressed_kv_append_metadata) {
         kv_append_metadata_arr.push_back(value);
       }

--- a/cpp/serve/config.h
+++ b/cpp/serve/config.h
@@ -6,12 +6,12 @@
 #define MLC_LLM_SERVE_CONFIG_H_
 
 #include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/shape.h>
 #include <tvm/ffi/extra/json.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
 #include <tvm/runtime/device_api.h>
-#include <tvm/runtime/int_tuple.h>
-#include <tvm/runtime/object.h>
 
 #include <optional>
 
@@ -25,7 +25,11 @@ namespace serve {
 using namespace tvm;
 using namespace tvm::runtime;
 using tvm::ffi::Array;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectPtr;
+using tvm::ffi::ObjectRef;
 using tvm::ffi::Optional;
+using tvm::ffi::Shape;
 using tvm::ffi::String;
 
 /****************** GenerationConfig ******************/
@@ -72,7 +76,7 @@ enum class GrammarExecutionMode : int {
 class DisaggConfig {
  public:
   DisaggRequestKind kind = DisaggRequestKind::kNone;
-  std::vector<IntTuple> kv_append_metadata;
+  std::vector<Shape> kv_append_metadata;
   // "kv_window_begin" and "kv_window_end" denote the KV interval of interests.
   // "kv_window_end" supports Python style negative indexing.
   // The concrete meaning varies for different special request kind:

--- a/cpp/serve/data.cc
+++ b/cpp/serve/data.cc
@@ -49,9 +49,9 @@ std::pair<Array<Data>, Array<Data>> SplitData(const Array<Data>& original_data, 
     TVM_FFI_ICHECK_GT(length_to_truncate, 0);
     TVM_FFI_ICHECK_LT(length_to_truncate, last_data_length);
     TokenData lhs_token_data(
-        IntTuple{token_data->token_ids.begin(), token_data->token_ids.end() - length_to_truncate});
+        Shape{token_data->token_ids.begin(), token_data->token_ids.end() - length_to_truncate});
     TokenData rhs_token_data(
-        IntTuple{token_data->token_ids.end() - length_to_truncate, token_data->token_ids.end()});
+        Shape{token_data->token_ids.end() - length_to_truncate, token_data->token_ids.end()});
     TVM_FFI_ICHECK_EQ(total_length - last_data_length + lhs_token_data->GetLength(), split_pos);
     lhs.pop_back();
     lhs.push_back(lhs_token_data);
@@ -89,7 +89,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 /****************** TokenData ******************/
 
-TokenData::TokenData(IntTuple token_ids) {
+TokenData::TokenData(Shape token_ids) {
   ObjectPtr<TokenDataNode> n = tvm::ffi::make_object<TokenDataNode>();
   n->token_ids = std::move(token_ids);
   data_ = std::move(n);
@@ -97,7 +97,7 @@ TokenData::TokenData(IntTuple token_ids) {
 
 TokenData::TokenData(std::vector<int32_t> token_ids) {
   ObjectPtr<TokenDataNode> n = tvm::ffi::make_object<TokenDataNode>();
-  n->token_ids = IntTuple(token_ids.begin(), token_ids.end());
+  n->token_ids = Shape(token_ids.begin(), token_ids.end());
   data_ = std::move(n);
 }
 
@@ -236,7 +236,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def("mlc.serve.RequestStreamOutputUnpack", [](RequestStreamOutput output) {
     TVM_FFI_ICHECK(!output->unpacked)
         << "One RequestStreamOutput can be unpacked for at most once.";
-    std::vector<IntTuple> group_delta_token_ids;
+    std::vector<Shape> group_delta_token_ids;
     std::vector<Array<String>> group_delta_logprob_json_strs;
     group_delta_token_ids.reserve(output->group_delta_token_ids.size());
     if (output->group_delta_logprob_json_strs.has_value()) {
@@ -249,7 +249,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       }
     }
     Array<Any> ret = {output->request_id,
-                      Array<IntTuple>(std::move(group_delta_token_ids)),
+                      Array<Shape>(std::move(group_delta_token_ids)),
                       output->group_delta_logprob_json_strs.has_value()
                           ? Array<Array<String>>(std::move(group_delta_logprob_json_strs))
                           : Optional<Array<Array<String>>>(),

--- a/cpp/serve/data.h
+++ b/cpp/serve/data.h
@@ -7,12 +7,11 @@
 
 #include <tvm/ffi/container/array.h>
 #include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
-#include <tvm/node/cast.h>
-#include <tvm/runtime/int_tuple.h>
-#include <tvm/runtime/object.h>
+#include <tvm/ir/cast.h>
 #include <tvm/runtime/tensor.h>
 
 #include <atomic>
@@ -25,7 +24,11 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectPtr;
+using tvm::ffi::ObjectRef;
 using tvm::ffi::Optional;
+using tvm::ffi::Shape;
 
 class Model;
 
@@ -103,7 +106,7 @@ class TextData : public Data {
 class TokenDataNode : public DataNode {
  public:
   /*! \brief The token ids. */
-  IntTuple token_ids;
+  Shape token_ids;
 
   int GetLength() const final;
   ObjectRef GetEmbedding(Model model, ObjectRef* dst = nullptr, int offset = 0) const final;
@@ -118,7 +121,7 @@ class TokenDataNode : public DataNode {
 
 class TokenData : public Data {
  public:
-  explicit TokenData(IntTuple token_ids);
+  explicit TokenData(Shape token_ids);
 
   explicit TokenData(std::vector<int32_t> token_ids);
 

--- a/cpp/serve/draft_token_workspace_manager.h
+++ b/cpp/serve/draft_token_workspace_manager.h
@@ -20,6 +20,8 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 struct ModelWorkspace;
 

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -6,13 +6,12 @@
 #include "engine.h"
 
 #include <dlpack/dlpack.h>
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/memory/memory_manager.h>
-#include <tvm/runtime/module.h>
 #include <tvm/runtime/nvtx.h>
-#include <tvm/runtime/threading_backend.h>
 #include <xgrammar/xgrammar.h>
 
 #include <cstdlib>
@@ -23,7 +22,9 @@
 #include <unordered_set>
 
 #include "../support/json_parser.h"
+#include "../support/module_vtable.h"
 #include "../support/result.h"
+#include "../support/threading_backend.h"
 #include "../support/utils.h"
 #include "../tokenizers/tokenizers.h"
 #include "engine_actions/action.h"
@@ -42,6 +43,7 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
+using tvm::Downcast;
 using tvm::ffi::Function;
 
 class EngineModule;
@@ -573,7 +575,7 @@ class EngineImpl : public Engine {
       request->inputs = SplitData(request->inputs, input_length, kv_window_end).first;
       // - Check the invariant: "end - begin" equals the expanded metadata length.
       TVM_FFI_ICHECK_EQ(disagg_config.kv_append_metadata.size(), models_.size());
-      for (const IntTuple& compressed_kv_append_metadata : disagg_config.kv_append_metadata) {
+      for (const Shape& compressed_kv_append_metadata : disagg_config.kv_append_metadata) {
         TVM_FFI_ICHECK(!compressed_kv_append_metadata.empty());
         int num_segments = compressed_kv_append_metadata[0];
         TVM_FFI_ICHECK_EQ(compressed_kv_append_metadata.size(), num_segments * 2 + 1);

--- a/cpp/serve/engine_actions/action.h
+++ b/cpp/serve/engine_actions/action.h
@@ -20,6 +20,8 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 /*!
  * \brief The abstraction of actions that an Engine can take at each time step.

--- a/cpp/serve/engine_actions/action_commons.h
+++ b/cpp/serve/engine_actions/action_commons.h
@@ -21,6 +21,7 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
 
 /*! \brief Create the engine actions based on engine config. */
 Array<EngineAction> CreateEngineActions(Array<Model> models, EngineConfig engine_config,

--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -124,7 +124,7 @@ class BatchDecodeActionObj : public EngineActionObj {
     // - Compute embeddings.
     RECORD_EVENT(trace_recorder_, request_ids, "start embedding");
     ObjectRef embeddings =
-        models_[0]->TokenEmbed({IntTuple(input_tokens.begin(), input_tokens.end())});
+        models_[0]->TokenEmbed({Shape(input_tokens.begin(), input_tokens.end())});
     RECORD_EVENT(trace_recorder_, request_ids, "finish embedding");
 
     // - Invoke model decode.

--- a/cpp/serve/engine_actions/batch_draft.cc
+++ b/cpp/serve/engine_actions/batch_draft.cc
@@ -211,7 +211,7 @@ class BatchDraftActionObj : public EngineActionObj {
         RECORD_EVENT(trace_recorder_, request_ids, "start proposal embedding");
         TVM_FFI_ICHECK_LE(input_tokens.size(), engine_config_->prefill_chunk_size);
         ObjectRef embeddings =
-            models_[model_id]->TokenEmbed({IntTuple{input_tokens.begin(), input_tokens.end()}});
+            models_[model_id]->TokenEmbed({Shape{input_tokens.begin(), input_tokens.end()}});
         RECORD_EVENT(trace_recorder_, request_ids, "finish proposal embedding");
 
         // - Invoke model decode.
@@ -325,8 +325,7 @@ class BatchDraftActionObj : public EngineActionObj {
     lengths.reserve(num_rsentries);
 
     auto f_run_prefill = [&model, &input_tokens, &request_internal_ids, &lengths]() {
-      ObjectRef embeddings =
-          model->TokenEmbed({IntTuple{input_tokens.begin(), input_tokens.end()}});
+      ObjectRef embeddings = model->TokenEmbed({Shape{input_tokens.begin(), input_tokens.end()}});
       model->BatchPrefill(embeddings, request_internal_ids, lengths);
     };
 

--- a/cpp/serve/engine_actions/batch_jumpforward.cc
+++ b/cpp/serve/engine_actions/batch_jumpforward.cc
@@ -4,7 +4,6 @@
  */
 
 #include <tvm/runtime/nvtx.h>
-#include <tvm/runtime/threading_backend.h>
 
 #include <cmath>
 #include <exception>

--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -371,10 +371,10 @@ std::pair<Array<Data>, int> BatchPrefillBaseActionObj::ChunkPrefillInputData(
     // Return the first part for prefill, and keep the second part.
     int chunked_input_length = max_prefill_length - cum_input_length;
     TVM_FFI_ICHECK_GT(input_length, chunked_input_length);
-    TokenData chunked_input(IntTuple{token_input->token_ids.begin(),
-                                     token_input->token_ids.begin() + chunked_input_length});
-    TokenData remaining_input(IntTuple{token_input->token_ids.begin() + chunked_input_length,
-                                       token_input->token_ids.end()});
+    TokenData chunked_input(Shape{token_input->token_ids.begin(),
+                                  token_input->token_ids.begin() + chunked_input_length});
+    TokenData remaining_input(
+        Shape{token_input->token_ids.begin() + chunked_input_length, token_input->token_ids.end()});
     inputs.push_back(chunked_input);
     cum_input_length += chunked_input_length;
     std::vector<Data> remaining_inputs{mstate->inputs.begin() + i + 1, mstate->inputs.end()};

--- a/cpp/serve/engine_actions/batch_prefill_base.h
+++ b/cpp/serve/engine_actions/batch_prefill_base.h
@@ -97,10 +97,10 @@ class BatchPrefillBaseActionObj : public EngineActionObj {
       const std::vector<bool>& rsentry_activated, const std::vector<SampleResult>& sample_results);
 
   /*!
-   * \brief Get the concatenated IntTuple of RequestModelState input data, return empty IntTuple if
+   * \brief Get the concatenated Shape of RequestModelState input data, return empty Shape if
    * there is untokenized data.
    * \param mstate The RequestModelState whose input data is to be concatenated.
-   * \return The concatenate IntTuple.
+   * \return The concatenate Shape.
    */
   std::vector<int32_t> GetConcatPrefillInputData(const RequestModelState& mstate);
 

--- a/cpp/serve/engine_actions/batch_verify.cc
+++ b/cpp/serve/engine_actions/batch_verify.cc
@@ -3,8 +3,6 @@
  * \file serve/engine_actions/batch_verify.cc
  */
 
-#include <tvm/runtime/threading_backend.h>
-
 #include <cmath>
 #include <exception>
 #include <numeric>
@@ -114,7 +112,7 @@ class BatchVerifyActionObj : public EngineActionObj {
 
     RECORD_EVENT(trace_recorder_, request_ids, "start verify embedding");
     ObjectRef embeddings = models_[verify_model_id_]->TokenEmbed(
-        {IntTuple{all_tokens_to_verify.begin(), all_tokens_to_verify.end()}});
+        {Shape{all_tokens_to_verify.begin(), all_tokens_to_verify.end()}});
     RECORD_EVENT(trace_recorder_, request_ids, "finish verify embedding");
 
     RECORD_EVENT(trace_recorder_, request_ids, "start verify");
@@ -245,8 +243,8 @@ class BatchVerifyActionObj : public EngineActionObj {
             rsentries[rsentry_id]->mstates[draft_model_id_]->internal_id);
       }
       // - Compute embeddings.
-      ObjectRef embeddings = models_[draft_model_id_]->TokenEmbed(
-          {IntTuple{input_tokens.begin(), input_tokens.end()}});
+      ObjectRef embeddings =
+          models_[draft_model_id_]->TokenEmbed({Shape{input_tokens.begin(), input_tokens.end()}});
       // - Invoke model decode.
       Tensor logits =
           models_[draft_model_id_]->BatchDecode(embeddings, fully_accepted_request_internal_ids);

--- a/cpp/serve/engine_actions/disagg_prepare_recv.cc
+++ b/cpp/serve/engine_actions/disagg_prepare_recv.cc
@@ -72,7 +72,7 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
       // - Add the sequence to each model.
       int prefill_length = -1;
       Tensor logits_for_sample{nullptr};
-      std::vector<IntTuple> kv_append_metadata;
+      std::vector<Shape> kv_append_metadata;
       kv_append_metadata.reserve(models_.size());
       for (int model_id = 0; model_id < static_cast<int>(models_.size()); ++model_id) {
         const RequestStateEntry& rsentry = prefill_input.rsentry;
@@ -116,7 +116,7 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
 
         int64_t request_internal_id = mstate->internal_id;
         RECORD_EVENT(trace_recorder_, request_ids, "start prefill");
-        IntTuple compressed_kv_append_metadata = {0};
+        Shape compressed_kv_append_metadata = {0};
         if (prefill_length > 0) {
           compressed_kv_append_metadata =
               models_[model_id]->DisaggPrepareKVRecv(request_internal_id, prefill_length);
@@ -144,7 +144,7 @@ class DisaggPrepareReceiveActionObj : public BatchPrefillBaseActionObj {
         response_body.Set("prefix_matched_length", static_cast<int64_t>(prefix_matched_length));
         // We further flatten the metadata array of all models into a single array.
         tvm::ffi::json::Array kv_append_metadata_arr;
-        for (const IntTuple& compressed_kv_append_metadata : kv_append_metadata) {
+        for (const Shape& compressed_kv_append_metadata : kv_append_metadata) {
           for (int64_t value : compressed_kv_append_metadata) {
             kv_append_metadata_arr.push_back(value);
           }

--- a/cpp/serve/engine_actions/eagle_batch_draft.cc
+++ b/cpp/serve/engine_actions/eagle_batch_draft.cc
@@ -121,7 +121,7 @@ class EagleBatchDraftActionObj : public EngineActionObj {
         // - Compute embeddings.
         RECORD_EVENT(trace_recorder_, request_ids, "start proposal embedding");
         ObjectRef embeddings =
-            models_[model_id]->TokenEmbed({IntTuple{input_tokens.begin(), input_tokens.end()}});
+            models_[model_id]->TokenEmbed({Shape{input_tokens.begin(), input_tokens.end()}});
         RECORD_EVENT(trace_recorder_, request_ids, "finish proposal embedding");
 
         // - Invoke model decode.

--- a/cpp/serve/engine_actions/eagle_batch_verify.cc
+++ b/cpp/serve/engine_actions/eagle_batch_verify.cc
@@ -3,8 +3,6 @@
  * \file serve/engine_actions/eagle_batch_verify.cc
  */
 
-#include <tvm/runtime/threading_backend.h>
-
 #include <cmath>
 #include <exception>
 #include <numeric>
@@ -19,6 +17,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::Downcast;
 
 /*!
  * \brief The action that runs verification for requests in the
@@ -121,7 +121,7 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
 
     RECORD_EVENT(trace_recorder_, request_ids, "start verify embedding");
     ObjectRef embeddings = models_[verify_model_id_]->TokenEmbed(
-        {IntTuple{all_tokens_to_verify.begin(), all_tokens_to_verify.end()}});
+        {Shape{all_tokens_to_verify.begin(), all_tokens_to_verify.end()}});
     RECORD_EVENT(trace_recorder_, request_ids, "finish verify embedding");
 
     RECORD_EVENT(trace_recorder_, request_ids, "start verify");
@@ -240,8 +240,8 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
       }
 
       // - Compute embeddings.
-      ObjectRef embeddings = models_[draft_model_id_]->TokenEmbed(
-          {IntTuple{input_tokens.begin(), input_tokens.end()}});
+      ObjectRef embeddings =
+          models_[draft_model_id_]->TokenEmbed({Shape{input_tokens.begin(), input_tokens.end()}});
       // - Gather hidden states
       ObjectRef hidden_states_for_fully_accepted = models_[draft_model_id_]->GatherHiddenStates(
           hidden_states, hidden_states_positions_for_fully_accepted,
@@ -289,8 +289,8 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
       if (engine_config_->speculative_mode == SpeculativeMode::kEagle) {
         // - Compute embeddings.
         RECORD_EVENT(trace_recorder_, request_ids, "start proposal embedding");
-        embeddings = models_[draft_model_id_]->TokenEmbed(
-            {IntTuple{input_tokens.begin(), input_tokens.end()}});
+        embeddings =
+            models_[draft_model_id_]->TokenEmbed({Shape{input_tokens.begin(), input_tokens.end()}});
         RECORD_EVENT(trace_recorder_, request_ids, "finish proposal embedding");
 
         // - Invoke model decode.

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -10,6 +10,8 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
+using tvm::Downcast;
+
 /*!
  * \brief The action that prefills requests in the `waiting_queue` of
  * the engine state.
@@ -106,9 +108,8 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
             for (int j = 1; j < static_cast<int>(models_.size()); ++j) {
               TVM_FFI_ICHECK(rsentry->mstates[j]->inputs.size());
               TokenData token_data = Downcast<TokenData>(rsentry->mstates[j]->inputs[0]);
-              rsentry->mstates[j]->inputs.Set(
-                  0, TokenData(
-                         IntTuple(token_data->token_ids.begin() + 1, token_data->token_ids.end())));
+              rsentry->mstates[j]->inputs.Set(0, TokenData(Shape(token_data->token_ids.begin() + 1,
+                                                                 token_data->token_ids.end())));
             }
           }
         }
@@ -307,7 +308,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
                 int ninputs =
                     static_cast<int>(rsentries_for_sample[i]->mstates[mid]->inputs.size());
                 rsentries_for_sample[i]->mstates[mid]->inputs.Set(
-                    ninputs - 1, TokenData(IntTuple(token_ids.begin(), token_ids.end())));
+                    ninputs - 1, TokenData(Shape(token_ids.begin(), token_ids.end())));
               }
             }
           }

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -18,6 +18,8 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 typedef TypedFunction<void(Array<RequestStreamOutput>)> FRequestStreamCallback;
 

--- a/cpp/serve/event_trace_recorder.h
+++ b/cpp/serve/event_trace_recorder.h
@@ -7,9 +7,9 @@
 #define MLC_LLM_SERVE_EVENT_TRACE_RECORDER_H_
 
 #include <tvm/ffi/container/array.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/object.h>
 
 #include <string>
 
@@ -17,8 +17,9 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
-using namespace tvm::runtime;
 using tvm::ffi::Array;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 using tvm::ffi::String;
 
 /*! \brief The event trace recorder for requests. */

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -6,10 +6,10 @@
 
 #include "function_table.h"
 
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/function.h>
 #include <tvm/runtime/disco/session.h>
 #include <tvm/runtime/memory/memory_manager.h>
-#include <tvm/runtime/module.h>
 #include <tvm/runtime/tensor.h>
 
 #include <cstdlib>
@@ -25,7 +25,9 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
-Optional<IntTuple> GetDiscoWorkerCPUBinding(int num_workers) {
+using tvm::Downcast;
+
+Optional<Shape> GetDiscoWorkerCPUBinding(int num_workers) {
   const char* raw_cpu_binding = std::getenv("MLC_DISCO_WORKER_CPU_BINDING");
   if (raw_cpu_binding == nullptr) {
     return std::nullopt;
@@ -47,7 +49,7 @@ Optional<IntTuple> GetDiscoWorkerCPUBinding(int num_workers) {
                << num_workers << "CPU ids but only " << cpu_ids.size() << " are given.";
   }
 
-  return IntTuple{cpu_ids};
+  return Shape{cpu_ids};
 }
 
 Function FunctionTable::SessionFuncAsPackedFunc(Session sess, DRef sess_func, String name) {
@@ -87,8 +89,8 @@ void FunctionTable::Init(String reload_lib_path, Device device, tvm::ffi::json::
       return SessionFuncAsPackedFunc(sess, func, name);
     };
     if (num_stages == 1) {
-      if (Optional<IntTuple> cpu_ids = GetDiscoWorkerCPUBinding(/*num_workers=*/num_shards)) {
-        IntTuple cpu_ids_value = cpu_ids.value();
+      if (Optional<Shape> cpu_ids = GetDiscoWorkerCPUBinding(/*num_workers=*/num_shards)) {
+        Shape cpu_ids_value = cpu_ids.value();
         sess->CallPacked(sess->GetGlobalFunc("runtime.disco.bind_worker_to_cpu_core"),
                          cpu_ids_value);
       }
@@ -330,8 +332,8 @@ ObjectRef FunctionTable::CopyToWorker0(const Tensor& host_array, String buffer_c
     if (it != cached_buffers.end()) {
       buffer = Downcast<Tensor>((*it).second);
       if (buffer_cache_key == "image") {
-        if (runtime::GetDataSize(*buffer.operator->()) <
-            runtime::GetDataSize(*host_array.operator->())) {
+        if (tvm::ffi::GetDataSize(*buffer.operator->()) <
+            tvm::ffi::GetDataSize(*host_array.operator->())) {
           buffer = Tensor::Empty(max_reserved_shape, host_array->dtype, local_gpu_device);
           cached_buffers.Set(buffer_cache_key, buffer);
         }

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -13,7 +13,6 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/runtime/disco/session.h>
-#include <tvm/runtime/module.h>
 #include <tvm/runtime/tensor.h>
 
 #include <string>
@@ -28,7 +27,10 @@ using tvm::Device;
 using namespace tvm::runtime;
 using tvm::ffi::Function;
 using tvm::ffi::Map;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 using tvm::ffi::Optional;
+using tvm::ffi::Shape;
 using tvm::ffi::TypedFunction;
 
 //--------------------------------------------------------

--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -8,7 +8,6 @@
 #include <tvm/ffi/function.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/nvtx.h>
-#include <tvm/runtime/threading_backend.h>
 
 namespace mlc {
 namespace llm {

--- a/cpp/serve/logit_processor.h
+++ b/cpp/serve/logit_processor.h
@@ -7,8 +7,8 @@
 #ifndef MLC_LLM_SERVE_LOGIT_PROCESSOR_H_
 #define MLC_LLM_SERVE_LOGIT_PROCESSOR_H_
 
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/module.h>
 
 #include "../base.h"
 #include "config.h"
@@ -22,6 +22,8 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 /*!
  * \brief The logit processor class that updates logits with regard

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -22,6 +22,8 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
+using tvm::Downcast;
+
 /*********************** Model Implementation ***********************/
 
 TVM_FFI_STATIC_INIT_BLOCK() { ModelObj::RegisterReflection(); }
@@ -82,7 +84,7 @@ class ModelImpl : public ModelObj {
 
   /*********************** Model Computation  ***********************/
 
-  ObjectRef TokenEmbed(IntTuple token_ids, ObjectRef* dst, int offset) final {
+  ObjectRef TokenEmbed(Shape token_ids, ObjectRef* dst, int offset) final {
     NVTXScopedRange nvtx_scope("TokenEmbed");
     int num_tokens = token_ids.size();
     if (seqlen_padding_factor_ > 1) {
@@ -269,8 +271,8 @@ class ModelImpl : public ModelObj {
     TVM_FFI_ICHECK(kv_cache_.defined()) << "KV cache has not been initialized.";
 
     // Begin forward with the sequence ids and new lengths.
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple lengths_tuple(lengths.begin(), lengths.end());
+    Shape seq_ids_tuple(seq_ids);
+    Shape lengths_tuple(lengths.begin(), lengths.end());
     ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, lengths_tuple);
     if (kind == KVStateKind::kHybrid) {
       TVM_FFI_ICHECK(rnn_state_.defined()) << "RNN state has not been initialized.";
@@ -392,8 +394,8 @@ class ModelImpl : public ModelObj {
     TVM_FFI_ICHECK(kv_cache_.defined()) << "KV cache has not been initialized.";
 
     // Begin forward with the sequence ids and new lengths.
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple lengths_tuple(lengths.begin(), lengths.end());
+    Shape seq_ids_tuple(seq_ids);
+    Shape lengths_tuple(lengths.begin(), lengths.end());
     ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, lengths_tuple);
     if (kind == KVStateKind::kHybrid) {
       ft_.kv_cache_begin_forward_func_(rnn_state_, seq_ids_tuple, lengths_tuple);
@@ -460,8 +462,8 @@ class ModelImpl : public ModelObj {
 
     // Reserve in KV cache for the lengths of the input.
     // Begin forward with the sequence ids and new lengths.
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple lengths_tuple(std::vector<int64_t>(/*n=*/seq_ids.size(), /*v=*/1));
+    Shape seq_ids_tuple(seq_ids);
+    Shape lengths_tuple(std::vector<int64_t>(/*n=*/seq_ids.size(), /*v=*/1));
     ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, lengths_tuple);
     if (kind == KVStateKind::kHybrid) {
       ft_.kv_cache_begin_forward_func_(rnn_state_, seq_ids_tuple, lengths_tuple);
@@ -548,9 +550,9 @@ class ModelImpl : public ModelObj {
 
     // Reserve in KV cache for the lengths of the input.
     // Begin forward with the sequence ids and new lengths.
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple lengths_tuple(lengths.begin(), lengths.end());
-    IntTuple token_tree_parent_ptr_tuple(token_tree_parent_ptr);
+    Shape seq_ids_tuple(seq_ids);
+    Shape lengths_tuple(lengths.begin(), lengths.end());
+    Shape token_tree_parent_ptr_tuple(token_tree_parent_ptr);
     ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, lengths_tuple,
                                      token_tree_parent_ptr_tuple);
 
@@ -612,8 +614,8 @@ class ModelImpl : public ModelObj {
 
     // Reserve in KV cache for the lengths of the input.
     // Begin forward with the sequence ids and new lengths.
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple lengths_tuple(std::vector<int64_t>(/*n=*/seq_ids.size(), /*v=*/1));
+    Shape seq_ids_tuple(seq_ids);
+    Shape lengths_tuple(std::vector<int64_t>(/*n=*/seq_ids.size(), /*v=*/1));
     ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, lengths_tuple);
     if (kind == KVStateKind::kHybrid) {
       ft_.kv_cache_begin_forward_func_(rnn_state_, seq_ids_tuple, lengths_tuple);
@@ -689,9 +691,9 @@ class ModelImpl : public ModelObj {
     TVM_FFI_ICHECK(kv_cache_.defined()) << "KV cache has not been initialized.";
 
     // Begin forward with the sequence ids and new lengths.
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple lengths_tuple(lengths.begin(), lengths.end());
-    IntTuple token_tree_parent_ptr_tuple(token_tree_parent_ptr);
+    Shape seq_ids_tuple(seq_ids);
+    Shape lengths_tuple(lengths.begin(), lengths.end());
+    Shape token_tree_parent_ptr_tuple(token_tree_parent_ptr);
     ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, lengths_tuple,
                                      token_tree_parent_ptr_tuple);
     if (kind == KVStateKind::kHybrid) {
@@ -790,9 +792,9 @@ class ModelImpl : public ModelObj {
       embeddings_dref_or_nd = ft_.nd_view_func_(embeddings, embedding_shape).cast<ObjectRef>();
     }
     // Begin forward with the sequence ids and new lengths.
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple lengths_tuple(lengths.begin(), lengths.end());
-    IntTuple token_tree_parent_ptr_tuple(token_tree_parent_ptr);
+    Shape seq_ids_tuple(seq_ids);
+    Shape lengths_tuple(lengths.begin(), lengths.end());
+    Shape token_tree_parent_ptr_tuple(token_tree_parent_ptr);
     ft_.kv_cache_begin_forward_func_(kv_cache_, seq_ids_tuple, lengths_tuple,
                                      token_tree_parent_ptr_tuple);
     if (kind == KVStateKind::kHybrid) {
@@ -839,11 +841,11 @@ class ModelImpl : public ModelObj {
                      int prefix_cache_max_num_recycling_seqs = 0) final {
     KVStateKind kv_state_kind = GetMetadata().kv_state_kind;
     if (kv_state_kind == KVStateKind::kKVCache) {
-      IntTuple max_num_sequence_tuple{max_num_sequence};
-      IntTuple max_total_sequence_length_tuple{max_total_sequence_length};
-      IntTuple prefill_chunk_size_tuple{prefill_chunk_size};
-      IntTuple page_size_tuple{page_size};
-      IntTuple support_sliding_window{sliding_window_size_ != -1};
+      Shape max_num_sequence_tuple{max_num_sequence};
+      Shape max_total_sequence_length_tuple{max_total_sequence_length};
+      Shape prefill_chunk_size_tuple{prefill_chunk_size};
+      Shape page_size_tuple{page_size};
+      Shape support_sliding_window{sliding_window_size_ != -1};
       kv_cache_ = ft_.create_kv_cache_func_(max_num_sequence_tuple, max_total_sequence_length_tuple,
                                             prefill_chunk_size_tuple, page_size_tuple,
                                             support_sliding_window)
@@ -853,8 +855,8 @@ class ModelImpl : public ModelObj {
                             : kv_cache_;
     } else if (kv_state_kind == KVStateKind::kRNNState) {
       // RNN state needs extra slots for prefix cache recycling sequences.
-      IntTuple max_num_sequence_tuple{max_num_sequence + prefix_cache_max_num_recycling_seqs};
-      IntTuple max_history_size_tuple = {std::max(max_history_size, 1)};
+      Shape max_num_sequence_tuple{max_num_sequence + prefix_cache_max_num_recycling_seqs};
+      Shape max_history_size_tuple = {std::max(max_history_size, 1)};
       kv_cache_ = ft_.create_kv_cache_func_(max_num_sequence_tuple, max_history_size_tuple)
                       .cast<ObjectRef>();
       local_kv_cache_ = ft_.use_disco
@@ -862,11 +864,11 @@ class ModelImpl : public ModelObj {
                             : kv_cache_;
     } else if (kv_state_kind == KVStateKind::kHybrid) {
       // Hybrid: create both PagedKVCache (for attention layers) and RNNState (for GDN layers).
-      IntTuple max_num_sequence_tuple{max_num_sequence};
-      IntTuple max_total_sequence_length_tuple{max_total_sequence_length};
-      IntTuple prefill_chunk_size_tuple{prefill_chunk_size};
-      IntTuple page_size_tuple{page_size};
-      IntTuple support_sliding_window{sliding_window_size_ != -1};
+      Shape max_num_sequence_tuple{max_num_sequence};
+      Shape max_total_sequence_length_tuple{max_total_sequence_length};
+      Shape prefill_chunk_size_tuple{prefill_chunk_size};
+      Shape page_size_tuple{page_size};
+      Shape support_sliding_window{sliding_window_size_ != -1};
       kv_cache_ = ft_.create_kv_cache_func_(max_num_sequence_tuple, max_total_sequence_length_tuple,
                                             prefill_chunk_size_tuple, page_size_tuple,
                                             support_sliding_window)
@@ -877,8 +879,8 @@ class ModelImpl : public ModelObj {
       // Create RNN state for recurrent layers.
       // RNN state needs extra slots for prefix cache recycling sequences that
       // coexist with active sequences (e.g., during ForkSequence).
-      IntTuple rnn_max_batch{max_num_sequence + prefix_cache_max_num_recycling_seqs};
-      IntTuple rnn_max_history{std::max(max_history_size, 1)};
+      Shape rnn_max_batch{max_num_sequence + prefix_cache_max_num_recycling_seqs};
+      Shape rnn_max_history{std::max(max_history_size, 1)};
       rnn_state_ = ft_.create_rnn_state_func_(rnn_max_batch, rnn_max_history).cast<ObjectRef>();
       local_rnn_state_ = ft_.use_disco
                              ? Downcast<DRef>(rnn_state_)->DebugGetFromRemote(0).cast<ObjectRef>()
@@ -935,8 +937,8 @@ class ModelImpl : public ModelObj {
   void CommitAcceptedTokenTreeNodesToKVCache(
       const std::vector<int64_t>& seq_ids,
       const std::vector<int64_t>& accepted_leaf_indices) final {
-    IntTuple seq_ids_tuple(seq_ids);
-    IntTuple accepted_leaf_indices_tuple(accepted_leaf_indices);
+    Shape seq_ids_tuple(seq_ids);
+    Shape accepted_leaf_indices_tuple(accepted_leaf_indices);
     ft_.kv_cache_commit_accepted_token_tree_nodes_func_(kv_cache_, seq_ids_tuple,
                                                         accepted_leaf_indices_tuple);
   }
@@ -951,7 +953,7 @@ class ModelImpl : public ModelObj {
     }
   }
 
-  IntTuple DisaggPrepareKVRecv(int64_t seq_id, int length) final {
+  Shape DisaggPrepareKVRecv(int64_t seq_id, int length) final {
     NVTXScopedRange nvtx_scope("DisaggPrepareKVRecv length=" + std::to_string(length));
 
     TVM_FFI_ICHECK(ft_.kv_cache_disagg_prepare_recv_func_.defined());
@@ -960,17 +962,17 @@ class ModelImpl : public ModelObj {
     // Run KV receive preparation.
     ObjectRef ret;
     ret = ft_.kv_cache_disagg_prepare_recv_func_(kv_cache_, seq_id, length).cast<ObjectRef>();
-    IntTuple compressed_kv_append_metadata;
+    Shape compressed_kv_append_metadata;
     if (ft_.use_disco) {
-      compressed_kv_append_metadata = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<IntTuple>();
+      compressed_kv_append_metadata = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Shape>();
     } else {
-      compressed_kv_append_metadata = Downcast<IntTuple>(ret);
+      compressed_kv_append_metadata = Downcast<Shape>(ret);
     }
 
     return compressed_kv_append_metadata;
   }
 
-  void DisaggMarkKVSend(int64_t seq_id, int begin_pos, IntTuple compressed_kv_append_metadata,
+  void DisaggMarkKVSend(int64_t seq_id, int begin_pos, Shape compressed_kv_append_metadata,
                         int dst_group_offset) final {
     NVTXScopedRange nvtx_scope("DisaggMarkKVSend seq_id=" + std::to_string(seq_id) +
                                " begin_pos=" + std::to_string(begin_pos));

--- a/cpp/serve/model.h
+++ b/cpp/serve/model.h
@@ -26,6 +26,9 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
+using tvm::ffi::Shape;
 
 // Declare the sampler class for `Model::CreateSampler`.
 class Sampler;
@@ -105,8 +108,7 @@ class ModelObj : public Object {
    * \return The updated destination embedding array or the computed embeddings.
    * \note When `dst` is undefined, we require `offset` to be 0.
    */
-  virtual ObjectRef TokenEmbed(IntTuple batch_token_ids, ObjectRef* dst = nullptr,
-                               int offset = 0) = 0;
+  virtual ObjectRef TokenEmbed(Shape batch_token_ids, ObjectRef* dst = nullptr, int offset = 0) = 0;
 
   /*!
    * \brief Compute embeddings for the input image.
@@ -277,11 +279,11 @@ class ModelObj : public Object {
   virtual void EnableSlidingWindowForSeq(int64_t seq_id) = 0;
 
   /*! \brief Prepare for the disaggregation KV data receive for the specified sequence and length.*/
-  virtual IntTuple DisaggPrepareKVRecv(int64_t seq_id, int length) = 0;
+  virtual Shape DisaggPrepareKVRecv(int64_t seq_id, int length) = 0;
 
   /*! \brief Prepare for the disaggregation KV data send for the specified sequence and length.*/
-  virtual void DisaggMarkKVSend(int64_t seq_id, int begin_pos,
-                                IntTuple compressed_kv_append_metadata, int dst_group_offset) = 0;
+  virtual void DisaggMarkKVSend(int64_t seq_id, int begin_pos, Shape compressed_kv_append_metadata,
+                                int dst_group_offset) = 0;
 
   /************** Raw Info Query **************/
 

--- a/cpp/serve/prefix_cache.h
+++ b/cpp/serve/prefix_cache.h
@@ -5,8 +5,8 @@
 #ifndef MLC_LLM_SERVE_PREFIX_CACHE_H_
 #define MLC_LLM_SERVE_PREFIX_CACHE_H_
 #include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/runtime/object.h>
 
 #include <functional>
 #include <optional>
@@ -22,6 +22,8 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 /*!
  * \brief The signature of callback removing function.

--- a/cpp/serve/radix_tree.cc
+++ b/cpp/serve/radix_tree.cc
@@ -492,7 +492,7 @@ class PagedRadixTreeImpl : public PagedRadixTreeObj {
    * \return The sequence tokens.
    * \throw Error if sequence ID is not valid.
    */
-  IntTuple GetSequence(int64_t seq_id) {
+  Shape GetSequence(int64_t seq_id) {
     TVM_FFI_ICHECK(seq2page.find(seq_id) != seq2page.end());
     size_t length = GetSequenceLength(seq_id);
     std::vector<int64_t> output(length);
@@ -503,7 +503,7 @@ class PagedRadixTreeImpl : public PagedRadixTreeObj {
         output[offset + i] = (*page)[i];
       }
     }
-    return IntTuple(output);
+    return Shape(output);
   }
 
   /*!
@@ -807,14 +807,14 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef()
       .def("mlc.serve.PagedRadixTree", []() { return PagedRadixTree::Create(); })
       .def("mlc.serve.PagedRadixTreeMatchPrefix",
-           [](PagedRadixTree paged_radix_tree, IntTuple tokens) {
+           [](PagedRadixTree paged_radix_tree, Shape tokens) {
              std::vector<int32_t> token_ids{tokens.begin(), tokens.end()};
              auto [offset, seq_ids] = paged_radix_tree->MatchPrefix(token_ids);
              seq_ids.insert(seq_ids.begin(), offset);
-             return IntTuple(seq_ids);
+             return Shape(seq_ids);
            })
       .def("mlc.serve.PagedRadixTreeExtendSequence",
-           [](PagedRadixTree paged_radix_tree, int64_t seq_id, IntTuple tokens) {
+           [](PagedRadixTree paged_radix_tree, int64_t seq_id, Shape tokens) {
              std::vector<int32_t> token_ids{tokens.begin(), tokens.end()};
              paged_radix_tree->ExtendSequence(seq_id, std::move(token_ids));
            })

--- a/cpp/serve/radix_tree.h
+++ b/cpp/serve/radix_tree.h
@@ -5,9 +5,8 @@
 #ifndef MLC_LLM_SERVE_RADIX_TREE_H_
 #define MLC_LLM_SERVE_RADIX_TREE_H_
 #include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/runtime/int_tuple.h>
-#include <tvm/runtime/object.h>
 
 #include <unordered_map>
 #include <unordered_set>
@@ -16,7 +15,9 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
-using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
+using tvm::ffi::Shape;
 
 /*!
  * \brief The paged radix tree data structure.
@@ -37,7 +38,7 @@ class PagedRadixTreeObj : public Object {
    * \return The sequence tokens.
    * \throw Error if sequence ID is not valid.
    */
-  virtual IntTuple GetSequence(int64_t seq_id) = 0;
+  virtual Shape GetSequence(int64_t seq_id) = 0;
 
   /*!
    * \brief Get all sequences with longest common prefix with give prefix tokens.

--- a/cpp/serve/request.h
+++ b/cpp/serve/request.h
@@ -7,9 +7,9 @@
 #define MLC_LLM_SERVE_REQUEST_H_
 
 #include <tvm/ffi/container/array.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/object.h>
 
 #include "../tokenizers/tokenizers.h"
 #include "config.h"
@@ -20,6 +20,8 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 /****************** Request ******************/
 

--- a/cpp/serve/request_state.h
+++ b/cpp/serve/request_state.h
@@ -7,7 +7,7 @@
 #define MLC_LLM_SERVE_REQUEST_STATE_H_
 
 #include <tvm/ffi/container/array.h>
-#include <tvm/runtime/object.h>
+#include <tvm/ffi/object.h>
 #include <tvm/runtime/tensor.h>
 #include <xgrammar/xgrammar.h>
 
@@ -24,6 +24,8 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 /*!
  * \brief The state of a request with regard to some single model.

--- a/cpp/serve/sampler/cpu_sampler.cc
+++ b/cpp/serve/sampler/cpu_sampler.cc
@@ -5,12 +5,12 @@
  */
 #include <tvm/ffi/function.h>
 #include <tvm/runtime/tensor.h>
-#include <tvm/runtime/threading_backend.h>
 
 #include <algorithm>
 #include <cmath>
 
 #include "../../support/random.h"
+#include "../../support/threading_backend.h"
 #include "sampler.h"
 
 namespace mlc {

--- a/cpp/serve/sampler/sampler.h
+++ b/cpp/serve/sampler/sampler.h
@@ -7,8 +7,8 @@
 #ifndef MLC_LLM_SERVE_SAMPLER_SAMPLER_H_
 #define MLC_LLM_SERVE_SAMPLER_SAMPLER_H_
 
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/module.h>
 
 #include "../../base.h"
 #include "../../support/random.h"
@@ -23,6 +23,8 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 /*!
  * \brief The base class of runtime sampler.

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -5,9 +5,9 @@
  */
 #include "threaded_engine.h"
 
+#include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/runtime/module.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -15,6 +15,7 @@
 #include <optional>
 
 #include "../support/json_parser.h"
+#include "../support/module_vtable.h"
 #include "../support/result.h"
 #include "engine.h"
 #include "request.h"
@@ -25,6 +26,7 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
+using tvm::Downcast;
 
 /*! \brief The threaded engine instruction kind. */
 enum class InstructionKind : int {

--- a/cpp/support/json_parser.h
+++ b/cpp/support/json_parser.h
@@ -205,7 +205,7 @@ struct SymShapeTuple {
 namespace details {
 
 inline tvm::runtime::DataType DTypeFromString(const std::string& s) {
-  return tvm::runtime::DataType(tvm::runtime::StringToDLDataType(s));
+  return tvm::runtime::DataType(tvm::ffi::StringToDLDataType(s));
 }
 
 inline SymShapeTuple SymShapeTupleFromArray(const Array& shape) {

--- a/cpp/support/module_vtable.h
+++ b/cpp/support/module_vtable.h
@@ -1,0 +1,107 @@
+/*!
+ * \file support/module_vtable.h
+ * \brief Compatibility shim providing the TVM_MODULE_VTABLE_* macros that
+ *        previously lived in <tvm/runtime/module.h>. After the TVM runtime
+ *        refactor the macros were moved into TVM's private
+ *        src/runtime/vm/module_utils.h, so we vendor the surface mlc-llm uses
+ *        here to keep the existing call sites unchanged.
+ */
+#ifndef MLC_LLM_SUPPORT_MODULE_VTABLE_H_
+#define MLC_LLM_SUPPORT_MODULE_VTABLE_H_
+
+#include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/module.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/object.h>
+
+#include <utility>
+
+namespace mlc {
+namespace llm {
+namespace module_vtable_detail {
+
+template <typename T>
+struct EntryHelper {};
+
+template <typename T, typename R, typename... Args>
+struct EntryHelper<R (T::*)(Args...) const> {
+  using MemFnType = R (T::*)(Args...) const;
+  TVM_FFI_INLINE static void Call(::tvm::ffi::Any* rv, T* self, MemFnType f,
+                                  ::tvm::ffi::PackedArgs args) {
+    auto wrapped = [self, f](Args... args) -> R { return (self->*f)(std::forward<Args>(args)...); };
+    ::tvm::ffi::details::unpack_call<R>(std::make_index_sequence<sizeof...(Args)>{}, nullptr,
+                                        wrapped, args.data(), args.size(), rv);
+  }
+};
+
+template <typename T, typename R, typename... Args>
+struct EntryHelper<R (T::*)(Args...)> {
+  using MemFnType = R (T::*)(Args...);
+  TVM_FFI_INLINE static void Call(::tvm::ffi::Any* rv, T* self, MemFnType f,
+                                  ::tvm::ffi::PackedArgs args) {
+    auto wrapped = [self, f](Args... args) -> R { return (self->*f)(std::forward<Args>(args)...); };
+    ::tvm::ffi::details::unpack_call<R>(std::make_index_sequence<sizeof...(Args)>{}, nullptr,
+                                        wrapped, args.data(), args.size(), rv);
+  }
+};
+
+template <typename T, typename... Args>
+struct EntryHelper<void (T::*)(Args...) const> {
+  using MemFnType = void (T::*)(Args...) const;
+  TVM_FFI_INLINE static void Call(::tvm::ffi::Any* rv, T* self, MemFnType f,
+                                  ::tvm::ffi::PackedArgs args) {
+    auto wrapped = [self, f](Args... args) -> void { (self->*f)(std::forward<Args>(args)...); };
+    ::tvm::ffi::details::unpack_call<void>(std::make_index_sequence<sizeof...(Args)>{}, nullptr,
+                                           wrapped, args.data(), args.size(), rv);
+  }
+};
+
+template <typename T, typename... Args>
+struct EntryHelper<void (T::*)(Args...)> {
+  using MemFnType = void (T::*)(Args...);
+  TVM_FFI_INLINE static void Call(::tvm::ffi::Any* rv, T* self, MemFnType f,
+                                  ::tvm::ffi::PackedArgs args) {
+    auto wrapped = [self, f](Args... args) -> void { (self->*f)(std::forward<Args>(args)...); };
+    ::tvm::ffi::details::unpack_call<void>(std::make_index_sequence<sizeof...(Args)>{}, nullptr,
+                                           wrapped, args.data(), args.size(), rv);
+  }
+};
+
+}  // namespace module_vtable_detail
+}  // namespace llm
+}  // namespace mlc
+
+#define TVM_MODULE_VTABLE_BEGIN(TypeKey)                                                  \
+  const char* kind() const final { return TypeKey; }                                      \
+  ::tvm::ffi::Optional<::tvm::ffi::Function> GetFunction(const ::tvm::ffi::String& _name) \
+      override {                                                                          \
+    using SelfPtr = std::remove_cv_t<decltype(this)>;                                     \
+    ::tvm::ffi::ObjectPtr<::tvm::ffi::Object> _self =                                     \
+        ::tvm::ffi::GetObjectPtr<::tvm::ffi::Object>(this);
+#define TVM_MODULE_VTABLE_END() \
+  return std::nullopt;          \
+  }
+#define TVM_MODULE_VTABLE_END_WITH_DEFAULT(MemFunc) \
+  {                                                 \
+    auto f = (MemFunc);                             \
+    return (this->*f)(_name);                       \
+  }                                                 \
+  }
+#define TVM_MODULE_VTABLE_ENTRY(Name, MemFunc)                                             \
+  if (_name == Name) {                                                                     \
+    return ::tvm::ffi::Function::FromPacked(                                               \
+        [_self](::tvm::ffi::PackedArgs args, ::tvm::ffi::Any* rv) -> void {                \
+          using Helper = ::mlc::llm::module_vtable_detail::EntryHelper<decltype(MemFunc)>; \
+          SelfPtr self = static_cast<SelfPtr>(_self.get());                                \
+          Helper::Call(rv, self, MemFunc, args);                                           \
+        });                                                                                \
+  }
+#define TVM_MODULE_VTABLE_ENTRY_PACKED(Name, MemFunc)                       \
+  if (_name == Name) {                                                      \
+    return ::tvm::ffi::Function(                                            \
+        [_self](::tvm::ffi::PackedArgs args, ::tvm::ffi::Any* rv) -> void { \
+          (static_cast<SelfPtr>(_self.get())->*(MemFunc))(args, rv);        \
+        });                                                                 \
+  }
+
+#endif  // MLC_LLM_SUPPORT_MODULE_VTABLE_H_

--- a/cpp/support/threading_backend.h
+++ b/cpp/support/threading_backend.h
@@ -1,0 +1,73 @@
+/*!
+ * \file support/threading_backend.h
+ * \brief Compatibility shim providing the threading helpers that used to live
+ *        at <tvm/runtime/threading_backend.h>. The public TVM header was
+ *        removed in a runtime refactor, but the underlying symbols
+ *        (TVMBackendParallelLaunch, threading::MaxConcurrency,
+ *        threading::SetMaxConcurrency) are still exported from libtvm_runtime.
+ *        We re-declare the inline parallel-for template here so existing
+ *        mlc-llm call sites keep compiling.
+ */
+#ifndef MLC_LLM_SUPPORT_THREADING_BACKEND_H_
+#define MLC_LLM_SUPPORT_THREADING_BACKEND_H_
+
+#include <tvm/runtime/base.h>
+#include <tvm/runtime/c_backend_api.h>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace tvm {
+namespace runtime {
+namespace threading {
+
+/*! \return the maximum number of effective workers for this system. */
+int MaxConcurrency();
+/*! \brief Setting the maximum number of available cores. */
+void SetMaxConcurrency(int value);
+
+}  // namespace threading
+
+namespace detail {
+
+template <typename T>
+struct ParallelForWithThreadingBackendLambdaInvoker {
+  static int TVMParallelLambdaInvoke(int task_id, TVMParallelGroupEnv* penv, void* cdata) {
+    int num_task = penv->num_task;
+    T* lambda_ptr = static_cast<T*>(cdata);
+    (*lambda_ptr)(task_id, num_task);
+    return 0;
+  }
+};
+
+template <typename T>
+inline void parallel_launch_with_threading_backend(T flambda) {
+  void* cdata = &flambda;
+  TVMBackendParallelLaunch(ParallelForWithThreadingBackendLambdaInvoker<T>::TVMParallelLambdaInvoke,
+                           cdata, /*num_task=*/0);
+}
+
+}  // namespace detail
+
+template <typename T>
+inline void parallel_for_with_threading_backend(T flambda, int64_t begin, int64_t end) {
+  if (end - begin == 1) {
+    flambda(begin);
+    return;
+  }
+  auto flaunch = [begin, end, flambda](int task_id, int num_task) {
+    int64_t total_len = end - begin;
+    int64_t step = (total_len + num_task - 1) / num_task;
+    int64_t local_begin = std::min(begin + step * task_id, end);
+    int64_t local_end = std::min(local_begin + step, end);
+    for (int64_t i = local_begin; i < local_end; ++i) {
+      flambda(i);
+    }
+  };
+  detail::parallel_launch_with_threading_backend(flaunch);
+}
+
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // MLC_LLM_SUPPORT_THREADING_BACKEND_H_

--- a/cpp/tokenizers/streamer.cc
+++ b/cpp/tokenizers/streamer.cc
@@ -5,9 +5,9 @@
 
 #include "streamer.h"
 
+#include <tvm/ffi/container/shape.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/runtime/int_tuple.h>
 
 #include <algorithm>
 #include <string>
@@ -149,7 +149,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("mlc.tokenizers.TextStreamer",
            [](Tokenizer tokenizer) { return TextStreamer(std::move(tokenizer)); })
       .def("mlc.tokenizers.TextStreamerPut",
-           [](TextStreamer text_streamer, const IntTuple& delta_tokens) {
+           [](TextStreamer text_streamer, const Shape& delta_tokens) {
              return text_streamer->Put(
                  {delta_tokens->data, delta_tokens->data + delta_tokens->size});
            })
@@ -277,13 +277,13 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](StopStrHandler handler, int token_id) {
              std::vector<int64_t> delta_tokens;
              handler->Put(token_id, &delta_tokens);
-             return IntTuple(std::move(delta_tokens));
+             return Shape(std::move(delta_tokens));
            })
       .def("mlc.tokenizers.StopStringHandlerFinish",
            [](StopStrHandler handler) {
              std::vector<int64_t> remaining_token_ids;
              handler->Finish(&remaining_token_ids);
-             return IntTuple(std::move(remaining_token_ids));
+             return Shape(std::move(remaining_token_ids));
            })
       .def_method("mlc.tokenizers.StopStrHandlerStopTriggered", &StopStrHandlerObj::StopTriggered);
 }

--- a/cpp/tokenizers/streamer.h
+++ b/cpp/tokenizers/streamer.h
@@ -8,9 +8,9 @@
 #define MLC_LLM_STREAMER_H_
 
 #include <tvm/ffi/container/array.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/object.h>
 
 #include "tokenizers.h"
 
@@ -18,6 +18,8 @@ namespace mlc {
 namespace llm {
 
 using namespace tvm::runtime;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectRef;
 
 /****************** TextStreamer ******************/
 

--- a/cpp/tokenizers/tokenizers.cc
+++ b/cpp/tokenizers/tokenizers.cc
@@ -6,10 +6,10 @@
 #include "tokenizers.h"
 
 #include <tokenizers_cpp.h>
+#include <tvm/ffi/container/shape.h>
 #include <tvm/ffi/extra/json.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/runtime/int_tuple.h>
 #include <tvm/runtime/logging.h>
 
 #include <array>
@@ -482,20 +482,20 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("mlc.tokenizers.TokenizerEncode",
            [](const Tokenizer& tokenizer, const String& text) {
              std::vector<int32_t> token_ids = tokenizer->Encode(text);
-             return IntTuple{token_ids.begin(), token_ids.end()};
+             return Shape{token_ids.begin(), token_ids.end()};
            })
       .def("mlc.tokenizers.TokenizerEncodeBatch",
            [](const Tokenizer& tokenizer, const Array<String>& texts) {
              std::vector<std::vector<int32_t>> results = tokenizer->EncodeBatch(texts);
-             Array<IntTuple> ret;
+             Array<Shape> ret;
              ret.reserve(results.size());
              for (const auto& result : results) {
-               ret.push_back(IntTuple{result.begin(), result.end()});
+               ret.push_back(Shape{result.begin(), result.end()});
              }
              return ret;
            })
       .def("mlc.tokenizers.TokenizerDecode",
-           [](const Tokenizer& tokenizer, const IntTuple& token_ids) {
+           [](const Tokenizer& tokenizer, const Shape& token_ids) {
              return tokenizer->Decode({token_ids->data, token_ids->data + token_ids->size});
            })
       .def("mlc.tokenizers.DetectTokenizerInfo",

--- a/cpp/tokenizers/tokenizers.h
+++ b/cpp/tokenizers/tokenizers.h
@@ -9,9 +9,10 @@
 
 #include <tokenizers_cpp.h>
 #include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/object.h>
 
 #include <optional>
 #include <unordered_map>
@@ -24,6 +25,10 @@ namespace llm {
 
 using namespace tvm::runtime;
 using tvm::ffi::Array;
+using tvm::ffi::Object;
+using tvm::ffi::ObjectPtr;
+using tvm::ffi::ObjectRef;
+using tvm::ffi::Shape;
 using tvm::ffi::String;
 
 /*! \brief Useful information of the tokenizer during generation. */

--- a/python/mlc_llm/serve/embedding_engine.py
+++ b/python/mlc_llm/serve/embedding_engine.py
@@ -9,7 +9,8 @@ from typing import List, Literal, Optional, Tuple, Union  # noqa: UP035
 import numpy as np
 import tvm
 from tvm import relax
-from tvm.runtime import Device, ShapeTuple
+from tvm.runtime import Device
+from tvm_ffi import Shape
 
 from mlc_llm.serve import engine_utils
 from mlc_llm.support.auto_device import detect_device
@@ -374,11 +375,11 @@ class AsyncEmbeddingEngine:
 
         # Create KV cache for the entire batch
         kv_cache = self._create_kv_cache_func(
-            ShapeTuple([batch_size]),
-            ShapeTuple([max_seq_len]),
-            ShapeTuple([prefill_chunk]),
-            ShapeTuple([16]),
-            ShapeTuple([support_sliding]),
+            Shape([batch_size]),
+            Shape([max_seq_len]),
+            Shape([prefill_chunk]),
+            Shape([16]),
+            Shape([support_sliding]),
         )
 
         # Register all sequences
@@ -388,7 +389,7 @@ class AsyncEmbeddingEngine:
             self._kv_state_add_sequence(kv_cache, sid)
 
         # Begin forward with all sequences at once
-        self._kv_state_begin_forward(kv_cache, ShapeTuple(seq_ids), ShapeTuple(seq_lens))
+        self._kv_state_begin_forward(kv_cache, Shape(seq_ids), Shape(seq_lens))
 
         # Concatenate all tokens → embed → batch prefill
         all_tokens = []
@@ -396,7 +397,7 @@ class AsyncEmbeddingEngine:
             all_tokens.extend(tokens)
         token_ids = tvm.runtime.tensor(np.array(all_tokens, dtype=np.int32), device=self.device)
         all_embed = self._embed_func(token_ids, self._params)
-        all_embed = self._nd_reshape(all_embed, ShapeTuple([1, total_tokens, all_embed.shape[-1]]))
+        all_embed = self._nd_reshape(all_embed, Shape([1, total_tokens, all_embed.shape[-1]]))
 
         hidden_states, _ = self._batch_prefill_to_hidden_func(all_embed, kv_cache, self._params)
         # .numpy() copies to CPU, escaping TVM workspace buffer reuse across calls.
@@ -438,11 +439,11 @@ class AsyncEmbeddingEngine:
 
             # Create KV cache for this single sequence
             kv_cache = self._create_kv_cache_func(
-                ShapeTuple([1]),
-                ShapeTuple([max_seq_len]),
-                ShapeTuple([prefill_chunk]),
-                ShapeTuple([16]),
-                ShapeTuple([support_sliding]),
+                Shape([1]),
+                Shape([max_seq_len]),
+                Shape([prefill_chunk]),
+                Shape([16]),
+                Shape([support_sliding]),
             )
             self._kv_state_add_sequence(kv_cache, 0)
 
@@ -458,9 +459,9 @@ class AsyncEmbeddingEngine:
                 )
                 chunk_embed = self._embed_func(token_ids, self._params)
                 chunk_embed = self._nd_reshape(
-                    chunk_embed, ShapeTuple([1, chunk_len, chunk_embed.shape[-1]])
+                    chunk_embed, Shape([1, chunk_len, chunk_embed.shape[-1]])
                 )
-                self._kv_state_begin_forward(kv_cache, ShapeTuple([0]), ShapeTuple([chunk_len]))
+                self._kv_state_begin_forward(kv_cache, Shape([0]), Shape([chunk_len]))
                 hidden, kv_cache = self._prefill_to_hidden_func(chunk_embed, kv_cache, self._params)
                 # .numpy() copies to CPU, escaping TVM buffer aliasing.
                 hidden_np = hidden.numpy()

--- a/python/mlc_llm/serve/radix_tree.py
+++ b/python/mlc_llm/serve/radix_tree.py
@@ -3,7 +3,8 @@
 from typing import List, Tuple, Union  # noqa: UP035
 
 import tvm_ffi
-from tvm.runtime import Object, ShapeTuple
+from tvm.runtime import Object
+from tvm_ffi import Shape
 
 from . import _ffi_api
 
@@ -18,24 +19,24 @@ class PagedRadixTree(Object):
         """
         self.__init_handle_by_constructor__(_ffi_api.PagedRadixTree)
 
-    def match(self, tokens: Union[ShapeTuple, List, Tuple]) -> Tuple[int, ShapeTuple]:  # noqa: UP006
+    def match(self, tokens: Union[Shape, List, Tuple]) -> Tuple[int, Shape]:  # noqa: UP006
         """
         Get all sequences with longest common prefix with given prefix tokens.
 
         Parameters
         ----------
-        tokens : Union[ShapeTuple, List, Tuple]
+        tokens : Union[Shape, List, Tuple]
             The prefix tokens for reference.
 
         Returns
         ------
         matched_offset : int
             The matched prefix length.
-        seq_ids : ShapeTuple
+        seq_ids : Shape
             The array of matched sequence indice.
         """
         if isinstance(tokens, (list, tuple)):
-            tokens = ShapeTuple(tokens)
+            tokens = Shape(tokens)
         output = _ffi_api.PagedRadixTreeMatchPrefix(self, tokens)
         if len(output) == 1:
             return output[0], []
@@ -63,7 +64,7 @@ class PagedRadixTree(Object):
         """
         _ffi_api.PagedRadixTreeRemoveSequence(self, seq_id)
 
-    def extend(self, seq_id: int, tokens: Union[ShapeTuple, List, Tuple]) -> None:  # noqa: UP006
+    def extend(self, seq_id: int, tokens: Union[Shape, List, Tuple]) -> None:  # noqa: UP006
         """
         Extend a sequence with given tokens.
 
@@ -71,11 +72,11 @@ class PagedRadixTree(Object):
         ----------
         seq_id : int
             The sequence ID for index.
-        tokens : Union[ShapeTuple, List, Tuple]
+        tokens : Union[Shape, List, Tuple]
             The given tokens to extend.
         """
         if isinstance(tokens, (list, tuple)):
-            tokens = ShapeTuple(tokens)
+            tokens = Shape(tokens)
         _ffi_api.PagedRadixTreeExtendSequence(self, seq_id, tokens)
 
     def rollback(self, seq_id: int, num_tokens: int) -> None:
@@ -109,7 +110,7 @@ class PagedRadixTree(Object):
         """
         _ffi_api.PagedRadixTreeForkSequence(self, seq_id, parent_seq_id, forked_offset)
 
-    def get(self, seq_id: int) -> ShapeTuple:
+    def get(self, seq_id: int) -> Shape:
         """
         Get a sequence's all tokens.
 
@@ -120,7 +121,7 @@ class PagedRadixTree(Object):
 
         Returns
         ------
-        tokens : ShapeTuple
+        tokens : Shape
             The sequence tokens.
         """
         return _ffi_api.PagedRadixTreeGetSequence(self, seq_id)

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -364,7 +364,7 @@ def _register_cuda_hook(target: Target):
         logger.info("Generating code for CUDA architecture: %s", multi_arch)
 
     @register_global_func("tvm_callback_cuda_compile", override=True)
-    def tvm_callback_cuda_compile(code, target):
+    def tvm_callback_cuda_compile(code):
         """use nvcc to generate fatbin code for better optimization"""
         from tvm.contrib import nvcc
 

--- a/python/mlc_llm/testing/debug_chat.py
+++ b/python/mlc_llm/testing/debug_chat.py
@@ -10,8 +10,9 @@ import tvm
 import tvm_ffi
 from tvm import DataType, relax
 from tvm.contrib import tvmjs
-from tvm.runtime import Device, Module, Object, ShapeTuple
+from tvm.runtime import Device, Module, Object
 from tvm.runtime.vm import VirtualMachine
+from tvm_ffi import Shape
 
 from mlc_llm.conversation_template import ConvTemplateRegistry
 from mlc_llm.interface.help import HELP
@@ -351,7 +352,7 @@ class DebugChat:
         )
         concat_embeddings = self.nd_view_func(
             concat_embeddings,
-            ShapeTuple([1, concat_embeddings.shape[0], concat_embeddings.shape[1]]),
+            Shape([1, concat_embeddings.shape[0], concat_embeddings.shape[1]]),
         )
         input_len = concat_embeddings.shape[1]
 
@@ -359,7 +360,7 @@ class DebugChat:
 
     def _prefill(self, embedding: tvm.runtime.Tensor, input_len: int):
         print("======================= Starts Prefill =======================")
-        seq_len_shape = ShapeTuple([input_len])
+        seq_len_shape = Shape([input_len])
         max_num_sequence = 1
         page_size = 16
         sliding_window_size = (
@@ -383,21 +384,21 @@ class DebugChat:
         support_sliding_window = int(sliding_window_size != -1)
 
         kv_caches = self.create_kv_cache_func(
-            ShapeTuple([max_num_sequence]),
-            ShapeTuple([max_total_sequence_length]),
-            ShapeTuple([prefill_chunk_size]),
-            ShapeTuple([page_size]),
-            ShapeTuple([support_sliding_window]),
+            Shape([max_num_sequence]),
+            Shape([max_total_sequence_length]),
+            Shape([prefill_chunk_size]),
+            Shape([page_size]),
+            Shape([support_sliding_window]),
         )
         self.add_sequence_func(kv_caches, 0)
-        self.begin_forward_func(kv_caches, ShapeTuple([0]), seq_len_shape)
+        self.begin_forward_func(kv_caches, Shape([0]), seq_len_shape)
         logits, kv_caches = self.prefill_func(embedding, kv_caches, self.params)
         self.end_forward_func(kv_caches)
         return logits, kv_caches
 
     def _decode(self, token: int, kv_caches: Object):
         embedding, _ = self._embed([[token]])
-        self.begin_forward_func(kv_caches, ShapeTuple([0]), ShapeTuple([1]))
+        self.begin_forward_func(kv_caches, Shape([0]), Shape([1]))
         logits, kv_caches = self.decode_func(embedding, kv_caches, self.params)
         self.end_forward_func(kv_caches)
         return logits

--- a/python/mlc_llm/tokenizers/streamer.py
+++ b/python/mlc_llm/tokenizers/streamer.py
@@ -3,7 +3,8 @@
 from typing import List, Union  # noqa: UP035
 
 import tvm_ffi
-from tvm.runtime import Object, ShapeTuple
+from tvm.runtime import Object
+from tvm_ffi import Shape
 
 from . import _ffi_api
 from .tokenizers import Tokenizer
@@ -22,7 +23,7 @@ class TextStreamer(Object):
             tokenizer,
         )
 
-    def put(self, delta_tokens: Union[List[int], ShapeTuple]) -> str:  # noqa: UP006
+    def put(self, delta_tokens: Union[List[int], Shape]) -> str:  # noqa: UP006
         """Put new delta tokens into the streamer, and get the UTF-8-valid
         delta string. The text streamer may hold some of the input delta tokens
         which cannot decode into valid UTF-8 strings. The returned string
@@ -30,7 +31,7 @@ class TextStreamer(Object):
 
         Parameters
         ----------
-        delta_tokens : Union[List[int], ShapeTuple]
+        delta_tokens : Union[List[int], Shape]
             The new tokens to put into the streamer.
 
         Returns
@@ -39,7 +40,7 @@ class TextStreamer(Object):
             The decoded delta string after putting the input new tokens.
         """
         if isinstance(delta_tokens, list):
-            delta_tokens = ShapeTuple(delta_tokens)
+            delta_tokens = Shape(delta_tokens)
         return _ffi_api.TextStreamerPut(self, delta_tokens)
 
     def finish(self) -> str:

--- a/python/mlc_llm/tokenizers/tokenizers.py
+++ b/python/mlc_llm/tokenizers/tokenizers.py
@@ -8,7 +8,6 @@ import json
 from dataclasses import asdict, dataclass
 from typing import List, Literal  # noqa: UP035
 
-import tvm
 import tvm_ffi
 from tvm.runtime import Object
 
@@ -109,7 +108,7 @@ class Tokenizer(Object):
         text : str
             The decoded text string.
         """
-        return _ffi_api.TokenizerDecode(self, tvm.runtime.ShapeTuple(token_ids))
+        return _ffi_api.TokenizerDecode(self, tvm_ffi.Shape(token_ids))
 
     @staticmethod
     def detect_tokenizer_info(tokenizer_path: str) -> TokenizerInfo:


### PR DESCRIPTION
Mainline TVM removed several public headers and re-namespaced their contents. Update C++ includes to the new tvm/ffi and tvm/ir paths, rename IntTuple to ffi::Shape, replace tvm::runtime re-exports with explicit `using tvm::ffi::Object/...; using tvm::Downcast;`, switch linking from `tvm` to `tvm_runtime`, and vendor two small shims under cpp/support/ for the removed `parallel_for_with_threading_backend` helper and the now-private TVM_MODULE_VTABLE_* macros.

Python: ShapeTuple is gone — use tvm_ffi.Shape in the five affected modules, and drop the now-removed `target` arg from the tvm_callback_cuda_compile hook (TVM now fetches it via Target.current).