### PR TITLE
[Fix] argparse `type=bool` makes --disaggregation and --stream impossible to turn off

### DIFF
--- a/python/mlc_llm/bench/__main__.py
+++ b/python/mlc_llm/bench/__main__.py
@@ -281,7 +281,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--stream",
-        type=bool,
+        type=argparse.boolean,
         default=True,
         help="Whether to benchmark stream responses. "
         "When not enabled, metrics such as time-to-first-token (TTFT) will not be available. "

--- a/python/mlc_llm/cli/gen_config.py
+++ b/python/mlc_llm/cli/gen_config.py
@@ -7,7 +7,7 @@ from mlc_llm.interface.gen_config import CONV_TEMPLATES, gen_config
 from mlc_llm.interface.help import HELP
 from mlc_llm.model import MODELS
 from mlc_llm.quantization import QUANTIZATION
-from mlc_llm.support.argparse import ArgumentParser
+from mlc_llm.support.argparse import ArgumentParser, boolean
 from mlc_llm.support.auto_config import detect_config, detect_model_type
 
 
@@ -85,7 +85,7 @@ def main(argv):
     )
     parser.add_argument(
         "--disaggregation",
-        type=bool,
+        type=boolean,
         default=None,
         help=HELP["disaggregation"] + ' (default: "%(default)s")',
     )

--- a/python/mlc_llm/support/argparse.py
+++ b/python/mlc_llm/support/argparse.py
@@ -3,6 +3,26 @@
 import argparse
 import sys
 
+TRUE_VALUES = ("1", "true", "yes", "on")
+FALSE_VALUES = ("0", "false", "no", "off")
+
+
+def boolean(value: str) -> bool:
+    """Parse a boolean value taken from the command line.
+
+    `type=bool` cannot be used for this: argparse applies the callable to the raw string,
+    and `bool("false")` is `True`, so every non-empty value turns the flag on and the flag
+    can never be switched off.
+    """
+    normalized = value.strip().lower()
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+    raise argparse.ArgumentTypeError(
+        f"Invalid boolean value: {value}. Expected one of {', '.join(TRUE_VALUES + FALSE_VALUES)}."
+    )
+
 
 class ArgumentParser(argparse.ArgumentParser):
     """An enhanced argument parser for mlc-chat."""

--- a/tests/python/support/test_argparse_boolean.py
+++ b/tests/python/support/test_argparse_boolean.py
@@ -1,0 +1,65 @@
+import argparse as stdlib_argparse
+from pathlib import Path
+
+import pytest
+
+from mlc_llm.cli import gen_config as gen_config_cli
+from mlc_llm.support.argparse import boolean
+
+pytestmark = [pytest.mark.unittest]
+
+
+@pytest.mark.parametrize("value", ["1", "true", "True", "TRUE", "yes", "on", " true "])
+def test_boolean_accepts_true_spellings(value):
+    assert boolean(value) is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "FALSE", "no", "off", " false "])
+def test_boolean_accepts_false_spellings(value):
+    assert boolean(value) is False
+
+
+@pytest.mark.parametrize("value", ["", "maybe", "2"])
+def test_boolean_rejects_other_values(value):
+    with pytest.raises(stdlib_argparse.ArgumentTypeError):
+        boolean(value)
+
+
+@pytest.mark.parametrize(
+    "flag_value, expected",
+    [("false", False), ("true", True), ("0", False), ("1", True)],
+)
+def test_gen_config_cli_forwards_disaggregation(monkeypatch, tmp_path, flag_value, expected):
+    """`--disaggregation false` must reach gen_config() as False.
+
+    `ModelConfigOverride.apply` skips a `None` override, so `False` is a distinct value
+    that force-disables disaggregation. With `type=bool` it was unreachable, because
+    argparse converts the raw string and `bool("false")` is `True`.
+    """
+    captured = {}
+
+    monkeypatch.setattr(gen_config_cli, "detect_config", Path)
+    monkeypatch.setattr(gen_config_cli, "detect_model_type", lambda _type, _config: "dummy")
+    monkeypatch.setattr(gen_config_cli, "MODELS", {"dummy": object()})
+    monkeypatch.setattr(gen_config_cli, "QUANTIZATION", {"q0f16": object()})
+    monkeypatch.setattr(gen_config_cli, "CONV_TEMPLATES", ["llama-3"])
+    monkeypatch.setattr(gen_config_cli, "gen_config", captured.update)
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    gen_config_cli.main(
+        [
+            str(config_path),
+            "--quantization",
+            "q0f16",
+            "--conv-template",
+            "llama-3",
+            "--disaggregation",
+            flag_value,
+            "--output",
+            str(tmp_path / "output"),
+        ]
+    )
+
+    assert captured["disaggregation"] is expected


