### PR TITLE
[Chat] Add random-token benchmarking and token-count stats

### DIFF
--- a/python/mlc_llm/cli/chat.py
+++ b/python/mlc_llm/cli/chat.py
@@ -32,10 +32,37 @@ def main(argv):
         default="",
         help=HELP["modelconfig_overrides"] + ' (default: "%(default)s")',
     )
+    parser.add_argument(
+        "--random-tokens",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Generate N random tokens and run the model automatically before "
+            "entering the interactive prompt. The token count compensates for "
+            "chat-template overhead so the reported prompt tokens match N. "
+            "Use /stats afterwards to see tok/s and exact token counts. "
+            '(default: "%(default)s")'
+        ),
+    )
+    parser.add_argument(
+        "--max-decode-tokens",
+        type=int,
+        default=None,
+        metavar="M",
+        help=(
+            "Maximum number of tokens to generate in the decode step when "
+            "--random-tokens is used. Has no effect on subsequent interactive "
+            "prompts. "
+            '(default: "%(default)s")'
+        ),
+    )
     parsed = parser.parse_args(argv)
     chat(
         model=parsed.model,
         device=parsed.device,
         model_lib=parsed.model_lib,
         overrides=parsed.overrides,
+        random_tokens=parsed.random_tokens,
+        max_decode_tokens=parsed.max_decode_tokens,
     )

--- a/python/mlc_llm/interface/chat.py
+++ b/python/mlc_llm/interface/chat.py
@@ -1,7 +1,10 @@
 """Python entrypoint of chat."""
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Union  # noqa: UP035
+import json
+import random
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: UP035
 
 from prompt_toolkit import prompt as get_prompt
 from prompt_toolkit.key_binding import KeyBindings
@@ -17,17 +20,62 @@ from mlc_llm.support.config import ConfigOverrideBase
 
 def _print_help_str():
     help_str = """You can use the following special commands:
-  /help               print the special commands
-  /exit               quit the cli
-  /stats              print out stats of last request (token/sec)
-  /metrics            print out full engine metrics
-  /reset              restart a fresh chat
-  /set [overrides]    override settings in the generation config. For example,
-                      `/set temperature=0.5;top_p=0.8;seed=23;max_tokens=100;stop=str1,str2`
-                      Note: Separate stop words in the `stop` option with commas (,).
+  /help                    print the special commands
+  /exit                    quit the cli
+  /stats                   print out stats of last request (tok/s and exact token counts)
+  /metrics                 print out full engine metrics
+  /reset                   restart a fresh chat
+  /random-tokens <N>       generate N random prompt tokens and run the model
+  /set [overrides]         override settings in the generation config. For example,
+                           `/set temperature=0.5;top_p=0.8;seed=23;max_tokens=100;stop=str1,str2`
+                           Note: Separate stop words in the `stop` option with commas (,).
   Multi-line input: Use escape+enter to start a new line.
 """
     print(help_str)
+
+
+def _get_vocab_size(engine: Any) -> int:
+    """Return tokenizer vocab size from the model directory, or a common fallback."""
+    engine_config = getattr(engine, "engine_config", None)
+    model_path = getattr(engine_config, "model", None)
+    if model_path is None:
+        return 32000
+
+    tokenizer_json_path = Path(model_path) / "tokenizer.json"
+    if not tokenizer_json_path.exists():
+        return 32000
+
+    try:
+        with tokenizer_json_path.open("r", encoding="utf-8") as tokenizer_file:
+            tokenizer_data = json.load(tokenizer_file)
+    except (OSError, json.JSONDecodeError):
+        return 32000
+
+    vocab = tokenizer_data.get("model", {}).get("vocab", {})
+    return len(vocab) if vocab else 32000
+
+
+def _parse_random_tokens_command(prompt: str) -> Tuple[int, Optional[int]]:  # noqa: UP006
+    """Parse `/random-tokens <N> [max_decode_tokens]`."""
+    parts = prompt.split()
+    if len(parts) < 2 or len(parts) > 3:
+        raise ValueError(
+            "Usage: /random-tokens <N> [max_decode_tokens]\n"
+            "  N                 - target prompt token count\n"
+            "  max_decode_tokens - optional decode token limit"
+        )
+
+    try:
+        token_size = int(parts[1])
+        max_decode_tokens = int(parts[2]) if len(parts) == 3 else None
+    except ValueError as err:
+        raise ValueError("Both N and max_decode_tokens must be integers.") from err
+
+    if token_size <= 0:
+        raise ValueError("Token size must be a positive integer.")
+    if max_decode_tokens is not None and max_decode_tokens <= 0:
+        raise ValueError("Max decode tokens must be a positive integer.")
+    return token_size, max_decode_tokens
 
 
 def _set_up_key_bindings():
