### PR TITLE
fix(serve): copy request.stop so get_generation_config can't mutate it (#3512)

### DIFF
--- a/python/mlc_llm/serve/engine_utils.py
+++ b/python/mlc_llm/serve/engine_utils.py
@@ -49,7 +49,7 @@ def openai_api_get_generation_config(request: RequestProtocol) -> Dict[str, Any]
         # exceeding model capability or hit any stop criteria.
         kwargs["max_tokens"] = -1
     if request.stop is not None:
-        kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
+        kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else list(request.stop)
     if isinstance(request, openai_api_protocol.ChatCompletionRequest):
         kwargs["logprobs"] = request.logprobs
         kwargs["top_logprobs"] = request.top_logprobs


### PR DESCRIPTION
## Problem

`openai_api_get_generation_config` in `python/mlc_llm/serve/engine_utils.py` aliases `request.stop` directly into the generation-config kwargs when `stop` is already a list:

```python
if request.stop is not None:
    kwargs["stop_strs"] = [request.stop] if isinstance(request.stop, str) else request.stop
```

`get_generation_config` then extends that same list in place with the model's template stop strings:

```python
if extra_stop_str is not None:
    stop_strs = kwargs.get("stop_strs", [])
    assert isinstance(stop_strs, list)
    stop_strs += extra_stop_str          # mutates request.stop when it was a list
    kwargs["stop_strs"] = stop_strs
```

Because `kwargs["stop_strs"]` is the *same* list object as `request.stop`, `stop_strs += extra_stop_str` mutates the caller's `request.stop`. Both call sites in `engine_base.py` pass `extra_stop_str=conv_template.stop_str`, which is non-empty for most chat templates, so any client that sends `stop` as a list (rather than a single string) has its request object silently rewritten with the template's stop strings — a problem if the request is inspected, logged, or retried afterwards.

The string branch is already safe (it builds a fresh `[request.stop]`); only the list branch aliases.

## Fix

Copy the list with `list(request.stop)` so the later in-place `+=` operates on config-owned state and leaves `request.stop` untouched. One-line change; `stop_token_ids` is unaffected because `openai_api_get_generation_config` never seeds it (the `.get(..., [])` there already returns a fresh list).

Fixes #3512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
