### PR TITLE
fix: typo "to to" in CLI subcommand help string

### DIFF
--- a/python/mlc_llm/__main__.py
+++ b/python/mlc_llm/__main__.py
@@ -24,7 +24,7 @@ def main():
             "calibrate",
             "router",
         ],
-        help="Subcommand to to run. (choices: %(choices)s)",
+        help="Subcommand to run. (choices: %(choices)s)",
     )
     parsed = parser.parse_args(sys.argv[1:2])
     if parsed.subcommand == "compile":


### PR DESCRIPTION
Tiny one-line fix in `python/mlc_llm/__main__.py`: the `--help` text for the subcommand argument says "Subcommand to to run", which has a duplicated "to". This PR removes the duplicate. No functional change.