### PR TITLE
[Fix] Adapt tensor_ir_op kernels to current TVM APIs

### DIFF
--- a/python/mlc_llm/compiler_pass/attach_sampler.py
+++ b/python/mlc_llm/compiler_pass/attach_sampler.py
@@ -138,14 +138,14 @@ def _attach_argsort_func(bb: relax.BlockBuilder):
 
 
 @T.prim_func(s_tir=True)
-def full(var_result: T.handle, value: T.int32):
+def full(value: T.int64, var_result: T.handle):
     """The filling function for top k."""
     batch_size = T.int32()
     result = T.match_buffer(var_result, (batch_size, 1), "int32")
     for i in T.serial(batch_size):
         with T.sblock("block"):
             vi = T.axis.spatial(batch_size, i)
-            result[vi, 0] = value
+            result[vi, 0] = T.Cast("int32", value)
 
 
 def _attach_sample_with_top_p(bb: relax.BlockBuilder):

--- a/python/mlc_llm/compiler_pass/attach_sampler.py
+++ b/python/mlc_llm/compiler_pass/attach_sampler.py
@@ -145,7 +145,7 @@ def full(value: T.int64, var_result: T.handle):
     for i in T.serial(batch_size):
         with T.sblock("block"):
             vi = T.axis.spatial(batch_size, i)
-            result[vi, 0] = T.Cast("int32", value)
+            result[vi, 0] = T.cast(value, "int32")
 
 
 def _attach_sample_with_top_p(bb: relax.BlockBuilder):

--- a/python/mlc_llm/compiler_pass/scatter_tuple_get_item.py
+++ b/python/mlc_llm/compiler_pass/scatter_tuple_get_item.py
@@ -42,7 +42,7 @@ class _Scatter(PyExprMutator):
 
     def visit_dataflow_var_(self, var: relax.DataflowVar) -> Expr:
         if var in self.var_map:
-            new_var = self.builder_.emit(self.var_map[var], name_hint=var.name_hint)
+            new_var = self.builder_.emit(self.var_map[var], name_hint=var.name)
             self.set_var_remap(var, new_var)
             self.var_map.pop(var)
             return new_var

--- a/python/mlc_llm/model/phi3v/phi3v_image.py
+++ b/python/mlc_llm/model/phi3v/phi3v_image.py
@@ -81,11 +81,11 @@ class Phi3ImageEmbedding(Module):
             @T.prim_func(s_tir=True)
             def dyn_repeat_4d_tensor_func(  # pylint disable=too-many-locals
                 input_tensor: T.handle,
-                output: T.handle,
                 ch0: T.int64(),
                 ch1: T.int64(),
                 ch2: T.int64(),
                 ch3: T.int64(),
+                output: T.handle,
             ):
                 T.func_attr({"op_pattern": 8, "tirx.noalias": True, "tirx.is_scheduled": 1})
                 n, c, h, w = T.int64(), T.int64(), T.int64(), T.int64()

--- a/python/mlc_llm/model/vision/image_processing.py
+++ b/python/mlc_llm/model/vision/image_processing.py
@@ -97,11 +97,11 @@ class ImageProcessor(Module):
             @T.prim_func(s_tir=True)
             def crop_func(
                 image: T.handle,
-                out: T.handle,
                 top: T.int64(),
                 bottom: T.int64(),
                 left: T.int64(),
                 right: T.int64(),
+                out: T.handle,
             ):
                 T.func_attr({"op_pattern": 8, "tirx.noalias": True, "tirx.is_scheduled": 1})
                 n, c, h, w = T.int64(), T.int64(), T.int64(), T.int64()
@@ -113,9 +113,9 @@ class ImageProcessor(Module):
                     for c_idx in T.thread_binding(c, thread="blockIdx.y"):
                         for h_idx, w_idx in T.grid(out_h, out_w):
                             with T.sblock("crop"):
