### PR TITLE
[Embedding][Serve]Phase 2a: Add single-task embedding serve mode

### DIFF
--- a/docs/deploy/rest.rst
+++ b/docs/deploy/rest.rst
@@ -62,6 +62,32 @@ If you want to enable tensor parallelism to run LLMs on multiple GPUs, please sp
 
    mlc_llm serve HF://mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC --overrides "tensor_parallel_shards=2"
 
+Serve an Embedding Model
+------------------------
+
+When the model's ``mlc-chat-config.json`` has ``"model_task": "embedding"``, the server
+automatically starts in embedding-only mode. No extra flags are needed besides ``--model-lib``
+(required for embedding models):
+
+.. code:: bash
+
+   mlc_llm serve ./dist/Qwen3-Embedding-0.6B-q0f32-MLC \
+       --model-lib ./dist/libs/Qwen3-Embedding-0.6B-q0f32-metal.dylib
+
+In this mode the server exposes only ``GET /v1/models`` and ``POST /v1/embeddings``
+(OpenAI-compatible):
+
+.. code:: bash
+
+   curl http://127.0.0.1:8000/v1/embeddings \
+       -H "Content-Type: application/json" \
+       -d '{"model": "./dist/Qwen3-Embedding-0.6B-q0f32-MLC", "input": ["hello", "world"]}'
+
+Chat-engine options (``--mode``, ``--additional-models``, speculative decoding, etc.) do not
+apply to embedding models and are ignored. The previous way of serving embeddings alongside a
+chat model (``--embedding-model``/``--embedding-model-lib``) still works but is deprecated in
+favor of serving the embedding model directly.
+
 ------------------------------------------------
 
 

--- a/python/mlc_llm/cli/serve.py
+++ b/python/mlc_llm/cli/serve.py
@@ -143,13 +143,15 @@ def main(argv):
         "--embedding-model",
         type=str,
         default=None,