@@ -219,21 +267,107 @@ class ChatState:
         if finish_reason_length:
             self.slide_history()
 
+    def _get_template_overhead(self) -> int:
+        """Measure and cache the number of tokens added by the chat template."""
+        if hasattr(self, "_template_overhead_cache"):
+            return self._template_overhead_cache
+
+        if not hasattr(self.engine, "tokenizer"):
+            self._template_overhead_cache = 0
+            return 0
+
+        calibration_text = "a"
+        content_token_count = len(self.engine.tokenizer.encode(calibration_text))
+        saved_usage = self.last_finished_request_usage
+
+        overhead = 0
+        for response in self.engine.chat.completions.create(
+            messages=[{"role": "user", "content": calibration_text}],
+            max_tokens=1,
+            model=self.model,
+            stream=True,
+            stream_options={"include_usage": True},
+        ):
+            if response.usage is not None:
+                overhead = max(0, response.usage.prompt_tokens - content_token_count)
+                break
+
+        self._template_overhead_cache = overhead
+        self.last_finished_request_usage = saved_usage
+        return overhead
+
+    def generate_random_tokens(self, token_size: int, max_decode_tokens: Optional[int] = None):
+        """Generate a random prompt targeting exactly ``token_size`` prompt tokens."""
+        vocab_size = max(2, _get_vocab_size(self.engine))
+        template_overhead = self._get_template_overhead()
+        content_needed = max(1, token_size - template_overhead)
+
+        if hasattr(self.engine, "tokenizer"):
+            token_ids = [random.randint(1, vocab_size - 1) for _ in range(content_needed)]
+            prompt = self.engine.tokenizer.decode(token_ids)
+
+            for _ in range(3):
+                actual_content = len(self.engine.tokenizer.encode(prompt))
+                if actual_content == content_needed:
+                    break
+                current_token_ids = self.engine.tokenizer.encode(prompt)
+                if actual_content < content_needed:
+                    current_token_ids.extend(
+                        random.randint(1, vocab_size - 1)
+                        for _ in range(content_needed - actual_content)
+                    )
+                else:
+                    current_token_ids = current_token_ids[:content_needed]
+                prompt = self.engine.tokenizer.decode(current_token_ids)
+
+            actual_content = len(self.engine.tokenizer.encode(prompt))
+        else:
+            prompt = " ".join(
+                str(token_id)
+                for token_id in [random.randint(1, vocab_size - 1) for _ in range(content_needed)]
+            )
+            actual_content = content_needed
+
+        expected_total = actual_content + template_overhead
+        print(
+            f"[random-tokens] target={token_size}, "
+            f"template_overhead={template_overhead}, "
+            f"content_tokens={actual_content}, "
+            f"expected_total~{expected_total}"
+        )
+
+        saved_max_tokens = self.overrides.max_tokens
+        if max_decode_tokens is not None:
+            self.overrides.max_tokens = max_decode_tokens
+        try:
+            self.generate(prompt)
+        finally:
+            self.overrides.max_tokens = saved_max_tokens
+
     def stats(self):
-        """Print statistics of the prefill and decode speed."""
+        """Print statistics of the prefill/decode speed and exact token counts."""
 
         def get_stats_text():
             """Get text"""
             if self.last_finished_request_usage is None:
                 return "N/A"
-            last_finished_request = self.last_finished_request_usage.extra
+
+            usage = self.last_finished_request_usage
+            last_finished_request = usage.extra
             if last_finished_request is None:
