### PR TITLE
[Refactor] Adapt to tvm-ffi Optional and Relax Id refactor

### DIFF
--- a/cpp/json_ffi/json_ffi_engine.cc
+++ b/cpp/json_ffi/json_ffi_engine.cc
@@ -174,7 +174,7 @@ class JSONFFIEngineImpl : public JSONFFIEngine, public ffi::ModuleObj {
                             Optional<Function> request_stream_callback) {
     DLDevice device{static_cast<DLDeviceType>(device_type), device_id};
     this->device_ = device;
-    TVM_FFI_ICHECK(request_stream_callback.defined())
+    TVM_FFI_ICHECK(request_stream_callback.has_value())
         << "JSONFFIEngine requires request stream callback function, but it is not given.";
     this->request_stream_callback_ = request_stream_callback.value();
 

--- a/cpp/metadata/model.cc
+++ b/cpp/metadata/model.cc
@@ -140,7 +140,7 @@ ModelMetadata ModelMetadata::FromJSON(const tvm::ffi::json::Object& metadata,
 ModelMetadata ModelMetadata::FromModule(Module module, const tvm::ffi::json::Object& model_config) {
   std::string json_str = "";
   Optional<Function> pf = module->GetFunction("_metadata");
-  TVM_FFI_ICHECK(pf.defined()) << "ValueError: _metadata function not found in module";
+  TVM_FFI_ICHECK(pf.has_value()) << "ValueError: _metadata function not found in module";
   json_str = pf.value()().cast<String>();
   tvm::ffi::json::Object json = json::ParseToJSONObject(json_str);
   try {

--- a/cpp/multi_gpu/builtin.cc
+++ b/cpp/multi_gpu/builtin.cc
@@ -64,7 +64,7 @@ ObjectRef SendFromLastGroupToWorker0(Tensor send, Optional<Tensor> recv, Shape s
   TVM_FFI_ICHECK_NE(world_size, group_size) << "Cannot perform when there is only one group.";
   int sender_id = world_size - group_size;
   if (worker_id == 0) {
-    TVM_FFI_ICHECK(recv.defined()) << "The receive Tensor is undefined for worker 0.";
+    TVM_FFI_ICHECK(recv.has_value()) << "The receive Tensor is undefined for worker 0.";
     Tensor recv_arr = recv.value().CreateView(shape, dtype);
     RecvFromWorker(recv_arr, sender_id);
     return recv_arr;
@@ -78,12 +78,12 @@ ObjectRef SendFromLastGroupToWorker0(Tensor send, Optional<Tensor> recv, Shape s
           << "The src Tensor has mismatched shape than the expected shape.";
     }
     SendToWorker(send, /*receiver_id=*/0);
-    return recv;
+    return recv.value_or(Tensor(nullptr));
   }
 
   // We only process for worker 0 and the first worker of the last group.
   // For other workers, we return the input object.
-  return recv;
+  return recv.value_or(Tensor(nullptr));
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/cpp/serve/engine.cc
+++ b/cpp/serve/engine.cc
@@ -404,7 +404,7 @@ class EngineImpl : public Engine {
       const auto& [model_str, model_lib] = models_and_model_libs[i];
       Model model = Model::Create(model_lib, model_str, model_configs[i], device, session,
                                   num_shards, model_num_pipeline_stages[i],
-                                  /*trace_enabled=*/trace_recorder.defined());
+                                  /*trace_enabled=*/trace_recorder.has_value());
       n->models_.push_back(model);
     }
     // - Initialize NVSHMEM
@@ -780,7 +780,7 @@ class EngineImpl : public Engine {
       if (!StartsWith(model_lib, "system://")) {
         Module executable = ffi::Module::LoadFromFile(model_lib);
         Optional<Function> fload_exec = executable->GetFunction("vm_load_executable");
-        TVM_FFI_ICHECK(fload_exec.defined()) << "TVM runtime cannot find vm_load_executable";
+        TVM_FFI_ICHECK(fload_exec.has_value()) << "TVM runtime cannot find vm_load_executable";
         Module local_vm = fload_exec.value()().cast<Module>();
         local_vm->GetFunction("vm_initialization")
             .value()(static_cast<int>(device.device_type), device.device_id,

--- a/cpp/serve/engine_actions/action_commons.cc
+++ b/cpp/serve/engine_actions/action_commons.cc
@@ -153,7 +153,7 @@ void RemoveRequestFromModel(EngineState estate, int64_t req_internal_id,
 void RemoveRequestStateEntry(EngineState estate, const Array<Model>& models,
                              RequestStateEntry rsentry,
                              Optional<DraftTokenWorkspaceManager> draft_token_workspace_manager) {
-  if (draft_token_workspace_manager.defined()) {
+  if (draft_token_workspace_manager.has_value()) {
     std::vector<int> draft_token_slots;
     for (const RequestModelState& mstate : rsentry->mstates) {
       mstate->RemoveAllDraftTokens(&draft_token_slots);
@@ -363,7 +363,7 @@ RequestStateEntry PreemptLastRunningRequestStateEntry(
   rsentry->status = RequestStateStatus::kPending;
   std::vector<int> draft_token_slots;
   for (RequestModelState mstate : rsentry->mstates) {
-    if (draft_token_workspace_manager.defined()) {
+    if (draft_token_workspace_manager.has_value()) {
       mstate->RemoveAllDraftTokens(&draft_token_slots);
       draft_token_workspace_manager.value()->FreeSlots(draft_token_slots);
     }

--- a/cpp/serve/event_trace_recorder.h
+++ b/cpp/serve/event_trace_recorder.h
@@ -70,7 +70,7 @@ class EventTraceRecorder : public ObjectRef {
 
 /*! \brief Record a event for the input request or list or requests. */
 #define RECORD_EVENT(trace_recorder, request_ids, event)  \
-  if (trace_recorder.defined()) {                         \
+  if (trace_recorder.has_value()) {                       \
     trace_recorder.value()->AddEvent(request_ids, event); \
   }
 

--- a/cpp/serve/function_table.cc
+++ b/cpp/serve/function_table.cc
@@ -72,7 +72,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, tvm::ffi::json::
 
   int num_workers = num_shards * num_stages;
   if (num_workers > 1) {
-    TVM_FFI_ICHECK(session.defined());
+    TVM_FFI_ICHECK(session.has_value());
     this->sess = session.value();
     this->use_disco = true;
     this->disco_mod = sess->CallPacked(sess->GetGlobalFunc("runtime.disco.load_vm_module"),
@@ -100,7 +100,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, tvm::ffi::json::
         this->disco_mod.value()->DebugGetFromRemote(0).cast<Module>(), std::move(model_config));
     this->_InitFunctions();
   } else {
-    TVM_FFI_ICHECK(!session.defined());
+    TVM_FFI_ICHECK(!session.has_value());
     Optional<Module> executable = std::nullopt;
     Optional<Function> fload_exec;
     if (StartsWith(reload_lib_path, "system://")) {
@@ -109,7 +109,7 @@ void FunctionTable::Init(String reload_lib_path, Device device, tvm::ffi::json::
       std::replace(system_lib_prefix.begin(), system_lib_prefix.end(), /*old=*/'-', /*new=*/'_');
       executable = f_load_system_lib(system_lib_prefix + "_").cast<Module>();
       fload_exec = executable.value()->GetFunction("vm_load_executable");
-      TVM_FFI_ICHECK(fload_exec.defined())
+      TVM_FFI_ICHECK(fload_exec.has_value())
           << "Cannot find system lib with " << system_lib_prefix
           << ", please make sure you set model_lib field consistently with the compilation ";
     } else {
@@ -118,13 +118,13 @@ void FunctionTable::Init(String reload_lib_path, Device device, tvm::ffi::json::
       /* precompile opencl kernel programs */
       if (device.device_type == kDLOpenCL) {
         auto f_get = executable.value()->GetFunction("opencl.GetPreCompiledPrograms", true);
-        TVM_FFI_ICHECK(f_get.defined()) << "Cannot find opencl.GetPreCompiledPrograms";
+        TVM_FFI_ICHECK(f_get.has_value()) << "Cannot find opencl.GetPreCompiledPrograms";
         tvm::ffi::String bytes = f_get.value()().cast<String>();
         auto f_set = executable.value()->GetFunction("opencl.SetPreCompiledPrograms", true);
-        TVM_FFI_ICHECK(f_set.defined()) << "Cannot find opencl.SetPreCompiledPrograms";
+        TVM_FFI_ICHECK(f_set.has_value()) << "Cannot find opencl.SetPreCompiledPrograms";
         f_set.value()(tvm::ffi::String(bytes));
       }
-      TVM_FFI_ICHECK(fload_exec.defined()) << "TVM runtime cannot find vm_load_executable";
+      TVM_FFI_ICHECK(fload_exec.has_value()) << "TVM runtime cannot find vm_load_executable";
     }
     this->use_disco = false;
     this->local_vm = fload_exec.value()().cast<Module>();

--- a/cpp/serve/logit_processor.cc
+++ b/cpp/serve/logit_processor.cc
@@ -202,7 +202,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
     TVM_FFI_ICHECK_EQ(probs->shape[0], num_total_token);
     TVM_FFI_ICHECK_EQ(probs->shape[1], 1);
     TVM_FFI_ICHECK_EQ(probs->shape[2], vocab_size_);
-    if (trace_recorder_.defined()) {
+    if (trace_recorder_.has_value()) {
       DeviceAPI::Get(device_)->StreamSync(device_, /*stream=*/nullptr);
     }
     RECORD_EVENT(trace_recorder_, request_ids, "finish softmax");
@@ -262,7 +262,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
 
     // - Call kernel.
     apply_logit_bias_func_(logits, pos2seq_id_device, token_ids_device, token_logit_bias_device);
-    if (trace_recorder_.defined()) {
+    if (trace_recorder_.has_value()) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
     }
   }
@@ -364,7 +364,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
     // - Call kernel.
     apply_penalty_func_(logits, seq_ids_device, pos2seq_id_device, token_ids_device,
                         token_cnt_device, penalties_device);
-    if (trace_recorder_.defined()) {
+    if (trace_recorder_.has_value()) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
     }
   }
@@ -452,7 +452,7 @@ class LogitProcessorImpl : public LogitProcessorObj {
 
     // - Call kernel.
     apply_bitmask_func_(logits, seq_ids_device, bitmask_device);
-    if (trace_recorder_.defined()) {
+    if (trace_recorder_.has_value()) {
       DeviceAPI::Get(device_)->StreamSync(device_, nullptr);
     }
   }

--- a/cpp/serve/threaded_engine.cc
+++ b/cpp/serve/threaded_engine.cc
@@ -43,7 +43,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
   void InitThreadedEngine(Device device, Optional<Function> request_stream_callback,
                           Optional<EventTraceRecorder> trace_recorder) final {
     device_ = device;
-    TVM_FFI_ICHECK(request_stream_callback.defined())
+    TVM_FFI_ICHECK(request_stream_callback.has_value())
         << "ThreadedEngine requires request stream callback function, but it is not given.";
     request_stream_callback_ = request_stream_callback.value();
     trace_recorder_ = trace_recorder;
@@ -232,7 +232,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
   /************** Query/Profile/Debug **************/
 
   GenerationConfig GetDefaultGenerationConfig() const final {
-    TVM_FFI_ICHECK(default_generation_config_.defined())
+    TVM_FFI_ICHECK(default_generation_config_.has_value())
         << "The default generation config has not been set.";
     return default_generation_config_.value();
   }
@@ -245,7 +245,7 @@ class ThreadedEngineImpl : public ThreadedEngine {
   }
 
   EngineConfig GetCompleteEngineConfig() const final {
-    TVM_FFI_ICHECK(complete_engine_config_.defined()) << "The engine config has not been set.";
+    TVM_FFI_ICHECK(complete_engine_config_.has_value()) << "The engine config has not been set.";
     return complete_engine_config_.value();
   }
 

--- a/python/mlc_llm/compiler_pass/attach_logit_processor.py
+++ b/python/mlc_llm/compiler_pass/attach_logit_processor.py
@@ -54,9 +54,9 @@ def _get_apply_logit_bias_inplace_cpu():
                 "tirx.is_scheduled": True,
             }
         )
-        batch_size = T.int32(is_size_var=True)
-        vocab_size = T.int32(is_size_var=True)
-        num_token = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        vocab_size = T.int32()
+        num_token = T.int32()
         logits = T.match_buffer(var_logits, (batch_size, vocab_size), "float32")
         # seq_ids
         pos2seq_id = T.match_buffer(var_pos2seq_id, (num_token,), "int32")
@@ -90,9 +90,9 @@ def _get_apply_logit_bias_inplace(target: tvm.target.Target):
                 "tirx.is_scheduled": True,
             }
         )
-        batch_size = T.int32(is_size_var=True)
-        vocab_size = T.int32(is_size_var=True)
-        num_token = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        vocab_size = T.int32()
+        num_token = T.int32()
         logits = T.match_buffer(var_logits, (batch_size, vocab_size), "float32")
         # seq_ids
         pos2seq_id = T.match_buffer(var_pos2seq_id, (num_token,), "int32")
@@ -127,10 +127,10 @@ def _get_apply_penalty_inplace_cpu():
                 "tirx.is_scheduled": True,
             }
         )
-        batch_size = T.int32(is_size_var=True)
-        vocab_size = T.int32(is_size_var=True)
-        num_token = T.int32(is_size_var=True)
-        num_seq = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        vocab_size = T.int32()
+        num_token = T.int32()
+        num_seq = T.int32()
         logits = T.match_buffer(var_logits, (batch_size, vocab_size), "float32")
         seq_ids = T.match_buffer(var_seq_ids, (num_seq,), "int32")
         pos2seq_id = T.match_buffer(var_pos2seq_id, (num_token,), "int32")
@@ -176,10 +176,10 @@ def _get_apply_penalty_inplace(target: tvm.target.Target):
                 "tirx.is_scheduled": True,
             }
         )
-        batch_size = T.int32(is_size_var=True)
-        vocab_size = T.int32(is_size_var=True)
-        num_token = T.int32(is_size_var=True)
-        num_seq = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        vocab_size = T.int32()
+        num_token = T.int32()
+        num_seq = T.int32()
         logits = T.match_buffer(var_logits, (batch_size, vocab_size), "float32")
         seq_ids = T.match_buffer(var_seq_ids, (num_seq,), "int32")
         pos2seq_id = T.match_buffer(var_pos2seq_id, (num_token,), "int32")
@@ -222,9 +222,9 @@ def _get_apply_bitmask_inplace_cpu():
                 "tirx.is_scheduled": True,
             }
         )
-        batch_size = T.int32(is_size_var=True)
-        vocab_size = T.int32(is_size_var=True)
-        num_seq = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        vocab_size = T.int32()
+        num_seq = T.int32()
         logits = T.match_buffer(var_logits, (batch_size, vocab_size), "float32")
         seq_ids = T.match_buffer(var_seq_ids, (num_seq,), "int32")
         bitmask = T.match_buffer(var_bitmask, (batch_size, (vocab_size + 31) // 32), "int32")
@@ -263,9 +263,9 @@ def _get_apply_bitmask_inplace(target: tvm.target.Target):
                 "tirx.is_scheduled": True,
             }
         )
-        batch_size = T.int32(is_size_var=True)
-        vocab_size = T.int32(is_size_var=True)
-        num_seq = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        vocab_size = T.int32()
+        num_seq = T.int32()
         logits = T.match_buffer(var_logits, (batch_size, vocab_size), "float32")
         seq_ids = T.match_buffer(var_seq_ids, (num_seq,), "int32")
         bitmask = T.match_buffer(var_bitmask, (batch_size, (vocab_size + 31) // 32), "int32")

--- a/python/mlc_llm/compiler_pass/attach_sampler.py
+++ b/python/mlc_llm/compiler_pass/attach_sampler.py
@@ -67,9 +67,9 @@ class AttachGPUSamplingFunc:
 
 
 def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
-    batch_size = tirx.SizeVar("batch_size", "int64")
-    num_samples = tirx.SizeVar("num_samples", "int64")
-    vocab_size = tirx.SizeVar("vocab_size", "int64")
+    batch_size = tirx.Var("batch_size", "int64")
+    num_samples = tirx.Var("num_samples", "int64")
+    vocab_size = tirx.Var("vocab_size", "int64")
     probs = relax.Var("probs", relax.TensorType((batch_size, vocab_size), "float32"))
     uniform_samples = relax.Var("uniform_samples", relax.TensorType((num_samples,), "float32"))
     sample_indices = relax.Var("sample_indices", relax.TensorType((num_samples,), "int32"))
@@ -116,8 +116,8 @@ def _attach_multinomial_sampling_func(bb: relax.BlockBuilder):
 
 
 def _attach_argsort_func(bb: relax.BlockBuilder):
-    batch_size = tirx.SizeVar("batch_size", "int64")
-    vocab_size = tirx.SizeVar("vocab_size", "int64")
+    batch_size = tirx.Var("batch_size", "int64")
+    vocab_size = tirx.Var("vocab_size", "int64")
     probs = relax.Var("probs", relax.TensorType((batch_size, vocab_size), "float32"))
     with bb.function("argsort_probs", [probs]):
         with bb.dataflow():
@@ -140,7 +140,7 @@ def _attach_argsort_func(bb: relax.BlockBuilder):
 @T.prim_func(s_tir=True)
 def full(var_result: T.handle, value: T.int32):
     """The filling function for top k."""
-    batch_size = T.int32(is_size_var=True)
+    batch_size = T.int32()
     result = T.match_buffer(var_result, (batch_size, 1), "int32")
     for i in T.serial(batch_size):
         with T.sblock("block"):
@@ -149,9 +149,9 @@ def full(var_result: T.handle, value: T.int32):
 
 
 def _attach_sample_with_top_p(bb: relax.BlockBuilder):
-    batch_size = tirx.SizeVar("batch_size", "int64")
-    num_samples = tirx.SizeVar("num_samples", "int64")
-    vocab_size = tirx.SizeVar("vocab_size", "int64")
+    batch_size = tirx.Var("batch_size", "int64")
+    num_samples = tirx.Var("num_samples", "int64")
+    vocab_size = tirx.Var("vocab_size", "int64")
     sorted_probs = relax.Var("sorted_probs", relax.TensorType((batch_size, vocab_size), "float32"))
     sorted_indices = relax.Var(
         "sorted_indices", relax.TensorType((batch_size, vocab_size), "int32")
@@ -227,8 +227,8 @@ def _attach_sample_with_top_p(bb: relax.BlockBuilder):
 
 
 def _attach_renormalize_by_top_p(bb: relax.BlockBuilder, target: tvm.target.Target):
-    batch_size = tirx.SizeVar("batch_size", "int64")
-    vocab_size = tirx.SizeVar("vocab_size", "int64")
+    batch_size = tirx.Var("batch_size", "int64")
+    vocab_size = tirx.Var("vocab_size", "int64")
     num_pivots = 3
     probs = relax.Var("probs", relax.TensorType((batch_size, vocab_size), "float32"))
     top_p = relax.Var("top_p", relax.TensorType((batch_size,), "float32"))
@@ -256,10 +256,10 @@ def _attach_renormalize_by_top_p(bb: relax.BlockBuilder, target: tvm.target.Targ
 
 
 def _attach_take_probs_func(bb: relax.BlockBuilder):
-    batch_size = tirx.SizeVar("batch_size", "int64")
-    num_samples = tirx.SizeVar("num_samples", "int64")
-    num_positions = tirx.SizeVar("num_positions", "int64")
-    vocab_size = tirx.SizeVar("vocab_size", "int64")
+    batch_size = tirx.Var("batch_size", "int64")
+    num_samples = tirx.Var("num_samples", "int64")
+    num_positions = tirx.Var("num_positions", "int64")
+    vocab_size = tirx.Var("vocab_size", "int64")
     unsorted_probs = relax.Var(
         "unsorted_probs", relax.TensorType((batch_size, vocab_size), "float32")
     )
@@ -281,10 +281,10 @@ def _attach_take_probs_func(bb: relax.BlockBuilder):
         var_top_prob_probs: T.handle,
         var_top_prob_indices: T.handle,
     ):
-        batch_size = T.int32(is_size_var=True)
-        num_samples = T.int32(is_size_var=True)
-        num_positions = T.int32(is_size_var=True)
-        vocab_size = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        num_samples = T.int32()
+        num_positions = T.int32()
+        vocab_size = T.int32()
         unsorted_probs = T.match_buffer(var_unsorted_probs, (batch_size, vocab_size), "float32")
         sorted_indices = T.match_buffer(var_sorted_indices, (batch_size, vocab_size), "int32")
         sample_indices = T.match_buffer(var_sample_indices, (num_samples,), "int32")
@@ -344,9 +344,9 @@ def _attach_take_probs_func(bb: relax.BlockBuilder):
 
 
 def _attach_batch_verifier(bb: relax.BlockBuilder):
-    num_nodes = tirx.SizeVar("num_nodes", "int64")
-    nbatch = tirx.SizeVar("nbatch", "int64")
-    vocab_size = tirx.SizeVar("vocab_size", "int64")
+    num_nodes = tirx.Var("num_nodes", "int64")
+    nbatch = tirx.Var("nbatch", "int64")
+    vocab_size = tirx.Var("vocab_size", "int64")
     draft_probs = relax.Var("draft_probs", relax.TensorType((num_nodes, vocab_size), "float32"))
     draft_tokens = relax.Var("draft_tokens", relax.TensorType((num_nodes,), "int32"))
     model_probs = relax.Var("model_probs", relax.TensorType((num_nodes, vocab_size), "float32"))

--- a/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
+++ b/python/mlc_llm/compiler_pass/attach_softmax_with_temperature.py
@@ -45,8 +45,8 @@ class _Rewriter(PyExprMutator):
 
     def transform(self) -> IRModule:
         """Entry point"""
-        batch_size = tirx.SizeVar("batch_size", "int64")
-        vocab_size = tirx.SizeVar("vocab_size", "int64")
+        batch_size = tirx.Var("batch_size", "int64")
+        vocab_size = tirx.Var("vocab_size", "int64")
         dtype = "float32"
         logits = relax.Var("logits", relax.TensorType([batch_size, 1, vocab_size], dtype))
         temperature = relax.Var("temperature", relax.TensorType([batch_size], dtype))
@@ -124,9 +124,9 @@ def _get_lse_and_softmax_func(target: tvm.target.Target, chunk_size: int, active
         var_chunked_max: T.handle,
     ):
         T.func_attr({"tirx.noalias": True})
-        batch_size = T.int64(is_size_var=True)
-        vocab_size = T.int64(is_size_var=True)
-        num_chunks = T.int64(is_size_var=True)
+        batch_size = T.int64()
+        vocab_size = T.int64()
+        num_chunks = T.int64()
         A = T.match_buffer(var_A, (batch_size, vocab_size), dtype="float32")
         temperature = T.match_buffer(var_temperature, (batch_size,), dtype="float32")
         chunked_sum = T.match_buffer(var_chunked_sum, (batch_size, num_chunks), dtype="float32")
@@ -190,9 +190,9 @@ def _get_lse_and_softmax_func(target: tvm.target.Target, chunk_size: int, active
         var_softmax: T.handle,
     ):
         T.func_attr({"tirx.noalias": True, "tirx.is_scheduled": 1})
-        batch_size = T.int64(is_size_var=True)
-        vocab_size = T.int64(is_size_var=True)
-        num_chunks = T.int64(is_size_var=True)
+        batch_size = T.int64()
+        vocab_size = T.int64()
+        num_chunks = T.int64()
         A = T.match_buffer(var_A, (batch_size, vocab_size), dtype="float32")
         temperature = T.match_buffer(var_temperature, (batch_size,), dtype="float32")
         chunked_sum = T.match_buffer(var_chunked_sum, (batch_size, num_chunks), dtype="float32")

--- a/python/mlc_llm/compiler_pass/attach_spec_decode_aux_funcs.py
+++ b/python/mlc_llm/compiler_pass/attach_spec_decode_aux_funcs.py
@@ -39,9 +39,9 @@ def _get_scatter_2d_inplace(dtype: str, global_symbol: str):
     @T.prim_func(s_tir=True)
     def _scatter_2d(var_src: T.handle, var_indices: T.handle, var_dst: T.handle):
         T.func_attr({"global_symbol": global_symbol, "tirx.noalias": True})
-        batch_size = T.int32(is_size_var=True)
-        m = T.int32(is_size_var=True)
-        n = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        m = T.int32()
+        n = T.int32()
         src = T.match_buffer(var_src, (batch_size, n), dtype)
         indices = T.match_buffer(var_indices, (batch_size,), "int32")
         dst = T.match_buffer(var_dst, (m, n), dtype)
@@ -57,9 +57,9 @@ def _get_gather_2d_inplace(dtype: str, global_symbol: str):
     @T.prim_func(s_tir=True)
     def _gather_2d(var_src: T.handle, var_indices: T.handle, var_dst: T.handle):
         T.func_attr({"global_symbol": global_symbol, "tirx.noalias": True})
-        batch_size = T.int32(is_size_var=True)
-        m = T.int32(is_size_var=True)
-        n = T.int32(is_size_var=True)
+        batch_size = T.int32()
+        m = T.int32()
+        n = T.int32()
         src = T.match_buffer(var_src, (m, n), dtype)
         indices = T.match_buffer(var_indices, (batch_size,), "int32")
         dst = T.match_buffer(var_dst, (batch_size, n), dtype)
@@ -72,9 +72,9 @@ def _get_gather_2d_inplace(dtype: str, global_symbol: str):
 
 
 def _add_scatter_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dtype: str):
-    batch_size = tirx.SizeVar("batch_size", "int64")
-    m = tirx.SizeVar("m", "int64")
-    n = tirx.SizeVar("n", "int64")
+    batch_size = tirx.Var("batch_size", "int64")
+    m = tirx.Var("m", "int64")
+    n = tirx.Var("n", "int64")
     src = relax.Var("src", ty=TensorType([batch_size, n], dtype))
     indices = relax.Var("indices", ty=TensorType([batch_size], "int32"))
     dst = relax.Var("dst", ty=TensorType([m, n], dtype))
@@ -98,9 +98,9 @@ def _add_scatter_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dt
 
 
 def _add_gather_hidden_states(bb: BlockBuilder, tensor_parallel_shards: int, dtype: str):
-    batch_size = tirx.SizeVar("batch_size", "int64")
-    m = tirx.SizeVar("m", "int64")
-    n = tirx.SizeVar("n", "int64")
+    batch_size = tirx.Var("batch_size", "int64")
+    m = tirx.Var("m", "int64")
+    n = tirx.Var("n", "int64")
     src = relax.Var("src", ty=TensorType([m, n], dtype))
     indices = relax.Var("indices", ty=TensorType([batch_size], "int32"))
     dst = relax.Var("dst", ty=TensorType([batch_size, n], dtype))

--- a/python/mlc_llm/compiler_pass/fuse_add_norm.py
+++ b/python/mlc_llm/compiler_pass/fuse_add_norm.py
@@ -234,5 +234,5 @@ class _FuseAddRMSNormRewriter(PyExprMutator):
         )
         new_o = relax.TupleGetItem(tuple_output, 0)
         new_y = self.builder_.emit(relax.TupleGetItem(tuple_output, 1))
-        self.set_var_remap(call.args[0].vid, new_y)
+        self.set_var_remap(call.args[0], new_y)
         return new_o

--- a/python/mlc_llm/compiler_pass/fuse_dequantize_take.py
+++ b/python/mlc_llm/compiler_pass/fuse_dequantize_take.py
@@ -80,7 +80,7 @@ def _pattern(n_aux_tensor: int, match_tir_vars: bool):
     def _check(ctx: relax.transform.PatternCheckContext) -> bool:
         take = ctx.annotated_expr["take"]
         dequantize = ctx.annotated_expr["dequantize"]
-        if not isinstance(dequantize, relax.expr.Call):
+        if not isinstance(dequantize, relax.Call):
             return False
         if not isinstance(take.args[0], relax.GlobalVar) or not isinstance(
             dequantize.args[0], relax.GlobalVar

--- a/python/mlc_llm/compiler_pass/lift_global_buffer_alloc.py
+++ b/python/mlc_llm/compiler_pass/lift_global_buffer_alloc.py
@@ -101,7 +101,7 @@ def remove_global_buf_alloc(
     alloc_buffers = []
 
     insertion_point = len(params)
-    while params[insertion_point - 1].ty.dtype != "handle":
+    while not isinstance(params[insertion_point - 1].ty, tvm.ir.PointerType):
         insertion_point -= 1
         assert insertion_point >= 1
 
@@ -159,7 +159,7 @@ def _resolve_tir_var_mapping(
     tensor_sinfo: List[relax.TensorType],  # noqa: UP006
 ) -> Tuple[List[relax.TensorType], bool]:  # noqa: UP006
     """Resolve the TIR symbolic var relationship across sides of PrimFunc and Relax Function"""
-    var_map: Dict[tirx.Var, tirx.PrimExpr] = {}  # noqa: UP006
+    var_map: Dict[tirx.Var, tirx.Expr] = {}  # noqa: UP006
 
     n_arg = len(call.args[1].fields)
     for i in range(n_arg):

--- a/python/mlc_llm/compiler_pass/pipeline_parallel_rewrite.py
+++ b/python/mlc_llm/compiler_pass/pipeline_parallel_rewrite.py
@@ -118,10 +118,10 @@ class _PipelineParallelRewriter(PyExprMutator):
         # Prepare the func parameters (except the shape variables and packed params)
         params, args = self._prepare_stage_func_params_and_args(required_func_params)
         for new_param, old_param in zip(params, required_func_params):
-            self.set_var_remap(old_param.vid, new_param)
+            self.set_var_remap(old_param, new_param)
         # Create new packed params
         self.new_stage_func_packed_params = relax.Var("packed_params", relax.ObjectType())
-        self.set_var_remap(self.old_packed_params_var.vid, self.new_stage_func_packed_params)
+        self.set_var_remap(self.old_packed_params_var, self.new_stage_func_packed_params)
 
         new_func_outputs = []
         with self.builder_.function(func_name, pure=False):
@@ -136,7 +136,7 @@ class _PipelineParallelRewriter(PyExprMutator):
                         ),
                         name_hint=receive_var.name_hint,
                     )
-                    self.set_var_remap(receive_var.vid, new_receive_var)
+                    self.set_var_remap(receive_var, new_receive_var)
                 # Process the bindings in this stage.
                 for stage_binding in stage_bindings:
                     if stage_binding.var in stage_send_vars or stage_binding.var.same_as(
@@ -147,13 +147,13 @@ class _PipelineParallelRewriter(PyExprMutator):
                             self.visit_expr(stage_binding.value),
                             name_hint=stage_binding.var.name_hint,
                         )
-                        self.set_var_remap(stage_binding.var.vid, new_var)
+                        self.set_var_remap(stage_binding.var, new_var)
                         new_func_outputs.append(new_var)
                     else:
                         self.visit_binding(stage_binding)
             # Emit the calls to send tensors to the next stage.
             for send_var in stage_send_vars:
-                new_send_var = self.get_var_remap(send_var.vid)
+                new_send_var = self.get_var_remap(send_var)
                 self.builder_.emit(
                     relax.Call(
                         relax.ExternFunc("runtime.disco.send_to_next_group"),
@@ -235,7 +235,7 @@ class _PipelineParallelRewriter(PyExprMutator):
             new_binding_var = self.builder_.match_cast(
                 new_binding_var, new_tensor_struct_info, binding.var.name_hint + "_cast"
             )
-        self.set_var_remap(binding.var.vid, new_binding_var)
+        self.set_var_remap(binding.var, new_binding_var)
 
     def visit_call_(self, call: relax.Call) -> relax.Call:
         call = super().visit_call_(call)
@@ -291,10 +291,10 @@ class _PipelineParallelRewriter(PyExprMutator):
 
     def _copy_undefined_var(
         self,
-        expr: tirx.PrimExpr,
+        expr: tirx.Expr,
         undefined_var_remap: Dict[tirx.Var, tirx.Var],  # noqa: UP006
     ) -> None:
-        def _visit_expr(e: tirx.PrimExpr) -> None:
+        def _visit_expr(e: tirx.Expr) -> None:
             if isinstance(e, tirx.Var) and e not in undefined_var_remap:
                 new_var = tirx.Var(e.name, e.ty)
                 undefined_var_remap[e] = new_var
@@ -303,9 +303,9 @@ class _PipelineParallelRewriter(PyExprMutator):
 
     def _update_shape(
         self,
-        shape: List[tirx.PrimExpr],  # noqa: UP006
+        shape: List[tirx.Expr],  # noqa: UP006
         undefined_var_remap: Dict[tirx.Var, tirx.Var],  # noqa: UP006
-    ) -> List[tirx.PrimExpr]:  # noqa: UP006
+    ) -> List[tirx.Expr]:  # noqa: UP006
         new_shape = []
         for v in shape:
             self._copy_undefined_var(v, undefined_var_remap)

--- a/python/mlc_llm/compiler_pass/scatter_tuple_get_item.py
+++ b/python/mlc_llm/compiler_pass/scatter_tuple_get_item.py
@@ -43,7 +43,7 @@ class _Scatter(PyExprMutator):
     def visit_dataflow_var_(self, var: relax.DataflowVar) -> Expr:
         if var in self.var_map:
             new_var = self.builder_.emit(self.var_map[var], name_hint=var.name_hint)
-            self.set_var_remap(var.vid, new_var)
+            self.set_var_remap(var, new_var)
             self.var_map.pop(var)
             return new_var
         return var

--- a/python/mlc_llm/model/vision/image_processing.py
+++ b/python/mlc_llm/model/vision/image_processing.py
@@ -40,14 +40,14 @@ class ImageProcessor(Module):
                 long = tirx.Select(w > h, w, h)
                 requested_new_short = params["shortest_edge"]
                 new_short, new_long = (
-                    tirx.generic.cast(requested_new_short, "int64"),
-                    tirx.generic.cast(
+                    tirx.Cast("int64", requested_new_short),
+                    tirx.Cast(
+                        "int64",
                         requested_new_short
                         * tirx.div(
-                            tirx.generic.cast(long, "float32"),
-                            tirx.generic.cast(short, "float32"),
+                            tirx.Cast("float32", long),
+                            tirx.Cast("float32", short),
                         ),
-                        "int64",
                     ),
                 )
                 ret_h = tirx.Select(w <= h, new_long, new_short)
@@ -58,27 +58,27 @@ class ImageProcessor(Module):
                 pad_num = 336 if "pad_num" not in params else params["pad_num"]
                 ratio = tirx.Select(
                     w > h,
-                    tirx.div(tirx.generic.cast(w, "float32"), tirx.generic.cast(h, "float32")),
-                    tirx.div(tirx.generic.cast(h, "float32"), tirx.generic.cast(w, "float32")),
+                    tirx.div(tirx.Cast("float32", w), tirx.Cast("float32", h)),
+                    tirx.div(tirx.Cast("float32", h), tirx.Cast("float32", w)),
                 )
 
-                scale = tirx.ceil(tirx.sqrt(tirx.generic.cast(hd_num, "float32") * ratio))
+                scale = tirx.ceil(tirx.sqrt(tirx.Cast("float32", hd_num) * ratio))
 
                 scale = tirx.Select(
                     (scale * tirx.ceil(tirx.div(scale, ratio))) > hd_num,
                     scale - 1,
                     scale,
                 )
-                scale = tirx.generic.cast(scale, "int64")
+                scale = tirx.Cast("int64", scale)
 
                 new_w = tirx.Select(
                     w >= h,
                     scale * pad_num,
-                    tirx.generic.cast(tirx.div(scale * pad_num, ratio), "int64"),
+                    tirx.Cast("int64", tirx.div(scale * pad_num, ratio)),
                 )
                 new_h = tirx.Select(
                     w >= h,
-                    tirx.generic.cast(tirx.div(new_w, ratio), "int64"),
+                    tirx.Cast("int64", tirx.div(new_w, ratio)),
                     scale * pad_num,
                 )
                 return (new_h, new_w)

--- a/python/mlc_llm/nn/rnn_state.py
+++ b/python/mlc_llm/nn/rnn_state.py
@@ -74,7 +74,7 @@ class RNNState(Object):
         self,
         layer_id: int,
         state_id: int,
-        shape: Sequence[tirx.PrimExpr],
+        shape: Sequence[tirx.Expr],
         dtype: str,
     ) -> Tensor:
         """Get the state of the RNN layer.
@@ -90,7 +90,7 @@ class RNNState(Object):
             The layer id.
         state_id : int
             The state id.
-        shape : Sequence[tirx.PrimExpr]
+        shape : Sequence[tirx.Expr]
             The shape of the state tensor.
         dtype: str
             The data type of the state tensor.
@@ -180,7 +180,7 @@ class RNNState(Object):
                 var_history_slot_ids: T.handle,
                 var_output: T.handle,
             ):
-                batch_size = T.int32(is_size_var=True)
+                batch_size = T.int32()
                 T.func_attr({"global_symbol": f"rnn_state_get_{state_id}"})
 
                 storage = T.match_buffer(
@@ -209,7 +209,7 @@ class RNNState(Object):
                 var_history_slot_ids: T.handle,
                 var_output: T.handle,
             ):
-                batch_size = T.int32(is_size_var=True)
+                batch_size = T.int32()
                 T.func_attr({"global_symbol": f"rnn_state_get_{state_id}"})
 
                 storage = T.match_buffer(var_storage, (max_batch_size, max_history, *shape), dtype)
@@ -277,7 +277,7 @@ class RNNState(Object):
                 var_history_slot_ids: T.handle,
                 var_data: T.handle,
             ):
-                batch_size = T.int32(is_size_var=True)
+                batch_size = T.int32()
                 T.func_attr({"global_symbol": f"rnn_state_set_{state_id}"})
 
                 storage = T.match_buffer(
@@ -307,7 +307,7 @@ class RNNState(Object):
                 var_history_slot_ids: T.handle,
                 var_data: T.handle,
             ):
-                batch_size = T.int32(is_size_var=True)
+                batch_size = T.int32()
                 T.func_attr({"global_symbol": f"rnn_state_set_{state_id}"})
 
                 storage = T.match_buffer(var_storage, (max_batch_size, max_history, *shape), dtype)

--- a/python/mlc_llm/op/batch_spec_verify.py
+++ b/python/mlc_llm/op/batch_spec_verify.py
@@ -73,8 +73,8 @@ def batch_spec_verify(vocab_size):
         ]
         """
         T.func_attr({"tirx.is_scheduled": 1, "tirx.noalias": True})
-        num_nodes = T.int32(is_size_var=True)
-        nbatch = T.int32(is_size_var=True)
+        num_nodes = T.int32()
+        nbatch = T.int32()
 
         draft_probs = T.match_buffer(var_draft_probs, (num_nodes, vocab_size), "float32")
         draft_tokens = T.match_buffer(var_draft_tokens, (num_nodes,), "int32")
@@ -148,9 +148,9 @@ def batch_spec_verify(vocab_size):
                                         T.attr(
                                             T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
                                             "reduce_scope",
-                                            T.reinterpret("handle", T.uint64(0)),
+                                            T.int32(0),
                                         )
-                                        T.tvm_thread_allreduce(T.uint32(1), psum[0], True, t0[0], tx, dtype="handle")  # noqa: E501
+                                        T.tvm_thread_allreduce(T.uint32(1), psum[0], True, t0[0], tx, dtype="void")  # noqa: E501
 
                                     if t0[0] < 1e-7:
                                         # accept the proposal, we move to child

--- a/python/mlc_llm/op/moe_matmul.py
+++ b/python/mlc_llm/op/moe_matmul.py
@@ -427,7 +427,7 @@ def group_gemm(x: Tensor, w: Tensor, indptr: Tensor):
         var_o: T.handle,
     ):
         T.func_attr({"tirx.is_scheduled": 1, "tirx.noalias": True})
-        B = T.int32(is_size_var=True)
+        B = T.int32()
         X = T.match_buffer(var_x, (B, K), dtype)
         W = T.match_buffer(var_w, (Ne, N, K), dtype)
         indptr = T.match_buffer(var_indptr, (Ne + 1,), "int32")
@@ -638,7 +638,7 @@ def dequantize_group_gemm(
         var_o: T.handle,
     ):
         T.func_attr({"tirx.is_scheduled": 1, "tirx.noalias": True})
-        B = T.int32(is_size_var=True)
+        B = T.int32()
         X = T.match_buffer(var_x, (B, K), model_dtype)
         out = T.match_buffer(var_o, (B, N), model_dtype)
         for _bx in T.thread_binding(CTA_COUNT, thread="blockIdx.x"):

--- a/python/mlc_llm/op/moe_misc.py
+++ b/python/mlc_llm/op/moe_misc.py
@@ -497,8 +497,8 @@ def get_indices(cumsum: Tensor, expert_indices: Tensor) -> Tuple[Tensor, Tensor]
         var_token_indices: T.handle,
     ):
         T.func_attr({"tirx.is_scheduled": 1, "tirx.noalias": True})
-        batch_size = T.SizeVar("batch_size", "int32")
-        cumsum_len = T.SizeVar("cumsum_len", "int32")  # [experts_per_tok * batch_size]
+        batch_size = T.int32()
+        cumsum_len = T.int32()  # [experts_per_tok * batch_size]
         cumsum = T.match_buffer(var_cumsum, [cumsum_len], "int32")
         expert_indices = T.match_buffer(var_expert_indices, [batch_size, experts_per_tok], "int32")
         reverse_indices = T.match_buffer(

--- a/python/mlc_llm/op/top_p_pivot.py
+++ b/python/mlc_llm/op/top_p_pivot.py
@@ -58,8 +58,8 @@ def top_p_pivot(pN, target: tvm.target.Target):
         var_final_lsum: T.handle,
     ):
         T.func_attr({"tirx.is_scheduled": 1, "tirx.noalias": True})
-        B = T.int32(is_size_var=True)
-        N = T.int32(is_size_var=True)
+        B = T.int32()
+        N = T.int32()
         prob = T.match_buffer(var_prob, (B, N,), "float32")
         top_p_arr = T.match_buffer(var_top_p_arr, (B,), dtype="float32")
         init_pivots = T.match_buffer(var_init_pivots, (B, pN), "float32")
@@ -160,9 +160,9 @@ def top_p_pivot(pN, target: tvm.target.Target):
                                         T.attr(
                                             T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
                                             "reduce_scope",
-                                            T.reinterpret("handle", T.uint64(0)),
+                                            T.int32(0),
                                         )
-                                        T.tvm_thread_allreduce(T.uint32(1), total_sum[0], True, total_sum_reduce[0], tx, dtype="handle")  # noqa: E501
+                                        T.tvm_thread_allreduce(T.uint32(1), total_sum[0], True, total_sum_reduce[0], tx, dtype="void")  # noqa: E501
                                     # T.tvm_storage_sync("shared")
 
                                     if tx == 0:
@@ -182,9 +182,9 @@ def top_p_pivot(pN, target: tvm.target.Target):
                                     T.attr(
                                         T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
                                         "reduce_scope",
-                                        T.reinterpret("handle", T.uint64(0)),
+                                        T.int32(0),
                                     )
-                                    T.tvm_thread_allreduce(T.uint32(1), lsum[pidx], True, lsum_reduce[0], tx, dtype="handle")  # noqa: E501
+                                    T.tvm_thread_allreduce(T.uint32(1), lsum[pidx], True, lsum_reduce[0], tx, dtype="void")  # noqa: E501
 
                                 # reduce lmin over tx for pivot[j]
                                 with T.sblock("block_cross_thread"):
@@ -193,9 +193,9 @@ def top_p_pivot(pN, target: tvm.target.Target):
                                     T.attr(
                                         T.comm_reducer(lambda x0, y0: T.min(x0, y0), [T.float32(0)]),  # noqa: E501
                                         "reduce_scope",
-                                        T.reinterpret("handle", T.uint64(0)),
+                                        T.int32(0),
                                     )
-                                    T.tvm_thread_allreduce(T.uint32(1), lmin[pidx], True, lmin_reduce[0], tx, dtype="handle")  # noqa: E501
+                                    T.tvm_thread_allreduce(T.uint32(1), lmin[pidx], True, lmin_reduce[0], tx, dtype="void")  # noqa: E501
 
                                 if tx == 0:
                                     # broadcast lmin to all threads
@@ -216,9 +216,9 @@ def top_p_pivot(pN, target: tvm.target.Target):
                                     T.attr(
                                         T.comm_reducer(lambda x0, y0: x0 + y0, [T.int32(0)]),
                                         "reduce_scope",
-                                        T.reinterpret("handle", T.uint64(0)),
+                                        T.int32(0),
                                     )
-                                    T.tvm_thread_allreduce(T.uint32(1), cmin[pidx], True, cmin_reduce[0], tx, dtype="handle")  # noqa: E501
+                                    T.tvm_thread_allreduce(T.uint32(1), cmin[pidx], True, cmin_reduce[0], tx, dtype="void")  # noqa: E501
 
                                 if tx == 0:
                                     # only the leader thread updates cmin
@@ -305,8 +305,8 @@ def top_p_renorm(target: tvm.target.Target = None):
         var_renorm_prob: T.handle,
     ):
         T.func_attr({"tirx.is_scheduled": 1, "tirx.noalias": True})
-        B = T.int32(is_size_var=True)
-        N = T.int32(is_size_var=True)
+        B = T.int32()
+        N = T.int32()
         prob = T.match_buffer(var_prob, (B, N,), "float32")
         final_pivot = T.match_buffer(var_final_pivot, (B,), "float32")
         final_lsum = T.match_buffer(var_final_lsum, (B,), "float32")

--- a/python/mlc_llm/op/triton.py
+++ b/python/mlc_llm/op/triton.py
@@ -310,7 +310,7 @@ def get_tir_w8a8_block_fp8_matmul(
             var_C: T.handle,
         ):
             T.func_attr({"op_pattern": 8, "tirx.is_scheduled": 1})
-            M = T.SizeVar("M", "int32")
+            M = T.int32()
             A = T.match_buffer(var_A, (M, K), dtype=in_dtype)
             B = T.match_buffer(var_B, (N, K), dtype=in_dtype)
             As = T.match_buffer(var_As, (M, (K + block_k - 1) // block_k), "float32")
@@ -414,7 +414,7 @@ def get_tir_w8a8_block_fp8_group_matmul(
             var_C: T.handle,
         ):
             T.func_attr({"op_pattern": 8, "tirx.is_scheduled": 1})
-            EM = T.SizeVar("EM", "int32")
+            EM = T.int32()
             A = T.match_buffer(var_A, (EM, K), dtype=in_dtype)
             B = T.match_buffer(var_B, (num_experts, N, K), dtype=in_dtype)
             As = T.match_buffer(var_As, (EM, (K + block_k - 1) // block_k), "float32")

--- a/python/mlc_llm/quantization/awq_quantization.py
+++ b/python/mlc_llm/quantization/awq_quantization.py
@@ -135,7 +135,7 @@ class AWQQuantize:
         weight: te.Tensor,
         zeros: te.Tensor,
         scale: te.Tensor,
-        out_shape: Optional[List[tirx.PrimExpr]] = None,  # noqa: UP006
+        out_shape: Optional[List[tirx.Expr]] = None,  # noqa: UP006
     ):
         float_weight = convert_uint_to_float(
             weight,
@@ -164,8 +164,8 @@ class AWQQuantize:
                 if out_shape is None
                 else out_shape
             ),
-            fcompute=lambda i, j: tirx.multiply(
-                tirx.subtract(float_weight[i, j], float_zeros[i, j // self.group_size]),
+            fcompute=lambda i, j: tirx.Mul(
+                tirx.Sub(float_weight[i, j], float_zeros[i, j // self.group_size]),
                 scale[i, j // self.group_size],
             ),
             name="dequantize",

--- a/python/mlc_llm/quantization/group_quantization.py
+++ b/python/mlc_llm/quantization/group_quantization.py
@@ -157,7 +157,7 @@ class GroupQuantize:
         weight: te.Tensor,
         scale: te.Tensor,
         axis: int,
-        out_shape: Optional[List[tirx.PrimExpr]] = None,  # noqa: UP006
+        out_shape: Optional[List[tirx.Expr]] = None,  # noqa: UP006
     ):
         tir_max_int = tirx.const(self.max_int_value, self.model_dtype)
         float_weight = convert_uint_to_float(
@@ -175,8 +175,8 @@ class GroupQuantize:
         axis = axis if axis >= 0 else len(out_shape) + axis
         return te.compute(
             shape=out_shape,
-            fcompute=lambda *idx: tirx.multiply(
-                tirx.subtract(
+            fcompute=lambda *idx: tirx.Mul(
+                tirx.Sub(
                     float_weight(*idx),
                     tir_max_int,
                 ),

--- a/python/mlc_llm/quantization/per_tensor_quantization.py
+++ b/python/mlc_llm/quantization/per_tensor_quantization.py
@@ -288,7 +288,7 @@ class PerTensorQuantize:
         self,
         q_weight: te.Tensor,
         scale: Optional[te.Tensor] = None,
-        out_shape: Optional[Sequence[tirx.PrimExpr]] = None,
+        out_shape: Optional[Sequence[tirx.Expr]] = None,
     ) -> te.Tensor:
         if self.use_scale:
             assert scale is not None
@@ -304,7 +304,7 @@ class PerTensorQuantize:
         q_tensor: te.Tensor,
         scale: Optional[te.Tensor],
         quantize_dtype: str,
-        out_shape: Optional[Sequence[tirx.PrimExpr]] = None,
+        out_shape: Optional[Sequence[tirx.Expr]] = None,
     ) -> te.Tensor:
         """Dequantize a fp8 tensor (input or weight) to higher-precision float."""
         if quantize_dtype != self.storage_dtype:

--- a/python/mlc_llm/quantization/utils.py
+++ b/python/mlc_llm/quantization/utils.py
@@ -19,7 +19,7 @@ def convert_uint_to_float(
     storage_dtype: str,
     model_dtype: str,
     axis: int = -1,
-    out_shape: Optional[List[tirx.PrimExpr]] = None,  # noqa: UP006
+    out_shape: Optional[List[tirx.Expr]] = None,  # noqa: UP006
     ft_reorder: Optional[bool] = False,
 ) -> te.Tensor:
     """Convert a quantized uint weight to an unquantized float weight."""
@@ -101,7 +101,7 @@ def convert_uint_packed_fp8_to_float(
     model_dtype: str,
     quant_dtype: str,
     axis: int = -1,
-    out_shape: Optional[Sequence[tirx.PrimExpr]] = None,
+    out_shape: Optional[Sequence[tirx.Expr]] = None,
 ) -> te.Tensor:
     """Unpack a fp8 value from the storage dtype and convert to float."""
     assert quant_dtype in ["float8_e4m3fn", "float8_e5m2"]
@@ -139,7 +139,7 @@ def pack_weight(
     num_elem_per_storage: int,
     weight_dtype: str,
     storage_dtype: str,
-    out_shape: Optional[Sequence[tirx.PrimExpr]] = None,
+    out_shape: Optional[Sequence[tirx.Expr]] = None,
 ):
     """Convert a tensor to a packed format by packing consecutive bits.
     This can be useful for sub-byte quantization.
@@ -156,7 +156,7 @@ def pack_weight(
         The dtype of the input tensor.
     storage_dtype : str
         The dtype of the packed tensor.
-    out_shape : Optional[Sequence[tirx.PrimExpr]]
+    out_shape : Optional[Sequence[tirx.Expr]]
         The output shape of the packed tensor. Zero-padding is added if needed.
     """
     assert weight.dtype == storage_dtype


### PR DESCRIPTION
A newer TVM bumps tvm-ffi so that `Optional<T>` follows std::optional semantics: `.defined()` is dropped in favor of `.has_value()`, and `Optional<Tensor>` no longer implicitly converts to `ObjectRef`. Update the C++ runtime to call `.has_value()` on the affected `Optional` receivers (leaving `.defined()` on plain `ObjectRef`/`Function`/`Module` handles intact) and return `recv.value_or(Tensor(nullptr))` from the multi-GPU send/recv passthrough.

On the Python side, adapt the compiler passes and ops to the Relax/tirx API changes. The Relax `Id` indirection is gone, so `PyExprMutator` var remaps take the `Var` directly instead of `var.vid`. Symbolic size vars drop `is_size_var`/`SizeVar` for plain `T.int32()`/`tirx.Var`; `tirx.PrimExpr`/`multiply`/`subtract`/`generic.cast` become `Expr`/`Mul`/`Sub`/`Cast`; the cross-thread all-reduce idiom uses `T.int32(0)` with `dtype="void"`; `relax.expr.Call` becomes `relax.Call`; and handle parameters are detected via `isinstance(v.ty, PointerType)` now that a var's `.ty` carries a `PrimType`/`PointerType` rather than a dtype string.

Verified end to end by compiling and chatting with both Phi-4-mini-instruct and Qwen3-30B-A3B under tensor_parallel_shards=2.