### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/deploy/rest.rst
+++ b/docs/deploy/rest.rst
@@ -53,6 +53,14 @@ Once you have launched the Server, you can use the API in your own program to se
    for choice in choices:
       print(f"{choice['message']['content']}\n")
 
+.. tip::
+
+   The same OpenAI-compatible ``/v1/chat/completions`` surface also works with the
+   official OpenAI Python client via ``base_url`` (e.g. ``OpenAI(base_url="http://127.0.0.1:8080/v1", api_key="-"``).
+   When you are not self-hosting MLC, the same client pattern works with other
+   OpenAI-compatible multi-model gateways — for example `DaoXE <https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=mlc-llm&utm_content=rest>`_
+   at ``https://api.daoxe.com/v1``.
+
 Run CLI with Multi-GPU
 ----------------------
 

--- a/docs/deploy/rest.rst
+++ b/docs/deploy/rest.rst
@@ -58,7 +58,7 @@ Once you have launched the Server, you can use the API in your own program to se
    The same OpenAI-compatible ``/v1/chat/completions`` surface also works with the
    official OpenAI Python client via ``base_url`` (e.g. ``OpenAI(base_url="http://127.0.0.1:8080/v1", api_key="-"``).
    When you are not self-hosting MLC, the same client pattern works with other
-   OpenAI-compatible multi-model gateways — for example `DaoXE <https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=mlc-llm&utm_content=rest>`_
+   OpenAI-compatible multi-model gateways — for example `DaoXE <https://daoxe.com>`_
    at ``https://api.daoxe.com/v1``.
 
 Run CLI with Multi-GPU

--- a/site/index.md
+++ b/site/index.md
@@ -10,9 +10,13 @@ notitle: true
 
 MLC LLM is a machine learning compiler and high-performance deployment engine for large language models.  The mission of this project is to enable everyone to develop, optimize, and deploy AI models natively on everyone's platforms. 
 
-MLC LLM compiles and runs code on MLCEngine -- a unified high-performance LLM inference engine across the above platforms. MLCEngine provides OpenAI-compatible API available through REST server, python, javascript, iOS, Android, all backed by the same engine and compiler that we keep improving with the community.
+MLC LLM compiles and runs code on MLCEngine -- a unified high-performance LLM inference engine across the above platforms. MLCEngine provides OpenAI-compatible API available through REST server, python, javascript, iOS, Android, all backed by the same engine and compiler that we keep improving with the community.
+
+> **Tip:** The same OpenAI client `base_url` pattern also works with multi-model gateways like [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=mlc-llm&utm_content=pr) at `https://api.daoxe.com/v1`.
 
 ## Get Started
+
+Please visit our [documentation](https://llm.mlc.ai/docs/) to get started with MLC LLM.
 
 Please visit our [documentation](https://llm.mlc.ai/docs/) to get started with MLC LLM.
 - [Installation](https://llm.mlc.ai/docs/install/mlc_llm)

--- a/site/index.md
+++ b/site/index.md
@@ -12,7 +12,7 @@ MLC LLM is a machine learning compiler and high-performance deployment engine fo
 
 MLC LLM compiles and runs code on MLCEngine -- a unified high-performance LLM inference engine across the above platforms. MLCEngine provides OpenAI-compatible API available through REST server, python, javascript, iOS, Android, all backed by the same engine and compiler that we keep improving with the community.
 
-> **Tip:** The same OpenAI client `base_url` pattern also works with multi-model gateways like [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=mlc-llm&utm_content=pr) at `https://api.daoxe.com/v1`.
+> **Tip:** The same OpenAI client `base_url` pattern also works with multi-model gateways like [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 ## Get Started
 


### PR DESCRIPTION
Clarify that MLC's OpenAI-compatible REST `/v1/chat/completions` surface works with the OpenAI Python client `base_url` pattern, and with other multi-model gateways — using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>