-                return "N/A"
-            prefill_speed = last_finished_request.get("prefill_tokens_per_s", None)
-            decode_speed = last_finished_request.get("decode_tokens_per_s", None)
-            prefill_speed = f"{prefill_speed:.1f}" if prefill_speed is not None else "N/A"
-            decode_speed = f"{decode_speed:.1f}" if decode_speed is not None else "N/A"
-            return f"prefill: {prefill_speed} tok/s, decode: {decode_speed} tok/s"
+                prefill_speed = "N/A"
+                decode_speed = "N/A"
+            else:
+                prefill_speed = last_finished_request.get("prefill_tokens_per_s", None)
+                decode_speed = last_finished_request.get("decode_tokens_per_s", None)
+                prefill_speed = f"{prefill_speed:.1f}" if prefill_speed is not None else "N/A"
+                decode_speed = f"{decode_speed:.1f}" if decode_speed is not None else "N/A"
+            return (
+                f"prefill: {prefill_speed} tok/s, decode: {decode_speed} tok/s\n"
+                f"prompt tokens: {usage.prompt_tokens}, "
+                f"completion tokens: {usage.completion_tokens}, "
+                f"total tokens: {usage.total_tokens}"
+            )
 
         print(get_stats_text(), flush=True)
 
@@ -246,11 +380,20 @@ class ChatState:
         self.history = []
         self.history_window_begin = 0
 
-    def chat(self):
+    def chat(
+        self,
+        random_tokens: Optional[int] = None,
+        max_decode_tokens: Optional[int] = None,
+    ):
         """Start an interactive chat session."""
         _print_help_str()
 
         self.process_system_prompts()
+        if random_tokens is not None and random_tokens > 0:
+            print(f"[random-tokens] Auto-running with {random_tokens} random tokens...")
+            self.generate_random_tokens(random_tokens, max_decode_tokens=max_decode_tokens)
+            self.stats()
+
         # Multi-line input support: set escape+enter as start a new line
         kb = _set_up_key_bindings()
 
@@ -278,6 +421,16 @@ class ChatState:
                 break
             elif prompt[:5] == "/help":
                 _print_help_str()
+            elif prompt[:14] == "/random-tokens":
+                try:
+                    token_size, max_decode_tokens = _parse_random_tokens_command(prompt)
+                except ValueError as err:
+                    print(err)
+                else:
+                    self.generate_random_tokens(
+                        token_size,
+                        max_decode_tokens=max_decode_tokens,
+                    )
             else:
                 self.generate(prompt)
 
@@ -287,6 +440,8 @@ def chat(
     device: str,
     model_lib: Optional[str],
     overrides: ModelConfigOverride,
+    random_tokens: Optional[int] = None,
+    max_decode_tokens: Optional[int] = None,
 ):
     """Chat cli entry"""
     # By default we use JSONFFIEngine
@@ -306,6 +461,6 @@ def chat(
         ),
     )
     try:
-        ChatState(engine).chat()
+        ChatState(engine).chat(random_tokens=random_tokens, max_decode_tokens=max_decode_tokens)
     finally:
         engine.terminate()

