### PR TITLE
fix(serve): don't mutate request.stop when it's passed as a list

### DIFF
--- a/python/mlc_llm/serve/engine_utils.py
+++ b/python/mlc_llm/serve/engine_utils.py
@@ -49,7 +49,9 @@ def openai_api_get_generation_config(request: RequestProtocol) -> Dict[str, Any]
         # exceeding model capability or hit any stop criteria.
         kwargs["max_tokens"] = -1
     if request.stop is not None:
-        kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
+        kwargs["stop_strs"] = (
+            [request.stop] if isinstance(request.stop, str) else list(request.stop)
+        )
     if isinstance(request, openai_api_protocol.ChatCompletionRequest):
         kwargs["logprobs"] = request.logprobs
         kwargs["top_logprobs"] = request.top_logprobs


### PR DESCRIPTION
Fixes #3512.

`openai_api_get_generation_config` aliased `request.stop` directly into `kwargs["stop_strs"]` whenever `stop` was already a list, instead of copying it:

```python
kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
```

`get_generation_config` then extends that value in place with the model's own stop strings from the conversation template:

```python
stop_strs = kwargs.get("stop_strs", [])
stop_strs += extra_stop_str
kwargs["stop_strs"] = stop_strs
```

Since `kwargs["stop_strs"]` was the *same* list object as `request.stop` in the list case, `+=` mutated the request's `stop` field in place. Both call sites in `engine_base.py` (chat completion and completion request handling) pass `extra_stop_str=conv_template.stop_str`, which comes from the model's chat template and is non-empty for most models - so this hits the standard request path any time a client sends `stop` as a list rather than a single string, not just some rare configuration.

## Fix

Wrap the list branch in `list(...)` so it copies instead of aliasing:

```python
kwargs["stop_strs"] = (
    [request.stop] if isinstance(request.stop, str) else list(request.stop)
)
```

The string case already built a fresh single-element list, so this only changes behavior for the aliasing bug itself.

## Testing

I don't have a working `tvm` build in my sandbox, so I couldn't import the real `mlc_llm` package or exercise this against the actual `ChatCompletionRequest`/engine classes. I verified the logic by copying both functions verbatim into a standalone script with a minimal stand-in object exposing the same fields, confirming the bug reproduces on the pre-fix code and is gone after the fix:

```python
original_stop_list = ["<|user|>", "<|end|>"]
req = FakeRequest(stop=original_stop_list)
cfg = get_generation_config(req, extra_stop_str=["SYSTEM_INTERNAL_STOP"])

# before fix:
# req.stop == ["<|user|>", "<|end|>", "SYSTEM_INTERNAL_STOP"]  (mutated!)
# req.stop is cfg["stop_strs"]  ==  True

# after fix:
# req.stop == ["<|user|>", "<|end|>"]  (untouched)
# req.stop is cfg["stop_strs"]  ==  False
```

I didn't find an existing test file for `engine_utils.py` to extend, and given I can't run the suite in my environment I didn't want to add a test I couldn't confirm actually collects and passes against the real package - flagging that rather than claiming coverage I don't have. Happy to add one if a maintainer can point me at how tests in this file are normally structured, or if CI here can validate it directly.