### PR TITLE
Fix follow-up to TVM runtime refactor

### DIFF
--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -18,6 +18,7 @@ namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::ffi::GetRef;
 using tvm::ffi::Object;
 using tvm::ffi::ObjectRef;
 


### PR DESCRIPTION
#3495 missed a `GetRef` reference in cpp/serve/engine_state.cc that wasn't surfaced locally (clang accepts it as a C++20 extension; GCC 11 under -std=gnu++17 rejects it). Add the missing
`using tvm::ffi::GetRef;` to engine_state.h. Also bumps the tvm submodule alongside.