-        help="Path to the embedding model weight directory (enables /v1/embeddings endpoint)",
+        help="[DEPRECATED] Path to the embedding model weight directory (enables /v1/embeddings "
+        "endpoint). Prefer serving the embedding model directly: mlc_llm serve <embedding-model>",
     )
     parser.add_argument(
         "--embedding-model-lib",
         type=str,
         default=None,
-        help="Path to the compiled embedding model library (.so/.dylib file)",
+        help="[DEPRECATED] Path to the compiled embedding model library (.so/.dylib file). "
+        "Prefer serving the embedding model directly with --model-lib",
     )
     parser.add_argument(
         "--speculative-mode",

--- a/python/mlc_llm/interface/help.py
+++ b/python/mlc_llm/interface/help.py
@@ -24,6 +24,9 @@ The quantization mode we use to compile. If unprovided, will infer from `model`.
     "model": """
 A path to ``mlc-chat-config.json``, or an MLC model directory that contains `mlc-chat-config.json`.
 It can also be a link to a HF repository pointing to an MLC compiled model.
+When the model's ``model_task`` field is ``"embedding"``, the server starts in embedding-only
+mode, exposing ``GET /v1/models`` and ``POST /v1/embeddings``; chat-engine options are ignored
+in this mode and ``--model-lib`` is required.
 """.strip(),
     "model_lib": """
 The full path to the model library file to use (e.g. a ``.so`` file). If unspecified, we will use

--- a/python/mlc_llm/interface/serve.py
+++ b/python/mlc_llm/interface/serve.py
@@ -17,6 +17,7 @@ from mlc_llm.serve.entrypoints import (
 )
 from mlc_llm.serve.server import ServerContext
 from mlc_llm.support import logging
+from mlc_llm.support.auto_config import detect_model_task_and_config
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,30 @@ def serve(
     api_key: Optional[str] = None,
 ):
     """Serve the model with the specified configuration."""
+    # An embedding primary model is served in embedding-only mode; all other
+    # models go through the existing chat serve path unchanged.
+    model_task, model_config_path = detect_model_task_and_config(model)
+    if model_task == "embedding":
+        if embedding_model is not None:
+            raise ValueError(
+                "--embedding-model cannot be combined with an embedding primary model. "
+                "Serve the embedding model directly: mlc_llm serve <embedding-model>."
+            )
+        _serve_embedding(
+            model=model,
+            model_path=str(model_config_path.parent),
+            device=device,
+            model_lib=model_lib,
+            host=host,
+            port=port,
+            allow_credentials=allow_credentials,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            api_key=api_key,
+        )
+        return
+
     # Create engine and start the background loop
     async_engine = engine.AsyncMLCEngine(
         model=model,
@@ -89,6 +114,11 @@ def serve(
     # Set up embedding model if specified
     emb_engine = None
     if embedding_model is not None:
+        logger.warning(
+            "--embedding-model/--embedding-model-lib are deprecated. "
+            "Serve the embedding model directly instead: "
+            "mlc_llm serve <embedding-model> --model-lib <lib>."
+        )
         if embedding_model_lib is None:
             raise ValueError(
                 "--embedding-model-lib is required when --embedding-model is specified."
@@ -127,5 +157,60 @@ def serve(
 
         app.exception_handler(error_protocol.BadRequestError)(
             error_protocol.bad_request_error_handler
+        )
+        uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def _serve_embedding(  # pylint: disable=too-many-arguments
+    *,
+    model: str,
+    model_path: str,
+    device: str,
+    model_lib: Optional[str],
+    host: str,
+    port: int,
+    allow_credentials: bool,
+    allow_origins: Any,
+    allow_methods: Any,
+    allow_headers: Any,
+    api_key: Optional[str],
+):
+    """Serve an embedding model as the primary (and only) model.
+
+    Exposes only the endpoints an embedding server can answer:
+    GET /v1/models and POST /v1/embeddings. Chat-engine options do not apply
+    in this mode.
+    """
+    if model_lib is None:
+        raise ValueError("--model-lib is required when serving an embedding model.")
+
+    emb_engine = AsyncEmbeddingEngine(
+        model=model_path,
+        model_lib=model_lib,
+        device=device,
+    )
+    logger.info("Embedding model %s loaded successfully.", model)
+
+    with ServerContext() as server_context:
+        server_context.add_embedding_engine(model, emb_engine)
+        server_context.api_key = api_key
+
+        app = fastapi.FastAPI()
+        app.add_middleware(
+            CORSMiddleware,
+            allow_credentials=allow_credentials,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+        )
+        app.include_router(openai_entrypoints.embedding_app)
+        app.exception_handler(error_protocol.BadRequestError)(
+            error_protocol.bad_request_error_handler
+        )
+        logger.info(
+            "Embedding server started at http://%s:%d (endpoints: GET /v1/models, "
+            "POST /v1/embeddings)",
+            host,
+            port,
         )
         uvicorn.run(app, host=host, port=port, log_level="info")

--- a/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
+++ b/python/mlc_llm/serve/entrypoints/openai_entrypoints.py
@@ -338,3 +338,13 @@ async def request_chat_completion(request: ChatCompletionRequest, raw_request: f
         use_function_calling=use_function_calling,
         usage=request_final_usage,
     )
+
+
+################ Embedding-only router ################
+
+# Router for embedding-only serving (`mlc_llm serve` with a primary model whose
+# `model_task` is "embedding"). It reuses the handlers above but exposes only the
+# endpoints an embedding server can answer.
+embedding_app = fastapi.APIRouter(dependencies=[fastapi.Depends(verify_api_key)])
+embedding_app.get("/v1/models")(request_models)
+embedding_app.post("/v1/embeddings")(request_embedding)

--- a/python/mlc_llm/support/auto_config.py
+++ b/python/mlc_llm/support/auto_config.py
@@ -68,6 +68,31 @@ def detect_mlc_chat_config(mlc_chat_config: str) -> Path:
     return mlc_chat_config_json_path
 
 
+def detect_model_task_and_config(model: str) -> "tuple[str, Path]":
+    """Detect a model's task and return it with the resolved ``mlc-chat-config.json`` path.
+
+    Returns
+    -------
+    model_task : str
+        The ``model_task`` field of the config, defaulting to ``"chat"`` when absent.
+    mlc_chat_config_json_path : pathlib.Path
+        The path pointing to ``mlc-chat-config.json``.
+    """
+    config_path = detect_mlc_chat_config(model)
+    with open(config_path, encoding="utf-8") as f:
+        cfg = json.load(f)
+    return cfg.get("model_task", "chat"), config_path
+
+
+def detect_model_task(model: str) -> str:
+    """Detect the ``model_task`` field from a model's ``mlc-chat-config.json``.
+
+    Returns ``"chat"`` or ``"embedding"``. Defaults to ``"chat"`` when the field is absent.
+    """
+    model_task, _ = detect_model_task_and_config(model)
+    return model_task
+
+
 def detect_config(config: str) -> Path:
     """Detect and return the path that points to config.json. If `config` is a directory,
     it looks for config.json below it.

--- a/tests/python/serve/test_single_task_serve.py
+++ b/tests/python/serve/test_single_task_serve.py
@@ -1,0 +1,151 @@
+"""Unit tests for single-task embedding serve dispatch."""
+
+# pylint: disable=missing-function-docstring,protected-access
+import json
+from pathlib import Path
+
+import pytest
+
+from mlc_llm.interface import serve as serve_interface
+from mlc_llm.serve.entrypoints import openai_entrypoints
+from mlc_llm.support.auto_config import detect_model_task, detect_model_task_and_config
+
+
+def _write_model_dir(tmp_path: Path, config: dict) -> Path:
+    (tmp_path / "mlc-chat-config.json").write_text(json.dumps(config), encoding="utf-8")
+    return tmp_path
+
+
+def _serve_kwargs(model: str, **overrides):
+    kwargs = dict(
+        model=model,
+        device="auto",
+        model_lib="dummy-lib.so",
+        mode="local",
+        enable_debug=False,
+        additional_models=[],
+        embedding_model=None,
+        embedding_model_lib=None,
+        tensor_parallel_shards=None,
+        pipeline_parallel_stages=None,
+        opt=None,
+        max_num_sequence=None,
+        max_total_sequence_length=None,
+        max_single_sequence_length=None,
+        prefill_chunk_size=None,
+        sliding_window_size=None,
+        attention_sink_size=None,
+        max_history_size=None,
+        gpu_memory_utilization=None,
+        speculative_mode="disable",
+        spec_draft_length=None,
+        spec_tree_width=None,
+        prefix_cache_mode="radix",
+        prefix_cache_max_num_recycling_seqs=None,
+        prefill_mode="hybrid",
+        enable_tracing=False,
+        host="127.0.0.1",
+        port=8000,
+        allow_credentials=True,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+        api_key=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_detect_model_task_embedding(tmp_path):
+    model_dir = _write_model_dir(tmp_path, {"model_task": "embedding"})
+    assert detect_model_task(str(model_dir)) == "embedding"
+
+
+def test_detect_model_task_defaults_to_chat(tmp_path):
+    model_dir = _write_model_dir(tmp_path, {"model_type": "llama"})
+    assert detect_model_task(str(model_dir)) == "chat"
+
+
+def test_detect_model_task_and_config_returns_config_path(tmp_path):
+    model_dir = _write_model_dir(tmp_path, {"model_task": "embedding"})
+    task, config_path = detect_model_task_and_config(str(model_dir))
+    assert task == "embedding"
+    assert config_path == model_dir / "mlc-chat-config.json"
+
+
+def test_embedding_app_exposes_only_embedding_endpoints():
+    routes = {
+        (method, route.path)
+        for route in openai_entrypoints.embedding_app.routes
+        for method in route.methods
+    }
+    assert routes == {("GET", "/v1/models"), ("POST", "/v1/embeddings")}
+
+
+def test_chat_serve_router_keeps_all_endpoints():
+    routes = {
+        (method, route.path) for route in openai_entrypoints.app.routes for method in route.methods
+    }
+    assert ("POST", "/v1/embeddings") in routes
+    assert ("POST", "/v1/completions") in routes
+    assert ("POST", "/v1/chat/completions") in routes
+    assert ("GET", "/v1/models") in routes
+
+
+def test_serve_dispatches_embedding_model(tmp_path, monkeypatch):
+    model_dir = _write_model_dir(tmp_path, {"model_task": "embedding"})
+    called = {}
+
+    monkeypatch.setattr(serve_interface, "_serve_embedding", called.update)
+    monkeypatch.setattr(
+        serve_interface.engine,
+        "AsyncMLCEngine",
+        lambda *a, **k: pytest.fail("chat engine must not be created for embedding models"),
+    )
+
+    serve_interface.serve(**_serve_kwargs(str(model_dir)))
+
+    assert called["model"] == str(model_dir)
+    assert called["model_path"] == str(model_dir)
+    assert called["model_lib"] == "dummy-lib.so"
+
+
+def test_serve_rejects_sidecar_flags_with_embedding_primary(tmp_path, monkeypatch):
+    model_dir = _write_model_dir(tmp_path, {"model_task": "embedding"})
+    monkeypatch.setattr(
+        serve_interface.engine,
+        "AsyncMLCEngine",
+        lambda *a, **k: pytest.fail("chat engine must not be created"),
+    )
+    with pytest.raises(ValueError, match="--embedding-model"):
+        serve_interface.serve(**_serve_kwargs(str(model_dir), embedding_model="some-model"))
+
+
+def test_serve_embedding_requires_model_lib(tmp_path):
+    model_dir = _write_model_dir(tmp_path, {"model_task": "embedding"})
+    with pytest.raises(ValueError, match="--model-lib"):
+        serve_interface.serve(**_serve_kwargs(str(model_dir), model_lib=None))
+
+
+class _ChatPathTaken(Exception):
+    """Sentinel raised by the fake chat engine to prove the chat path was taken."""
+
+
+def test_serve_dispatches_chat_model(tmp_path, monkeypatch):
+    model_dir = _write_model_dir(tmp_path, {"model_type": "llama"})
+
+    def _fake_engine(*_args, **_kwargs):
+        raise _ChatPathTaken
+
+    monkeypatch.setattr(serve_interface.engine, "AsyncMLCEngine", _fake_engine)
+    monkeypatch.setattr(
+        serve_interface,
+        "_serve_embedding",
+        lambda **k: pytest.fail("embedding path must not be taken for chat models"),
+    )
+    with pytest.raises(_ChatPathTaken):
+        serve_interface.serve(**_serve_kwargs(str(model_dir)))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Previously, serving embeddings through `mlc_llm serve` required a primary chat model and the embedding sidecar flags.

This PR allows embedding models to be served directly when `mlc-chat-config.json` contains `"model_task": "embedding"`, without loading a chat engine.

### Before:

```bash
mlc_llm serve ./dist/chat-model \
  --embedding-model ./dist/Qwen3-Embedding-0.6B-q0f16-MLC \
  --embedding-model-lib ./dist/libs/Qwen3-Embedding-0.6B-q0f16-metal.dylib
```

### After:

```bash
mlc_llm serve ./dist/Qwen3-Embedding-0.6B-q0f16-MLC \
  --model-lib ./dist/libs/Qwen3-Embedding-0.6B-q0f16-metal.dylib
```

The embedding-only server exposes `/v1/models` and `/v1/embeddings`:

```bash
curl http://127.0.0.1:8000/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{
    "model": "./dist/Qwen3-Embedding-0.6B-q0f16-MLC",
    "input": ["hello", "world"]
  }'
```

The sidecar flags remain supported but are deprecated.

Tested with unit tests and local Qwen3-Embedding and BGE-M3 serving.

Related to #3451.