### PR TITLE
[Fix] Anchor version regex to the project version line in pyproject.toml

### DIFF
--- a/version.py
+++ b/version.py
@@ -152,7 +152,11 @@ def sync_version(pub_ver, local_ver, dry_run):
     # pyproject.toml
     update(
         os.path.join(PROJ_ROOT, "pyproject.toml"),
-        r"(?<=version = \")[.0-9a-z\+]+",
+        # Anchor to the start of the line so we only rewrite the project
+        # `version = "..."` and not other lines that end in `version = "..."`
+        # (e.g. ruff's `target-version = "py39"`). `update` is called per line,
+        # so `^` matches the beginning of each line.
+        r"(?<=^version = \")[.0-9a-z\+]+",
         pub_ver,
         dry_run,
     )


### PR DESCRIPTION
## Problem

`sync_version` in `version.py` rewrites the `version = "..."` line of `pyproject.toml` using an unanchored lookbehind regex. Since #3486 added ruff config to `pyproject.toml`, the regex also matches the `target-version = "py39"` line, so `update()` sees two hits and raises `RuntimeError: Cannot find version` **before writing the file**.

In the mlc-ai/package wheel pipeline this failure is currently swallowed, so every nightly/stable wheel on every platform has been built with the placeholder version `0.20.0.dev0` instead of the git-describe version (e.g. `0.26.dev2`). Because `0.20.0.dev0 < 0.20.dev162` under PEP 440, pip resolves to the ancient `0.20.dev162` nightly wheels, which are incompatible with current `mlc-ai-nightly-*` wheels — this is the root cause of the `dlopen ... libtvm.dylib` failure in #3516.

From the nightly build log:

```
mlc-llm/pyproject.toml: 0.20.0.dev0 -> 0.26.dev2
mlc-llm/pyproject.toml: py39 -> 0.26.dev2        <- second match
RuntimeError: Cannot find version in .../mlc-llm/pyproject.toml
```

## Fix

Anchor the lookbehind to the start of the line (`update()` matches line by line, so `^` is the line start). Verified locally:

```
$ python3 version.py --git-describe --dry-run
pyproject.toml: 0.20.0.dev0 -> 0.26.dev3
```