### PR DESCRIPTION
### Problem

Two CLI flags are declared with `type=bool`. argparse applies the callable to the **raw
string**, and `bool("false")` is `True`, so every non-empty value turns the flag on:

```console
$ python -c "
import argparse
p = argparse.ArgumentParser()
p.add_argument('--disaggregation', type=bool, default=None)
print(p.parse_args(['--disaggregation', 'false']))
print(p.parse_args(['--disaggregation', '0']))
"
Namespace(disaggregation=True)
Namespace(disaggregation=True)
```

Both flags can therefore be switched **on** but never **off** (short of passing an empty
string, `--disaggregation ""`).

**`mlc_llm gen_config --disaggregation`** (`python/mlc_llm/cli/gen_config.py:88`)

`ConfigOverrideBase.apply` skips an override only when it is `None`
(`python/mlc_llm/support/config.py:96`), so `False` is a distinct, meaningful value that
force-disables disaggregation for a model whose `config.json` enables it. `disaggregation`
reaches `DispatchKVCacheCreation` as `enable_disaggregation` and changes the KV cache that
gets compiled, so `--disaggregation false` silently compiles the opposite of what was asked.

The **same option name** on the `--overrides` path already parses strings correctly
(`ModelConfigOverride.from_str`, `python/mlc_llm/interface/compiler_flags.py:180-184`):

```python
parser.add_argument(
    "--disaggregation",
    type=lambda x: str(x).lower() in ["true", "1", "yes", "True"],
    default=None,
)
```

so the two entry points for one option currently disagree.

**`mlc_llm.bench --stream`** (`python/mlc_llm/bench/__main__.py:284`)

`--stream` is the only one of the eight boolean flags in that parser not using
`action="store_true"` — it can't, because it defaults to `True`. `args.stream` flows into
`AttachStreamFlag`, which honours `False`, and the help text documents the disabled state
("When not enabled, metrics such as time-to-first-token (TTFT) will not be available") —
a state the CLI cannot currently reach.

### Fix

Add a `boolean` type callable to `mlc_llm/support/argparse.py` (the module both call sites
already import) that accepts `1/true/yes/on` and `0/false/no/off` case-insensitively and
raises `argparse.ArgumentTypeError` otherwise, and use it for both flags. Previously
working invocations (`--disaggregation true`, `--stream 1`, or omitting the flag) are
unchanged; only the values that used to be silently inverted change behaviour.

`OptimizationFlags.from_str` keeps its own stricter local `boolean` (`0`/`1` only) —
that one is already correct, and widening it would change the `--opt` string format.

### Verification

`mlc_llm` needs a built TVM runtime that isn't available here, so `gen_config.main` was
exercised by `exec`-ing the real, unmodified `python/mlc_llm/cli/gen_config.py` with the
real (patched) `support/argparse.py` and stubs for the heavy imports, capturing what
`gen_config()` receives:

| `--disaggregation` | before | after |
|---|---|---|
| `false` | `True` | `False` |
| `0` | `True` | `False` |
| `true` | `True` | `True` |
| `1` | `True` | `True` |
| `maybe` | `True` | exits 2 with `Invalid boolean value` |

`tests/python/support/test_argparse_boolean.py` adds the same check as a regression test
(following the `monkeypatch` pattern in `tests/python/support/test_cli_convert_weight.py`)
plus coverage of the accepted/rejected spellings.

`ruff check` and `ruff format --check` pass with the pinned `v0.12.3` from
`.pre-commit-config.yaml`, using the repo's `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
