### PR TITLE
fix(ministral3): join the split log/error strings instead of passing them as extra args

### DIFF
--- a/python/mlc_llm/model/ministral3/ministral3_model.py
+++ b/python/mlc_llm/model/ministral3/ministral3_model.py
@@ -84,18 +84,18 @@ class Ministral3Config(ConfigBase):
                             or len(self.weight_block_size) != 2
                         ):
                             raise ValueError(
-                                "Invalid Ministral3 quantization config: ",
-                                "weight_block_size must be a list or tuple of two integers, ",
-                                f"got {self.weight_block_size} of type",
-                                f"{type(self.weight_block_size)}",
+                                "Invalid Ministral3 quantization config: "
+                                "weight_block_size must be a list or tuple of two integers, "
+                                f"got {self.weight_block_size} of type "
+                                f"{type(self.weight_block_size)}"
                             )
                     else:
                         # Set default block size if not provided.
                         self.weight_block_size = (128, 128)
                         logger.info(
-                            "Setting default weight_block_size=%s, ",
-                            "since quantization_config does not provide ",
-                            "FP8 block-scale details required by ",
+                            "Setting default weight_block_size=%s, "
+                            "since quantization_config does not provide "
+                            "FP8 block-scale details required by "
                             "MLC (activation_scheme=%s, quant_method=%s)",
                             self.weight_block_size,
                             activation_scheme,
@@ -103,15 +103,15 @@ class Ministral3Config(ConfigBase):
                         )
                 else:
                     raise ValueError(
-                        "Invalid Ministral 3 model quantization config: ",
-                        "only FP8 static quantization is supported, ",
-                        f"got activation_scheme={activation_scheme}, quant_method={quant_method}",
+                        "Invalid Ministral 3 model quantization config: "
+                        "only FP8 static quantization is supported, "
+                        f"got activation_scheme={activation_scheme}, quant_method={quant_method}"
                     )
             else:
                 raise ValueError(
-                    "Invalid Ministral 3 model quantization config: ",
-                    "unrecognized quantization config: ",
-                    f"{quantization_config}",
+                    "Invalid Ministral 3 model quantization config: "
+                    "unrecognized quantization config: "
+                    f"{quantization_config}"
                 )
 
         if self.position_embedding_base == 0:


### PR DESCRIPTION
## Problem

All four multi-line messages in `Ministral3Config.__post_init__`
(`python/mlc_llm/model/ministral3/ministral3_model.py`) are written as
**comma-separated** string fragments where implicit string concatenation was
meant. The commas turn the continuation fragments into extra *arguments*.

The `logger.info` call is the damaging one:

```python
logger.info(
    "Setting default weight_block_size=%s, ",          # <- template: ONE %s
    "since quantization_config does not provide ",     # <- becomes args[0]
    "FP8 block-scale details required by ",            # <- args[1]
    "MLC (activation_scheme=%s, quant_method=%s)",     # <- args[2]
    self.weight_block_size,                            # <- args[3]
    activation_scheme,                                 # <- args[4]
    quant_method,                                      # <- args[5]
)
```

The template holds a single `%s` but six arguments are supplied, so `logging`
raises `TypeError: not all arguments converted during string formatting` while
rendering the record. `logging` swallows that internally: **the record is
dropped and `--- Logging error ---` plus a traceback is written to stderr.**
Anyone loading a Ministral 3 FP8 checkpoint without an explicit
`weight_block_size` therefore never sees the notice that MLC silently defaulted
to `(128, 128)` — they get a spurious traceback instead.

The three `raise ValueError(...)` calls in the same method have the same slip.
`ValueError` accepts varargs, so nothing crashes, but `str(e)` renders the
tuple repr instead of the intended sentence:

```
('Invalid Ministral 3 model quantization config: ', 'only FP8 static quantization is supported, ', 'got activation_scheme=dynamic, quant_method=awq')
```

## Fix

Drop the commas so the fragments are implicitly concatenated into one string,
which is what the `%s` placeholders and the trailing `", "` / `": "` separators
were clearly written for. One space was added to
`f"got {self.weight_block_size} of type "` so the joined sentence reads
correctly.

No behavioural change beyond the messages themselves; no control flow touched.

## Verification

Replaying both call shapes against the real `logging` machinery
(`raiseExceptions` at its default `True`), capturing the handler stream and
stderr separately:

| case | record emitted | stderr |
|---|---|---|
| `logger.info` **before** | *(nothing — record dropped)* | `--- Logging error ---` + 24 lines |
| `logger.info` **after** | `INFO Setting default weight_block_size=(128, 128), since quantization_config does not provide FP8 block-scale details required by MLC (activation_scheme=static, quant_method=fp8)` | *(empty)* |

`ValueError` before → `str(e)` is the 3-tuple repr shown above; after → the
plain sentence.

Lint: `ruff check` and `ruff format --check` both pass on the patched file with
the version pinned in `.pre-commit-config.yaml` (`v0.12.3`) and the repository's
own `pyproject.toml` (`line-length = 100`). The pristine upstream file was run
through the same commands first as a baseline — it also passes, so the results
are comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
