### PR TITLE
[Refactor] Adapt to TVM PrimType and tirx refactor

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -36,6 +36,14 @@ jobs:
         conda info
         conda list
         python --version
+    # The wheel is built with scikit-build-core, which uses the Ninja
+    # generator on Windows. Ninja needs cl.exe on PATH, so activate the MSVC
+    # developer environment before building (otherwise CMake aborts with
+    # "CMAKE_C_COMPILER not set, after EnableLanguage").
+    - name: Set up MSVC developer environment
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
     - name: Build MLC-LLM
       run: >-
         ci/task/build_win.bat

--- a/ci/build-environment.yaml
+++ b/ci/build-environment.yaml
@@ -4,6 +4,9 @@ channels:
   - conda-forge
 
 dependencies:
+  # Pin Python: the unpinned env resolved to 3.10, but core deps (numpy,
+  # pandas, networkx, ...) have dropped 3.10 wheels.
+  - python=3.11
   - conda-build
   - anaconda-client
   - libvulkan-headers

--- a/ci/task/build_win.bat
+++ b/ci/task/build_win.bat
@@ -4,6 +4,11 @@ mkdir build
 
 echo set(USE_VULKAN ON) >> config.cmake
 
+REM Conda ships a GNU coreutils link.exe in %CONDA_PREFIX%\Library\usr\bin that
+REM shadows the MSVC linker on PATH and breaks the Rust (cargo) build of the
+REM tokenizers crate. Remove it so cargo/rustc pick up the MSVC link.exe.
+if exist "%CONDA_PREFIX%\Library\usr\bin\link.exe" del /f /q "%CONDA_PREFIX%\Library\usr\bin\link.exe"
+
 pip install . -v
 
 if %errorlevel% neq 0 exit %errorlevel%

--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -22,7 +22,7 @@ ModelMetadata::Param::Preproc ModelMetadata::Param::Preproc::FromJSON(
   json::SymShapeTuple sym_in_shape =
       json::LookupOrDefault<json::SymShapeTuple>(js, "in_shape", sym_out_shape);
   preproc.in_shape = sym_in_shape.ToStatic(model_config);
-  preproc.out_dtype = json::Lookup<DataType>(js, "out_dtype");
+  preproc.out_dtype = json::Lookup<DLDataType>(js, "out_dtype");
   return preproc;
 }
 