--- a/tests/python/interface/test_chat.py
+++ b/tests/python/interface/test_chat.py
@@ -1,0 +1,137 @@
+import types
+
+import pytest
+
+from mlc_llm.cli import chat as chat_cli
+from mlc_llm.interface.chat import (
+    ChatState,
+    ModelConfigOverride,
+    _get_vocab_size,
+    _parse_random_tokens_command,
+)
+from mlc_llm.protocol.openai_api_protocol import CompletionUsage
+
+
+class FakeTokenizer:
+    def encode(self, text):
+        if text == "":
+            return []
+        return [int(token) for token in text.split()]
+
+    def decode(self, token_ids):
+        return " ".join(str(token_id) for token_id in token_ids)
+
+
+class FakeEngine:
+    def __init__(self, model_path=None):
+        self.engine_config = types.SimpleNamespace(model=model_path)
+        self.tokenizer = FakeTokenizer()
+
+
+def test_cli_forwards_random_token_options(monkeypatch):
+    captured_kwargs = {}
+
+    def fake_chat(**kwargs):
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(chat_cli, "chat", fake_chat)
+
+    chat_cli.main(
+        [
+            "dist/model",
+            "--device",
+            "vulkan",
+            "--model-lib",
+            "model.so",
+            "--random-tokens",
+            "512",
+            "--max-decode-tokens",
+            "128",
+        ]
+    )
+
+    assert captured_kwargs == {
+        "model": "dist/model",
+        "device": "vulkan",
+        "model_lib": "model.so",
+        "overrides": ModelConfigOverride(),
+        "random_tokens": 512,
+        "max_decode_tokens": 128,
+    }
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        ("/random-tokens 512", (512, None)),
+        ("/random-tokens 512 128", (512, 128)),
+    ],
+)
+def test_parse_random_tokens_command(prompt, expected):
+    assert _parse_random_tokens_command(prompt) == expected
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "/random-tokens",
+        "/random-tokens 0",
+        "/random-tokens abc",
+        "/random-tokens 512 0",
+        "/random-tokens 512 128 extra",
+    ],
+)
+def test_parse_random_tokens_command_rejects_invalid_input(prompt):
+    with pytest.raises(ValueError):
+        _parse_random_tokens_command(prompt)
+
+
+def test_get_vocab_size_reads_tokenizer_json(tmp_path):
+    (tmp_path / "tokenizer.json").write_text(
+        '{"model": {"vocab": {"<s>": 0, "hello": 1, "world": 2}}}',
+        encoding="utf-8",
+    )
+
+    assert _get_vocab_size(FakeEngine(model_path=str(tmp_path))) == 3
+
+
+def test_get_vocab_size_uses_common_fallback_without_tokenizer_json(tmp_path):
+    assert _get_vocab_size(FakeEngine(model_path=str(tmp_path))) == 32000
+
+
+def test_stats_prints_speed_and_exact_token_counts(capsys):
+    chat_state = ChatState(FakeEngine())
+    chat_state.last_finished_request_usage = CompletionUsage(
+        prompt_tokens=11,
+        completion_tokens=7,
+        total_tokens=18,
+        extra={"prefill_tokens_per_s": 123.45, "decode_tokens_per_s": 67.89},
+    )
+
+    chat_state.stats()
+
+    assert capsys.readouterr().out == (
+        "prefill: 123.5 tok/s, decode: 67.9 tok/s\n"
+        "prompt tokens: 11, completion tokens: 7, total tokens: 18\n"
+    )
+
+
+def test_generate_random_tokens_applies_temporary_decode_limit(monkeypatch, capsys):
+    chat_state = ChatState(FakeEngine())
+    chat_state.overrides.max_tokens = 7
+    generated_prompts = []
+
+    monkeypatch.setattr("mlc_llm.interface.chat._get_vocab_size", lambda _engine: 100)
+    monkeypatch.setattr(chat_state, "_get_template_overhead", lambda: 2)
+
+    def fake_generate(prompt):
+        assert chat_state.overrides.max_tokens == 13
+        generated_prompts.append(prompt)
+
+    monkeypatch.setattr(chat_state, "generate", fake_generate)
+
+    chat_state.generate_random_tokens(5, max_decode_tokens=13)
+
+    assert chat_state.overrides.max_tokens == 7
+    assert len(chat_state.engine.tokenizer.encode(generated_prompts[0])) == 3
+    assert "[random-tokens] target=5, template_overhead=2" in capsys.readouterr().out


### PR DESCRIPTION
# PR: mlc_llm chat – Random Token Benchmarking & Enhanced /stats

## Summary

This PR adds two improvements to `python -m mlc_llm chat`:

1. Random-token benchmarking utility – generate a prompt of exactly N tokens from random vocabulary IDs and run the model, without having to type or prepare a real prompt.
2. Enhanced `/stats` output – in addition to tok/s, `/stats` now also reports the exact prompt, completion, and total token counts from the last request.
|

```bash
# Run with exactly 512 prompt tokens, limit decode to 128 tokens
python -m mlc_llm chat --existing_commands \
    --random-tokens 512 \
    --max-decode-tokens 128
```

Tested manually with Qwen on Adreno (Vulkan)

- All new parameters are optional with `None` defaults.
- Existing `chat()` call sites without the new arguments continue to work unchanged.
- `/stats` output gains a second line; scripts that parse the first line are unaffected.