+                                T.writes(out_buf[n_idx, c_idx, h_idx, w_idx])
+                                T.reads(image_buf[n_idx, c_idx, h_idx + top, w_idx + left])
                                 if (h_idx + T.int64(top)) < h and (w_idx + T.int64(left)) < w:
-                                    T.writes(out_buf[n_idx, c_idx, h_idx, w_idx])
-                                    T.reads(image_buf[n_idx, c_idx, h_idx + top, w_idx + left])
                                     out_buf[n_idx, c_idx, h_idx, w_idx] = image_buf[
                                         n_idx, c_idx, h_idx + top, w_idx + left
                                     ]
@@ -238,7 +238,7 @@ class ImageProcessor(Module):
 
         def create_pad_func(left, right, fill=255):
             @T.prim_func(s_tir=True)
-            def pad_func(image: T.handle, out: T.handle, t: T.int64(), b: T.int64()):
+            def pad_func(image: T.handle, t: T.int64(), b: T.int64(), out: T.handle):
                 T.func_attr({"op_pattern": 8, "tirx.noalias": True, "tirx.is_scheduled": 1})
                 n, c, h, w = T.int64(), T.int64(), T.int64(), T.int64()
                 image_buf = T.match_buffer(image, (n, c, h, w), dtype=dtype)

--- a/python/mlc_llm/op/moe_misc.py
+++ b/python/mlc_llm/op/moe_misc.py
@@ -577,7 +577,7 @@ def get_indptr(
     out_shape = [num_local_experts if inclusive else num_local_experts + 1]
 
     @T.prim_func(private=True, s_tir=True)
-    def _func_exclusive(var_cumsum: T.handle, var_indptr: T.handle, batch_size: T.int64):
+    def _func_exclusive(var_cumsum: T.handle, batch_size: T.int64, var_indptr: T.handle):
         T.func_attr({"tirx.noalias": True})
         cumsum = T.match_buffer(var_cumsum, shape=[batch_size * num_local_experts], dtype="int32")
         indptr = T.match_buffer(var_indptr, shape=out_shape, dtype=out_dtype)
@@ -587,7 +587,7 @@ def get_indptr(
                 indptr[i] = T.Select(i > 0, cumsum[i * batch_size - 1], T.int32(0))
 
     @T.prim_func(private=True, s_tir=True)
-    def _func_inclusive(var_cumsum: T.handle, var_indptr: T.handle, batch_size: T.int64):
+    def _func_inclusive(var_cumsum: T.handle, batch_size: T.int64, var_indptr: T.handle):
         T.func_attr({"tirx.noalias": True})
         cumsum = T.match_buffer(var_cumsum, shape=[batch_size * num_local_experts], dtype="int32")
         indptr = T.match_buffer(var_indptr, shape=out_shape, dtype=out_dtype)

--- a/python/mlc_llm/op/triton.py
+++ b/python/mlc_llm/op/triton.py
@@ -526,8 +526,8 @@ def _compute_expert_id_per_block(
     @T.prim_func(s_tir=True)
     def tir_compute_expert_id_per_block(
         var_indptr: T.handle,
-        var_expert_ids: T.handle,
         M: T.int64,
+        var_expert_ids: T.handle,
     ):
         T.func_attr({"op_pattern": 8, "tirx.is_scheduled": 1})
         indptr = T.match_buffer(var_indptr, (num_experts + 1,), "int32")


### PR DESCRIPTION
Adapt to TVM API and `call_tir` convention changes:
1. Update `DataflowVar.name_hint` to `DataflowVar.name`
2. Change sampler full kernel to accept int64 value before its output buffer and cast to int32
3. Reorder parameters for `tensor_ir_op` PrimFuncs so tensor/scalar arguments precede output buffers (Triton expert-ID generation, MoE indptr generation, vision crop and padding, Phi-3V dynamic repeat)
4. Move crop's `T.reads` and `T.writes` declarations to top of `T.sblock` as required by current TIR parser