@@ -30,7 +30,7 @@ ModelMetadata::Param ModelMetadata::Param::FromJSON(const tvm::ffi::json::Object
                                                     const tvm::ffi::json::Object& model_config) {
   Param result;
   result.name = json::Lookup<std::string>(param, "name");
-  result.dtype = json::Lookup<DataType>(param, "dtype");
+  result.dtype = json::Lookup<DLDataType>(param, "dtype");
   // A shape being `-1` means that it is dynamic
   json::SymShapeTuple sym_shape = json::Lookup<json::SymShapeTuple>(param, "shape");
   result.shape = sym_shape.ToStatic(model_config);

--- a/cpp/metadata/model.h
+++ b/cpp/metadata/model.h
@@ -6,10 +6,10 @@
 #define MLC_LLM_CPP_MODEL_METADATA_H_
 
 #include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/dtype.h>
 #include <tvm/ffi/extra/json.h>
 #include <tvm/ffi/extra/module.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/data_type.h>
 #include <tvm/runtime/logging.h>
 
 #include <unordered_map>
@@ -20,7 +20,6 @@ namespace llm {
 using tvm::ffi::Module;
 using tvm::ffi::Shape;
 using tvm::ffi::String;
-using tvm::runtime::DataType;
 
 /*! \brief The kind of cache. */
 enum class KVStateKind : int {
@@ -63,14 +62,14 @@ struct ModelMetadata {
       String func_name;
       Shape in_shape;
       Shape out_shape;
-      DataType out_dtype;
+      DLDataType out_dtype;
       static Preproc FromJSON(const tvm::ffi::json::Object& js,
                               const tvm::ffi::json::Object& model_config);
     };
 
     String name;
     Shape shape;
-    DataType dtype;
+    DLDataType dtype;
     std::vector<Preproc> preprocs;
     std::vector<int> pipeline_stages;
     static Param FromJSON(const tvm::ffi::json::Object& param_obj,

--- a/cpp/multi_gpu/builtin.cc
+++ b/cpp/multi_gpu/builtin.cc
@@ -9,7 +9,6 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/ir/cast.h>
 #include <tvm/runtime/disco/builtin.h>
 #include <tvm/runtime/disco/disco_worker.h>
 #include <tvm/runtime/tensor.h>
@@ -20,7 +19,6 @@ namespace llm {
 namespace multi_gpu {
 
 using namespace tvm::runtime;
-using tvm::Downcast;
 using tvm::ffi::Array;
 using tvm::ffi::ObjectRef;
 using tvm::ffi::Optional;
@@ -41,7 +39,7 @@ ObjectRef DispatchFunctionByGroup(tvm::ffi::AnyView vm_arg,
   int group_id = worker->worker_id / group_size;
   TVM_FFI_ICHECK(!funcs_and_args[group_id].empty())
       << "No function is provided for group " << group_id;
-  VMClosure func = Downcast<VMClosure>(funcs_and_args[group_id][0]);
+  VMClosure func = funcs_and_args[group_id][0].as_or_throw<VMClosure>();
 
   int num_args = static_cast<int>(funcs_and_args[group_id].size()) - 1;
   std::vector<tvm::ffi::AnyView> packed_args(num_args);
@@ -52,13 +50,13 @@ ObjectRef DispatchFunctionByGroup(tvm::ffi::AnyView vm_arg,
   }
 
   tvm::ffi::Any rv;
-  vm->InvokeClosurePacked(Downcast<VMClosure>(funcs_and_args[group_id][0]),
+  vm->InvokeClosurePacked(funcs_and_args[group_id][0].as_or_throw<VMClosure>(),
                           tvm::ffi::PackedArgs(packed_args.data(), packed_args.size()), &rv);
   return rv.cast<ObjectRef>();
 }
 
 ObjectRef SendFromLastGroupToWorker0(Tensor send, Optional<Tensor> recv, Shape shape,
-                                     DataType dtype) {
+                                     DLDataType dtype) {
   DiscoWorker* worker = DiscoWorker::ThreadLocal();
   int worker_id = worker->worker_id;
   int world_size = worker->num_workers;
@@ -71,7 +69,7 @@ ObjectRef SendFromLastGroupToWorker0(Tensor send, Optional<Tensor> recv, Shape s
     RecvFromWorker(recv_arr, sender_id);
     return recv_arr;
   } else if (worker_id == sender_id) {
-    TVM_FFI_ICHECK_EQ(DataType(send->dtype), dtype)
+    TVM_FFI_ICHECK_EQ(send->dtype, dtype)
         << "The src Tensor has mismatched dtype than the expected dtype.";
     TVM_FFI_ICHECK_EQ(send->ndim, shape.size())
         << "The src Tensor has mismatched shape than the expected shape.";

--- a/cpp/multi_gpu/multi_gpu_loader.cc
+++ b/cpp/multi_gpu/multi_gpu_loader.cc
@@ -116,7 +116,7 @@ Tensor BroadcastOrShardAndScatter(Tensor param, const ModelMetadata::Param& para
   }
   Device device = param->device;
   Shape shape = param_info.preprocs.back().out_shape;
-  DataType dtype = param_info.preprocs.back().out_dtype;
+  DLDataType dtype = param_info.preprocs.back().out_dtype;
   TVM_FFI_ICHECK(shape.size() >= 1 && shape[0] == num_shards)
       << "ValueError: The first dimension of the output shape must be equal to the "
       << "number of shards, but got: " << shape << " and num_shards = " << num_shards;
@@ -132,7 +132,7 @@ Tensor ReceiveBroadcastedOrSharded(Device device, const ModelMetadata::Param& pa
   Tensor result;
   if (needs_sharding) {
     Shape shape = param_info.preprocs.back().out_shape;
-    DataType dtype = param_info.preprocs.back().out_dtype;
+    DLDataType dtype = param_info.preprocs.back().out_dtype;
     result = Tensor::Empty(Shape(shape.begin() + 1, shape.end()), dtype, device);
     ScatterFromWorker0(std::nullopt, /*in_group=*/true, result);
   } else {

--- a/cpp/serve/config.cc
+++ b/cpp/serve/config.cc
@@ -839,7 +839,7 @@ Result<InferrableEngineConfig> InferrableEngineConfig::InferForKVCache(
   int64_t temp_buffer_bytes = 0;
   for (const ModelMetadata& metadata : model_metadata) {
     for (const ModelMetadata::Param& param : metadata.params) {
-      int64_t param_size = param.dtype.bytes();
+      int64_t param_size = (param.dtype.bits * param.dtype.lanes + 7) / 8;
       for (int64_t v : param.shape) {
         TVM_FFI_ICHECK_GE(v, 0);
         param_size *= v;
@@ -973,7 +973,7 @@ Result<InferrableEngineConfig> InferrableEngineConfig::InferForRNNState(
   int64_t temp_buffer_bytes = 0;
   for (const ModelMetadata& metadata : model_metadata) {
     for (const ModelMetadata::Param& param : metadata.params) {
-      int64_t param_size = param.dtype.bytes();
+      int64_t param_size = (param.dtype.bits * param.dtype.lanes + 7) / 8;
       for (int64_t v : param.shape) {
         TVM_FFI_ICHECK_GE(v, 0);
         param_size *= v;

--- a/cpp/serve/data.h
+++ b/cpp/serve/data.h
@@ -11,7 +11,6 @@
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
-#include <tvm/ir/cast.h>
 #include <tvm/runtime/tensor.h>
 
 #include <atomic>

--- a/cpp/serve/draft_token_workspace_manager.cc
+++ b/cpp/serve/draft_token_workspace_manager.cc
@@ -63,9 +63,9 @@ void DraftTokenWorkspaceManagerObj::FreeSlots(const std::vector<int>& slots) {
 void DraftTokenWorkspaceManagerObj::AllocWorkspace(ModelWorkspace* workspace,
                                                    bool require_hidden_states) {
   workspace->draft_probs =
-      Tensor::Empty({max_num_tokens_, vocab_size_}, DataType::Float(32), device_);
+      Tensor::Empty({max_num_tokens_, vocab_size_}, DLDataType{kDLFloat, 32, 1}, device_);
   workspace->draft_probs_storage =
-      Tensor::Empty({max_num_tokens_, vocab_size_}, DataType::Float(32), device_);
+      Tensor::Empty({max_num_tokens_, vocab_size_}, DLDataType{kDLFloat, 32, 1}, device_);
   if (require_hidden_states) {
     workspace->draft_hidden_states_storage = ft_.Empty(
         {max_num_tokens_, hidden_size_}, hidden_states_dtype_, device_, /*worker0_only=*/false);

--- a/cpp/serve/draft_token_workspace_manager.h
+++ b/cpp/serve/draft_token_workspace_manager.h
@@ -92,7 +92,7 @@ class DraftTokenWorkspaceManagerObj : public Object {
   int max_num_tokens_;
   int vocab_size_;
   int hidden_size_;
-  DataType hidden_states_dtype_;
+  DLDataType hidden_states_dtype_;
   DLDevice device_;
   const FunctionTable& ft_;
   std::unordered_map<int, int> ref_count_;

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -43,7 +43,6 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
-using tvm::Downcast;
 using tvm::ffi::Function;
 using tvm::support::NVTXScopedRange;
 

--- a/cpp/serve/engine_actions/eagle_batch_verify.cc
+++ b/cpp/serve/engine_actions/eagle_batch_verify.cc
@@ -18,8 +18,6 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
-using tvm::Downcast;
-
 /*!
  * \brief The action that runs verification for requests in the
  * `running_queue` of engine state. Preempt low-priority requests
@@ -256,10 +254,12 @@ class EagleBatchVerifyActionObj : public EngineActionObj {
       // next runs of BatchDecode.
       // This is because we do not do sample for this round of batch decode.
       if (hidden_states_for_fully_accepted->IsInstance<DRefObj>()) {
-        Downcast<Session>(Downcast<DRef>(hidden_states_for_fully_accepted)->session)->SyncWorker(0);
+        (hidden_states_for_fully_accepted.as_or_throw<DRef>()->session)
+            .as_or_throw<Session>()
+            ->SyncWorker(0);
       } else {
         Tensor hidden_states_for_fully_accepted_nd =
-            Downcast<Tensor>(hidden_states_for_fully_accepted);
+            hidden_states_for_fully_accepted.as_or_throw<Tensor>();
         DeviceAPI::Get(hidden_states_for_fully_accepted_nd->device)
             ->StreamSync(hidden_states_for_fully_accepted_nd->device, nullptr);
       }

--- a/cpp/serve/engine_actions/eagle_new_request_prefill.cc
+++ b/cpp/serve/engine_actions/eagle_new_request_prefill.cc
@@ -12,7 +12,6 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
-using tvm::Downcast;
 using tvm::support::NVTXScopedRange;
 
 /*!
@@ -110,7 +109,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
           if (model_id == 0) {
             for (int j = 1; j < static_cast<int>(models_.size()); ++j) {
               TVM_FFI_ICHECK(rsentry->mstates[j]->inputs.size());
-              TokenData token_data = Downcast<TokenData>(rsentry->mstates[j]->inputs[0]);
+              TokenData token_data = rsentry->mstates[j]->inputs[0].as_or_throw<TokenData>();
               rsentry->mstates[j]->inputs.Set(0, TokenData(Shape(token_data->token_ids.begin() + 1,
                                                                  token_data->token_ids.end())));
             }
@@ -304,7 +303,7 @@ class EagleNewRequestPrefillActionObj : public BatchPrefillBaseActionObj {
             for (int i = 0; i < static_cast<int>(rsentries_for_sample.size()); ++i) {
               for (int mid = 1; mid < static_cast<int>(models_.size()); ++mid) {
                 TokenData token_data =
-                    Downcast<TokenData>(rsentries_for_sample[i]->mstates[mid]->inputs.back());
+                    rsentries_for_sample[i]->mstates[mid]->inputs.back().as_or_throw<TokenData>();
                 std::vector<int32_t> token_ids = {token_data->token_ids.begin(),
                                                   token_data->token_ids.end()};
                 token_ids.push_back(sample_results[i].GetTokenId());

--- a/cpp/serve/engine_state.h
+++ b/cpp/serve/engine_state.h
@@ -5,6 +5,7 @@
 #ifndef MLC_LLM_SERVE_ENGINE_STATE_H_
 #define MLC_LLM_SERVE_ENGINE_STATE_H_
 
+#include <tvm/ffi/cast.h>
 #include <tvm/ffi/string.h>
 
 #include "config.h"

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -25,8 +25,6 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
-using tvm::Downcast;
-
 Optional<Shape> GetDiscoWorkerCPUBinding(int num_workers) {
   const char* raw_cpu_binding = std::getenv("MLC_DISCO_WORKER_CPU_BINDING");
   if (raw_cpu_binding == nullptr) {
@@ -297,7 +295,7 @@ void FunctionTable::_InitFunctions() {
   this->scatter_hidden_states_func_ = mod_get_func("scatter_hidden_states");
 }
 
-ObjectRef FunctionTable::Empty(Shape shape, DataType dtype, Device device,
+ObjectRef FunctionTable::Empty(Shape shape, DLDataType dtype, Device device,
                                bool worker0_only) const {
   if (this->use_disco) {
     DRef empty_func = sess->GetGlobalFunc("runtime.disco.empty");
@@ -316,10 +314,11 @@ ObjectRef FunctionTable::CopyToWorker0(const Tensor& host_array, String buffer_c
     Optional<DRef> buffer = std::nullopt;
     auto it = cached_buffers.find(buffer_cache_key);
     if (it != cached_buffers.end()) {
-      buffer = Downcast<DRef>((*it).second);
+      buffer = (*it).second.as_or_throw<DRef>();
     } else {
-      buffer = Downcast<DRef>(this->Empty(max_reserved_shape, host_array.DataType(), null_device,
-                                          /*worker0_only=*/false));
+      buffer = this->Empty(max_reserved_shape, host_array.DataType(), null_device,
+                           /*worker0_only=*/false)
+                   .as_or_throw<DRef>();
       cached_buffers.Set(buffer_cache_key, buffer.value());
     }
     Shape real_shape = host_array.Shape();
@@ -330,7 +329,7 @@ ObjectRef FunctionTable::CopyToWorker0(const Tensor& host_array, String buffer_c
     auto it = cached_buffers.find(buffer_cache_key);
     Tensor buffer{nullptr};
     if (it != cached_buffers.end()) {
-      buffer = Downcast<Tensor>((*it).second);
+      buffer = (*it).second.as_or_throw<Tensor>();
       if (buffer_cache_key == "image") {
         if (tvm::ffi::GetDataSize(*buffer.operator->()) <
             tvm::ffi::GetDataSize(*host_array.operator->())) {

--- a/cpp/serve/function_table.h
+++ b/cpp/serve/function_table.h
@@ -57,7 +57,7 @@ struct FunctionTable {
 
   void _InitFunctions();
 
-  ObjectRef Empty(Shape shape, DataType dtype, Device device, bool worker0_only) const;
+  ObjectRef Empty(Shape shape, DLDataType dtype, Device device, bool worker0_only) const;
 
   /*!
    * \brief Copy a host array to the worker or local gpu.

--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -107,7 +107,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
     NVTXScopedRange nvtx_scope("Logit inplace update");
     TVM_FFI_ICHECK_EQ(logits->ndim, 2);
     TVM_FFI_ICHECK_EQ(logits->shape[1], vocab_size_);
-    TVM_FFI_ICHECK(logits.DataType() == DataType::Float(32));
+    TVM_FFI_ICHECK(logits.DataType() == (DLDataType{kDLFloat, 32, 1}));
     TVM_FFI_ICHECK_EQ(generation_cfg.size(), mstates.size());
     TVM_FFI_ICHECK_LE(logits->shape[0], max_num_token_);
     int num_total_token = logits->shape[0];
@@ -159,7 +159,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
     TVM_FFI_ICHECK_EQ(logits->ndim, 2);
     TVM_FFI_ICHECK_LE(logits->shape[0], max_num_token_);
     TVM_FFI_ICHECK_EQ(logits->shape[1], vocab_size_);
-    TVM_FFI_ICHECK(logits.DataType() == DataType::Float(32));
+    TVM_FFI_ICHECK(logits.DataType() == (DLDataType{kDLFloat, 32, 1}));
     int num_total_token = logits->shape[0];
     int num_sequence = generation_cfg.size();
 
@@ -461,9 +461,9 @@ class LogitProcessorImpl : public LogitProcessorObj {
   const int max_num_token_;
   const int vocab_size_;
   const int bitmask_size_;
-  const DLDataType dtype_i32_ = DataType::Int(32);
-  const DLDataType dtype_u32_ = DataType::UInt(32);
-  const DLDataType dtype_f32_ = DataType::Float(32);
+  const DLDataType dtype_i32_ = DLDataType{kDLInt, 32, 1};
+  const DLDataType dtype_u32_ = DLDataType{kDLUInt, 32, 1};
+  const DLDataType dtype_f32_ = DLDataType{kDLFloat, 32, 1};
   // Packed functions.
   Device device_;
   Function softmax_func_;

--- a/cpp/serve/model.cc
+++ b/cpp/serve/model.cc
@@ -22,7 +22,6 @@ namespace mlc {
 namespace llm {
 namespace serve {
 
-using tvm::Downcast;
 using tvm::support::NVTXScopedRange;
 
 /*********************** Model Implementation ***********************/
@@ -93,7 +92,7 @@ class ModelImpl : public ModelObj {
                    seqlen_padding_factor_;
     }
     // Copy input token ids to device.
-    DLDataType dtype(DataType::Int(32));
+    DLDataType dtype(DLDataType{kDLInt, 32, 1});
     Tensor token_ids_nd;
     {
       NVTXScopedRange nvtx_scope("Allocate token_ids at offset");
@@ -166,7 +165,7 @@ class ModelImpl : public ModelObj {
     ObjectRef hidden_states_dref_or_nd{nullptr};
     if (!ft_.use_disco && hidden_states->IsInstance<DRefObj>()) {
       hidden_states_dref_or_nd =
-          Downcast<DRef>(hidden_states)->DebugGetFromRemote(0).cast<ObjectRef>();
+          hidden_states.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<ObjectRef>();
     } else {
       hidden_states_dref_or_nd = hidden_states;
     }
@@ -176,9 +175,9 @@ class ModelImpl : public ModelObj {
     }
     Tensor logits{nullptr};
     if (ft_.use_disco) {
-      logits = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Tensor>();
+      logits = ret.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Tensor>();
     } else {
-      logits = Downcast<Tensor>(ret);
+      logits = ret.as_or_throw<Tensor>();
     }
     // logits: (b * s, v)
     return logits;
@@ -193,9 +192,9 @@ class ModelImpl : public ModelObj {
     ObjectRef ret = ft_.get_logits_func_(hidden_states, params_).cast<ObjectRef>();
     Array<Tensor> logits{nullptr};
     if (ft_.use_disco) {
-      logits = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Array<Tensor>>();
+      logits = ret.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Array<Tensor>>();
     } else {
-      logits = Downcast<Array<Tensor>>(ret);
+      logits = ret.as_or_throw<Array<Tensor>>();
     }
     return logits;
   }
@@ -207,7 +206,7 @@ class ModelImpl : public ModelObj {
     ObjectRef embeddings_dref_or_nd{nullptr};
     if (!embeddings->IsInstance<DRefObj>()) {
       // embeddings: (n, h)
-      Tensor embeddings_nd = Downcast<Tensor>(embeddings);
+      Tensor embeddings_nd = embeddings.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_NE(hidden_size_, -1);
       TVM_FFI_ICHECK_EQ(embeddings_nd->ndim, 2);
       TVM_FFI_ICHECK_GE(embeddings_nd->shape[0], batch_size * seq_len);
@@ -222,7 +221,7 @@ class ModelImpl : public ModelObj {
     ObjectRef previous_hidden_states_dref_or_nd{nullptr};
     if (!ft_.use_disco && previous_hidden_states->IsInstance<DRefObj>()) {
       previous_hidden_states_dref_or_nd =
-          Downcast<DRef>(previous_hidden_states)->DebugGetFromRemote(0).cast<ObjectRef>();
+          previous_hidden_states.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<ObjectRef>();
     } else {
       previous_hidden_states_dref_or_nd = previous_hidden_states;
     }
@@ -236,7 +235,7 @@ class ModelImpl : public ModelObj {
     if (ft_.use_disco) {
       return ft_.nd_view_func_(fused, out_shape).cast<ObjectRef>();
     } else {
-      Tensor fused_nd = Downcast<Tensor>(fused);
+      Tensor fused_nd = fused.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_EQ(fused_nd->ndim, 2);
       TVM_FFI_ICHECK_EQ(fused_nd->shape[0], batch_size * seq_len);
       return fused_nd.CreateView(out_shape, fused_nd->dtype);
@@ -262,7 +261,7 @@ class ModelImpl : public ModelObj {
     }
     NVTXScopedRange nvtx_scope("BatchPrefill num_seq=" + std::to_string(num_sequences) +
                                " total_len=" + std::to_string(total_length));
-    Tensor logit_pos_nd = logit_pos_arr_.CreateView({num_sequences}, DataType::Int(32));
+    Tensor logit_pos_nd = logit_pos_arr_.CreateView({num_sequences}, DLDataType{kDLInt, 32, 1});
 
     TVM_FFI_ICHECK(ft_.prefill_func_.defined())
         << "`prefill_with_embed` function is not found in the model. Please make sure the model is "
@@ -283,7 +282,7 @@ class ModelImpl : public ModelObj {
     ObjectRef embeddings_dref_or_nd;
     if (!embeddings->IsInstance<DRefObj>()) {
       // embeddings: (1, n, h)
-      Tensor embeddings_nd = Downcast<Tensor>(embeddings);
+      Tensor embeddings_nd = embeddings.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_NE(hidden_size_, -1);
       TVM_FFI_ICHECK_EQ(embeddings_nd->ndim, 2);
       TVM_FFI_ICHECK_GE(embeddings_nd->shape[0], total_length);
@@ -341,13 +340,16 @@ class ModelImpl : public ModelObj {
       if (num_stages_ > 1) {
         // Send the result from the last worker group to worker 0.
         Shape shape{1, num_sequences, vocab_size_};
-        DataType dtype = DataType::Float(32);
+        DLDataType dtype = DLDataType{kDLFloat, 32, 1};
         ret = ft_.last_group_send_to_worker_0_(ret, disco_logits_arr_, shape, dtype)
                   .cast<ObjectRef>();
       }
-      logits = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Tensor>();
+      logits = ret.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Tensor>();
     } else {
-      logits = Downcast<Array<Tensor>>(ret)[0];
+      // The function returns a (logits, kv_cache) tuple; extract element 0 as a
+      // generic Any before casting to Tensor. Casting the whole tuple to
+      // Array<Tensor> now fails strict element-type checking on the kv_cache.
+      logits = ret.as_or_throw<Array<Any>>()[0].cast<Tensor>();
     }
     if (trace_enabled_) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
@@ -380,7 +382,7 @@ class ModelImpl : public ModelObj {
     ObjectRef embedding_or_hidden_states_dref_or_nd{nullptr};
     Shape hidden_states_shape{1, total_length, hidden_size_};
     if (!ft_.use_disco) {
-      Tensor embedding_or_hidden_states_nd = Downcast<Tensor>(embedding_or_hidden_states);
+      Tensor embedding_or_hidden_states_nd = embedding_or_hidden_states.as_or_throw<Tensor>();
       embedding_or_hidden_states_dref_or_nd = embedding_or_hidden_states_nd.CreateView(
           hidden_states_shape, embedding_or_hidden_states_nd->dtype);
     } else {
@@ -441,7 +443,7 @@ class ModelImpl : public ModelObj {
     if (ft_.use_disco) {
       return ft_.nd_view_func_(hidden_states, out_shape).cast<ObjectRef>();
     } else {
-      Tensor hidden_states_nd = Downcast<Tensor>(hidden_states);
+      Tensor hidden_states_nd = hidden_states.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_EQ(hidden_states_nd->ndim, 3);
       TVM_FFI_ICHECK_EQ(hidden_states_nd->shape[0], 1);
       TVM_FFI_ICHECK_EQ(hidden_states_nd->shape[1], total_length);
@@ -473,7 +475,7 @@ class ModelImpl : public ModelObj {
     ObjectRef embeddings_dref_or_nd;
     if (!embeddings->IsInstance<DRefObj>()) {
       // embeddings: (1, b, h)
-      Tensor embeddings_nd = Downcast<Tensor>(embeddings);
+      Tensor embeddings_nd = embeddings.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_NE(hidden_size_, -1);
       TVM_FFI_ICHECK_EQ(embeddings_nd->ndim, 2);
       TVM_FFI_ICHECK_GE(embeddings_nd->shape[0], num_sequence);
@@ -505,13 +507,16 @@ class ModelImpl : public ModelObj {
       if (num_stages_ > 1) {
         // Send the result from the last worker group to worker 0.
         Shape shape{num_sequence, 1, vocab_size_};
-        DataType dtype = DataType::Float(32);
+        DLDataType dtype = DLDataType{kDLFloat, 32, 1};
         ret = ft_.last_group_send_to_worker_0_(ret, disco_logits_arr_, shape, dtype)
                   .cast<ObjectRef>();
       }
-      logits = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Tensor>();
+      logits = ret.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Tensor>();
     } else {
-      logits = Downcast<Array<Tensor>>(ret)[0];
+      // The function returns a (logits, kv_cache) tuple; extract element 0 as a
+      // generic Any before casting to Tensor. Casting the whole tuple to
+      // Array<Tensor> now fails strict element-type checking on the kv_cache.
+      logits = ret.as_or_throw<Array<Any>>()[0].cast<Tensor>();
     }
     if (trace_enabled_) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
@@ -560,7 +565,7 @@ class ModelImpl : public ModelObj {
     ObjectRef embeddings_dref_or_nd;
     if (!embeddings->IsInstance<DRefObj>()) {
       // embeddings: (1, n, h)
-      Tensor embeddings_nd = Downcast<Tensor>(embeddings);
+      Tensor embeddings_nd = embeddings.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_NE(hidden_size_, -1);
       TVM_FFI_ICHECK_EQ(embeddings_nd->ndim, 2);
       TVM_FFI_ICHECK_GE(embeddings_nd->shape[0], total_length);
@@ -584,10 +589,14 @@ class ModelImpl : public ModelObj {
     }
     Tensor logits;
     if (ft_.use_disco) {
-      Array<ObjectRef> result = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Array<ObjectRef>>();
-      logits = Downcast<Tensor>(result[0]);
+      Array<ObjectRef> result =
+          ret.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Array<ObjectRef>>();
+      logits = result[0].as_or_throw<Tensor>();
     } else {
-      logits = Downcast<Array<Tensor>>(ret)[0];
+      // The function returns a (logits, kv_cache) tuple; extract element 0 as a
+      // generic Any before casting to Tensor. Casting the whole tuple to
+      // Array<Tensor> now fails strict element-type checking on the kv_cache.
+      logits = ret.as_or_throw<Array<Any>>()[0].cast<Tensor>();
     }
     if (trace_enabled_) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
@@ -661,7 +670,7 @@ class ModelImpl : public ModelObj {
     if (ft_.use_disco) {
       return ft_.nd_view_func_(hidden_states, out_shape).cast<ObjectRef>();
     } else {
-      Tensor hidden_states_nd = Downcast<Tensor>(hidden_states);
+      Tensor hidden_states_nd = hidden_states.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_EQ(hidden_states_nd->ndim, 3);
       TVM_FFI_ICHECK_EQ(hidden_states_nd->shape[0], num_sequence);
       TVM_FFI_ICHECK_EQ(hidden_states_nd->shape[1], 1);
@@ -705,7 +714,7 @@ class ModelImpl : public ModelObj {
     ObjectRef embeddings_dref_or_nd;
     if (!embeddings->IsInstance<DRefObj>()) {
       // embeddings: (1, n, h)
-      Tensor embeddings_nd = Downcast<Tensor>(embeddings);
+      Tensor embeddings_nd = embeddings.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_NE(hidden_size_, -1);
       TVM_FFI_ICHECK_EQ(embeddings_nd->ndim, 2);
       TVM_FFI_ICHECK_GE(embeddings_nd->shape[0], total_length);
@@ -732,13 +741,16 @@ class ModelImpl : public ModelObj {
       if (num_stages_ > 1) {
         // Send the result from the last worker group to worker 0.
         Shape shape{1, total_length, vocab_size_};
-        DataType dtype = DataType::Float(32);
+        DLDataType dtype = DLDataType{kDLFloat, 32, 1};
         ret = ft_.last_group_send_to_worker_0_(ret, disco_logits_arr_, shape, dtype)
                   .cast<ObjectRef>();
       }
-      logits = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Tensor>();
+      logits = ret.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Tensor>();
     } else {
-      logits = Downcast<Array<Tensor>>(ret)[0];
+      // The function returns a (logits, kv_cache) tuple; extract element 0 as a
+      // generic Any before casting to Tensor. Casting the whole tuple to
+      // Array<Tensor> now fails strict element-type checking on the kv_cache.
+      logits = ret.as_or_throw<Array<Any>>()[0].cast<Tensor>();
     }
     if (trace_enabled_) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
@@ -779,7 +791,7 @@ class ModelImpl : public ModelObj {
     ObjectRef embeddings_dref_or_nd;
     if (!embeddings->IsInstance<DRefObj>()) {
       // embeddings: (1, n, h)
-      Tensor embeddings_nd = Downcast<Tensor>(embeddings);
+      Tensor embeddings_nd = embeddings.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_NE(hidden_size_, -1);
       TVM_FFI_ICHECK_EQ(embeddings_nd->ndim, 2);
       TVM_FFI_ICHECK_GE(embeddings_nd->shape[0], total_length);
@@ -824,7 +836,7 @@ class ModelImpl : public ModelObj {
 
     Shape out_shape{total_length, hidden_size_};
     if (!ft_.use_disco) {
-      Tensor hidden_states_nd = Downcast<Tensor>(hidden_states);
+      Tensor hidden_states_nd = hidden_states.as_or_throw<Tensor>();
       TVM_FFI_ICHECK_EQ(hidden_states_nd->ndim, 3);
       TVM_FFI_ICHECK_EQ(hidden_states_nd->shape[0], 1);
       TVM_FFI_ICHECK_EQ(hidden_states_nd->shape[1], total_length);
@@ -852,7 +864,7 @@ class ModelImpl : public ModelObj {
                                             support_sliding_window)
                       .cast<ObjectRef>();
       local_kv_cache_ = ft_.use_disco
-                            ? Downcast<DRef>(kv_cache_)->DebugGetFromRemote(0).cast<ObjectRef>()
+                            ? kv_cache_.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<ObjectRef>()
                             : kv_cache_;
     } else if (kv_state_kind == KVStateKind::kRNNState) {
       // RNN state needs extra slots for prefix cache recycling sequences.
@@ -861,7 +873,7 @@ class ModelImpl : public ModelObj {
       kv_cache_ = ft_.create_kv_cache_func_(max_num_sequence_tuple, max_history_size_tuple)
                       .cast<ObjectRef>();
       local_kv_cache_ = ft_.use_disco
-                            ? Downcast<DRef>(kv_cache_)->DebugGetFromRemote(0).cast<ObjectRef>()
+                            ? kv_cache_.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<ObjectRef>()
                             : kv_cache_;
     } else if (kv_state_kind == KVStateKind::kHybrid) {
       // Hybrid: create both PagedKVCache (for attention layers) and RNNState (for GDN layers).
@@ -875,7 +887,7 @@ class ModelImpl : public ModelObj {
                                             support_sliding_window)
                       .cast<ObjectRef>();
       local_kv_cache_ = ft_.use_disco
-                            ? Downcast<DRef>(kv_cache_)->DebugGetFromRemote(0).cast<ObjectRef>()
+                            ? kv_cache_.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<ObjectRef>()
                             : kv_cache_;
       // Create RNN state for recurrent layers.
       // RNN state needs extra slots for prefix cache recycling sequences that
@@ -883,9 +895,9 @@ class ModelImpl : public ModelObj {
       Shape rnn_max_batch{max_num_sequence + prefix_cache_max_num_recycling_seqs};
       Shape rnn_max_history{std::max(max_history_size, 1)};
       rnn_state_ = ft_.create_rnn_state_func_(rnn_max_batch, rnn_max_history).cast<ObjectRef>();
-      local_rnn_state_ = ft_.use_disco
-                             ? Downcast<DRef>(rnn_state_)->DebugGetFromRemote(0).cast<ObjectRef>()
-                             : rnn_state_;
+      local_rnn_state_ =
+          ft_.use_disco ? rnn_state_.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<ObjectRef>()
+                        : rnn_state_;
     } else if (kv_state_kind == KVStateKind::kNone) {
       // Do nothing
     } else {
@@ -965,9 +977,9 @@ class ModelImpl : public ModelObj {
     ret = ft_.kv_cache_disagg_prepare_recv_func_(kv_cache_, seq_id, length).cast<ObjectRef>();
     Shape compressed_kv_append_metadata;
     if (ft_.use_disco) {
-      compressed_kv_append_metadata = Downcast<DRef>(ret)->DebugGetFromRemote(0).cast<Shape>();
+      compressed_kv_append_metadata = ret.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Shape>();
     } else {
-      compressed_kv_append_metadata = Downcast<Shape>(ret);
+      compressed_kv_append_metadata = ret.as_or_throw<Shape>();
     }
 
     return compressed_kv_append_metadata;
@@ -1015,8 +1027,8 @@ class ModelImpl : public ModelObj {
 
   void SetMaxNumSequence(int max_num_sequence) final {
     this->max_num_sequence_ = max_num_sequence;
-    this->logit_pos_arr_ =
-        Tensor::Empty({max_num_sequence}, DataType::Int(32), Device{DLDeviceType::kDLCPU, 0});
+    this->logit_pos_arr_ = Tensor::Empty({max_num_sequence}, DLDataType{kDLInt, 32, 1},
+                                         Device{DLDeviceType::kDLCPU, 0});
   }
 
   void SetPrefillChunkSize(int prefill_chunk_size) final {
@@ -1026,12 +1038,12 @@ class ModelImpl : public ModelObj {
         preferred_host_device, memory::AllocatorType::kNaive);
     TVM_FFI_ICHECK_NOTNULL(allocator);
     token_ids_storage_ = memory::Storage(
-        allocator->Alloc(preferred_host_device, {prefill_chunk_size_}, DataType::Int(32)),
+        allocator->Alloc(preferred_host_device, {prefill_chunk_size_}, DLDataType{kDLInt, 32, 1}),
         allocator);
     if (this->num_stages_ > 1) {
       // Create a remote Tensor for logits when pipeline parallelism is enabled.
       disco_logits_arr_ =
-          ft_.Empty({prefill_chunk_size_, vocab_size_}, DataType::Float(32), device_,
+          ft_.Empty({prefill_chunk_size_, vocab_size_}, DLDataType{kDLFloat, 32, 1}, device_,
                     /*worker0_only=*/true);
     }
   }
@@ -1072,9 +1084,9 @@ class ModelImpl : public ModelObj {
     if (ft_.use_disco) {
       TVM_FFI_ICHECK(embedding->IsInstance<DRefObj>());
       ObjectRef shape_ref = ft_.nd_get_shape_func_(embedding).cast<ObjectRef>();
-      embedding_shape = Downcast<DRef>(shape_ref)->DebugGetFromRemote(0).cast<Shape>();
+      embedding_shape = shape_ref.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Shape>();
     } else {
-      Tensor embedding_nd = Downcast<Tensor>(embedding);
+      Tensor embedding_nd = embedding.as_or_throw<Tensor>();
       embedding_shape = embedding_nd.Shape();
     }
     TVM_FFI_ICHECK_NE(prefill_chunk_size_, -1);
@@ -1095,9 +1107,9 @@ class ModelImpl : public ModelObj {
     // Get the shape of the hidden_states tensor for hidden size.
     if (ft_.use_disco) {
       TVM_FFI_ICHECK(hidden_states->IsInstance<DRefObj>());
-      hidden_states_nd = Downcast<DRef>(hidden_states)->DebugGetFromRemote(0).cast<Tensor>();
+      hidden_states_nd = hidden_states.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Tensor>();
     } else {
-      hidden_states_nd = Downcast<Tensor>(hidden_states);
+      hidden_states_nd = hidden_states.as_or_throw<Tensor>();
     }
     Shape hidden_states_shape = hidden_states_nd.Shape();
     TVM_FFI_ICHECK_NE(prefill_chunk_size_, -1);
@@ -1132,11 +1144,11 @@ class ModelImpl : public ModelObj {
     if ((*dst)->IsInstance<DRefObj>()) {
       dst_view = ft_.nd_view_func_(*dst, out_shape).cast<ObjectRef>();
     } else {
-      Tensor dst_nd = Downcast<Tensor>(*dst);
+      Tensor dst_nd = (*dst).as_or_throw<Tensor>();
       dst_view = dst_nd.CreateView(out_shape, hidden_states_dtype_);
     }
-    Tensor indices_nd =
-        logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())}, DataType::Int(32));
+    Tensor indices_nd = logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())},
+                                                  DLDataType{kDLInt, 32, 1});
     indices_nd.CopyFromBytes(indices.data(), indices.size() * sizeof(int));
     TVM_FFI_ICHECK_NE(max_num_sequence_, -1);
     ObjectRef indices_device = ft_.CopyToWorker0(indices_nd, "logit_pos", {max_num_sequence_});
@@ -1146,8 +1158,8 @@ class ModelImpl : public ModelObj {
 
   void ScatterHiddenStates(const ObjectRef& input, const std::vector<int>& indices,
                            ObjectRef* dst) final {
-    Tensor indices_nd =
-        logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())}, DataType::Int(32));
+    Tensor indices_nd = logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())},
+                                                  DLDataType{kDLInt, 32, 1});
     indices_nd.CopyFromBytes(indices.data(), indices.size() * sizeof(int));
     TVM_FFI_ICHECK_NE(max_num_sequence_, -1);
     ObjectRef indices_device = ft_.CopyToWorker0(indices_nd, "logit_pos", {max_num_sequence_});
@@ -1155,10 +1167,10 @@ class ModelImpl : public ModelObj {
   }
 
   Tensor GatherDraftProbs(const Tensor& input, const std::vector<int>& indices, Tensor* dst) final {
-    Tensor dst_view =
-        dst->CreateView({static_cast<int64_t>(indices.size()), vocab_size_}, DataType::Float(32));
-    Tensor indices_nd =
-        logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())}, DataType::Int(32));
+    Tensor dst_view = dst->CreateView({static_cast<int64_t>(indices.size()), vocab_size_},
+                                      DLDataType{kDLFloat, 32, 1});
+    Tensor indices_nd = logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())},
+                                                  DLDataType{kDLInt, 32, 1});
     indices_nd.CopyFromBytes(indices.data(), indices.size() * sizeof(int));
     TVM_FFI_ICHECK_NE(max_num_sequence_, -1);
     ObjectRef indices_device =
@@ -1168,8 +1180,8 @@ class ModelImpl : public ModelObj {
   }
 
   void ScatterDraftProbs(const Tensor& input, const std::vector<int>& indices, Tensor* dst) final {
-    Tensor indices_nd =
-        logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())}, DataType::Int(32));
+    Tensor indices_nd = logit_pos_arr_.CreateView({static_cast<int64_t>(indices.size())},
+                                                  DLDataType{kDLInt, 32, 1});
     indices_nd.CopyFromBytes(indices.data(), indices.size() * sizeof(int));
     TVM_FFI_ICHECK_NE(max_num_sequence_, -1);
     ObjectRef indices_device =
@@ -1181,9 +1193,9 @@ class ModelImpl : public ModelObj {
     ObjectRef result = ft_.get_logits_func_(hidden_states).cast<ObjectRef>();
     Array<Tensor> logits{nullptr};
     if (ft_.use_disco) {
-      logits = Downcast<DRef>(result)->DebugGetFromRemote(0).cast<Array<Tensor>>();
+      logits = result.as_or_throw<DRef>()->DebugGetFromRemote(0).cast<Array<Tensor>>();
     } else {
-      logits = Downcast<Array<Tensor>>(result);
+      logits = result.as_or_throw<Array<Tensor>>();
     }
     return logits;
   }

--- a/cpp/serve/sampler/cpu_sampler.cc
+++ b/cpp/serve/sampler/cpu_sampler.cc
@@ -41,7 +41,7 @@ TokenProbPair SampleTopPFromProb(Tensor prob, int unit_offset, int input_prob_of
   // of the prob array we sample from.
 
   TVM_FFI_ICHECK(prob.IsContiguous());
-  TVM_FFI_ICHECK(prob.DataType() == DataType::Float(32));
+  TVM_FFI_ICHECK(prob.DataType() == (DLDataType{kDLFloat, 32, 1}));
   TVM_FFI_ICHECK_EQ(prob->device.device_type, DLDeviceType::kDLCPU);
 
   int64_t ndata = prob->shape[prob->ndim - 1];
@@ -176,7 +176,7 @@ void RenormalizeProbByTopP(Tensor prob, int unit_offset, double top_p, double ep
   // We use the `unit_offset` parameter to determine which slice
   // of the prob array we will renormalize.
   TVM_FFI_ICHECK(prob.IsContiguous());
-  TVM_FFI_ICHECK(prob.DataType() == DataType::Float(32));
+  TVM_FFI_ICHECK(prob.DataType() == (DLDataType{kDLFloat, 32, 1}));
   TVM_FFI_ICHECK_EQ(prob->device.device_type, DLDeviceType::kDLCPU);
 
   if (top_p == 1.0) {

--- a/cpp/serve/sampler/gpu_sampler.cc
+++ b/cpp/serve/sampler/gpu_sampler.cc
@@ -698,8 +698,8 @@ class GPUSampler : public SamplerObj {
   // Model configurations
   const int max_num_sample_;
   const int vocab_size_;
-  const DLDataType dtype_i32_ = DataType::Int(32);
-  const DLDataType dtype_f32_ = DataType::Float(32);
+  const DLDataType dtype_i32_ = DLDataType{kDLInt, 32, 1};
+  const DLDataType dtype_f32_ = DLDataType{kDLFloat, 32, 1};
   const bool flashinfer_sampling_available_;
   // Functions for sampling on GPU.
   Device device_;

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -26,7 +26,6 @@ namespace serve {
 
 using tvm::Device;
 using namespace tvm::runtime;
-using tvm::Downcast;
 
 /*! \brief The threaded engine instruction kind. */
 enum class InstructionKind : int {
@@ -155,7 +154,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
       for (const auto& [kind, arg] : local_instruction_queue) {
         if (kind == InstructionKind::kAddRequest) {
           TVM_FFI_ICHECK(background_engine_ != nullptr) << "Background engine is not loaded.";
-          background_engine_->AddRequest(Downcast<Request>(arg));
+          background_engine_->AddRequest(arg.as_or_throw<Request>());
         } else if (kind == InstructionKind::kAbortRequest) {
           // in a rare case, abort request can happen after unloading
           // aka background engine is nullptr
@@ -163,22 +162,22 @@ class ThreadedEngineImpl : public ThreadedEngine {
           // the engine get unloaded, and then abort was called.
           // it is safe to ignore these abort in such case
           if (background_engine_ != nullptr) {
-            background_engine_->AbortRequest(Downcast<String>(arg));
+            background_engine_->AbortRequest(arg.as_or_throw<String>());
           }
         } else if (kind == InstructionKind::kUnloadEngine) {
           EngineUnloadImpl();
         } else if (kind == InstructionKind::kReloadEngine) {
           EngineUnloadImpl();
-          EngineReloadImpl(Downcast<String>(arg));
+          EngineReloadImpl(arg.as_or_throw<String>());
         } else if (kind == InstructionKind::kResetEngine) {
           if (background_engine_ != nullptr) {
             background_engine_->Reset();
           }
         } else if (kind == InstructionKind::kDebugCallFuncOnAllAllWorker) {
           TVM_FFI_ICHECK(background_engine_ != nullptr) << "Background engine is not loaded.";
-          Array<Any> packed_args = Downcast<Array<Any>>(arg);
+          Array<Any> packed_args = arg.as_or_throw<Array<Any>>();
           background_engine_->DebugCallFuncOnAllAllWorker(
-              Downcast<String>(packed_args[0]), Downcast<Optional<String>>(packed_args[1]));
+              packed_args[0].as_or_throw<String>(), packed_args[1].as_or_throw<Optional<String>>());
         } else {
           LOG(FATAL) << "Cannot reach here";
         }

--- a/cpp/support/json_parser.h
+++ b/cpp/support/json_parser.h
@@ -6,9 +6,9 @@
 #define MLC_LLM_SUPPORT_JSON_PARSER_H_
 
 #include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/dtype.h>
 #include <tvm/ffi/extra/json.h>
 #include <tvm/ffi/string.h>
-#include <tvm/runtime/data_type.h>
 #include <tvm/runtime/logging.h>
 
 #include <optional>
@@ -204,9 +204,7 @@ struct SymShapeTuple {
 
 namespace details {
 
-inline tvm::runtime::DataType DTypeFromString(const std::string& s) {
-  return tvm::runtime::DataType(tvm::ffi::StringToDLDataType(s));
-}
+inline DLDataType DTypeFromString(const std::string& s) { return tvm::ffi::StringToDLDataType(s); }
 
 inline SymShapeTuple SymShapeTupleFromArray(const Array& shape) {
   std::vector<int64_t> result;
@@ -251,12 +249,12 @@ inline ValueType Lookup(const Array& json, int index) {
 }
 
 template <>
-inline tvm::runtime::DataType Lookup(const Object& json, const std::string& key) {
+inline DLDataType Lookup(const Object& json, const std::string& key) {
   return details::DTypeFromString(Lookup<std::string>(json, key));
 }
 
 template <>
-inline tvm::runtime::DataType Lookup(const Array& json, int index) {
+inline DLDataType Lookup(const Array& json, int index) {
   return details::DTypeFromString(Lookup<std::string>(json, index));
 }
 

--- a/python/mlc_llm/compiler_pass/attach_cuda_graph_alloc_init_func.py
+++ b/python/mlc_llm/compiler_pass/attach_cuda_graph_alloc_init_func.py
@@ -26,8 +26,8 @@ class AttachCUDAGraphAllocInitFunc:
             bb.emit_func_output(
                 relax.op.call_builtin_with_ctx(
                     "vm.builtin.cuda_graph.get_cached_alloc",
-                    args=[alloc_func_gv, relax.PrimValue(0)],
-                    sinfo_args=relax.ObjectStructInfo(),
+                    args=[alloc_func_gv, relax.prim_value(0)],
+                    ty_args=relax.ObjectType(),
                 )
             )
         return bb.finalize()

--- a/python/mlc_llm/compiler_pass/attach_embedding_allocator.py
+++ b/python/mlc_llm/compiler_pass/attach_embedding_allocator.py
@@ -23,8 +23,8 @@ class AttachAllocEmbeddingTensorFunc:
         if embed_func is None:
             return mod
 
-        hidden_size = embed_func.ret_struct_info.shape[-1]
-        dtype = embed_func.ret_struct_info.dtype
+        hidden_size = embed_func.ret_ty.shape[-1]
+        dtype = relax.DataTypeImm(embed_func.ret_ty.dtype.dtype)
         bb = relax.BlockBuilder(mod)
         with bb.function("alloc_embedding_tensor", []):
             bb.emit_func_output(

--- a/python/mlc_llm/compiler_pass/attach_logit_processor.py
+++ b/python/mlc_llm/compiler_pass/attach_logit_processor.py
@@ -39,7 +39,7 @@ class AttachLogitProcessFunc:
 
 
 def _get_apply_logit_bias_inplace_cpu():
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _apply_logit_bias_inplace(
         var_logits: T.handle,
         var_pos2seq_id: T.handle,
@@ -75,7 +75,7 @@ def _get_apply_logit_bias_inplace(target: tvm.target.Target):
     tx = min(tx, max_num_threads_per_block)
     check_thread_limits(target, bdx=tx, bdy=1, bdz=1, gdz=1)
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _apply_logit_bias_inplace(
         var_logits: T.handle,
         var_pos2seq_id: T.handle,
@@ -110,7 +110,7 @@ def _get_apply_logit_bias_inplace(target: tvm.target.Target):
 
 
 def _get_apply_penalty_inplace_cpu():
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _apply_penalty_inplace(
         var_logits: T.handle,
         var_seq_ids: T.handle,
@@ -159,7 +159,7 @@ def _get_apply_penalty_inplace(target: tvm.target.Target):
     tx = min(tx, max_num_threads_per_block)
     check_thread_limits(target, bdx=tx, bdy=1, bdz=1, gdz=1)
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _apply_penalty_inplace(
         var_logits: T.handle,
         var_seq_ids: T.handle,
@@ -208,7 +208,7 @@ def _get_apply_penalty_inplace(target: tvm.target.Target):
 
 
 def _get_apply_bitmask_inplace_cpu():
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _apply_bitmask_inplace(
         var_logits: T.handle,
         var_seq_ids: T.handle,
@@ -249,7 +249,7 @@ def _get_apply_bitmask_inplace(target: tvm.target.Target):
     tx = min(tx, max_num_threads_per_block)
     check_thread_limits(target, bdx=tx, bdy=1, bdz=1, gdz=1)
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _apply_bitmask_inplace(
         var_logits: T.handle,
         var_seq_ids: T.handle,

--- a/python/mlc_llm/compiler_pass/attach_sampler.py
+++ b/python/mlc_llm/compiler_pass/attach_sampler.py
@@ -70,11 +70,9 @@ def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
     batch_size = tirx.SizeVar("batch_size", "int64")
     num_samples = tirx.SizeVar("num_samples", "int64")
     vocab_size = tirx.SizeVar("vocab_size", "int64")
-    probs = relax.Var("probs", relax.TensorStructInfo((batch_size, vocab_size), "float32"))
-    uniform_samples = relax.Var(
-        "uniform_samples", relax.TensorStructInfo((num_samples,), "float32")
-    )
-    sample_indices = relax.Var("sample_indices", relax.TensorStructInfo((num_samples,), "int32"))
+    probs = relax.Var("probs", relax.TensorType((batch_size, vocab_size), "float32"))
+    uniform_samples = relax.Var("uniform_samples", relax.TensorType((num_samples,), "float32"))
+    sample_indices = relax.Var("sample_indices", relax.TensorType((num_samples,), "int32"))
     with bb.function("multinomial_from_uniform", [probs, uniform_samples, sample_indices]):
         with bb.dataflow():
             sample_shape = relax.ShapeExpr([num_samples, 1])
@@ -84,7 +82,7 @@ def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
                     "vm.builtin.reshape",
                     uniform_samples,
                     sample_shape,
-                    sinfo_args=relax.TensorStructInfo(sample_shape, "float32"),
+                    ty_args=relax.TensorType(sample_shape, "float32"),
                 ),
                 name="uniform_samples",
             )
@@ -93,7 +91,7 @@ def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
                     "vm.builtin.reshape",
                     sample_indices,
                     sample_shape,
-                    sinfo_args=relax.TensorStructInfo(sample_shape, "int32"),
+                    ty_args=relax.TensorType(sample_shape, "int32"),
                 ),
                 name="sample_indices",
             )
@@ -108,8 +106,8 @@ def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
                 relax.call_pure_packed(
                     "vm.builtin.reshape",
                     result_tensor._expr,
-                    sample_indices.struct_info.shape,
-                    sinfo_args=sample_indices.struct_info,
+                    sample_indices.ty.shape,
+                    ty_args=sample_indices.ty,
                 )
             )
             output = bb.emit_output(result)
@@ -120,7 +118,7 @@ def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
 def _attach_argsort_func(bb: relax.BlockBuilder):
     batch_size = tirx.SizeVar("batch_size", "int64")
     vocab_size = tirx.SizeVar("vocab_size", "int64")
-    probs = relax.Var("probs", relax.TensorStructInfo((batch_size, vocab_size), "float32"))
+    probs = relax.Var("probs", relax.TensorType((batch_size, vocab_size), "float32"))
     with bb.function("argsort_probs", [probs]):
         with bb.dataflow():
             sorted_indices = bb.emit(relax.op.argsort(probs, descending=True, dtype="int32"))
@@ -139,7 +137,7 @@ def _attach_argsort_func(bb: relax.BlockBuilder):
     return gv
 
 
-@T.prim_func
+@T.prim_func(s_tir=True)
 def full(var_result: T.handle, value: T.int32):
     """The filling function for top k."""
     batch_size = T.int32(is_size_var=True)
@@ -154,17 +152,13 @@ def _attach_sample_with_top_p(bb: relax.BlockBuilder):
     batch_size = tirx.SizeVar("batch_size", "int64")
     num_samples = tirx.SizeVar("num_samples", "int64")
     vocab_size = tirx.SizeVar("vocab_size", "int64")
-    sorted_probs = relax.Var(
-        "sorted_probs", relax.TensorStructInfo((batch_size, vocab_size), "float32")
-    )
+    sorted_probs = relax.Var("sorted_probs", relax.TensorType((batch_size, vocab_size), "float32"))
     sorted_indices = relax.Var(
-        "sorted_indices", relax.TensorStructInfo((batch_size, vocab_size), "int32")
+        "sorted_indices", relax.TensorType((batch_size, vocab_size), "int32")
     )
-    uniform_samples = relax.Var(
-        "uniform_samples", relax.TensorStructInfo((num_samples,), "float32")
-    )
-    sample_indices = relax.Var("sample_indices", relax.TensorStructInfo((num_samples,), "int32"))
-    top_p = relax.Var("top_p", relax.TensorStructInfo((batch_size,), "float32"))
+    uniform_samples = relax.Var("uniform_samples", relax.TensorType((num_samples,), "float32"))
+    sample_indices = relax.Var("sample_indices", relax.TensorType((num_samples,), "int32"))
+    top_p = relax.Var("top_p", relax.TensorType((batch_size,), "float32"))
 
     with bb.function(
         "sample_with_top_p",
@@ -180,7 +174,7 @@ def _attach_sample_with_top_p(bb: relax.BlockBuilder):
                     "vm.builtin.reshape",
                     uniform_samples,
                     sample_shape,
-                    sinfo_args=relax.TensorStructInfo(sample_shape, "float32"),
+                    ty_args=relax.TensorType(sample_shape, "float32"),
                 ),
                 name="uniform_samples",
             )
@@ -189,7 +183,7 @@ def _attach_sample_with_top_p(bb: relax.BlockBuilder):
                     "vm.builtin.reshape",
                     sample_indices,
                     sample_shape,
-                    sinfo_args=relax.TensorStructInfo(sample_shape, "int32"),
+                    ty_args=relax.TensorType(sample_shape, "int32"),
                 ),
                 name="sample_indices",
             )
@@ -198,7 +192,7 @@ def _attach_sample_with_top_p(bb: relax.BlockBuilder):
                     "vm.builtin.reshape",
                     top_p,
                     top_p_shape,
-                    sinfo_args=relax.TensorStructInfo(top_p_shape, "float32"),
+                    ty_args=relax.TensorType(top_p_shape, "float32"),
                 ),
                 name="sample_indices",
             )
@@ -224,8 +218,8 @@ def _attach_sample_with_top_p(bb: relax.BlockBuilder):
                 relax.call_pure_packed(
                     "vm.builtin.reshape",
                     result_tensor._expr,
-                    sample_indices.struct_info.shape,
-                    sinfo_args=sample_indices.struct_info,
+                    sample_indices.ty.shape,
+                    ty_args=sample_indices.ty,
                 )
             )
         gv = bb.emit_func_output(result)
@@ -236,18 +230,16 @@ def _attach_renormalize_by_top_p(bb: relax.BlockBuilder, target: tvm.target.Targ
     batch_size = tirx.SizeVar("batch_size", "int64")
     vocab_size = tirx.SizeVar("vocab_size", "int64")
     num_pivots = 3
-    probs = relax.Var("probs", relax.TensorStructInfo((batch_size, vocab_size), "float32"))
-    top_p = relax.Var("top_p", relax.TensorStructInfo((batch_size,), "float32"))
-    init_pivots = relax.Var(
-        "init_pivots", relax.TensorStructInfo((batch_size, num_pivots), "float32")
-    )
+    probs = relax.Var("probs", relax.TensorType((batch_size, vocab_size), "float32"))
+    top_p = relax.Var("top_p", relax.TensorType((batch_size,), "float32"))
+    init_pivots = relax.Var("init_pivots", relax.TensorType((batch_size, num_pivots), "float32"))
     with bb.function("renormalize_by_top_p", [probs, top_p, init_pivots]):
         with bb.dataflow():
             cutoff_output = bb.emit(
                 relax.call_tir(
                     bb.add_func(top_p_pivot(num_pivots, target), "top_p_pivot_cutoff"),
                     args=[probs, top_p, init_pivots],
-                    out_sinfo=[top_p.struct_info, top_p.struct_info],
+                    out_ty=[top_p.ty, top_p.ty],
                 )
             )
             final_pivot = cutoff_output[0]
@@ -256,7 +248,7 @@ def _attach_renormalize_by_top_p(bb: relax.BlockBuilder, target: tvm.target.Targ
                 relax.call_tir(
                     bb.add_func(top_p_renorm(target), "top_p_renorm_after_cutoff"),
                     args=[probs, final_pivot, renorm_sum],
-                    out_sinfo=probs.struct_info,
+                    out_ty=probs.ty,
                 )
             )
         gv = bb.emit_func_output(renormalized_probs)
@@ -269,18 +261,16 @@ def _attach_take_probs_func(bb: relax.BlockBuilder):
     num_positions = tirx.SizeVar("num_positions", "int64")
     vocab_size = tirx.SizeVar("vocab_size", "int64")
     unsorted_probs = relax.Var(
-        "unsorted_probs", relax.TensorStructInfo((batch_size, vocab_size), "float32")
+        "unsorted_probs", relax.TensorType((batch_size, vocab_size), "float32")
     )
     sorted_indices = relax.Var(
-        "sorted_indices", relax.TensorStructInfo((batch_size, vocab_size), "int32")
+        "sorted_indices", relax.TensorType((batch_size, vocab_size), "int32")
     )
-    sample_indices = relax.Var("sample_indices", relax.TensorStructInfo((num_samples,), "int32"))
-    sampling_results = relax.Var("sampling_result", relax.TensorStructInfo((num_samples,), "int32"))
-    top_prob_offsets = relax.Var(
-        "lobprob_offsets", relax.TensorStructInfo((num_positions,), "int32")
-    )
+    sample_indices = relax.Var("sample_indices", relax.TensorType((num_samples,), "int32"))
+    sampling_results = relax.Var("sampling_result", relax.TensorType((num_samples,), "int32"))
+    top_prob_offsets = relax.Var("lobprob_offsets", relax.TensorType((num_positions,), "int32"))
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def sampler_take_probs_tir(
         var_unsorted_probs: T.handle,
         var_sorted_indices: T.handle,
@@ -303,17 +293,31 @@ def _attach_take_probs_func(bb: relax.BlockBuilder):
         sampled_values = T.match_buffer(var_sampled_values, (num_samples,), "float32")
         top_prob_probs = T.match_buffer(var_top_prob_probs, (num_positions,), "float32")
         top_prob_indices = T.match_buffer(var_top_prob_indices, (num_positions,), "int32")
-        for i in T.serial(num_positions + num_samples):
-            with T.sblock("block"):
-                vi = T.axis.spatial(num_positions + num_samples, i)
-                if vi < num_positions:
-                    row = T.floordiv(top_prob_offsets[vi], vocab_size)
-                    col = T.floormod(top_prob_offsets[vi], vocab_size)
-                    top_prob_indices[vi] = sorted_indices[row, col]
-                    top_prob_probs[vi] = unsorted_probs[row, sorted_indices[row, col]]
-                else:
-                    vj: T.int32 = vi - num_positions
-                    sampled_values[vj] = unsorted_probs[sample_indices[vj], sampling_results[vj]]
+        for i in T.serial(num_positions):
+            with T.sblock("top_prob"):
+                vi = T.axis.spatial(num_positions, i)
+                # Reads are data-dependent gathers; declare full-buffer read
+                # regions explicitly so tirx does not infer data-dependent regions.
+                T.reads(
+                    top_prob_offsets[vi],
+                    sorted_indices[0:batch_size, 0:vocab_size],
+                    unsorted_probs[0:batch_size, 0:vocab_size],
+                )
+                T.writes(top_prob_indices[vi], top_prob_probs[vi])
+                row = T.floordiv(top_prob_offsets[vi], vocab_size)
+                col = T.floormod(top_prob_offsets[vi], vocab_size)
+                top_prob_indices[vi] = sorted_indices[row, col]
+                top_prob_probs[vi] = unsorted_probs[row, sorted_indices[row, col]]
+        for i in T.serial(num_samples):
+            with T.sblock("sample"):
+                vj = T.axis.spatial(num_samples, i)
+                T.reads(
+                    sample_indices[vj],
+                    sampling_results[vj],
+                    unsorted_probs[0:batch_size, 0:vocab_size],
+                )
+                T.writes(sampled_values[vj])
+                sampled_values[vj] = unsorted_probs[sample_indices[vj], sampling_results[vj]]
 
     args = [
         unsorted_probs,
@@ -328,10 +332,10 @@ def _attach_take_probs_func(bb: relax.BlockBuilder):
                 relax.call_tir(
                     bb.add_func(sampler_take_probs_tir, "sampler_take_probs_tir"),
                     args,
-                    out_sinfo=[
-                        relax.TensorStructInfo((num_samples,), "float32"),
-                        relax.TensorStructInfo((num_positions,), "float32"),
-                        relax.TensorStructInfo((num_positions,), "int32"),
+                    out_ty=[
+                        relax.TensorType((num_samples,), "float32"),
+                        relax.TensorType((num_positions,), "float32"),
+                        relax.TensorType((num_positions,), "int32"),
                     ],
                 )
             )
@@ -343,23 +347,17 @@ def _attach_batch_verifier(bb: relax.BlockBuilder):
     num_nodes = tirx.SizeVar("num_nodes", "int64")
     nbatch = tirx.SizeVar("nbatch", "int64")
     vocab_size = tirx.SizeVar("vocab_size", "int64")
-    draft_probs = relax.Var(
-        "draft_probs", relax.TensorStructInfo((num_nodes, vocab_size), "float32")
-    )
-    draft_tokens = relax.Var("draft_tokens", relax.TensorStructInfo((num_nodes,), "int32"))
-    model_probs = relax.Var(
-        "model_probs", relax.TensorStructInfo((num_nodes, vocab_size), "float32")
-    )
+    draft_probs = relax.Var("draft_probs", relax.TensorType((num_nodes, vocab_size), "float32"))
+    draft_tokens = relax.Var("draft_tokens", relax.TensorType((num_nodes,), "int32"))
+    model_probs = relax.Var("model_probs", relax.TensorType((num_nodes, vocab_size), "float32"))
     token_tree_first_child = relax.Var(
-        "token_tree_first_child", relax.TensorStructInfo((num_nodes,), "int32")
+        "token_tree_first_child", relax.TensorType((num_nodes,), "int32")
     )
     token_tree_next_sibling = relax.Var(
-        "token_tree_next_sibling", relax.TensorStructInfo((num_nodes,), "int32")
+        "token_tree_next_sibling", relax.TensorType((num_nodes,), "int32")
     )
-    uniform_samples = relax.Var("uniform_samples", relax.TensorStructInfo((num_nodes,), "float32"))
-    token_tree_parent_ptr = relax.Var(
-        "token_tree_parent_ptr", relax.TensorStructInfo((nbatch,), "int32")
-    )
+    uniform_samples = relax.Var("uniform_samples", relax.TensorType((num_nodes,), "float32"))
+    token_tree_parent_ptr = relax.Var("token_tree_parent_ptr", relax.TensorType((nbatch,), "int32"))
     args = [
         draft_probs,
         draft_tokens,
@@ -382,9 +380,9 @@ def _attach_batch_verifier(bb: relax.BlockBuilder):
                         args.index(model_probs),
                         args.index(token_tree_parent_ptr),
                     ],
-                    out_sinfo=[
-                        model_probs.struct_info,
-                        token_tree_parent_ptr.struct_info,
+                    out_ty=[
+                        model_probs.ty,
+                        token_tree_parent_ptr.ty,
                     ],
                 )
             )

--- a/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
+++ b/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
@@ -48,22 +48,22 @@ class _Rewriter(PyExprMutator):
         batch_size = tirx.SizeVar("batch_size", "int64")
         vocab_size = tirx.SizeVar("vocab_size", "int64")
         dtype = "float32"
-        logits = relax.Var("logits", relax.TensorStructInfo([batch_size, 1, vocab_size], dtype))
-        temperature = relax.Var("temperature", relax.TensorStructInfo([batch_size], dtype))
+        logits = relax.Var("logits", relax.TensorType([batch_size, 1, vocab_size], dtype))
+        temperature = relax.Var("temperature", relax.TensorType([batch_size], dtype))
         with self.builder_.function("softmax_with_temperature", params=[logits, temperature]):
             with self.builder_.dataflow():
-                output_struct_info = logits.struct_info
+                output_struct_info = logits.ty
                 new_shape = relax.ShapeExpr([batch_size, vocab_size])
                 logits = relax.call_pure_packed(
                     "vm.builtin.reshape",
                     logits,
                     new_shape,
-                    sinfo_args=relax.TensorStructInfo(new_shape, dtype),
+                    ty_args=relax.TensorType(new_shape, dtype),
                 )
                 f_chunk_lse, f_softmax_with_lse = _get_lse_and_softmax_func(
                     self.target, self.chunk_size, self.active_vocab_size
                 )
-                chunked_result_struct_info = relax.TensorStructInfo(
+                chunked_result_struct_info = relax.TensorType(
                     (batch_size, (vocab_size + self.chunk_size - 1) // self.chunk_size),
                     "float32",
                 )
@@ -71,7 +71,7 @@ class _Rewriter(PyExprMutator):
                     relax.call_tir(
                         self.builder_.add_func(f_chunk_lse, "chunk_lse"),
                         args=[logits, temperature],
-                        out_sinfo=[
+                        out_ty=[
                             chunked_result_struct_info,
                             chunked_result_struct_info,
                         ],
@@ -83,7 +83,7 @@ class _Rewriter(PyExprMutator):
                     relax.call_tir(
                         self.builder_.add_func(f_softmax_with_lse, "softmax_with_chunked_sum"),
                         args=[logits, temperature, chunked_sum, chunked_max],
-                        out_sinfo=logits.struct_info,
+                        out_ty=logits.ty,
                     )
                 )
                 softmax = self.builder_.emit_output(
@@ -91,7 +91,7 @@ class _Rewriter(PyExprMutator):
                         "vm.builtin.reshape",
                         softmax,
                         output_struct_info.shape,
-                        sinfo_args=output_struct_info,
+                        ty_args=output_struct_info,
                     )
                 )
             self.builder_.emit_func_output(softmax)
@@ -116,14 +116,14 @@ def _get_lse_and_softmax_func(target: tvm.target.Target, chunk_size: int, active
     # of the max value. The second kernel merges the max and counts, and set the
     # softmax of the maximum values to "max_value / max_count".
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def chunk_lse(
         var_A: T.handle,
         var_temperature: T.handle,
         var_chunked_sum: T.handle,
         var_chunked_max: T.handle,
     ):
-        T.func_attr({"tirx.noalias": T.bool(True)})
+        T.func_attr({"tirx.noalias": True})
         batch_size = T.int64(is_size_var=True)
         vocab_size = T.int64(is_size_var=True)
         num_chunks = T.int64(is_size_var=True)
@@ -181,7 +181,7 @@ def _get_lse_and_softmax_func(target: tvm.target.Target, chunk_size: int, active
                 )
                 chunked_max[v0, v1] = temp_max[v0, v1]
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def softmax_with_chunked_sum(
         var_A: T.handle,
         var_temperature: T.handle,
@@ -189,7 +189,7 @@ def _get_lse_and_softmax_func(target: tvm.target.Target, chunk_size: int, active
         var_chunked_max: T.handle,
         var_softmax: T.handle,
     ):
-        T.func_attr({"tirx.noalias": T.bool(True), "tirx.is_scheduled": 1})
+        T.func_attr({"tirx.noalias": True, "tirx.is_scheduled": 1})
         batch_size = T.int64(is_size_var=True)
         vocab_size = T.int64(is_size_var=True)
         num_chunks = T.int64(is_size_var=True)

--- a/python/mlc_llm/compiler_pass/attach_spec_decode_aux_funcs.py
+++ b/python/mlc_llm/compiler_pass/attach_spec_decode_aux_funcs.py
@@ -2,7 +2,7 @@
 
 import tvm
 from tvm import IRModule, relax, tirx
-from tvm.relax import BlockBuilder, TensorStructInfo
+from tvm.relax import BlockBuilder, TensorType
 from tvm.script import tirx as T
 
 
@@ -28,9 +28,7 @@ class AttachSpecDecodeAuxFuncs:
             "gather_probs",
         )
         if "prefill_to_last_hidden_states" in mod:
-            hidden_states_struct_info = mod["prefill_to_last_hidden_states"].ret_struct_info.fields[
-                0
-            ]
+            hidden_states_struct_info = mod["prefill_to_last_hidden_states"].ret_ty.fields[0]
             dtype = hidden_states_struct_info.dtype
             _add_gather_hidden_states(bb, self.tensor_parallel_shards, dtype)
             _add_scatter_hidden_states(bb, self.tensor_parallel_shards, dtype)
@@ -38,7 +36,7 @@ class AttachSpecDecodeAuxFuncs:
 
 
 def _get_scatter_2d_inplace(dtype: str, global_symbol: str):
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _scatter_2d(var_src: T.handle, var_indices: T.handle, var_dst: T.handle):
         T.func_attr({"global_symbol": global_symbol, "tirx.noalias": True})
         batch_size = T.int32(is_size_var=True)
@@ -56,7 +54,7 @@ def _get_scatter_2d_inplace(dtype: str, global_symbol: str):
 
 
 def _get_gather_2d_inplace(dtype: str, global_symbol: str):
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def _gather_2d(var_src: T.handle, var_indices: T.handle, var_dst: T.handle):
         T.func_attr({"global_symbol": global_symbol, "tirx.noalias": True})
         batch_size = T.int32(is_size_var=True)
@@ -77,9 +75,9 @@ def _add_scatter_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dt
     batch_size = tirx.SizeVar("batch_size", "int64")
     m = tirx.SizeVar("m", "int64")
     n = tirx.SizeVar("n", "int64")
-    src = relax.Var("src", struct_info=TensorStructInfo([batch_size, n], dtype))
-    indices = relax.Var("indices", struct_info=TensorStructInfo([batch_size], "int32"))
-    dst = relax.Var("dst", struct_info=TensorStructInfo([m, n], dtype))
+    src = relax.Var("src", ty=TensorType([batch_size, n], dtype))
+    indices = relax.Var("indices", ty=TensorType([batch_size], "int32"))
+    dst = relax.Var("dst", ty=TensorType([m, n], dtype))
     with bb.function("scatter_hidden_states", [src, indices, dst]):
         with bb.dataflow():
             if tensor_parallel_shards > 1:
@@ -92,7 +90,7 @@ def _add_scatter_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dt
                     ),
                     [src, indices, dst],
                     2,
-                    dst.struct_info,
+                    dst.ty,
                 )
             )
         gv = bb.emit_func_output(output)
@@ -103,9 +101,9 @@ def _add_gather_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dty
     batch_size = tirx.SizeVar("batch_size", "int64")
     m = tirx.SizeVar("m", "int64")
     n = tirx.SizeVar("n", "int64")
-    src = relax.Var("src", struct_info=TensorStructInfo([m, n], dtype))
-    indices = relax.Var("indices", struct_info=TensorStructInfo([batch_size], "int32"))
-    dst = relax.Var("dst", struct_info=TensorStructInfo([batch_size, n], dtype))
+    src = relax.Var("src", ty=TensorType([m, n], dtype))
+    indices = relax.Var("indices", ty=TensorType([batch_size], "int32"))
+    dst = relax.Var("dst", ty=TensorType([batch_size, n], dtype))
     with bb.function("gather_hidden_states", [src, indices, dst]):
         with bb.dataflow():
             if tensor_parallel_shards > 1:
@@ -118,7 +116,7 @@ def _add_gather_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dty
                     ),
                     [src, indices, dst],
                     2,
-                    dst.struct_info,
+                    dst.ty,
                 )
             )
         gv = bb.emit_func_output(output)

--- a/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
+++ b/python/mlc_llm/compiler_pass/dispatch_kv_cache_creation.py
@@ -32,7 +32,7 @@ def extract_creation_args(func: relax.Function) -> Dict[str, Any]:  # noqa: UP00
         assert args[0].value in ["mha", "mla"]
         attn_kind = args[0].value
     else:
-        assert len(args[0].fields) == args[3].value.value
+        assert len(args[0].fields) == args[3].value
         for i, attention_type in enumerate(args[0].fields):
             assert isinstance(attention_type, relax.StringImm)
             assert attention_type.value in ["mha", "mla", "mha_sliding"]
@@ -43,10 +43,13 @@ def extract_creation_args(func: relax.Function) -> Dict[str, Any]:  # noqa: UP00
     for i in range(3, 18):
         if i in [13, 14, 17]:
             continue
-        assert isinstance(args[i], relax.PrimValue), f"args[{i}] is {type(args[i])}"
-        assert isinstance(args[i].value, (tvm.tirx.IntImm, tvm.tirx.FloatImm))
+        # PrimValue wrappers were phased out of Relax: scalar args are now bare
+        # tirx PrimExprs (IntImm/FloatImm) directly.
+        assert isinstance(args[i], (tvm.tirx.IntImm, tvm.tirx.FloatImm)), (
+            f"args[{i}] is {type(args[i])}"
+        )
     assert isinstance(args[13], relax.StringImm)
-    assert isinstance(args[16], (relax.Constant, relax.PrimValue))
+    assert isinstance(args[16], (relax.Constant, tvm.tirx.IntImm, tvm.tirx.FloatImm))
     assert isinstance(args[17], relax.DataTypeImm)
 
     return {
@@ -57,20 +60,20 @@ def extract_creation_args(func: relax.Function) -> Dict[str, Any]:  # noqa: UP00
         "page_size": args[1].values[3],
         "support_sliding_window": args[1].values[4],
         "layer_partition": args[2],
-        "num_hidden_layers": args[3].value.value,
-        "num_attention_heads": args[4].value.value,
-        "num_key_value_heads": args[5].value.value,
-        "qk_head_dim": args[6].value.value,
-        "v_head_dim": args[7].value.value,
-        "mla_original_qk_head_dim": args[8].value.value,
-        "mla_original_v_head_dim": args[9].value.value,
-        "rope_mode": args[10].value.value,
-        "rope_scale": args[11].value.value,
-        "rope_theta": args[12].value.value,
+        "num_hidden_layers": args[3].value,
+        "num_attention_heads": args[4].value,
+        "num_key_value_heads": args[5].value,
+        "qk_head_dim": args[6].value,
+        "v_head_dim": args[7].value,
+        "mla_original_qk_head_dim": args[8].value,
+        "mla_original_v_head_dim": args[9].value,
+        "rope_mode": args[10].value,
+        "rope_scale": args[11].value,
+        "rope_theta": args[12].value,
         "rope_scaling": json.loads(args[13].value),
         "rope_ext_factors": args[14],
-        "rotary_dim": args[15].value.value,
-        "enable_disaggregation": bool(args[16].value.value),
+        "rotary_dim": args[15].value,
+        "enable_disaggregation": bool(args[16].value),
         "dtype": args[17].value,
     }
 
@@ -150,19 +153,17 @@ class DispatchKVCacheCreation:
         kwargs: Dict[str, Any],  # noqa: UP006
     ) -> List[tvm.runtime.Module]:  # noqa: UP006
         """Create the TIR-based PagedKVCache"""
-        max_batch_size = relax.Var(
-            "max_batch_size_", relax.ShapeStructInfo([kwargs["max_batch_size"]])
-        )
+        max_batch_size = relax.Var("max_batch_size_", relax.ShapeType([kwargs["max_batch_size"]]))
         max_total_seq_len = relax.Var(
-            "max_total_seq_len_", relax.ShapeStructInfo([kwargs["max_total_seq_len"]])
+            "max_total_seq_len_", relax.ShapeType([kwargs["max_total_seq_len"]])
         )
         prefill_chunk_size = relax.Var(
-            "prefill_chunk_size_", relax.ShapeStructInfo([kwargs["prefill_chunk_size"]])
+            "prefill_chunk_size_", relax.ShapeType([kwargs["prefill_chunk_size"]])
         )
-        page_size = relax.Var("page_size_", relax.ShapeStructInfo([kwargs["page_size"]]))
+        page_size = relax.Var("page_size_", relax.ShapeType([kwargs["page_size"]]))
         support_sliding_window = relax.Var(
             "support_sliding_window_",
-            relax.ShapeStructInfo([kwargs["support_sliding_window"]]),
+            relax.ShapeType([kwargs["support_sliding_window"]]),
         )
 
         # Ensure 'enable_disaggregation' is optional
@@ -205,19 +206,17 @@ class DispatchKVCacheCreation:
         ):
             return []
 
-        max_batch_size = relax.Var(
-            "max_batch_size_", relax.ShapeStructInfo([kwargs["max_batch_size"]])
-        )
+        max_batch_size = relax.Var("max_batch_size_", relax.ShapeType([kwargs["max_batch_size"]]))
         max_total_seq_len = relax.Var(
-            "max_total_seq_len_", relax.ShapeStructInfo([kwargs["max_total_seq_len"]])
+            "max_total_seq_len_", relax.ShapeType([kwargs["max_total_seq_len"]])
         )
         prefill_chunk_size = relax.Var(
-            "prefill_chunk_size_", relax.ShapeStructInfo([kwargs["prefill_chunk_size"]])
+            "prefill_chunk_size_", relax.ShapeType([kwargs["prefill_chunk_size"]])
         )
-        page_size = relax.Var("page_size_", relax.ShapeStructInfo([kwargs["page_size"]]))
+        page_size = relax.Var("page_size_", relax.ShapeType([kwargs["page_size"]]))
         support_sliding_window = relax.Var(
             "support_sliding_window_",
-            relax.ShapeStructInfo([kwargs["support_sliding_window"]]),
+            relax.ShapeType([kwargs["support_sliding_window"]]),
         )
 
         try:

--- a/python/mlc_llm/compiler_pass/dispatch_triton_kernel.py
+++ b/python/mlc_llm/compiler_pass/dispatch_triton_kernel.py
@@ -52,15 +52,15 @@ class _Rewriter(PyExprMutator):
         global_symbol = str(call.args[0].global_symbol)
         assert isinstance(call.args[1], relax.Tuple)
         if global_symbol == "mlc.triton.w8a8_block_fp8_matmul":
-            return self.w8a8_block_fp8_matmul(call.args[1].fields, call.struct_info)
+            return self.w8a8_block_fp8_matmul(call.args[1].fields, call.ty)
         if global_symbol == "mlc.triton.w8a8_block_fp8_group_matmul":
-            return self.w8a8_block_fp8_group_matmul(call.args[1].fields, call.struct_info)
+            return self.w8a8_block_fp8_group_matmul(call.args[1].fields, call.ty)
         raise ValueError(f"Unknown mlc.triton kernel identifier: {global_symbol}")
 
     def w8a8_block_fp8_matmul(
         self,
         args: List[relax.Expr],  # noqa: UP006
-        out_sinfo: relax.StructInfo,
+        out_ty: relax.Type,
     ) -> relax.Expr:
         """Emit the w8a8_block_fp8_matmul triton kernel."""
         assert len(args) == 16
@@ -101,12 +101,12 @@ class _Rewriter(PyExprMutator):
             # Add the TIR function to the IRModule
             gv = self.builder_.add_func(prim_func, func_name)
 
-        return relax.call_tir(gv, [x, weight, x_scale, weight_scale], out_sinfo=out_sinfo)
+        return relax.call_tir(gv, [x, weight, x_scale, weight_scale], out_ty=out_ty)
 
     def w8a8_block_fp8_group_matmul(
         self,
         args: List[relax.Expr],  # noqa: UP006
-        out_sinfo: relax.StructInfo,
+        out_ty: relax.Type,
     ) -> relax.Expr:
         """Emit the w8a8_block_fp8_group_matmul triton kernel."""
         assert len(args) == 19
@@ -152,7 +152,7 @@ class _Rewriter(PyExprMutator):
         return relax.call_tir(
             gv,
             [x, weight, x_scale, weight_scale, expert_ids, indptr],
-            out_sinfo=out_sinfo,
+            out_ty=out_ty,
         )
 
 

--- a/python/mlc_llm/compiler_pass/fuse_add_norm.py
+++ b/python/mlc_llm/compiler_pass/fuse_add_norm.py
@@ -18,9 +18,9 @@ def _get_add_rms_norm_decode(hidden_size: int, eps: float, TX: int, in_dtype: st
     eps = T.float32(eps)
     add_local_size = hidden_size // TX
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def decode_add_rms(pA: T.handle, pB: T.handle, pC: T.handle, pO: T.handle, pAdd: T.handle):
-        T.func_attr({"tirx.noalias": T.bool(True), "tirx.is_scheduled": 1})
+        T.func_attr({"tirx.noalias": True, "tirx.is_scheduled": 1})
         batch_size = T.int32()
         A = T.match_buffer(pA, (batch_size, 1, hidden_size), in_dtype)
         B = T.match_buffer(pB, (batch_size, 1, hidden_size), in_dtype)
@@ -87,9 +87,9 @@ def _get_add_rms_norm_prefill(hidden_size: int, eps: float, TX: int, in_dtype: s
     eps = T.float32(eps)
     add_local_size = hidden_size // TX
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def prefill_add_rms(pA: T.handle, pB: T.handle, pC: T.handle, pO: T.handle, pAdd: T.handle):
-        T.func_attr({"tirx.noalias": T.bool(True), "tirx.is_scheduled": 1})
+        T.func_attr({"tirx.noalias": True, "tirx.is_scheduled": 1})
         seq_len = T.int32()
         A = T.match_buffer(pA, (1, seq_len, hidden_size), in_dtype)
         B = T.match_buffer(pB, (1, seq_len, hidden_size), in_dtype)
@@ -188,7 +188,7 @@ class _FuseAddRMSNormRewriter(PyExprMutator):
         call = super().visit_call_(call)
 
         # Match the "rms_norm(add(x1, x2), w)" pattern
-        if call.op != tvm.ir.Op.get("relax.nn.rms_norm") or call.struct_info.dtype not in [
+        if call.op != tvm.ir.Op.get("relax.nn.rms_norm") or call.ty.dtype not in [
             "bfloat16",
             "float16",
         ]:
@@ -204,7 +204,7 @@ class _FuseAddRMSNormRewriter(PyExprMutator):
         x1 = y.args[0]
         x2 = y.args[1]
         # Extra check
-        n, _, h = x1.struct_info.shape
+        n, _, h = x1.ty.shape
         h = int(h)
         if h % self.TX != 0:
             return call
@@ -214,13 +214,13 @@ class _FuseAddRMSNormRewriter(PyExprMutator):
         if func_gv is None:
             if is_prefill:
                 func_gv = self.builder_.add_func(
-                    _get_add_rms_norm_prefill(h, eps, self.TX, call.struct_info.dtype),
+                    _get_add_rms_norm_prefill(h, eps, self.TX, call.ty.dtype),
                     "fuse_add_norm_prefill",
                 )
                 self.prefill_norm_gv = func_gv
             else:
                 func_gv = self.builder_.add_func(
-                    _get_add_rms_norm_decode(h, eps, self.TX, call.struct_info.dtype),
+                    _get_add_rms_norm_decode(h, eps, self.TX, call.ty.dtype),
                     "fuse_add_norm_decode",
                 )
                 self.decode_norm_gv = func_gv
@@ -229,7 +229,7 @@ class _FuseAddRMSNormRewriter(PyExprMutator):
             relax.call_tir(
                 func_gv,
                 [x1, x2, weight],
-                out_sinfo=[x1.struct_info, x2.struct_info],
+                out_ty=[x1.ty, x2.ty],
             )
         )
         new_o = relax.TupleGetItem(tuple_output, 0)

--- a/python/mlc_llm/compiler_pass/fuse_dequantize_transpose.py
+++ b/python/mlc_llm/compiler_pass/fuse_dequantize_transpose.py
@@ -43,9 +43,9 @@ class _DequantizeTransposeFuser(PyExprMutator):
             return call
         # Do not fuse dequantize-transpose for GeMM
         if (
-            call.args[0].struct_info.ndim < 2
-            or not isinstance(call.args[0].struct_info.shape[-2], tirx.IntImm)
-            or call.args[0].struct_info.shape[-2].value != 1
+            call.args[0].ty.ndim < 2
+            or not isinstance(call.args[0].ty.shape[-2], tirx.IntImm)
+            or call.args[0].ty.shape[-2].value != 1
         ):
             return call
 
@@ -53,7 +53,7 @@ class _DequantizeTransposeFuser(PyExprMutator):
         if (
             not isinstance(matmul_rhs, relax.Call)
             or matmul_rhs.op != tvm.ir.Op.get("relax.permute_dims")
-            or matmul_rhs.args[0].struct_info.ndim != 2
+            or matmul_rhs.args[0].ty.ndim != 2
             or matmul_rhs.attrs.axes is not None
         ):
             return call
@@ -63,7 +63,7 @@ class _DequantizeTransposeFuser(PyExprMutator):
             not isinstance(transpose_input, relax.Call)
             or transpose_input.op != tvm.ir.Op.get("relax.call_tir")
             or not transpose_input.args[0].name_hint.startswith("dequantize")
-            or not isinstance(transpose_input.struct_info, relax.TensorStructInfo)
+            or not isinstance(transpose_input.ty, relax.TensorType)
         ):
             return call
 
@@ -102,6 +102,6 @@ class _DequantizeTransposeFuser(PyExprMutator):
         new_func = s_tir.renew_defs(new_func)
         g_var = self.builder_.add_func(new_func, func_name="dequantize")
         dequantize_matmul_rhs = self.builder_.emit(
-            relax.call_tir(g_var, transpose_input.args[1], out_sinfo=matmul_rhs.struct_info)
+            relax.call_tir(g_var, transpose_input.args[1], out_ty=matmul_rhs.ty)
         )
         return relax.op.matmul(call.args[0], dequantize_matmul_rhs, out_dtype=call.attrs.out_dtype)

--- a/python/mlc_llm/compiler_pass/fuse_ft_dequantize_matmul_epilogue.py
+++ b/python/mlc_llm/compiler_pass/fuse_ft_dequantize_matmul_epilogue.py
@@ -68,10 +68,9 @@ def fuse_bias(func: relax.Function) -> relax.Function:
                 return expr
             matched_bias = match[bias]
             bias_stride = (
-                matched_bias.struct_info.shape[-1]
+                matched_bias.ty.shape[-1]
                 if bias
-                and not reduce(operator.mul, matched_bias.struct_info.shape, 1)
-                == matched_bias.struct_info.shape[-1]
+                and not reduce(operator.mul, matched_bias.ty.shape, 1) == matched_bias.ty.shape[-1]
                 else 0
             )
             return relax.call_dps_packed(
@@ -88,7 +87,7 @@ def fuse_bias(func: relax.Function) -> relax.Function:
                     args_list[7],  # group_size
                     bias_stride,  # bias_stride
                 ],
-                out_sinfo=match[decode_matmul].struct_info,
+                out_ty=match[decode_matmul].ty,
             )
         return expr
 
@@ -151,7 +150,7 @@ def fuse_activation(func: relax.Function) -> relax.Function:
                     args_list[6],  # k
                     args_list[7],  # group_size
                 ],
-                out_sinfo=match[decode_matmul].struct_info,
+                out_ty=match[decode_matmul].ty,
             )
         if match[decode_matmul].args[0].global_symbol == "fastertransformer.gemm_fp16_int_bias":
             matched_activation = match[pattern]
@@ -177,7 +176,7 @@ def fuse_activation(func: relax.Function) -> relax.Function:
                     args_list[8],  # group_size
                     args_list[9],  # bias_stride
                 ],
-                out_sinfo=match[decode_matmul].struct_info,
+                out_ty=match[decode_matmul].ty,
             )
         return expr
 
@@ -255,7 +254,7 @@ def fuse_residual_binary(func: relax.Function) -> relax.Function:
                     args_list[7],  # k
                     args_list[8],  # group_size
                 ],
-                out_sinfo=match[decode_matmul].struct_info,
+                out_ty=match[decode_matmul].ty,
             )
         return expr
 
@@ -325,7 +324,7 @@ def fuse_residual_unary(func: relax.Function) -> relax.Function:
                     args_list[10],  # k
                     args_list[11],  # group_size
                 ],
-                out_sinfo=match[decode_matmul].struct_info,
+                out_ty=match[decode_matmul].ty,
             )
         return expr
 

--- a/python/mlc_llm/compiler_pass/fuse_transpose_matmul.py
+++ b/python/mlc_llm/compiler_pass/fuse_transpose_matmul.py
@@ -38,7 +38,7 @@ def _pattern():
 
     def _check(context: relax.transform.PatternCheckContext) -> bool:
         transpose_call = context.annotated_expr["wT"]
-        ndim = transpose_call.args[0].struct_info.ndim
+        ndim = transpose_call.args[0].ty.ndim
         if ndim == -1:
             return False
         if ndim == 2 and transpose_call.attrs.axes is None:
@@ -77,13 +77,11 @@ class _TransposeMatmulFuser(PyExprMutator):
             is_a_larger = len(a_shape) > len(b_shape)
             offset = len(a_shape) - len(b_shape) if is_a_larger else len(b_shape) - len(a_shape)
 
-            a_relax = relax.Var("a", relax.TensorStructInfo(a.shape))
+            a_relax = relax.Var("a", relax.TensorType(a.shape))
             bT_shape = list(b.shape)
             bT_shape[-1], bT_shape[-2] = bT_shape[-2], bT_shape[-1]
-            bT_relax = relax.Var("b", relax.TensorStructInfo(bT_shape))
-            output_shape = self.builder_.normalize(
-                relax.op.matmul(a_relax, bT_relax)
-            ).struct_info.shape
+            bT_relax = relax.Var("b", relax.TensorType(bT_shape))
+            output_shape = self.builder_.normalize(relax.op.matmul(a_relax, bT_relax)).ty.shape
 
             def matmul_compute(*idx_spatial):
                 k = te.reduce_axis((0, a_shape[-1]), name="k")
@@ -136,7 +134,7 @@ class _TransposeMatmulFuser(PyExprMutator):
                 "Composite" in function.attrs
                 and function.attrs["Composite"] == "transpose_matmul_fuse"
             ):
-                out_dtype = function.ret_struct_info.dtype
+                out_dtype = function.ret_ty.dtype
                 return self.builder_.call_te(
                     te_transposed_matmul,
                     call.args[1],

--- a/python/mlc_llm/compiler_pass/lift_global_buffer_alloc.py
+++ b/python/mlc_llm/compiler_pass/lift_global_buffer_alloc.py
@@ -29,7 +29,7 @@ class _TIRGlobalAllocRewriter(PyExprMutator):
         self.mod = mod
         self.gv2new_tensor_sinfo: Dict[  # noqa: UP006
             tvm.ir.GlobalVar,
-            Tuple[tvm.ir.GlobalVar, List[relax.TensorStructInfo], tirx.PrimFunc],  # noqa: UP006
+            Tuple[tvm.ir.GlobalVar, List[relax.TensorType], tirx.PrimFunc],  # noqa: UP006
         ] = {}
 
     def transform(self) -> IRModule:
@@ -62,7 +62,7 @@ class _TIRGlobalAllocRewriter(PyExprMutator):
         g_var = call.args[0]
         new_gv, tensor_sinfo, func_before_update = self.gv2new_tensor_sinfo[g_var]
 
-        assert len(call.sinfo_args) == 1
+        assert len(call.ty_args) == 1
         if any(_has_symbolic_var(sinfo) for sinfo in tensor_sinfo):
             tensor_sinfo, success = _resolve_tir_var_mapping(func_before_update, call, tensor_sinfo)
             if not success:
@@ -72,27 +72,27 @@ class _TIRGlobalAllocRewriter(PyExprMutator):
 
         args = list(call.args)
         args[0] = new_gv
-        if isinstance(call.sinfo_args[0], relax.TensorStructInfo):
+        if isinstance(call.ty_args[0], relax.TensorType):
             new_call = relax.Call(
                 call.op,
                 args=args,
-                sinfo_args=[relax.TupleStructInfo(list(call.sinfo_args) + tensor_sinfo)],
+                ty_args=[relax.TupleType(list(call.ty_args) + tensor_sinfo)],
                 attrs=call.attrs,
             )
             emitted_tuple = self.builder_.emit(new_call)
             return relax.TupleGetItem(emitted_tuple, 0)
-        assert isinstance(call.sinfo_args[0], relax.TupleStructInfo)
+        assert isinstance(call.ty_args[0], relax.TupleType)
         return relax.Call(
             call.op,
             args=args,
-            sinfo_args=[relax.TupleStructInfo(list(call.sinfo_args[0].fields) + tensor_sinfo)],
+            ty_args=[relax.TupleType(list(call.ty_args[0].fields) + tensor_sinfo)],
             attrs=call.attrs,
         )
 
 
 def remove_global_buf_alloc(
     func: tirx.PrimFunc,
-) -> Tuple[tirx.PrimFunc, List[relax.TensorStructInfo]]:  # noqa: UP006
+) -> Tuple[tirx.PrimFunc, List[relax.TensorType]]:  # noqa: UP006
     """Remove the global buffer allocation for a given TIR PrimFunc."""
     assert isinstance(func.body, tirx.SBlockRealize)
     params = list(func.params)
@@ -101,7 +101,7 @@ def remove_global_buf_alloc(
     alloc_buffers = []
 
     insertion_point = len(params)
-    while params[insertion_point - 1].dtype != "handle":
+    while params[insertion_point - 1].ty.dtype != "handle":
         insertion_point -= 1
         assert insertion_point >= 1
 
@@ -112,7 +112,7 @@ def remove_global_buf_alloc(
             params.insert(insertion_point, param)
             insertion_point += 1
             buffer_map[param] = buf_alloc
-            tensor_sinfo.append(relax.TensorStructInfo(buf_alloc.shape, buf_alloc.dtype))
+            tensor_sinfo.append(relax.TensorType(buf_alloc.shape, buf_alloc.dtype))
         else:
             alloc_buffers.append(buf_alloc)
 
@@ -145,7 +145,7 @@ def remove_global_buf_alloc(
     return updated_func, tensor_sinfo
 
 
-def _has_symbolic_var(tensor_sinfo: relax.TensorStructInfo) -> bool:
+def _has_symbolic_var(tensor_sinfo: relax.TensorType) -> bool:
     assert isinstance(tensor_sinfo.shape, relax.ShapeExpr)
     for dim in tensor_sinfo.shape.values:
         if not isinstance(dim, tirx.IntImm):
@@ -156,15 +156,15 @@ def _has_symbolic_var(tensor_sinfo: relax.TensorStructInfo) -> bool:
 def _resolve_tir_var_mapping(
     func: tirx.PrimFunc,
     call: relax.Call,
-    tensor_sinfo: List[relax.TensorStructInfo],  # noqa: UP006
-) -> Tuple[List[relax.TensorStructInfo], bool]:  # noqa: UP006
+    tensor_sinfo: List[relax.TensorType],  # noqa: UP006
+) -> Tuple[List[relax.TensorType], bool]:  # noqa: UP006
     """Resolve the TIR symbolic var relationship across sides of PrimFunc and Relax Function"""
     var_map: Dict[tirx.Var, tirx.PrimExpr] = {}  # noqa: UP006
 
     n_arg = len(call.args[1].fields)
     for i in range(n_arg):
         buffer_shape = func.buffer_map[func.params[i]].shape
-        arg_shape = call.args[1][i].struct_info.shape.values
+        arg_shape = call.args[1][i].ty.shape.values
         assert len(buffer_shape) == len(arg_shape)
         for v_l, v_r in zip(buffer_shape, arg_shape):
             if isinstance(v_l, tirx.Var):
@@ -172,11 +172,9 @@ def _resolve_tir_var_mapping(
             elif not isinstance(v_l, tirx.IntImm):
                 return [], False
 
-    ret_tensors = call.sinfo_args[0]
+    ret_tensors = call.ty_args[0]
     ret_tensors = (
-        [ret_tensors]
-        if isinstance(ret_tensors, relax.TensorStructInfo)
-        else list(ret_tensors.fields)
+        [ret_tensors] if isinstance(ret_tensors, relax.TensorType) else list(ret_tensors.fields)
     )
     for i, ret_tensor in enumerate(ret_tensors):
         buffer_shape = func.buffer_map[func.params[n_arg + i]].shape
@@ -196,5 +194,5 @@ def _resolve_tir_var_mapping(
         new_shape = []
         for dim in sinfo.shape.values:
             new_shape.append(tirx.stmt_functor.substitute(dim, var_map))
-        updated_tensor_sinfo.append(relax.TensorStructInfo(new_shape, sinfo.dtype))
+        updated_tensor_sinfo.append(relax.TensorType(new_shape, sinfo.dtype))
     return updated_tensor_sinfo, True

--- a/python/mlc_llm/compiler_pass/low_batch_specialization.py
+++ b/python/mlc_llm/compiler_pass/low_batch_specialization.py
@@ -1,6 +1,7 @@
 """A compiler pass that dispatch low-batch-gemm to gemv schedule."""
 
 import tvm
+import tvm_ffi
 from tvm import tirx
 from tvm.ir.module import IRModule
 from tvm.s_tir import dlight as dl
@@ -29,7 +30,7 @@ class LowBatchGemvSpecialize:
                     )(low_batch_mod)
                     low_batch_funcs.append(low_batch_mod["main"])
                 if any(
-                    tvm.ir.structural_equal(low_batch_func, func)
+                    tvm_ffi.structural_equal(low_batch_func, func)
                     for low_batch_func in low_batch_funcs
                 ):
                     continue

--- a/python/mlc_llm/compiler_pass/pipeline_parallel_rewrite.py
+++ b/python/mlc_llm/compiler_pass/pipeline_parallel_rewrite.py
@@ -57,7 +57,7 @@ class _PipelineParallelRewriter(PyExprMutator):
                 and func.params[num_input].name_hint == "packed_params"
             ), 'Only the extra "packed_params" parameter is allowed'
             self.old_packed_params_var = func.params[num_input]
-            self.new_main_packed_params_var = relax.Var("packed_params", relax.ObjectStructInfo())
+            self.new_main_packed_params_var = relax.Var("packed_params", relax.ObjectType())
             for required_params in required_func_params:
                 for i, param in enumerate(required_params):
                     if param.same_as(self.old_packed_params_var):
@@ -93,7 +93,7 @@ class _PipelineParallelRewriter(PyExprMutator):
                     relax.op.call_builtin_with_ctx(
                         "mlc.multi_gpu.DispatchFunctionByGroup",
                         args=[dispatch_func_args],
-                        sinfo_args=relax.ObjectStructInfo(),
+                        ty_args=relax.ObjectType(),
                     )
                 )
                 dispatch_func_gv = bb.emit_func_output(output)
@@ -120,7 +120,7 @@ class _PipelineParallelRewriter(PyExprMutator):
         for new_param, old_param in zip(params, required_func_params):
             self.set_var_remap(old_param.vid, new_param)
         # Create new packed params
-        self.new_stage_func_packed_params = relax.Var("packed_params", relax.ObjectStructInfo())
+        self.new_stage_func_packed_params = relax.Var("packed_params", relax.ObjectType())
         self.set_var_remap(self.old_packed_params_var.vid, self.new_stage_func_packed_params)
 
         new_func_outputs = []
@@ -132,7 +132,7 @@ class _PipelineParallelRewriter(PyExprMutator):
                         relax.call_dps_packed(
                             "runtime.disco.recv_from_prev_group",
                             args=[],
-                            out_sinfo=self._update_struct_info(receive_var.struct_info),
+                            out_ty=self._update_struct_info(receive_var.ty),
                         ),
                         name_hint=receive_var.name_hint,
                     )
@@ -158,7 +158,7 @@ class _PipelineParallelRewriter(PyExprMutator):
                     relax.Call(
                         relax.ExternFunc("runtime.disco.send_to_next_group"),
                         args=[new_send_var],
-                        sinfo_args=None,
+                        ty_args=None,
                     )
                 )
             # Create the param for the shape variables.
@@ -171,7 +171,7 @@ class _PipelineParallelRewriter(PyExprMutator):
                 if shape_var_arg not in self.undefined_param_shape_vars_remap:
                     shape_var_params.append(shape_var_param)
                     shape_var_args.append(shape_var_arg)
-            params.append(relax.Var("s", relax.ShapeStructInfo(shape_var_params)))
+            params.append(relax.Var("s", relax.ShapeType(shape_var_params)))
             args.append(relax.ShapeExpr(shape_var_args))
             # Add the packed params.
             params.append(self.new_stage_func_packed_params)
@@ -183,7 +183,7 @@ class _PipelineParallelRewriter(PyExprMutator):
                 (
                     new_func_outputs[0]
                     if len(new_func_outputs) == 1
-                    and isinstance(new_func_outputs[0].struct_info, relax.TupleStructInfo)
+                    and isinstance(new_func_outputs[0].ty, relax.TupleType)
                     else new_func_outputs
                 ),
                 params=params,
@@ -209,10 +209,10 @@ class _PipelineParallelRewriter(PyExprMutator):
             super().visit_var_binding_(binding)
             return
 
-        assert isinstance(binding.var.struct_info, relax.TensorStructInfo)
+        assert isinstance(binding.var.ty, relax.TensorType)
         cur_num_undefined_param_shape_vars = len(self.undefined_param_shape_vars_remap)
         new_tensor_struct_info = self._update_struct_info(
-            binding.var.struct_info, self.undefined_param_shape_vars_remap
+            binding.var.ty, self.undefined_param_shape_vars_remap
         )
         has_new_undefined_shape_var = (
             len(self.undefined_param_shape_vars_remap) != cur_num_undefined_param_shape_vars
@@ -222,13 +222,13 @@ class _PipelineParallelRewriter(PyExprMutator):
             **self.undefined_param_shape_vars_remap,
         }
         ret_sinfo = (
-            new_tensor_struct_info if not has_new_undefined_shape_var else relax.ObjectStructInfo()
+            new_tensor_struct_info if not has_new_undefined_shape_var else relax.ObjectType()
         )
         call = relax.call_pure_packed(
             "vm.builtin.tuple_getitem",
             self.new_stage_func_packed_params,
-            relax.PrimValue(binding.value.index),
-            sinfo_args=ret_sinfo,
+            relax.prim_value(binding.value.index),
+            ty_args=ret_sinfo,
         )
         new_binding_var = self.builder_.emit(call, binding.var.name_hint)
         if has_new_undefined_shape_var:
@@ -243,7 +243,7 @@ class _PipelineParallelRewriter(PyExprMutator):
             call.op,
             call.args,
             call.attrs,
-            sinfo_args=[self._update_struct_info(struct_info) for struct_info in call.sinfo_args],
+            ty_args=[self._update_struct_info(struct_info) for struct_info in call.ty_args],
         )
 
     def _prepare_stage_func_params_and_args(
@@ -253,7 +253,7 @@ class _PipelineParallelRewriter(PyExprMutator):
         params: List[relax.Var] = []  # noqa: UP006
         args: List[relax.Expr] = []  # noqa: UP006
         for required_param in required_func_params:
-            struct_info = self._update_struct_info(required_param.struct_info)
+            struct_info = self._update_struct_info(required_param.ty)
             params.append(relax.Var(required_param.name_hint, struct_info))
             args.append(required_param)
 
@@ -261,30 +261,30 @@ class _PipelineParallelRewriter(PyExprMutator):
 
     def _update_struct_info(
         self,
-        struct_info: relax.StructInfo,
+        struct_info: relax.Type,
         undefined_var_remap: Optional[Dict[tirx.Var, tirx.Var]] = None,  # noqa: UP006
-    ) -> relax.StructInfo:
+    ) -> relax.Type:
         if undefined_var_remap is None:
             undefined_var_remap = self.undefined_shape_vars_remap
-        if isinstance(struct_info, relax.TensorStructInfo):
+        if isinstance(struct_info, relax.TensorType):
             return (
-                relax.TensorStructInfo(
+                relax.TensorType(
                     self._update_shape(struct_info.shape.values, undefined_var_remap),
                     struct_info.dtype,
                 )
                 if struct_info.shape is not None and isinstance(struct_info.shape, relax.ShapeExpr)
                 else struct_info
             )
-        if isinstance(struct_info, relax.ShapeStructInfo):
+        if isinstance(struct_info, relax.ShapeType):
             return (
-                relax.ShapeStructInfo(self._update_shape(struct_info.values, undefined_var_remap))
+                relax.ShapeType(self._update_shape(struct_info.values, undefined_var_remap))
                 if struct_info.values is not None
                 else struct_info
             )
-        if isinstance(struct_info, relax.ObjectStructInfo):
-            return relax.ObjectStructInfo()
-        if isinstance(struct_info, relax.TupleStructInfo):
-            return relax.TupleStructInfo(
+        if isinstance(struct_info, relax.ObjectType):
+            return relax.ObjectType()
+        if isinstance(struct_info, relax.TupleType):
+            return relax.TupleType(
                 [self._update_struct_info(field_sinfo) for field_sinfo in struct_info.fields]
             )
         return struct_info
@@ -296,7 +296,7 @@ class _PipelineParallelRewriter(PyExprMutator):
     ) -> None:
         def _visit_expr(e: tirx.PrimExpr) -> None:
             if isinstance(e, tirx.Var) and e not in undefined_var_remap:
-                new_var = tirx.Var(e.name, e.dtype)
+                new_var = tirx.Var(e.name, e.ty)
                 undefined_var_remap[e] = new_var
 
         tirx.stmt_functor.post_order_visit(expr, _visit_expr)

--- a/python/mlc_llm/interface/compile.py
+++ b/python/mlc_llm/interface/compile.py
@@ -125,7 +125,7 @@ def _compile(args: CompileArgs, model_config: ConfigBase):
             "name": name,
             # Record dynamic shape as -1 (e.g. vocab_size)
             "shape": [s if isinstance(s, int) else s.name for s in param.shape],
-            "dtype": param.dtype,
+            "dtype": str(param.dtype),
             "preprocs": param.attrs["preprocs"],
             "pipeline_stages": param.attrs.get("pipeline_stages", [0]),
         }

--- a/python/mlc_llm/interface/package.py
+++ b/python/mlc_llm/interface/package.py
@@ -171,9 +171,9 @@ def validate_model_lib(
 ) -> None:
     """Validate the model lib prefixes of model libraries."""
     if device == "android":
-        from tvm.contrib import ndk as cc
+        from tvm.support import ndk as cc
     else:
-        from tvm.contrib import cc
+        from tvm.support import cc
 
     with open(app_config_path, encoding="utf-8") as file:
         app_config = json.load(file)

--- a/python/mlc_llm/model/phi3v/phi3v_image.py
+++ b/python/mlc_llm/model/phi3v/phi3v_image.py
@@ -28,7 +28,7 @@ class ImageProjection(Module):
             .current()
             .match_cast(
                 image_features._expr,
-                relax.TensorStructInfo([shape_1, image_features.shape[1]], image_features.dtype),
+                relax.TensorType([shape_1, image_features.shape[1]], image_features.dtype),
             ),
             "image_features",
         )
@@ -41,7 +41,7 @@ class ImageProjection(Module):
             .current()
             .match_cast(
                 hidden_states._expr,
-                relax.TensorStructInfo([shape_2, hidden_states.shape[1]], hidden_states.dtype),
+                relax.TensorType([shape_2, hidden_states.shape[1]], hidden_states.dtype),
             ),
             "hidden_states",
         )
@@ -78,7 +78,7 @@ class Phi3ImageEmbedding(Module):
         assert 4 == input_tensor.ndim, "input_tensor should be 4D data tensor"
 
         def create_dyn_repeat_func(dtype):
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def dyn_repeat_4d_tensor_func(  # pylint disable=too-many-locals
                 input_tensor: T.handle,
                 output: T.handle,
@@ -115,7 +115,7 @@ class Phi3ImageEmbedding(Module):
 
     def dyn_concate_dim_2(self, input_1, input_2) -> Tensor:
         def create_dyn_concate_func(dtype):
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def dyn_concate_dim_2_func(input_1: T.handle, input_2: T.handle, output: T.handle):
                 T.func_attr({"op_pattern": 8, "tirx.noalias": True, "tirx.is_scheduled": 1})
                 n, c, h1, h2, w = T.int64(), T.int64(), T.int64(), T.int64(), T.int64()
@@ -154,7 +154,7 @@ class Phi3ImageEmbedding(Module):
 
     def dyn_concate_dim_1(self, input_1, input_2) -> Tensor:
         def create_dyn_concate_func(dtype):
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def dyn_concate_dim_1_func(input_1: T.handle, input_2: T.handle, output: T.handle):
                 T.func_attr({"op_pattern": 8, "tirx.noalias": True, "tirx.is_scheduled": 1})
                 c, h1, h2, w = T.int64(), T.int64(), T.int64(), T.int64()
@@ -208,7 +208,7 @@ class Phi3ImageEmbedding(Module):
             .current()
             .match_cast(
                 image_features._expr,
-                relax.TensorStructInfo(
+                relax.TensorType(
                     [
                         image_features.shape[0],
                         new_s1,
@@ -239,7 +239,7 @@ class Phi3ImageEmbedding(Module):
             .current()
             .match_cast(
                 image_features._expr,
-                relax.TensorStructInfo(
+                relax.TensorType(
                     [
                         image_features.shape[0],
                         new_s3,
@@ -301,7 +301,7 @@ class Phi3ImageEmbedding(Module):
             .current()
             .match_cast(
                 combined_image._expr,
-                relax.TensorStructInfo([new_s7, combined_image.shape[1]], combined_image.dtype),
+                relax.TensorType([new_s7, combined_image.shape[1]], combined_image.dtype),
             ),
             "combined_image",
         )

--- a/python/mlc_llm/model/phi3v/phi3v_model.py
+++ b/python/mlc_llm/model/phi3v/phi3v_model.py
@@ -239,7 +239,7 @@ class Phi3VForCausalLM(nn.Module):
             .current()
             .match_cast(
                 global_image._expr,
-                relax.TensorStructInfo(
+                relax.TensorType(
                     [global_image.shape[0], global_image.shape[1], 336, 336],
                     global_image.dtype,
                 ),
@@ -264,7 +264,7 @@ class Phi3VForCausalLM(nn.Module):
             .current()
             .match_cast(
                 combined_image._expr,
-                relax.TensorStructInfo([num_crops + 1, c, h, w], combined_image.dtype),
+                relax.TensorType([num_crops + 1, c, h, w], combined_image.dtype),
             ),
             "combined_image",
         )

--- a/python/mlc_llm/model/qwen35/qwen35_model.py
+++ b/python/mlc_llm/model/qwen35/qwen35_model.py
@@ -239,7 +239,7 @@ def create_gated_delta_net_func(
     K = key_head_dim  # 128
     V = value_head_dim  # 128
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def gdn_func(
         q_handle: T.handle,
         k_handle: T.handle,

--- a/python/mlc_llm/model/rwkv5/rwkv5_model.py
+++ b/python/mlc_llm/model/rwkv5/rwkv5_model.py
@@ -68,7 +68,7 @@ def create_wkv5_func(
     out_dtype: str,
     state_dtype: str,
 ):
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def wkv_func(
         r: T.handle,
         k: T.handle,

--- a/python/mlc_llm/model/rwkv6/rwkv6_model.py
+++ b/python/mlc_llm/model/rwkv6/rwkv6_model.py
@@ -68,7 +68,7 @@ def create_wkv6_func(
     out_dtype: str,
     state_dtype: str,
 ):
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def wkv_func(
         r: T.handle,
         k: T.handle,

--- a/python/mlc_llm/model/vision/image_processing.py
+++ b/python/mlc_llm/model/vision/image_processing.py
@@ -94,7 +94,7 @@ class ImageProcessor(Module):
         assert 3 == image.shape[1], "image layout should be NCHW"
 
         def create_crop_func(dtype):  # , top, bottom, left, right):
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def crop_func(
                 image: T.handle,
                 out: T.handle,
@@ -147,7 +147,7 @@ class ImageProcessor(Module):
         assert 3 == image.shape[1], "image layout should be NCHW"
 
         def create_rescale_func(rescale_factor, dtype, o_dtype):
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def rescale_func(image: T.handle, out: T.handle):
                 T.func_attr({"op_pattern": 8, "tirx.noalias": True, "tirx.is_scheduled": 1})
                 n, c, h, w = T.int64(), T.int64(), T.int64(), T.int64()
@@ -186,7 +186,7 @@ class ImageProcessor(Module):
         assert 3 == image.shape[1], "image layout should be NCHW"
 
         def create_normalize_func(dtype, o_dtype):
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def normalize_func(image: T.handle, out: T.handle):
                 n, c, h, w = T.int64(), T.int64(), T.int64(), T.int64()
                 image_buf = T.match_buffer(image, (n, c, h, w), dtype=dtype)
@@ -237,7 +237,7 @@ class ImageProcessor(Module):
         assert 3 == image.shape[1], "image layout should be NCHW"
 
         def create_pad_func(left, right, fill=255):
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def pad_func(image: T.handle, out: T.handle, t: T.int64(), b: T.int64()):
                 T.func_attr({"op_pattern": 8, "tirx.noalias": True, "tirx.is_scheduled": 1})
                 n, c, h, w = T.int64(), T.int64(), T.int64(), T.int64()

--- a/python/mlc_llm/nn/kv_cache.py
+++ b/python/mlc_llm/nn/kv_cache.py
@@ -66,28 +66,28 @@ class PagedKVCache(TVMPagedKVCache):
                     ]
                 ),
                 rx.ShapeExpr(layer_partition),
-                rx.PrimValue(num_hidden_layers),
-                rx.PrimValue(num_attention_heads),
-                rx.PrimValue(num_key_value_heads),
-                rx.PrimValue(qk_head_dim),
-                rx.PrimValue(v_head_dim),
-                rx.PrimValue(mla_original_qk_head_dim),
-                rx.PrimValue(mla_original_v_head_dim),
-                rx.PrimValue(rope_mode),
-                rx.PrimValue(rope_scale),
-                rx.PrimValue(rope_theta),
+                rx.prim_value(num_hidden_layers),
+                rx.prim_value(num_attention_heads),
+                rx.prim_value(num_key_value_heads),
+                rx.prim_value(qk_head_dim),
+                rx.prim_value(v_head_dim),
+                rx.prim_value(mla_original_qk_head_dim),
+                rx.prim_value(mla_original_v_head_dim),
+                rx.prim_value(rope_mode),
+                rx.prim_value(rope_scale),
+                rx.prim_value(rope_theta),
                 rx.StringImm(json.dumps(rope_scaling)),
                 (
                     rx.const(np.array(rope_ext_factors, "float32"))
                     if rope_ext_factors is not None
-                    else rx.PrimValue(0)
-                    # NOTE: since relax does not have "Optional" type, we use PrimValue(0)
+                    else rx.prim_value(0)
+                    # NOTE: since relax does not have "Optional" type, we use prim_value(0)
                     # to represent "undefined".
                 ),
-                rx.PrimValue(rotary_dim),
-                rx.PrimValue(int(enable_disaggregation)),
+                rx.prim_value(rotary_dim),
+                rx.prim_value(int(enable_disaggregation)),
                 rx.DataTypeImm(dtype),
-                sinfo_args=rx.ObjectStructInfo(),
+                ty_args=rx.ObjectType(),
             ),
             _name=name,
         )

--- a/python/mlc_llm/nn/rnn_state.py
+++ b/python/mlc_llm/nn/rnn_state.py
@@ -58,13 +58,13 @@ class RNNState(Object):
         ret = RNNState(
             _expr=rx.call_pure_packed(
                 "vm.builtin.rnn_state_create",
-                rx.PrimValue(num_hidden_layers),
+                rx.prim_value(num_hidden_layers),
                 max_batch_size,
                 max_history,
                 f_gets,
                 f_sets,
                 list(init_values),
-                sinfo_args=[rx.ObjectStructInfo()],
+                ty_args=[rx.ObjectType()],
             ),
             _name=name,
         )
@@ -107,7 +107,7 @@ class RNNState(Object):
                 rx.call_dps_packed(
                     "vm.builtin.rnn_state_get",
                     [self._expr, layer_id, state_id],
-                    out_sinfo=rx.TensorStructInfo(shape, dtype),
+                    out_ty=rx.TensorType(shape, dtype),
                 )
             )
         )
@@ -130,10 +130,10 @@ class RNNState(Object):
                 rx.call_pure_packed(
                     "vm.builtin.rnn_state_set",
                     self._expr,
-                    rx.PrimValue(layer_id),
-                    rx.PrimValue(state_id),
+                    rx.prim_value(layer_id),
+                    rx.prim_value(state_id),
                     value._expr,
-                    sinfo_args=[rx.ObjectStructInfo()],
+                    ty_args=[rx.ObjectType()],
                 )
             ),
             _name="rnn_state_set",
@@ -173,7 +173,7 @@ class RNNState(Object):
         """
 
         def _func_one_dim():
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def f(
                 var_storage: T.handle,
                 var_seq_slot_ids: T.handle,
@@ -202,7 +202,7 @@ class RNNState(Object):
 
         def _func_high_dim():
             # Add a wrapper function to avoid parse the following code when len(shape) = 1
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def f(
                 var_storage: T.handle,
                 var_seq_slot_ids: T.handle,
@@ -270,7 +270,7 @@ class RNNState(Object):
         """
 
         def _func_one_dim():
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def f(
                 var_storage: T.handle,
                 var_seq_slot_ids: T.handle,
@@ -300,7 +300,7 @@ class RNNState(Object):
             return f
 
         def _func_high_dim():
-            @T.prim_func
+            @T.prim_func(s_tir=True)
             def f(
                 var_storage: T.handle,
                 var_seq_slot_ids: T.handle,

--- a/python/mlc_llm/op/batch_spec_verify.py
+++ b/python/mlc_llm/op/batch_spec_verify.py
@@ -55,7 +55,7 @@ def batch_spec_verify(vocab_size):
         return T.sblock_alloc_buffer((1,), dtype, scope="local")
 
     # fmt: off
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         var_draft_probs: T.handle,
         var_draft_tokens: T.handle,

--- a/python/mlc_llm/op/moe_matmul.py
+++ b/python/mlc_llm/op/moe_matmul.py
@@ -46,7 +46,7 @@ def gemv(x: Tensor, w: Tensor, indptr: Tensor) -> Tensor:
     assert indptr.shape == [1, experts_per_tok] and indptr.dtype == "int32"
     assert x_leading_dim in [1, experts_per_tok]
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         x: T.Buffer((x_leading_dim, in_features), dtype),
         w: T.Buffer((local_experts, out_features, in_features), dtype),
@@ -144,7 +144,7 @@ def dequantize_gemv(
     assert indptr.shape == [1, experts_per_tok] and indptr.dtype == "int32"
     assert x_leading_dim in [1, experts_per_tok]
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         x: T.Buffer((x_leading_dim, in_features), model_dtype),
         w: T.Buffer((local_experts, out_features, num_storage), storage_dtype),
@@ -233,7 +233,7 @@ def dequantize_float8_gemv(
     def access_x(x, e, j):
         return x[0, j] if x_leading_dim == 1 else x[e, j]
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func_with_scale(
         x: T.Buffer((x_leading_dim, in_features), model_dtype),
         w: T.Buffer((local_experts, out_features, num_storage), storage_dtype),
@@ -257,7 +257,7 @@ def dequantize_float8_gemv(
                             o[e, i] = T.cast(T.float16(0), model_dtype)
                         o[e, i] += access_x(x, e, j) * y[i, j]
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func_without_scale(
         x: T.Buffer((x_leading_dim, in_features), model_dtype),
         w: T.Buffer((local_experts, out_features, num_storage), storage_dtype),
@@ -347,7 +347,7 @@ def dequantize_block_scale_float8_gemv(
     def load_x(x, e, j):
         return x[0, j] if x_leading_dim == 1 else x[e, j]
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         x: T.Buffer((x_leading_dim, in_features), model_dtype),
         w: T.Buffer((local_experts, out_features, k), quantize_dtype),
@@ -419,7 +419,7 @@ def group_gemm(x: Tensor, w: Tensor, indptr: Tensor):
     tiles_per_row = (N + BLK_N - 1) // BLK_N
     zero = tirx.const(0, dtype)
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         var_x: T.handle,
         var_w: T.handle,
@@ -629,7 +629,7 @@ def dequantize_group_gemm(
     if indptr_dtype == "int64":
         indptr = op.pad(indptr, [1, 0], "constant", 0)
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         var_x: T.handle,
         w: T.Buffer((Ne, N, num_storage), storage_dtype),

--- a/python/mlc_llm/op/moe_misc.py
+++ b/python/mlc_llm/op/moe_misc.py
@@ -85,7 +85,7 @@ def gating_topk(scores: Tensor, k: int) -> Tuple[Tensor, Tensor]:  # noqa: UP006
     TX = 1024
 
     def _get_topk_func(k_val: int):
-        @T.prim_func(private=True)
+        @T.prim_func(private=True, s_tir=True)
         def topk_func(
             var_x: T.handle,
             var_out: T.handle,
@@ -172,7 +172,7 @@ def gating_softmax_topk(x: Tensor, k: int, norm_topk_prob=True) -> Tuple[Tensor,
                 expr = expr + T.exp(local_top_k_f32[i] - local_top_k_max[0])
             return expr
 
-        @T.prim_func(private=True)
+        @T.prim_func(private=True, s_tir=True)
         def topk_softmax_norm_func(
             var_x: T.handle,
             var_out: T.handle,
@@ -302,7 +302,7 @@ def group_limited_greedy_topk(
         ).reshape(num_tokens, n_group)
     group_idx = gating_topk(group_scores, topk_group)[1]  # (num_tokens, top_k_group)
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def group_limited_mask_scores(
         var_scores: T.handle, var_group_idx: T.handle, var_output: T.handle
     ):
@@ -342,7 +342,7 @@ def group_limited_greedy_topk(
     expert_weights, expert_indices = gating_topk(tmp_scores, top_k)
     if topk_method == "noaux_tc":
 
-        @T.prim_func(private=True)
+        @T.prim_func(private=True, s_tir=True)
         def gather_scores(var_scores: T.handle, var_expert_indices: T.handle, var_output: T.handle):
             T.func_attr({"tirx.noalias": True})
             scores = T.match_buffer(
@@ -489,7 +489,7 @@ def get_indices(cumsum: Tensor, expert_indices: Tensor) -> Tuple[Tensor, Tensor]
     TX = 1024
     batch_size, experts_per_tok = expert_indices.shape
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         var_cumsum: T.handle,
         var_expert_indices: T.handle,
@@ -576,7 +576,7 @@ def get_indptr(
 
     out_shape = [num_local_experts if inclusive else num_local_experts + 1]
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func_exclusive(var_cumsum: T.handle, var_indptr: T.handle, batch_size: T.int64):
         T.func_attr({"tirx.noalias": True})
         cumsum = T.match_buffer(var_cumsum, shape=[batch_size * num_local_experts], dtype="int32")
@@ -586,7 +586,7 @@ def get_indptr(
                 i = T.axis.spatial(out_shape[0], vi)
                 indptr[i] = T.Select(i > 0, cumsum[i * batch_size - 1], T.int32(0))
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func_inclusive(var_cumsum: T.handle, var_indptr: T.handle, batch_size: T.int64):
         T.func_attr({"tirx.noalias": True})
         cumsum = T.match_buffer(var_cumsum, shape=[batch_size * num_local_experts], dtype="int32")
@@ -624,7 +624,7 @@ def scatter_output(x: Tensor, indices: Tensor) -> Tensor:
     dtype = x.dtype
     _, hidden_size = x.shape
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(var_x: T.handle, var_indices: T.handle, var_out: T.handle):
         T.func_attr({"tirx.noalias": True})
         indices_len = T.int64()

--- a/python/mlc_llm/op/pipeline_parallel.py
+++ b/python/mlc_llm/op/pipeline_parallel.py
@@ -23,10 +23,10 @@ def pipeline_stage_boundary(*tensors: Tensor) -> List[Tensor]:  # noqa: UP006
         relax.call_pure_packed(
             "mlc.pipeline_parallel_stage_boundary",
             *[tensor._expr for tensor in tensors],
-            sinfo_args=(
-                tensors[0]._expr.struct_info
+            ty_args=(
+                tensors[0]._expr.ty
                 if len(tensors) == 1
-                else relax.TupleStructInfo([tensor._expr.struct_info for tensor in tensors])
+                else relax.TupleType([tensor._expr.ty for tensor in tensors])
             ),
         ),
         name="pipeline_stage_boundary",

--- a/python/mlc_llm/op/top_p_pivot.py
+++ b/python/mlc_llm/op/top_p_pivot.py
@@ -49,7 +49,7 @@ def top_p_pivot(pN, target: tvm.target.Target):
         return tvm.tirx.all(lsum >= top_p, top_p > lsum - cmin * lmin)
 
     # fmt: off
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         var_prob: T.handle,
         var_top_p_arr: T.handle,
@@ -297,7 +297,7 @@ def top_p_renorm(target: tvm.target.Target = None):
         return T.sblock_alloc_buffer((1,), dtype, scope="local")
 
     # fmt: off
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         var_prob: T.handle,
         var_final_pivot: T.handle,

--- a/python/mlc_llm/op/triton.py
+++ b/python/mlc_llm/op/triton.py
@@ -301,7 +301,7 @@ def get_tir_w8a8_block_fp8_matmul(
 
     @I.ir_module
     class BlockFP8Matmul:
-        @T.prim_func(private=True)
+        @T.prim_func(private=True, s_tir=True)
         def tir_w8a8_block_fp8_matmul(
             var_A: T.handle,
             var_B: T.handle,
@@ -403,7 +403,7 @@ def get_tir_w8a8_block_fp8_group_matmul(
 
     @I.ir_module
     class BlockFP8GroupMatmul:
-        @T.prim_func(private=True)
+        @T.prim_func(private=True, s_tir=True)
         def tir_w8a8_block_fp8_group_gemm(
             var_A: T.handle,
             var_B: T.handle,
@@ -523,7 +523,7 @@ def _compute_expert_id_per_block(
         [(M + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M + num_experts,].
     """
 
-    @T.prim_func
+    @T.prim_func(s_tir=True)
     def tir_compute_expert_id_per_block(
         var_indptr: T.handle,
         var_expert_ids: T.handle,

--- a/python/mlc_llm/quantization/block_scale_quantization.py
+++ b/python/mlc_llm/quantization/block_scale_quantization.py
@@ -794,7 +794,7 @@ def dequantize_float8_groupwise_scaled_gemv(
             model_dtype
         )
 
-    @T.prim_func(private=True)
+    @T.prim_func(private=True, s_tir=True)
     def _func(
         x: T.Buffer((1, k), model_dtype),
         w: T.Buffer((n, k), quantize_dtype),

--- a/python/mlc_llm/quantization/ft_quantization.py
+++ b/python/mlc_llm/quantization/ft_quantization.py
@@ -198,9 +198,7 @@ class FTQuantize:
 
                 def _create_quantize_func() -> IRModule:
                     bb = relax.BlockBuilder()
-                    weight_var = relax.Var(
-                        "weight", relax.TensorStructInfo(weight.shape, weight.dtype)
-                    )
+                    weight_var = relax.Var("weight", relax.TensorType(weight.shape, weight.dtype))
                     with bb.function(name="main", params=[weight_var]):
                         with bb.dataflow():
                             lv0 = bb.emit_te(self._quantize, weight_var)
@@ -211,7 +209,7 @@ class FTQuantize:
                                     lv1,
                                     detect_cuda_arch_list(target=target)[0],
                                     DataType(self.quantize_dtype).bits == 4,
-                                    sinfo_args=lv1.struct_info,
+                                    ty_args=lv1.ty,
                                 )
                             )
                             gv = bb.emit_output(relax.Tuple([lv2, lv0[1]]))

--- a/python/mlc_llm/quantization/group_quantization.py
+++ b/python/mlc_llm/quantization/group_quantization.py
@@ -213,7 +213,7 @@ class GroupQuantize:
 
         def _create_quantize_func() -> IRModule:
             bb = relax.BlockBuilder()
-            weight_var = relax.Var("weight", relax.TensorStructInfo(weight.shape, weight.dtype))
+            weight_var = relax.Var("weight", relax.TensorType(weight.shape, weight.dtype))
             with bb.function(name="main", params=[weight_var]):
                 with bb.dataflow():
                     lv = bb.emit_te(self._quantize, weight_var, axis, output_transpose)

--- a/python/mlc_llm/support/auto_target.py
+++ b/python/mlc_llm/support/auto_target.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple  # noqa: UP035
 
 from tvm import IRModule, relax
-from tvm.contrib import ndk, tar, xcode
 from tvm.ir.transform import Pass
+from tvm.support import ndk, tar, xcode
 from tvm.target import Target
 from tvm_ffi import get_global_func, register_global_func
 
@@ -366,10 +366,10 @@ def _register_cuda_hook(target: Target):
     @register_global_func("tvm_callback_cuda_compile", override=True)
     def tvm_callback_cuda_compile(code):
         """use nvcc to generate fatbin code for better optimization"""
-        from tvm.contrib import nvcc
+        from tvm.support import nvcc
 
         if multi_arch is None:
-            ptx = nvcc.compile_cuda(code, target_format="fatbin")
+            ptx = nvcc.compile_cuda(code, target_format="fatbin", compiler="nvcc")
         else:
             arch = []
             for compute_version in multi_arch:
@@ -377,7 +377,7 @@ def _register_cuda_hook(target: Target):
                     "-gencode",
                     f"arch=compute_{compute_version},code=sm_{compute_version}",
                 ]
-            ptx = nvcc.compile_cuda(code, target_format="fatbin", arch=arch)
+            ptx = nvcc.compile_cuda(code, target_format="fatbin", arch=arch, compiler="nvcc")
         return ptx
 
 

--- a/python/mlc_llm/support/preshard.py
+++ b/python/mlc_llm/support/preshard.py
@@ -31,14 +31,14 @@ def _create_shard_func(bb: relax.BlockBuilder, param: nn.Parameter, tensor_paral
     weight_shape = param.shape
     weight_shape[shard_strategy.dim] = weight_shape[shard_strategy.dim] * tensor_parallel_shards
     sharded_weight_shape = [tensor_parallel_shards, *param.shape]
-    weight_var = relax.Var("weight", relax.TensorStructInfo(weight_shape, param.dtype))
+    weight_var = relax.Var("weight", relax.TensorType(weight_shape, param.dtype))
     with bb.function(name=shard_strategy.name, params=[weight_var]):
         with bb.dataflow():
             lv0 = bb.emit(
                 relax.call_tir(
                     tir_gvar,
                     weight_var,
-                    out_sinfo=relax.TensorStructInfo(sharded_weight_shape, param.dtype),
+                    out_ty=relax.TensorType(sharded_weight_shape, param.dtype),
                 )
             )
             lv1 = bb.emit(relax.op.split(lv0, indices_or_sections=tensor_parallel_shards, axis=0))

--- a/python/mlc_llm/support/tensor_parallel.py
+++ b/python/mlc_llm/support/tensor_parallel.py
@@ -88,7 +88,7 @@ class ShardSingleDim:
             "func_name": self.name,
             "in_shape": self._compute_in_shape(shards, weight),
             "out_shape": (shards, *weight.shape),
-            "out_dtype": weight.dtype,
+            "out_dtype": str(weight.dtype),
         }
 
     def _compute_in_shape(self, shards: int, weight: nn.Tensor) -> List[int]:  # noqa: UP006


### PR DESCRIPTION
Mainline TVM unified the PrimExpr type mechanism on PrimType (in place of DataType) and moved the runtime datatype/object accessors onto tvm-ffi. Update the C++ runtime to match: replace `tvm::Downcast<T>` with the tvm-ffi accessors `.cast<T>()` / `.as_or_throw<T>()`, and use `DLDataType` in place of `tvm::runtime::DataType`. In cpp/serve/model.cc the KV-cache creation function now returns a heterogeneous `Array<Any>`, so its elements are read as `Array<Any>[i].cast<Tensor>()` to avoid an Array type error at runtime.

On the Python side, adapt the compiler passes, model definitions, and ops to the refactored Relax/TIRScript API: parse TIRScript via `tvm.script.tirx`, follow the StructInfo->Type rename (`.struct_info`-> `.ty`, `sinfo_args`->`ty_args`), use `relax.prim_value` and `@T.prim_func(s_tir=True)`, and add explicit casts where the stricter tirx well-formedness rules no longer let `T.let` widen implicitly.

Bump the 3rdparty/tvm submodule to the matching revision.