### PR TITLE
[Refactor] Update TVM runtime integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ target_link_libraries(mlc_llm_objs PRIVATE tvm_ffi_header)
 add_library(mlc_llm SHARED $<TARGET_OBJECTS:mlc_llm_objs>)
 add_library(mlc_llm_static STATIC $<TARGET_OBJECTS:mlc_llm_objs>)
 add_dependencies(mlc_llm_static tokenizers_cpp sentencepiece-static
-                 tokenizers_c tvm_runtime)
+                 tokenizers_c tvm_runtime tvm_runtime_extra)
 set_target_properties(mlc_llm_static PROPERTIES OUTPUT_NAME mlc_llm)
 
 target_link_libraries(mlc_llm PUBLIC tvm_runtime)
@@ -163,6 +163,7 @@ endif()
 # when this option is on, we install all static lib deps into lib
 if(MLC_LLM_INSTALL_STATIC_LIB)
   install(TARGETS mlc_llm_static tokenizers_cpp sentencepiece-static tvm_runtime
+                  tvm_runtime_extra
           LIBRARY DESTINATION lib${LIB_SUFFIX})
   # tokenizers need special handling as it builds from rust
   if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_dependencies(mlc_llm_static tokenizers_cpp sentencepiece-static
 set_target_properties(mlc_llm_static PROPERTIES OUTPUT_NAME mlc_llm)
 
 target_link_libraries(mlc_llm PUBLIC tvm_runtime)
+target_link_libraries(mlc_llm PRIVATE tvm_runtime_extra)
 target_link_libraries(mlc_llm PRIVATE tokenizers_cpp)
 
 find_library(FLASH_ATTN_LIBRARY flash_attn
@@ -141,6 +142,7 @@ endif()
 
 add_library(mlc_llm_module SHARED $<TARGET_OBJECTS:mlc_llm_objs>)
 target_link_libraries(mlc_llm_module PUBLIC tvm_runtime)
+target_link_libraries(mlc_llm_module PRIVATE tvm_runtime_extra)
 target_link_libraries(mlc_llm_module PRIVATE tokenizers_cpp)
 
 set_property(
@@ -173,6 +175,7 @@ if(MLC_LLM_INSTALL_STATIC_LIB)
 else()
   install(
     TARGETS tvm_runtime
+            tvm_runtime_extra
             mlc_llm
             mlc_llm_module
             mlc_llm_static

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -11,7 +11,7 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/memory/memory_manager.h>
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 #include <xgrammar/xgrammar.h>
 
 #include <cstdlib>
@@ -45,6 +45,7 @@ using tvm::Device;
 using namespace tvm::runtime;
 using tvm::Downcast;
 using tvm::ffi::Function;
+using tvm::support::NVTXScopedRange;
 
 class EngineModule;
 

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -5,11 +5,13 @@
 
 #include "action_commons.h"
 
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 Array<EngineAction> CreateEngineActions(Array<Model> models, EngineConfig engine_config,
                                         std::vector<tvm::ffi::json::Object> model_configs,

--- a/cpp/serve/engine_actions/auto_spec_decode.cc
+++ b/cpp/serve/engine_actions/auto_spec_decode.cc
@@ -3,7 +3,7 @@
  * \file serve/engine_actions/auto_spec_decode.cc
  */
 
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 #include <numeric>
 
@@ -13,6 +13,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that first makes a decision on whether to run speculative

--- a/cpp/serve/engine_actions/auto_spec_decode.cc
+++ b/cpp/serve/engine_actions/auto_spec_decode.cc
@@ -3,8 +3,6 @@
  * \file serve/engine_actions/auto_spec_decode.cc
  */
 
-#include <tvm/support/cuda/nvtx.h>
-
 #include <numeric>
 
 #include "../config.h"
@@ -13,8 +11,6 @@
 namespace mlc {
 namespace llm {
 namespace serve {
-
-using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that first makes a decision on whether to run speculative

--- a/cpp/serve/engine_actions/batch_decode.cc
+++ b/cpp/serve/engine_actions/batch_decode.cc
@@ -3,7 +3,7 @@
  * \file serve/engine_actions/batch_decode.cc
  */
 
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 #include <numeric>
 
@@ -17,6 +17,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that runs one-step decode for requests in the

--- a/cpp/serve/engine_actions/batch_jumpforward.cc
+++ b/cpp/serve/engine_actions/batch_jumpforward.cc
@@ -3,7 +3,7 @@
  * \file serve/engine_actions/batch_verify.cc
  */
 
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 #include <cmath>
 #include <exception>
@@ -17,6 +17,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that runs verification for requests in the

--- a/cpp/serve/engine_actions/batch_prefill_base.cc
+++ b/cpp/serve/engine_actions/batch_prefill_base.cc
@@ -5,6 +5,8 @@
 
 #include "batch_prefill_base.h"
 
+#include <tvm/support/cuda/nvtx.h>
+
 #include <numeric>
 
 #include "../../support/json_parser.h"
@@ -12,6 +14,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 bool HasPrefillSpace(int num_required_pages, bool sliding_window_enabled, int new_batch_size,
                      int num_available_pages, int current_total_seq_len, int total_input_length,

--- a/cpp/serve/engine_actions/batch_prefill_base.h
+++ b/cpp/serve/engine_actions/batch_prefill_base.h
@@ -3,7 +3,7 @@
  * \file serve/engine_actions/batch_prefill_base.h
  */
 
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 #include "../config.h"
 #include "../model.h"
@@ -13,6 +13,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The base action of that prefills requests in the `waiting_queue` of

--- a/cpp/serve/engine_actions/batch_prefill_base.h
+++ b/cpp/serve/engine_actions/batch_prefill_base.h
@@ -3,8 +3,6 @@
  * \file serve/engine_actions/batch_prefill_base.h
  */
 
-#include <tvm/support/cuda/nvtx.h>
-
 #include "../config.h"
 #include "../model.h"
 #include "action.h"
@@ -13,8 +11,6 @@
 namespace mlc {
 namespace llm {
 namespace serve {
-
-using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The base action of that prefills requests in the `waiting_queue` of

--- a/cpp/serve/engine_actions/disagg_prepare_recv.cc
+++ b/cpp/serve/engine_actions/disagg_prepare_recv.cc
@@ -3,6 +3,8 @@
  * \file serve/engine_actions/new_request_prefill.cc
  */
 
+#include <tvm/support/cuda/nvtx.h>
+
 #include <optional>
 
 #include "../../support/utils.h"
@@ -12,6 +14,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that runs prefill preparation in disaggregation system.

--- a/cpp/serve/engine_actions/disagg_remote_send.cc
+++ b/cpp/serve/engine_actions/disagg_remote_send.cc
@@ -3,12 +3,16 @@
  * \file serve/engine_actions/new_request_prefill.cc
  */
 
+#include <tvm/support/cuda/nvtx.h>
+
 #include "../sampler/sampler.h"
 #include "batch_prefill_base.h"
 
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that prefills requests in the `waiting_queue` of

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -3,6 +3,8 @@
  * \file serve/engine_actions/eagle_new_request_prefill.cc
  */
 
+#include <tvm/support/cuda/nvtx.h>
+
 #include "../sampler/sampler.h"
 #include "batch_prefill_base.h"
 
@@ -11,6 +13,7 @@ namespace llm {
 namespace serve {
 
 using tvm::Downcast;
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that prefills requests in the `waiting_queue` of

--- a/cpp/serve/engine_actions/new_request_prefill.cc
+++ b/cpp/serve/engine_actions/new_request_prefill.cc
@@ -3,12 +3,16 @@
  * \file serve/engine_actions/new_request_prefill.cc
  */
 
+#include <tvm/support/cuda/nvtx.h>
+
 #include "../sampler/sampler.h"
 #include "batch_prefill_base.h"
 
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 /*!
  * \brief The action that prefills requests in the `waiting_queue` of

--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -7,11 +7,13 @@
 
 #include <tvm/ffi/function.h>
 #include <tvm/runtime/device_api.h>
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 inline void CopyArray(Tensor src, Tensor dst, TVMStreamHandle copy_stream) {
   DLTensor dl_dst = *(dst.operator->());

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -8,7 +8,7 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/runtime/memory/memory_manager.h>
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 #include <fstream>
 #include <unordered_set>
@@ -23,6 +23,7 @@ namespace llm {
 namespace serve {
 
 using tvm::Downcast;
+using tvm::support::NVTXScopedRange;
 
 /*********************** Model Implementation ***********************/
 

--- a/cpp/serve/prefix_cache.cc
+++ b/cpp/serve/prefix_cache.cc
@@ -5,13 +5,14 @@
 #include "prefix_cache.h"
 
 #include <tvm/ffi/function.h>
-#include <tvm/runtime/nvtx.h>
+#include <tvm/support/cuda/nvtx.h>
 
 namespace mlc {
 namespace llm {
 namespace serve {
 
 using namespace tvm::runtime;
+using tvm::support::NVTXScopedRange;
 
 TVM_FFI_STATIC_INIT_BLOCK() { PrefixCacheObj::RegisterReflection(); }
 

--- a/cpp/serve/sampler/gpu_sampler.cc
+++ b/cpp/serve/sampler/gpu_sampler.cc
@@ -5,8 +5,8 @@
  */
 #include <tvm/ffi/function.h>
 #include <tvm/runtime/device_api.h>
-#include <tvm/runtime/nvtx.h>
 #include <tvm/runtime/tensor.h>
+#include <tvm/support/cuda/nvtx.h>
 
 #include "../../support/random.h"
 #include "sampler.h"
@@ -14,6 +14,8 @@
 namespace mlc {
 namespace llm {
 namespace serve {
+
+using tvm::support::NVTXScopedRange;
 
 inline bool FlashInferSamplingAvailable(Device device) {
   // Device must be CUDA, and FlashInfer must be enabled.


### PR DESCRIPTION
1. Use relocated NVTX header under tvm/support/cuda and use NVTXScopedRange from tvm::support instead of tvm::runtime
2. Link and install tvm_runtime_extra so distributed runtime symbols are resolved correctly
3. Update tvm submodule pointer